### PR TITLE
Add tests for open vault validation messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "mocha -r mock-local-storage --config ./.mocharc.js",
     "test:coverage": "nyc --reporter=lcov yarn test && nyc report --reporter=text --reporter=text-summary",
     "coverage": " yarn test:coverage && codecov",
+    "coverage:no-upload": " yarn test:coverage",
     "test:fix": "yarn lint:fix && yarn tsc && yarn format:fix && yarn test && yarn typecheck",
     "test:e2e": "mocha --config ./server-test-e2e/.mocharc.js",
     "hardhat:node": "hardhat node",


### PR DESCRIPTION
Improving tests to cover following scenarios from Notion:
- Test validation of open vault - multiple branches
- Added script to omit uploading `codecov` report on local run