### PR TITLE
Account for debtOffset for insufficient dai allowance

### DIFF
--- a/features/manageVault/manageVaultConditions.ts
+++ b/features/manageVault/manageVaultConditions.ts
@@ -307,7 +307,7 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
   const insufficientDaiAllowance = !!(
     paybackAmount &&
     !paybackAmount.isZero() &&
-    (!daiAllowance || paybackAmount.gt(daiAllowance))
+    (!daiAllowance || paybackAmount.plus(vault.debtOffset).gt(daiAllowance))
   )
 
   const isLoadingStage = ([

--- a/features/manageVault/manageVaultTransitions.ts
+++ b/features/manageVault/manageVaultTransitions.ts
@@ -109,7 +109,7 @@ export function applyManageVaultTransition(
       paybackAmount,
       collateralAllowance,
       daiAllowance,
-      vault: { token },
+      vault: { token, debtOffset },
     } = state
     const canProgress = !errorMessages.length
     const hasProxy = !!proxyAddress
@@ -121,7 +121,7 @@ export function applyManageVaultTransition(
       collateralAllowance && depositAmount && collateralAllowance.gte(depositAmount)
 
     const paybackAmountLessThanDaiAllowance =
-      daiAllowance && paybackAmount && daiAllowance.gte(paybackAmount)
+      daiAllowance && paybackAmount && daiAllowance.gte(paybackAmount.plus(debtOffset))
 
     const hasCollateralAllowance =
       token === 'ETH' ? true : depositAmountLessThanCollateralAllowance || isDepositZero
@@ -149,7 +149,7 @@ export function applyManageVaultTransition(
       paybackAmount,
       collateralAllowance,
       daiAllowance,
-      vault: { token },
+      vault: { token, debtOffset },
     } = state
     const isDepositZero = depositAmount ? depositAmount.eq(zero) : true
     const isPaybackZero = paybackAmount ? paybackAmount.eq(zero) : true
@@ -157,7 +157,7 @@ export function applyManageVaultTransition(
     const depositAmountLessThanCollateralAllowance =
       collateralAllowance && depositAmount && collateralAllowance.gte(depositAmount)
     const paybackAmountLessThanDaiAllowance =
-      daiAllowance && paybackAmount && daiAllowance.gte(paybackAmount)
+      daiAllowance && paybackAmount && daiAllowance.gte(paybackAmount.plus(debtOffset))
     const hasCollateralAllowance =
       token === 'ETH' ? true : depositAmountLessThanCollateralAllowance || isDepositZero
     const hasDaiAllowance = paybackAmountLessThanDaiAllowance || isPaybackZero
@@ -172,10 +172,15 @@ export function applyManageVaultTransition(
   }
 
   if (change.kind === 'progressCollateralAllowance') {
-    const { originalEditingStage, paybackAmount, daiAllowance } = state
+    const {
+      originalEditingStage,
+      paybackAmount,
+      daiAllowance,
+      vault: { debtOffset },
+    } = state
     const isPaybackZero = paybackAmount ? paybackAmount.eq(zero) : true
     const paybackAmountLessThanDaiAllowance =
-      daiAllowance && paybackAmount && daiAllowance.gte(paybackAmount)
+      daiAllowance && paybackAmount && daiAllowance.gte(paybackAmount.plus(debtOffset))
     const hasDaiAllowance = paybackAmountLessThanDaiAllowance || isPaybackZero
 
     if (!hasDaiAllowance) {

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -1,201 +1,198 @@
 import BigNumber from 'bignumber.js'
-import { maxUint256 } from 'blockchain/calls/erc20'
 import { expect } from 'chai'
-import { mockManageVault, mockManageVault$ } from 'helpers/mocks/manageVault.mock'
+import { mockManageVault } from 'helpers/mocks/manageVault.mock'
 import { DEFAULT_PROXY_ADDRESS } from 'helpers/mocks/vaults.mock'
-import { getStateUnpacker } from 'helpers/testHelpers'
-import { zero } from 'helpers/zero'
 
 describe('manageVaultValidations', () => {
-  it('validates if deposit amount exceeds collateral balance or depositing all ETH', () => {
-    const depositAmountExceeds = new BigNumber('2')
-    const depositAmountAll = new BigNumber('1')
+  // it('validates if deposit amount exceeds collateral balance or depositing all ETH', () => {
+  //   const depositAmountExceeds = new BigNumber('2')
+  //   const depositAmountAll = new BigNumber('1')
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        balanceInfo: {
-          collateralBalance: new BigNumber('1'),
-        },
-        vault: {
-          ilk: 'ETH-A',
-        },
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       balanceInfo: {
+  //         collateralBalance: new BigNumber('1'),
+  //       },
+  //       vault: {
+  //         ilk: 'ETH-A',
+  //       },
+  //     }),
+  //   )
 
-    state().updateDeposit!(depositAmountExceeds)
-    expect(state().errorMessages).to.deep.equal(['depositAmountExceedsCollateralBalance'])
-    state().updateDeposit!(depositAmountAll)
-    expect(state().errorMessages).to.deep.equal(['depositingAllEthBalance'])
-  })
+  //   state().updateDeposit!(depositAmountExceeds)
+  //   expect(state().errorMessages).to.deep.equal(['depositAmountExceedsCollateralBalance'])
+  //   state().updateDeposit!(depositAmountAll)
+  //   expect(state().errorMessages).to.deep.equal(['depositingAllEthBalance'])
+  // })
 
-  it(`validates if generate doesn't exceeds debt ceiling, debt floor`, () => {
-    const depositAmount = new BigNumber('2')
-    const generateAmountAboveCeiling = new BigNumber('30')
-    const generateAmountBelowFloor = new BigNumber('9')
+  // it(`validates if generate doesn't exceeds debt ceiling, debt floor`, () => {
+  //   const depositAmount = new BigNumber('2')
+  //   const generateAmountAboveCeiling = new BigNumber('30')
+  //   const generateAmountBelowFloor = new BigNumber('9')
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        ilkData: {
-          debtCeiling: new BigNumber('8000025'),
-          debtFloor: new BigNumber('2000'),
-        },
-        vault: {
-          collateral: new BigNumber('3'),
-          debt: new BigNumber('1990'),
-          ilk: 'ETH-A',
-        },
-        priceInfo: {
-          ethChangePercentage: new BigNumber(-0.1),
-        },
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       ilkData: {
+  //         debtCeiling: new BigNumber('8000025'),
+  //         debtFloor: new BigNumber('2000'),
+  //       },
+  //       vault: {
+  //         collateral: new BigNumber('3'),
+  //         debt: new BigNumber('1990'),
+  //         ilk: 'ETH-A',
+  //       },
+  //       priceInfo: {
+  //         ethChangePercentage: new BigNumber(-0.1),
+  //       },
+  //     }),
+  //   )
 
-    state().updateDeposit!(depositAmount)
-    state().toggleDepositAndGenerateOption!()
-    state().updateGenerate!(generateAmountAboveCeiling)
-    expect(state().errorMessages).to.deep.equal(['generateAmountExceedsDebtCeiling'])
+  //   state().updateDeposit!(depositAmount)
+  //   state().toggleDepositAndGenerateOption!()
+  //   state().updateGenerate!(generateAmountAboveCeiling)
+  //   expect(state().errorMessages).to.deep.equal(['generateAmountExceedsDebtCeiling'])
 
-    state().updateGenerate!(generateAmountBelowFloor)
-    expect(state().errorMessages).to.deep.equal(['generateAmountLessThanDebtFloor'])
-  })
+  //   state().updateGenerate!(generateAmountBelowFloor)
+  //   expect(state().errorMessages).to.deep.equal(['generateAmountLessThanDebtFloor'])
+  // })
 
-  it(`validates if generate or withdraw amounts are putting vault at risk, danger or exceeding day yield`, () => {
-    const withdrawAmount = new BigNumber('0.1')
-    const generateAmountExceedsYield = new BigNumber(60)
-    const generateAmountWarnings = new BigNumber(20)
+  // it(`validates if generate or withdraw amounts are putting vault at risk, danger or exceeding day yield`, () => {
+  //   const withdrawAmount = new BigNumber('0.1')
+  //   const generateAmountExceedsYield = new BigNumber(60)
+  //   const generateAmountWarnings = new BigNumber(20)
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        ilkData: {
-          debtFloor: new BigNumber('1500'),
-        },
-        vault: {
-          collateral: new BigNumber('3'),
-          debt: new BigNumber('1990'),
-          ilk: 'ETH-A',
-        },
-        priceInfo: {
-          ethChangePercentage: new BigNumber(-0.25),
-        },
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       ilkData: {
+  //         debtFloor: new BigNumber('1500'),
+  //       },
+  //       vault: {
+  //         collateral: new BigNumber('3'),
+  //         debt: new BigNumber('1990'),
+  //         ilk: 'ETH-A',
+  //       },
+  //       priceInfo: {
+  //         ethChangePercentage: new BigNumber(-0.25),
+  //       },
+  //     }),
+  //   )
 
-    state().updateWithdraw!(withdrawAmount)
-    expect(state().errorMessages).to.deep.equal(['withdrawAmountExceedsFreeCollateralAtNextPrice'])
-    state().updateWithdraw!(undefined)
+  //   state().updateWithdraw!(withdrawAmount)
+  //   expect(state().errorMessages).to.deep.equal(['withdrawAmountExceedsFreeCollateralAtNextPrice'])
+  //   state().updateWithdraw!(undefined)
 
-    state().updateDeposit!(zero)
-    state().toggleDepositAndGenerateOption!()
-    state().updateGenerate!(generateAmountExceedsYield)
-    expect(state().errorMessages).to.deep.equal([
-      'generateAmountExceedsDaiYieldFromTotalCollateralAtNextPrice',
-    ])
+  //   state().updateDeposit!(zero)
+  //   state().toggleDepositAndGenerateOption!()
+  //   state().updateGenerate!(generateAmountExceedsYield)
+  //   expect(state().errorMessages).to.deep.equal([
+  //     'generateAmountExceedsDaiYieldFromTotalCollateralAtNextPrice',
+  //   ])
 
-    state().updateGenerate!(generateAmountWarnings)
-    expect(state().warningMessages).to.deep.equal([
-      'vaultWillBeAtRiskLevelDangerAtNextPrice',
-      'vaultWillBeAtRiskLevelWarning',
-    ])
-  })
+  //   state().updateGenerate!(generateAmountWarnings)
+  //   expect(state().warningMessages).to.deep.equal([
+  //     'vaultWillBeAtRiskLevelDangerAtNextPrice',
+  //     'vaultWillBeAtRiskLevelWarning',
+  //   ])
+  // })
 
-  it(`validates if generate will result in warning at next price`, () => {
-    const generateAmountWarnings = new BigNumber(20)
+  // it(`validates if generate will result in warning at next price`, () => {
+  //   const generateAmountWarnings = new BigNumber(20)
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        ilkData: {
-          debtFloor: new BigNumber('1500'),
-        },
-        vault: {
-          collateral: new BigNumber('3'),
-          debt: new BigNumber('1690'),
-          ilk: 'ETH-A',
-        },
-        priceInfo: {
-          ethChangePercentage: new BigNumber(-0.1),
-        },
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       ilkData: {
+  //         debtFloor: new BigNumber('1500'),
+  //       },
+  //       vault: {
+  //         collateral: new BigNumber('3'),
+  //         debt: new BigNumber('1690'),
+  //         ilk: 'ETH-A',
+  //       },
+  //       priceInfo: {
+  //         ethChangePercentage: new BigNumber(-0.1),
+  //       },
+  //     }),
+  //   )
 
-    state().updateDeposit!(zero)
-    state().toggleDepositAndGenerateOption!()
+  //   state().updateDeposit!(zero)
+  //   state().toggleDepositAndGenerateOption!()
 
-    state().updateGenerate!(generateAmountWarnings)
-    expect(state().warningMessages).to.deep.equal(['vaultWillBeAtRiskLevelWarningAtNextPrice'])
-  })
+  //   state().updateGenerate!(generateAmountWarnings)
+  //   expect(state().warningMessages).to.deep.equal(['vaultWillBeAtRiskLevelWarningAtNextPrice'])
+  // })
 
-  it('validates custom allowance setting for collateral', () => {
-    const depositAmount = new BigNumber('100')
-    const customAllowanceAmount = new BigNumber('99')
+  // it('validates custom allowance setting for collateral', () => {
+  //   const depositAmount = new BigNumber('100')
+  //   const customAllowanceAmount = new BigNumber('99')
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        proxyAddress: DEFAULT_PROXY_ADDRESS,
-        collateralAllowance: zero,
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       proxyAddress: DEFAULT_PROXY_ADDRESS,
+  //       collateralAllowance: zero,
+  //     }),
+  //   )
 
-    state().updateDeposit!(depositAmount)
+  //   state().updateDeposit!(depositAmount)
 
-    state().progress!()
-    expect(state().stage).to.deep.equal('collateralAllowanceWaitingForConfirmation')
-    state().resetCollateralAllowanceAmount!()
-    state().updateCollateralAllowanceAmount!(customAllowanceAmount)
-    expect(state().collateralAllowanceAmount!).to.deep.equal(customAllowanceAmount)
-    expect(state().errorMessages).to.deep.equal([
-      'customCollateralAllowanceAmountLessThanDepositAmount',
-    ])
+  //   state().progress!()
+  //   expect(state().stage).to.deep.equal('collateralAllowanceWaitingForConfirmation')
+  //   state().resetCollateralAllowanceAmount!()
+  //   state().updateCollateralAllowanceAmount!(customAllowanceAmount)
+  //   expect(state().collateralAllowanceAmount!).to.deep.equal(customAllowanceAmount)
+  //   expect(state().errorMessages).to.deep.equal([
+  //     'customCollateralAllowanceAmountLessThanDepositAmount',
+  //   ])
 
-    state().updateCollateralAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
-    expect(state().errorMessages).to.deep.equal([
-      'customCollateralAllowanceAmountExceedsMaxUint256',
-    ])
-  })
+  //   state().updateCollateralAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
+  //   expect(state().errorMessages).to.deep.equal([
+  //     'customCollateralAllowanceAmountExceedsMaxUint256',
+  //   ])
+  // })
 
-  it('validates custom allowance setting for dai', () => {
-    const paybackAmount = new BigNumber('100')
-    const customAllowanceAmount = new BigNumber('99')
+  // it('validates custom allowance setting for dai', () => {
+  //   const paybackAmount = new BigNumber('100')
+  //   const customAllowanceAmount = new BigNumber('99')
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        proxyAddress: DEFAULT_PROXY_ADDRESS,
-        daiAllowance: zero,
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       proxyAddress: DEFAULT_PROXY_ADDRESS,
+  //       daiAllowance: zero,
+  //     }),
+  //   )
 
-    state().toggle!()
-    state().updatePayback!(paybackAmount)
+  //   state().toggle!()
+  //   state().updatePayback!(paybackAmount)
 
-    state().progress!()
-    expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
-    state().resetDaiAllowanceAmount!()
-    state().updateDaiAllowanceAmount!(customAllowanceAmount)
-    expect(state().daiAllowanceAmount!).to.deep.equal(customAllowanceAmount)
-    expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountLessThanPaybackAmount'])
+  //   state().progress!()
+  //   expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
+  //   state().resetDaiAllowanceAmount!()
+  //   state().updateDaiAllowanceAmount!(customAllowanceAmount)
+  //   expect(state().daiAllowanceAmount!).to.deep.equal(customAllowanceAmount)
+  //   expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountLessThanPaybackAmount'])
 
-    state().updateDaiAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
-    expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountExceedsMaxUint256'])
-  })
+  //   state().updateDaiAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
+  //   expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountExceedsMaxUint256'])
+  // })
 
-  it('validates payback amount', () => {
-    const paybackAmountExceedsVaultDebt = new BigNumber('100')
-    const paybackAmountNotEnough = new BigNumber('20')
+  // it('validates payback amount', () => {
+  //   const paybackAmountExceedsVaultDebt = new BigNumber('100')
+  //   const paybackAmountNotEnough = new BigNumber('20')
 
-    const state = getStateUnpacker(
-      mockManageVault$({
-        vault: {
-          debt: new BigNumber('40'),
-        },
-      }),
-    )
+  //   const state = getStateUnpacker(
+  //     mockManageVault$({
+  //       vault: {
+  //         debt: new BigNumber('40'),
+  //       },
+  //     }),
+  //   )
 
-    state().toggle!()
-    state().updatePayback!(paybackAmountExceedsVaultDebt)
-    expect(state().errorMessages).to.deep.equal(['paybackAmountExceedsVaultDebt'])
+  //   state().toggle!()
+  //   state().updatePayback!(paybackAmountExceedsVaultDebt)
+  //   expect(state().errorMessages).to.deep.equal(['paybackAmountExceedsVaultDebt'])
 
-    state().updatePayback!(paybackAmountNotEnough)
-    expect(state().errorMessages).to.deep.equal(['debtWillBeLessThanDebtFloor'])
-  })
+  //   state().updatePayback!(paybackAmountNotEnough)
+  //   expect(state().errorMessages).to.deep.equal(['debtWillBeLessThanDebtFloor'])
+  // })
 
   it('validates if dai allowance is enought to payback whole amount and account debt offset', () => {
     const paybackAmount = new BigNumber('500')
@@ -213,13 +210,16 @@ describe('manageVaultValidations', () => {
     })
 
     state().toggle!()
-    state().updatePayback!(paybackAmount)
-    expect(state().insufficientDaiAllowance).to.be.true
-
     state().updatePayback!(paybackAmount.plus(state().vault.debtOffset))
     expect(state().insufficientDaiAllowance).to.be.true
 
     state().updatePayback!(paybackAmount.minus(state().vault.debtOffset))
     expect(state().insufficientDaiAllowance).to.be.false
+
+    state().updatePayback!(paybackAmount)
+    expect(state().insufficientDaiAllowance).to.be.true
+
+    state().progress!()
+    expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
   })
 })

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { maxUint256 } from 'blockchain/calls/erc20'
 import { expect } from 'chai'
 import { mockManageVault, mockManageVault$ } from 'helpers/mocks/manageVault.mock'
 import { DEFAULT_PROXY_ADDRESS } from 'helpers/mocks/vaults.mock'
@@ -196,7 +197,7 @@ describe('manageVaultValidations', () => {
     expect(state().errorMessages).to.deep.equal(['debtWillBeLessThanDebtFloor'])
   })
 
-  it('validates if dai allowance is enought to payback whole amount and account debt offset', () => {
+  it('validates if dai allowance is enough to payback whole amount and account debt offset', () => {
     const paybackAmount = new BigNumber('500')
 
     const state = mockManageVault({

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { maxUint256 } from 'blockchain/calls/erc20'
 import { expect } from 'chai'
-import { mockManageVault$ } from 'helpers/mocks/manageVault.mock'
+import { mockManageVault, mockManageVault$ } from 'helpers/mocks/manageVault.mock'
 import { DEFAULT_PROXY_ADDRESS } from 'helpers/mocks/vaults.mock'
 import { getStateUnpacker } from 'helpers/testHelpers'
 import { zero } from 'helpers/zero'
@@ -195,5 +195,31 @@ describe('manageVaultValidations', () => {
 
     state().updatePayback!(paybackAmountNotEnough)
     expect(state().errorMessages).to.deep.equal(['debtWillBeLessThanDebtFloor'])
+  })
+
+  it('validates if dai allowance is enought to payback whole amount and account debt offset', () => {
+    const paybackAmount = new BigNumber('500')
+
+    const state = mockManageVault({
+      proxyAddress: DEFAULT_PROXY_ADDRESS,
+      vault: {
+        collateral: new BigNumber('31'),
+        debt: new BigNumber('2000'),
+      },
+      daiAllowance: paybackAmount,
+      priceInfo: {
+        collateralPrice: new BigNumber('100'),
+      },
+    })
+
+    state().toggle!()
+    state().updatePayback!(paybackAmount)
+    expect(state().insufficientDaiAllowance).to.be.true
+
+    state().updatePayback!(paybackAmount.plus(state().vault.debtOffset))
+    expect(state().insufficientDaiAllowance).to.be.true
+
+    state().updatePayback!(paybackAmount.minus(state().vault.debtOffset))
+    expect(state().insufficientDaiAllowance).to.be.false
   })
 })

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -1,198 +1,200 @@
 import BigNumber from 'bignumber.js'
 import { expect } from 'chai'
-import { mockManageVault } from 'helpers/mocks/manageVault.mock'
+import { mockManageVault, mockManageVault$ } from 'helpers/mocks/manageVault.mock'
 import { DEFAULT_PROXY_ADDRESS } from 'helpers/mocks/vaults.mock'
+import { getStateUnpacker } from 'helpers/testHelpers'
+import { zero } from 'helpers/zero'
 
 describe('manageVaultValidations', () => {
-  // it('validates if deposit amount exceeds collateral balance or depositing all ETH', () => {
-  //   const depositAmountExceeds = new BigNumber('2')
-  //   const depositAmountAll = new BigNumber('1')
+  it('validates if deposit amount exceeds collateral balance or depositing all ETH', () => {
+    const depositAmountExceeds = new BigNumber('2')
+    const depositAmountAll = new BigNumber('1')
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       balanceInfo: {
-  //         collateralBalance: new BigNumber('1'),
-  //       },
-  //       vault: {
-  //         ilk: 'ETH-A',
-  //       },
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        balanceInfo: {
+          collateralBalance: new BigNumber('1'),
+        },
+        vault: {
+          ilk: 'ETH-A',
+        },
+      }),
+    )
 
-  //   state().updateDeposit!(depositAmountExceeds)
-  //   expect(state().errorMessages).to.deep.equal(['depositAmountExceedsCollateralBalance'])
-  //   state().updateDeposit!(depositAmountAll)
-  //   expect(state().errorMessages).to.deep.equal(['depositingAllEthBalance'])
-  // })
+    state().updateDeposit!(depositAmountExceeds)
+    expect(state().errorMessages).to.deep.equal(['depositAmountExceedsCollateralBalance'])
+    state().updateDeposit!(depositAmountAll)
+    expect(state().errorMessages).to.deep.equal(['depositingAllEthBalance'])
+  })
 
-  // it(`validates if generate doesn't exceeds debt ceiling, debt floor`, () => {
-  //   const depositAmount = new BigNumber('2')
-  //   const generateAmountAboveCeiling = new BigNumber('30')
-  //   const generateAmountBelowFloor = new BigNumber('9')
+  it(`validates if generate doesn't exceeds debt ceiling, debt floor`, () => {
+    const depositAmount = new BigNumber('2')
+    const generateAmountAboveCeiling = new BigNumber('30')
+    const generateAmountBelowFloor = new BigNumber('9')
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       ilkData: {
-  //         debtCeiling: new BigNumber('8000025'),
-  //         debtFloor: new BigNumber('2000'),
-  //       },
-  //       vault: {
-  //         collateral: new BigNumber('3'),
-  //         debt: new BigNumber('1990'),
-  //         ilk: 'ETH-A',
-  //       },
-  //       priceInfo: {
-  //         ethChangePercentage: new BigNumber(-0.1),
-  //       },
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtCeiling: new BigNumber('8000025'),
+          debtFloor: new BigNumber('2000'),
+        },
+        vault: {
+          collateral: new BigNumber('3'),
+          debt: new BigNumber('1990'),
+          ilk: 'ETH-A',
+        },
+        priceInfo: {
+          ethChangePercentage: new BigNumber(-0.1),
+        },
+      }),
+    )
 
-  //   state().updateDeposit!(depositAmount)
-  //   state().toggleDepositAndGenerateOption!()
-  //   state().updateGenerate!(generateAmountAboveCeiling)
-  //   expect(state().errorMessages).to.deep.equal(['generateAmountExceedsDebtCeiling'])
+    state().updateDeposit!(depositAmount)
+    state().toggleDepositAndGenerateOption!()
+    state().updateGenerate!(generateAmountAboveCeiling)
+    expect(state().errorMessages).to.deep.equal(['generateAmountExceedsDebtCeiling'])
 
-  //   state().updateGenerate!(generateAmountBelowFloor)
-  //   expect(state().errorMessages).to.deep.equal(['generateAmountLessThanDebtFloor'])
-  // })
+    state().updateGenerate!(generateAmountBelowFloor)
+    expect(state().errorMessages).to.deep.equal(['generateAmountLessThanDebtFloor'])
+  })
 
-  // it(`validates if generate or withdraw amounts are putting vault at risk, danger or exceeding day yield`, () => {
-  //   const withdrawAmount = new BigNumber('0.1')
-  //   const generateAmountExceedsYield = new BigNumber(60)
-  //   const generateAmountWarnings = new BigNumber(20)
+  it(`validates if generate or withdraw amounts are putting vault at risk, danger or exceeding day yield`, () => {
+    const withdrawAmount = new BigNumber('0.1')
+    const generateAmountExceedsYield = new BigNumber(60)
+    const generateAmountWarnings = new BigNumber(20)
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       ilkData: {
-  //         debtFloor: new BigNumber('1500'),
-  //       },
-  //       vault: {
-  //         collateral: new BigNumber('3'),
-  //         debt: new BigNumber('1990'),
-  //         ilk: 'ETH-A',
-  //       },
-  //       priceInfo: {
-  //         ethChangePercentage: new BigNumber(-0.25),
-  //       },
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtFloor: new BigNumber('1500'),
+        },
+        vault: {
+          collateral: new BigNumber('3'),
+          debt: new BigNumber('1990'),
+          ilk: 'ETH-A',
+        },
+        priceInfo: {
+          ethChangePercentage: new BigNumber(-0.25),
+        },
+      }),
+    )
 
-  //   state().updateWithdraw!(withdrawAmount)
-  //   expect(state().errorMessages).to.deep.equal(['withdrawAmountExceedsFreeCollateralAtNextPrice'])
-  //   state().updateWithdraw!(undefined)
+    state().updateWithdraw!(withdrawAmount)
+    expect(state().errorMessages).to.deep.equal(['withdrawAmountExceedsFreeCollateralAtNextPrice'])
+    state().updateWithdraw!(undefined)
 
-  //   state().updateDeposit!(zero)
-  //   state().toggleDepositAndGenerateOption!()
-  //   state().updateGenerate!(generateAmountExceedsYield)
-  //   expect(state().errorMessages).to.deep.equal([
-  //     'generateAmountExceedsDaiYieldFromTotalCollateralAtNextPrice',
-  //   ])
+    state().updateDeposit!(zero)
+    state().toggleDepositAndGenerateOption!()
+    state().updateGenerate!(generateAmountExceedsYield)
+    expect(state().errorMessages).to.deep.equal([
+      'generateAmountExceedsDaiYieldFromTotalCollateralAtNextPrice',
+    ])
 
-  //   state().updateGenerate!(generateAmountWarnings)
-  //   expect(state().warningMessages).to.deep.equal([
-  //     'vaultWillBeAtRiskLevelDangerAtNextPrice',
-  //     'vaultWillBeAtRiskLevelWarning',
-  //   ])
-  // })
+    state().updateGenerate!(generateAmountWarnings)
+    expect(state().warningMessages).to.deep.equal([
+      'vaultWillBeAtRiskLevelDangerAtNextPrice',
+      'vaultWillBeAtRiskLevelWarning',
+    ])
+  })
 
-  // it(`validates if generate will result in warning at next price`, () => {
-  //   const generateAmountWarnings = new BigNumber(20)
+  it(`validates if generate will result in warning at next price`, () => {
+    const generateAmountWarnings = new BigNumber(20)
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       ilkData: {
-  //         debtFloor: new BigNumber('1500'),
-  //       },
-  //       vault: {
-  //         collateral: new BigNumber('3'),
-  //         debt: new BigNumber('1690'),
-  //         ilk: 'ETH-A',
-  //       },
-  //       priceInfo: {
-  //         ethChangePercentage: new BigNumber(-0.1),
-  //       },
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtFloor: new BigNumber('1500'),
+        },
+        vault: {
+          collateral: new BigNumber('3'),
+          debt: new BigNumber('1690'),
+          ilk: 'ETH-A',
+        },
+        priceInfo: {
+          ethChangePercentage: new BigNumber(-0.1),
+        },
+      }),
+    )
 
-  //   state().updateDeposit!(zero)
-  //   state().toggleDepositAndGenerateOption!()
+    state().updateDeposit!(zero)
+    state().toggleDepositAndGenerateOption!()
 
-  //   state().updateGenerate!(generateAmountWarnings)
-  //   expect(state().warningMessages).to.deep.equal(['vaultWillBeAtRiskLevelWarningAtNextPrice'])
-  // })
+    state().updateGenerate!(generateAmountWarnings)
+    expect(state().warningMessages).to.deep.equal(['vaultWillBeAtRiskLevelWarningAtNextPrice'])
+  })
 
-  // it('validates custom allowance setting for collateral', () => {
-  //   const depositAmount = new BigNumber('100')
-  //   const customAllowanceAmount = new BigNumber('99')
+  it('validates custom allowance setting for collateral', () => {
+    const depositAmount = new BigNumber('100')
+    const customAllowanceAmount = new BigNumber('99')
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       proxyAddress: DEFAULT_PROXY_ADDRESS,
-  //       collateralAllowance: zero,
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        proxyAddress: DEFAULT_PROXY_ADDRESS,
+        collateralAllowance: zero,
+      }),
+    )
 
-  //   state().updateDeposit!(depositAmount)
+    state().updateDeposit!(depositAmount)
 
-  //   state().progress!()
-  //   expect(state().stage).to.deep.equal('collateralAllowanceWaitingForConfirmation')
-  //   state().resetCollateralAllowanceAmount!()
-  //   state().updateCollateralAllowanceAmount!(customAllowanceAmount)
-  //   expect(state().collateralAllowanceAmount!).to.deep.equal(customAllowanceAmount)
-  //   expect(state().errorMessages).to.deep.equal([
-  //     'customCollateralAllowanceAmountLessThanDepositAmount',
-  //   ])
+    state().progress!()
+    expect(state().stage).to.deep.equal('collateralAllowanceWaitingForConfirmation')
+    state().resetCollateralAllowanceAmount!()
+    state().updateCollateralAllowanceAmount!(customAllowanceAmount)
+    expect(state().collateralAllowanceAmount!).to.deep.equal(customAllowanceAmount)
+    expect(state().errorMessages).to.deep.equal([
+      'customCollateralAllowanceAmountLessThanDepositAmount',
+    ])
 
-  //   state().updateCollateralAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
-  //   expect(state().errorMessages).to.deep.equal([
-  //     'customCollateralAllowanceAmountExceedsMaxUint256',
-  //   ])
-  // })
+    state().updateCollateralAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
+    expect(state().errorMessages).to.deep.equal([
+      'customCollateralAllowanceAmountExceedsMaxUint256',
+    ])
+  })
 
-  // it('validates custom allowance setting for dai', () => {
-  //   const paybackAmount = new BigNumber('100')
-  //   const customAllowanceAmount = new BigNumber('99')
+  it('validates custom allowance setting for dai', () => {
+    const paybackAmount = new BigNumber('100')
+    const customAllowanceAmount = new BigNumber('99')
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       proxyAddress: DEFAULT_PROXY_ADDRESS,
-  //       daiAllowance: zero,
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        proxyAddress: DEFAULT_PROXY_ADDRESS,
+        daiAllowance: zero,
+      }),
+    )
 
-  //   state().toggle!()
-  //   state().updatePayback!(paybackAmount)
+    state().toggle!()
+    state().updatePayback!(paybackAmount)
 
-  //   state().progress!()
-  //   expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
-  //   state().resetDaiAllowanceAmount!()
-  //   state().updateDaiAllowanceAmount!(customAllowanceAmount)
-  //   expect(state().daiAllowanceAmount!).to.deep.equal(customAllowanceAmount)
-  //   expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountLessThanPaybackAmount'])
+    state().progress!()
+    expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
+    state().resetDaiAllowanceAmount!()
+    state().updateDaiAllowanceAmount!(customAllowanceAmount)
+    expect(state().daiAllowanceAmount!).to.deep.equal(customAllowanceAmount)
+    expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountLessThanPaybackAmount'])
 
-  //   state().updateDaiAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
-  //   expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountExceedsMaxUint256'])
-  // })
+    state().updateDaiAllowanceAmount!(maxUint256.plus(new BigNumber('1')))
+    expect(state().errorMessages).to.deep.equal(['customDaiAllowanceAmountExceedsMaxUint256'])
+  })
 
-  // it('validates payback amount', () => {
-  //   const paybackAmountExceedsVaultDebt = new BigNumber('100')
-  //   const paybackAmountNotEnough = new BigNumber('20')
+  it('validates payback amount', () => {
+    const paybackAmountExceedsVaultDebt = new BigNumber('100')
+    const paybackAmountNotEnough = new BigNumber('20')
 
-  //   const state = getStateUnpacker(
-  //     mockManageVault$({
-  //       vault: {
-  //         debt: new BigNumber('40'),
-  //       },
-  //     }),
-  //   )
+    const state = getStateUnpacker(
+      mockManageVault$({
+        vault: {
+          debt: new BigNumber('40'),
+        },
+      }),
+    )
 
-  //   state().toggle!()
-  //   state().updatePayback!(paybackAmountExceedsVaultDebt)
-  //   expect(state().errorMessages).to.deep.equal(['paybackAmountExceedsVaultDebt'])
+    state().toggle!()
+    state().updatePayback!(paybackAmountExceedsVaultDebt)
+    expect(state().errorMessages).to.deep.equal(['paybackAmountExceedsVaultDebt'])
 
-  //   state().updatePayback!(paybackAmountNotEnough)
-  //   expect(state().errorMessages).to.deep.equal(['debtWillBeLessThanDebtFloor'])
-  // })
+    state().updatePayback!(paybackAmountNotEnough)
+    expect(state().errorMessages).to.deep.equal(['debtWillBeLessThanDebtFloor'])
+  })
 
   it('validates if dai allowance is enought to payback whole amount and account debt offset', () => {
     const paybackAmount = new BigNumber('500')


### PR DESCRIPTION
# [Title](https://clubhouseLink) 
<please insert a clubhouse link abowe>
  
## Changes 👷‍♀️
- account for `debtOffset` in calculations for enough of `daiAllowance` for user
- add test scenario for setting values + input
  
## How to test 🧪
- open any of your existing vaults
- revoke daiAllowance in console, by typing `'dissaproveToken('DAI')` and submitting transaction
- click `Dai` to and set `Payback Amount` to max, you should be asked to `Set DAI Allowance`
- set `Custom DAI Allowance` it will have to be bigger than `PaybackAmount` and `debtOffset`
    
## Definition of done ✔️

- [x] Acceptance criteria for each issue met
- [x] Unit tests written where needed and passing
- [ ] ~~End-to-end tests for happy path~~
- [ ] ~~Documentation updated <When applicable>~~
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.) 
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
