### PR TITLE
Set Dai Allowanc for Payback Amount

### DIFF
--- a/blockchain/calls/erc20.ts
+++ b/blockchain/calls/erc20.ts
@@ -45,7 +45,7 @@ export type ApproveData = {
 
 export const approve: TransactionDef<ApproveData> = {
   call: ({ token }, { tokens, contract }) => contract<Erc20>(tokens[token]).methods.approve,
-  prepareArgs: ({ spender, amount }) => [spender, amountToWei(amount).toFixed()],
+  prepareArgs: ({ spender, amount }) => [spender, amountToWei(amount).toFixed(0)],
 }
 
 export type DisapproveData = {


### PR DESCRIPTION
# [Set Dai Allowanc for Payback Amount](https://app.clubhouse.io/oazo-apps/story/2089/bug-set-dai-allowance-for-payback-amount-not-triggering-transactions-when-using-max) 
<please insert a clubhouse link abowe>
  
## Changes 👷‍♀️
- add `0` as precision to `toFixed()` call - issue was that without it casted BN was having decimal places
  
## How to test 🧪
- open any of your existing vaults
- revoke daiAllowance in console, by typing 'dissaproveToken('DAI') and submitting transaction
- click Dai to and set Payback Amount to max, you should be asked to Set DAI Allowance
- set DAI Allowance to PaybackAmount - trigger tx
    
## Definition of done ✔️

- [x] Acceptance criteria for each issue met
- [ ] ~~Unit tests written where needed and passing~~
- [ ] ~~End-to-end tests for happy path~~
- [ ] ~~Documentation updated <When applicable>~~
- [x] Project builds without errors
- [x] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.) 
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
