### PR TITLE
Fix wallet connect QR prompt on reconnecting

### DIFF
--- a/components/connectWallet/ConnectWallet.tsx
+++ b/components/connectWallet/ConnectWallet.tsx
@@ -483,6 +483,17 @@ function autoConnect(
   }
 }
 
+export function disconnect(web3Context: Web3Context | undefined) {
+  if (web3Context?.status === 'connected') {
+    web3Context.deactivate()
+
+    // WalletConnect places this in LS and tries to reconnect without asking for QR
+    if (web3Context.connectionKind === 'walletConnect') {
+      localStorage.removeItem('walletconnect')
+    }
+  }
+}
+
 async function connectReadonly(web3Context: Web3ContextNotConnected) {
   web3Context.connect(await getConnector('network', getNetworkId()), 'network')
 }

--- a/features/account/Account.tsx
+++ b/features/account/Account.tsx
@@ -2,7 +2,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import BigNumber from 'bignumber.js'
 import { useAppContext } from 'components/AppContextProvider'
-import { getConnectionKindMessage } from 'components/connectWallet/ConnectWallet'
+import { disconnect, getConnectionKindMessage } from 'components/connectWallet/ConnectWallet'
 import { AppLink } from 'components/Links'
 import { Modal, ModalCloseIcon } from 'components/Modal'
 import { formatAddress, formatCryptoBalance } from 'helpers/formatters/format'
@@ -140,15 +140,9 @@ export function AccountModal({ close }: ModalProps) {
   const clipboardContentRef = useRef<HTMLTextAreaElement>(null)
   const { t } = useTranslation()
 
-  function disconnect() {
-    if (web3Context?.status === 'connected') {
-      web3Context.deactivate()
-    }
+  function disconnectHandler() {
+    disconnect(web3Context)
     close()
-    // for some reason queueing redirect is necessary
-    setTimeout(() => {
-      //replace(`/dashboard`)
-    }, 0)
   }
 
   function copyToClipboard() {
@@ -233,7 +227,7 @@ export function AccountModal({ close }: ModalProps) {
                     p: 0,
                     verticalAlign: 'baseline',
                   }}
-                  onClick={disconnect}
+                  onClick={disconnectHandler}
                 >
                   {t(`disconnect${connectionKind === 'magicLink' ? '-magic' : ''}`)}
                 </Button>

--- a/features/termsOfService/TermsOfService.tsx
+++ b/features/termsOfService/TermsOfService.tsx
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { Icon } from '@makerdao/dai-ui-icons'
 import { useAppContext } from 'components/AppContextProvider'
+import { disconnect } from 'components/connectWallet/ConnectWallet'
 import { AppLink } from 'components/Links'
 import { Modal, ModalErrorMessage } from 'components/Modal'
 import { useObservable } from 'helpers/observableHook'
@@ -174,13 +175,9 @@ export function TermsOfService() {
   const { web3Context$, termsAcceptance$ } = useAppContext()
   const termsAcceptance = useObservable(termsAcceptance$)
   const web3Context = useObservable(web3Context$)
-  // const { replace } = useRedirect()
 
-  function disconnect() {
-    if (web3Context?.status === 'connected') {
-      web3Context.deactivate()
-      // replace(`/connect`)
-    }
+  function disconnectHandler() {
+    disconnect(web3Context)
   }
 
   if (!termsAcceptance || hiddenStages.includes(termsAcceptance.stage)) return null
@@ -204,7 +201,7 @@ export function TermsOfService() {
             case 'jwtAuthWaiting4Acceptance':
             case 'jwtAuthInProgress':
             case 'acceptanceSaveInProgress':
-              return <TOSWaiting4Signature {...termsAcceptance} disconnect={disconnect} />
+              return <TOSWaiting4Signature {...termsAcceptance} disconnect={disconnectHandler} />
             case 'acceptanceCheckFailed':
             case 'jwtAuthFailed':
             case 'jwtAuthRejected':


### PR DESCRIPTION
# [Fix wallet connect QR prompt on reconnecting](https://app.clubhouse.io/oazo-apps/story/2083/bug-disconnecting-wallet-from-walletconnect-and-using-that-type-of-connection-again-goes-to-the-same-wallet)
  
## Changes 👷‍♀️
- remove `walletconnect` from Local Storage. It is injected by Wallet Connect library, upon disconnecting and connecting library was trying to restore connection to previous wallet without asking for QR prompt
  
## How to test 🧪
- go to `/connect` scan Wallet Connect QR of your choice
- connect with wallet, then disconnect from Account Modal or ToS sign prompt
- try to connect again via QR with same or new wallet - it should show up it again, rather than reestablishing previous connection
    
## Definition of done ✔️

- [x] Acceptance criteria for each issue met
- [ ] ~~Unit tests written where needed and passing~~
- [ ] ~~End-to-end tests for happy path~~
- [ ] ~~Documentation updated <When applicable>~~
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
