### PR TITLE
Rz/infra migration banner

### DIFF
--- a/components/Announcement.tsx
+++ b/components/Announcement.tsx
@@ -1,7 +1,9 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { WithChildren } from 'helpers/types'
 import React from 'react'
-import { Flex, SxProps } from 'theme-ui'
+import { Flex, Grid, SxProps, Text } from 'theme-ui'
+
+import { AppLink } from './Links'
 
 export function Announcement({ children, sx }: WithChildren & SxProps) {
   return (
@@ -29,9 +31,30 @@ export function Announcement({ children, sx }: WithChildren & SxProps) {
           justifyContent: 'center',
         }}
       >
-        <Icon name="announcement" height="25px" width="25px" sx={{ flexShrink: 0 }} />
+        <Icon name="announcement" height="25px" width="25px" />
       </Flex>
       {children}
     </Flex>
+  )
+}
+
+export function InfrastructureAnnouncement() {
+  return (
+    <Announcement sx={{ mb: 3, textAlign: 'left', zIndex: 1, mx: 'auto' }}>
+      <Grid gap={2} sx={{ flex: 1 }}>
+        <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
+          Our team will be performing maintenance on Oasis.app servers on Wednesday June 23rd.
+          <br />
+          To avoid downtime, we have set-up a back-up version at{' '}
+          <AppLink href="https://oazo.app/borrow">Oazo.app</AppLink> and{' '}
+          <AppLink href="https://oazo.io/borrow">Oazo.io</AppLink>. <br />
+          Check{' '}
+          <AppLink href="https://twitter.com/oasisdotapp">
+            https://twitter.com/oasisdotapp
+          </AppLink>{' '}
+          for updates.
+        </Text>
+      </Grid>
+    </Announcement>
   )
 }

--- a/components/Announcement.tsx
+++ b/components/Announcement.tsx
@@ -73,10 +73,9 @@ export function InfrastructureAnnouncement() {
       <Announcement sx={{ mb: 3, textAlign: 'left', zIndex: 1, mx: 'auto', boxShadow: 'banner' }}>
         <Grid gap={2} sx={{ flex: 1 }}>
           <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
-            Our team will be performing maintenance on Oasis.app servers on Wednesday June 23rd.
+            Our team will be performing maintenance on Oasis.app servers on Thursday June 24th.
             <br />
             To avoid downtime, we have set-up a back-up version at{' '}
-            <AppLink href="https://oazo.app/">Oazo.app</AppLink> and{' '}
             <AppLink href="https://oazo.io/">Oazo.io</AppLink>. <br />
             Check{' '}
             <AppLink href="https://twitter.com/oasisdotapp">

--- a/components/Announcement.tsx
+++ b/components/Announcement.tsx
@@ -69,25 +69,27 @@ export function InfrastructureAnnouncement() {
   const { t } = useTranslation()
 
   return (
-    <Announcement sx={{ mb: 3, textAlign: 'left', zIndex: 1, mx: 'auto' }}>
-      <Grid gap={2} sx={{ flex: 1 }}>
-        <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
-          Our team will be performing maintenance on Oasis.app servers on Wednesday June 23rd.
-          <br />
-          To avoid downtime, we have set-up a back-up version at{' '}
-          <AppLink href="https://oazo.app/">Oazo.app</AppLink> and{' '}
-          <AppLink href="https://oazo.io/">Oazo.io</AppLink>. <br />
-          Check{' '}
-          <AppLink href="https://twitter.com/oasisdotapp">
-            https://twitter.com/oasisdotapp
-          </AppLink>{' '}
-          for updates.
-        </Text>
-        <AppLink href={`${window.location.origin}/borrow-old`}>
-          <WithArrow>{t('visit-old-oasis')}</WithArrow>
-        </AppLink>
-      </Grid>
-    </Announcement>
+    <Box sx={{ px: 3 }}>
+      <Announcement sx={{ mb: 3, textAlign: 'left', zIndex: 1, mx: 'auto', boxShadow: 'banner' }}>
+        <Grid gap={2} sx={{ flex: 1 }}>
+          <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
+            Our team will be performing maintenance on Oasis.app servers on Wednesday June 23rd.
+            <br />
+            To avoid downtime, we have set-up a back-up version at{' '}
+            <AppLink href="https://oazo.app/">Oazo.app</AppLink> and{' '}
+            <AppLink href="https://oazo.io/">Oazo.io</AppLink>. <br />
+            Check{' '}
+            <AppLink href="https://twitter.com/oasisdotapp">
+              https://twitter.com/oasisdotapp
+            </AppLink>{' '}
+            for updates.
+          </Text>
+          <AppLink href={`${window.location.origin}/borrow-old`}>
+            <WithArrow>{t('visit-old-oasis')}</WithArrow>
+          </AppLink>
+        </Grid>
+      </Announcement>
+    </Box>
   )
 }
 

--- a/components/Announcement.tsx
+++ b/components/Announcement.tsx
@@ -1,7 +1,8 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { WithChildren } from 'helpers/types'
+import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Flex, Grid, SxProps, Text } from 'theme-ui'
+import { Box, Flex, Grid, SxProps, Text } from 'theme-ui'
 
 import { AppLink } from './Links'
 
@@ -38,7 +39,35 @@ export function Announcement({ children, sx }: WithChildren & SxProps) {
   )
 }
 
+function WithArrow({ children }: React.PropsWithChildren<{}>) {
+  return (
+    <Text
+      variant="paragraph3"
+      sx={{
+        fontWeight: 'semiBold',
+        fontSize: [1, 2],
+        position: 'relative',
+        '& .arrow': {
+          transition: 'ease-in-out 0.2s',
+          transform: 'translateX(0px)',
+        },
+        '&:hover .arrow': {
+          transform: 'translateX(5px)',
+        },
+      }}
+    >
+      <Box sx={{ display: 'inline', mr: 2 }}>{children}</Box>
+      <Box className="arrow" sx={{ display: 'inline', position: 'absolute' }}>
+        →
+      </Box>
+    </Text>
+  )
+}
+
+// To be removed after we migrate infrastructure
 export function InfrastructureAnnouncement() {
+  const { t } = useTranslation()
+
   return (
     <Announcement sx={{ mb: 3, textAlign: 'left', zIndex: 1, mx: 'auto' }}>
       <Grid gap={2} sx={{ flex: 1 }}>
@@ -46,15 +75,52 @@ export function InfrastructureAnnouncement() {
           Our team will be performing maintenance on Oasis.app servers on Wednesday June 23rd.
           <br />
           To avoid downtime, we have set-up a back-up version at{' '}
-          <AppLink href="https://oazo.app/borrow">Oazo.app</AppLink> and{' '}
-          <AppLink href="https://oazo.io/borrow">Oazo.io</AppLink>. <br />
+          <AppLink href="https://oazo.app/">Oazo.app</AppLink> and{' '}
+          <AppLink href="https://oazo.io/">Oazo.io</AppLink>. <br />
           Check{' '}
           <AppLink href="https://twitter.com/oasisdotapp">
             https://twitter.com/oasisdotapp
           </AppLink>{' '}
           for updates.
         </Text>
+        <AppLink href={`${window.location.origin}/borrow-old`}>
+          <WithArrow>{t('visit-old-oasis')}</WithArrow>
+        </AppLink>
       </Grid>
+    </Announcement>
+  )
+}
+
+export function WelcomeAnnouncement() {
+  const { t } = useTranslation()
+
+  return (
+    <Announcement sx={{ mb: 3, textAlign: 'left' }}>
+      <Flex sx={{ flexDirection: ['column', 'row'] }}>
+        <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
+          {t('welcome')}
+        </Text>
+        <Flex sx={{ flexDirection: ['column', 'row'] }}>
+          <AppLink href="https://blog.oasis.app/introducing-the-redesigned-oasis-borrow/">
+            <WithArrow>{t('read-blog-post')}</WithArrow>
+          </AppLink>
+          <Text
+            variant="paragraph3"
+            sx={{
+              fontWeight: 'semiBold',
+              color: 'muted',
+              mx: 3,
+              ml: 4,
+              display: ['none', 'block'],
+            }}
+          >
+            |
+          </Text>
+          <AppLink href={`${window.location.origin}/borrow-old`}>
+            <WithArrow>{t('visit-old-oasis')}</WithArrow>
+          </AppLink>
+        </Flex>
+      </Flex>
     </Announcement>
   )
 }

--- a/components/Layouts.tsx
+++ b/components/Layouts.tsx
@@ -7,6 +7,8 @@ import React from 'react'
 import { Container, Flex, SxStyleProp } from 'theme-ui'
 import { Background } from 'theme/Background'
 
+import { InfrastructureAnnouncement } from './Announcement'
+
 interface BasicLayoutProps extends WithChildren {
   header: JSX.Element
   footer?: JSX.Element
@@ -29,6 +31,7 @@ export function BasicLayout({ header, footer, children, sx, variant }: BasicLayo
       }}
     >
       {header}
+      <InfrastructureAnnouncement />
       <Container variant={variant || 'appContainer'} sx={{ flex: 2, mb: 5 }} as="main">
         <Flex sx={{ width: '100%', height: '100%' }}>{children}</Flex>
       </Container>

--- a/features/landing/LandingView.tsx
+++ b/features/landing/LandingView.tsx
@@ -1,7 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Pages } from 'analytics/analytics'
 import { getToken } from 'blockchain/tokensMetadata'
-import { Announcement } from 'components/Announcement'
 import { useAppContext } from 'components/AppContextProvider'
 import { AppLink } from 'components/Links'
 import { ColumnDef, Table, TableSortHeader } from 'components/Table'
@@ -117,31 +116,6 @@ const ilksColumns: ColumnDef<IlkWithBalance, IlksFilterState>[] = [
   },
 ]
 
-export function WithArrow({ children }: React.PropsWithChildren<{}>) {
-  return (
-    <Text
-      variant="paragraph3"
-      sx={{
-        fontWeight: 'semiBold',
-        fontSize: [1, 2],
-        position: 'relative',
-        '& .arrow': {
-          transition: 'ease-in-out 0.2s',
-          transform: 'translateX(0px)',
-        },
-        '&:hover .arrow': {
-          transform: 'translateX(5px)',
-        },
-      }}
-    >
-      <Box sx={{ display: 'inline', mr: 2 }}>{children}</Box>
-      <Box className="arrow" sx={{ display: 'inline', position: 'absolute' }}>
-        →
-      </Box>
-    </Text>
-  )
-}
-
 export function Hero({ sx, isConnected }: { sx?: SxStyleProp; isConnected: boolean }) {
   const { t } = useTranslation()
 
@@ -156,33 +130,8 @@ export function Hero({ sx, isConnected }: { sx?: SxStyleProp; isConnected: boole
         flexDirection: 'column',
       }}
     >
-      <Announcement sx={{ mb: 3, textAlign: 'left' }}>
-        <Flex sx={{ flexDirection: ['column', 'row'] }}>
-          <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
-            {t('welcome')}
-          </Text>
-          <Flex sx={{ flexDirection: ['column', 'row'] }}>
-            <AppLink href="https://blog.oasis.app/introducing-the-redesigned-oasis-borrow/">
-              <WithArrow>{t('read-blog-post')}</WithArrow>
-            </AppLink>
-            <Text
-              variant="paragraph3"
-              sx={{
-                fontWeight: 'semiBold',
-                color: 'muted',
-                mx: 3,
-                ml: 4,
-                display: ['none', 'block'],
-              }}
-            >
-              |
-            </Text>
-            <AppLink href={`${window.location.origin}/borrow-old`}>
-              <WithArrow>{t('visit-old-oasis')}</WithArrow>
-            </AppLink>
-          </Flex>
-        </Flex>
-      </Announcement>
+      {/* TO do revert back after infrastructure migration, possibly update copy if needed */}
+      {/* <WelcomeAnnouncement /> */}
       <Heading as="h1" variant="header2" sx={{ fontSize: 40, mb: 3 }}>
         {t('landing.hero.headline')}
       </Heading>

--- a/features/landing/LandingView.tsx
+++ b/features/landing/LandingView.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Pages } from 'analytics/analytics'
 import { getToken } from 'blockchain/tokensMetadata'
+import { Announcement } from 'components/Announcement'
 import { useAppContext } from 'components/AppContextProvider'
 import { AppLink } from 'components/Links'
 import { ColumnDef, Table, TableSortHeader } from 'components/Table'
@@ -155,6 +156,33 @@ export function Hero({ sx, isConnected }: { sx?: SxStyleProp; isConnected: boole
         flexDirection: 'column',
       }}
     >
+      <Announcement sx={{ mb: 3, textAlign: 'left' }}>
+        <Flex sx={{ flexDirection: ['column', 'row'] }}>
+          <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
+            {t('welcome')}
+          </Text>
+          <Flex sx={{ flexDirection: ['column', 'row'] }}>
+            <AppLink href="https://blog.oasis.app/introducing-the-redesigned-oasis-borrow/">
+              <WithArrow>{t('read-blog-post')}</WithArrow>
+            </AppLink>
+            <Text
+              variant="paragraph3"
+              sx={{
+                fontWeight: 'semiBold',
+                color: 'muted',
+                mx: 3,
+                ml: 4,
+                display: ['none', 'block'],
+              }}
+            >
+              |
+            </Text>
+            <AppLink href={`${window.location.origin}/borrow-old`}>
+              <WithArrow>{t('visit-old-oasis')}</WithArrow>
+            </AppLink>
+          </Flex>
+        </Flex>
+      </Announcement>
       <Heading as="h1" variant="header2" sx={{ fontSize: 40, mb: 3 }}>
         {t('landing.hero.headline')}
       </Heading>

--- a/features/landing/LandingView.tsx
+++ b/features/landing/LandingView.tsx
@@ -1,7 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Pages } from 'analytics/analytics'
 import { getToken } from 'blockchain/tokensMetadata'
-import { Announcement } from 'components/Announcement'
 import { useAppContext } from 'components/AppContextProvider'
 import { AppLink } from 'components/Links'
 import { ColumnDef, Table, TableSortHeader } from 'components/Table'
@@ -156,33 +155,6 @@ export function Hero({ sx, isConnected }: { sx?: SxStyleProp; isConnected: boole
         flexDirection: 'column',
       }}
     >
-      <Announcement sx={{ mb: 3, textAlign: 'left' }}>
-        <Flex sx={{ flexDirection: ['column', 'row'] }}>
-          <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
-            {t('welcome')}
-          </Text>
-          <Flex sx={{ flexDirection: ['column', 'row'] }}>
-            <AppLink href="https://blog.oasis.app/introducing-the-redesigned-oasis-borrow/">
-              <WithArrow>{t('read-blog-post')}</WithArrow>
-            </AppLink>
-            <Text
-              variant="paragraph3"
-              sx={{
-                fontWeight: 'semiBold',
-                color: 'muted',
-                mx: 3,
-                ml: 4,
-                display: ['none', 'block'],
-              }}
-            >
-              |
-            </Text>
-            <AppLink href={`${window.location.origin}/borrow-old`}>
-              <WithArrow>{t('visit-old-oasis')}</WithArrow>
-            </AppLink>
-          </Flex>
-        </Flex>
-      </Announcement>
       <Heading as="h1" variant="header2" sx={{ fontSize: 40, mb: 3 }}>
         {t('landing.hero.headline')}
       </Heading>


### PR DESCRIPTION
# [Infra migration banner](https://app.clubhouse.io/oazo-apps/story/2095/infra-transition-communication-about-transition-to-users)
  
## Changes 👷‍♀️
- adding infra migration banner + "Visit the old Oasis"
- extract `WelcomeAnnouncement` (might be removed or have copy changed after we remove infra banner)
  
![image](https://user-images.githubusercontent.com/19193499/122949211-c2f1d980-d37b-11eb-817d-812a46fea052.png)

  
## How to test 🧪
- run UI, check if banner is visible for all pages
    
## Definition of done ✔️
- [ ] Acceptance criteria for each issue met
- [ ] ~~Unit tests written where needed and passing~~
- [ ] ~~End-to-end tests for happy path~~
- [ ] ~~Documentation updated <When applicable>~~
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
