### PR TITLE
Dp/fix vault under dust limit

### DIFF
--- a/features/manageVault/ManageVaultErrors.tsx
+++ b/features/manageVault/ManageVaultErrors.tsx
@@ -76,6 +76,8 @@ export function ManageVaultErrors({
         return translate('depositing-all-eth-balance')
       case 'ledgerWalletContractDataDisabled':
         return translate('ledger-enable-contract-data')
+      case 'withdrawCollateralOnVaultUnderDebtFloor':
+        return translate('withdraw-collateral-on-vault-under-debt-floor')
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/manageVault/ManageVaultErrors.tsx
+++ b/features/manageVault/ManageVaultErrors.tsx
@@ -51,7 +51,7 @@ export function ManageVaultErrors({
             components={[
               <AppLink
                 sx={{ color: 'onError' }}
-                href="https://community-development.makerdao.com/en/learn/governance/param-debt-floor/"
+                href="https://kb.oasis.app/help/minimum-vault-debt-dust"
               />,
             ]}
           />
@@ -77,7 +77,19 @@ export function ManageVaultErrors({
       case 'ledgerWalletContractDataDisabled':
         return translate('ledger-enable-contract-data')
       case 'withdrawCollateralOnVaultUnderDebtFloor':
-        return translate('withdraw-collateral-on-vault-under-debt-floor')
+        return (
+          <Trans
+            i18nKey="manage-vault.errors.withdraw-collateral-on-vault-under-debt-floor"
+            values={{ debtFloor: formatCryptoBalance(debtFloor) }}
+            components={[
+              <AppLink
+                sx={{ color: 'onError' }}
+                href="https://kb.oasis.app/help/minimum-vault-debt-dust"
+              />,
+            ]}
+          />
+        )
+
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/manageVault/manageVaultConditions.ts
+++ b/features/manageVault/manageVaultConditions.ts
@@ -116,6 +116,7 @@ export interface ManageVaultConditions {
   customDaiAllowanceAmountEmpty: boolean
   customDaiAllowanceAmountExceedsMaxUint256: boolean
   customDaiAllowanceAmountLessThanPaybackAmount: boolean
+  withdrawCollateralOnVaultUnderDebtFloor: boolean
 }
 
 export const defaultManageVaultConditions: ManageVaultConditions = {
@@ -161,6 +162,8 @@ export const defaultManageVaultConditions: ManageVaultConditions = {
   customDaiAllowanceAmountEmpty: false,
   customDaiAllowanceAmountExceedsMaxUint256: false,
   customDaiAllowanceAmountLessThanPaybackAmount: false,
+
+  withdrawCollateralOnVaultUnderDebtFloor: false,
 }
 
 export function applyManageVaultConditions(state: ManageVaultState): ManageVaultState {
@@ -321,6 +324,12 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
     'manageWaitingForApproval',
   ] as ManageVaultStage[]).some((s) => s === stage)
 
+  const withdrawCollateralOnVaultUnderDebtFloor =
+    vault.debt.lt(ilkData.debtFloor) &&
+    withdrawAmount !== undefined &&
+    withdrawAmount.gt(zero) &&
+    (paybackAmount === undefined || paybackAmount.lt(vault.debt))
+
   const editingProgressionDisabled =
     isEditingStage &&
     (inputAmountsEmpty ||
@@ -336,7 +345,8 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
       generateAmountExceedsDebtCeiling ||
       generateAmountLessThanDebtFloor ||
       paybackAmountExceedsDaiBalance ||
-      paybackAmountExceedsVaultDebt)
+      paybackAmountExceedsVaultDebt ||
+      withdrawCollateralOnVaultUnderDebtFloor)
 
   const collateralAllowanceProgressionDisabled =
     isCollateralAllowanceStage &&
@@ -409,5 +419,7 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
     customDaiAllowanceAmountEmpty,
     customDaiAllowanceAmountExceedsMaxUint256,
     customDaiAllowanceAmountLessThanPaybackAmount,
+
+    withdrawCollateralOnVaultUnderDebtFloor,
   }
 }

--- a/features/manageVault/manageVaultValidations.ts
+++ b/features/manageVault/manageVaultValidations.ts
@@ -20,6 +20,7 @@ export type ManageVaultErrorMessage =
   | 'customDaiAllowanceAmountLessThanPaybackAmount'
   | 'depositingAllEthBalance'
   | 'ledgerWalletContractDataDisabled'
+  | 'withdrawCollateralOnVaultUnderDebtFloor'
 
 export type ManageVaultWarningMessage =
   | 'potentialGenerateAmountLessThanDebtFloor'
@@ -48,6 +49,7 @@ export function validateErrors(state: ManageVaultState): ManageVaultState {
     generateAmountExceedsDebtCeiling,
     paybackAmountExceedsDaiBalance,
     paybackAmountExceedsVaultDebt,
+    withdrawCollateralOnVaultUnderDebtFloor,
   } = state
 
   const errorMessages: ManageVaultErrorMessage[] = []
@@ -95,6 +97,10 @@ export function validateErrors(state: ManageVaultState): ManageVaultState {
 
     if (debtWillBeLessThanDebtFloor) {
       errorMessages.push('debtWillBeLessThanDebtFloor')
+    }
+
+    if (withdrawCollateralOnVaultUnderDebtFloor) {
+      errorMessages.push('withdrawCollateralOnVaultUnderDebtFloor')
     }
   }
 

--- a/features/manageVault/stories/ManageVaultErrors.stories.tsx
+++ b/features/manageVault/stories/ManageVaultErrors.stories.tsx
@@ -165,6 +165,21 @@ export const GenerateAmountLessThanDebtFloor = manageVaultStory({
   generateAmount: new BigNumber('1'),
 })
 
+export const WithdrawOnVaultUnderDebtFloor = manageVaultStory({
+  title:
+    'Error is shown when a user is trying to withdraw collateral on a vault that is under debt floor. In this case user should first payback all debt in order to withdraw any collateral.',
+  vault: {
+    ilk: 'WBTC-A',
+    collateral: new BigNumber('10'),
+    debt: new BigNumber(100),
+  },
+  ilkData: { debtFloor: new BigNumber('200') },
+  proxyAddress,
+})({
+  stage: 'daiEditing',
+  withdrawAmount: new BigNumber('1'),
+})
+
 export const PaybackAmountExceedsDaiBalance = manageVaultStory({
   title: 'Error occurs when user is trying to pay back more DAI than they have in their wallet',
   vault: {

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -226,7 +226,7 @@ describe('manageVaultValidations', () => {
     expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
   })
 
-  it.only('should show meaningful message when trying to withdraw collateral on dusty vault', () => {
+  it('should show meaningful message when trying to withdraw collateral on dusty vault', () => {
     const withdrawAmount = new BigNumber('5')
 
     const state = getStateUnpacker(

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -225,4 +225,31 @@ describe('manageVaultValidations', () => {
     state().progress!()
     expect(state().stage).to.deep.equal('daiAllowanceWaitingForConfirmation')
   })
+
+  it.only('should show meaningful message when trying to withdraw collateral on dusty vault', () => {
+    const withdrawAmount = new BigNumber('5')
+
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtFloor: new BigNumber(1000),
+        },
+        vault: {
+          debt: new BigNumber(100),
+          collateral: new BigNumber(10),
+        },
+        balanceInfo: {
+          daiBalance: new BigNumber(1000),
+        },
+        proxyAddress: DEFAULT_PROXY_ADDRESS,
+        daiAllowance: zero,
+      }),
+    )
+
+    state().updateWithdraw!(withdrawAmount)
+    expect(state().errorMessages).to.deep.eq(['withdrawCollateralOnVaultUnderDebtFloor'])
+    state().toggle!()
+    state().updatePaybackMax!()
+    expect(state().errorMessages).to.deep.eq([])
+  })
 })

--- a/features/openVault/OpenVaultErrors.tsx
+++ b/features/openVault/OpenVaultErrors.tsx
@@ -42,7 +42,7 @@ export function OpenVaultErrors({
             components={[
               <AppLink
                 sx={{ color: 'onError' }}
-                href="https://community-development.makerdao.com/en/learn/governance/param-debt-floor/"
+                href="https://kb.oasis.app/help/minimum-vault-debt-dust"
               />,
             ]}
           />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -223,7 +223,7 @@
       "generate-amount-exceeds-dai-yield-from-total-collateral": "The collateralization ratio for this Maker Vault is too low. Please generate less Dai",
       "generate-amount-exceeds-dai-yield-from-total-collateral-at-next-price": "The collateralization ratio for this Maker Vault is too low at the next price update. Please generate less Dai",
       "generate-amount-exceeds-debt-ceiling": "You are trying to generate more than the current debt ceiling allows. The amount of Dai that can be generated is {{maxGenerateAmount}} {{token}}",
-      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Dust Limit <0>here</0>.",
+      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Debt floor <0>here</0>.",
       "payback-amount-exceeds-dai-balance": "You cannot payback more Dai than the amount in your wallet",
       "payback-amount-exceeds-vault-debt": "You are trying to payback more than your Dai debt for this Maker Vault",
       "debt-will-be-less-than-debt-floor": "The Maker Vault debt amount either must be 0 or exceed {{debtFloor}} amount of Dai. Please change your payback amount",
@@ -232,7 +232,8 @@
       "custom-dai-allowance-amount-exceeds-maxuint256": "Allowance too large. Please decrease custom allowance amount",
       "custom-dai-allowance-amount-less-than-payback-amount": "You need at least an allowance of your payback amount to continue",
       "depositing-all-eth-balance": "You need some ETH to pay for the gas fees. Lower your deposit amount",
-      "ledger-enable-contract-data": "Please enable Contract data on the Ledgers Ethereum app Settings"
+      "ledger-enable-contract-data": "Please enable Contract data on the Ledgers Ethereum app Settings",
+      "withdraw-collateral-on-vault-under-debt-floor": "You cannot withdraw from your vault while it is below the minimum required of {{debtFloor}} Dai. To withdraw your collateral, payback your debt fully. Learn more about the debt floor <0>here</0>."
     }
   },
   "max": "Max",
@@ -271,7 +272,7 @@
       "generate-amount-exceeds-dai-yield-from-depositing-collateral": "The collateralization ratio for this Maker Vault will be too low. Please generate less Dai",
       "generate-amount-exceeds-dai-yield-from-depositing-collateral-at-next-price": "The collateralization ratio for this Maker Vault will be too low at the next price update. Please generate less Dai",
       "generate-amount-exceeds-debt-ceiling": "You are trying to generate more than the current debt ceiling allows. The amount of Dai that can be generated is {{maxGenerateAmount}} {{token}}",
-      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Dust Limit <0>here</0>.",
+      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Debt floor <0>here</0>.",
       "debt-will-be-less-than-debt-floor": "The Maker Vault debt amount either must be 0 or exceed {{debtFloor}} amount of Dai. Please change your payback amount",
       "custom-allowance-amount-exceeds-maxuint256": "Allowance too large. Please decrease custom allowance amount",
       "custom-allowance-amount-less-than-deposit-amount": "You need at least an allowance of your deposit amount to continue",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -223,7 +223,7 @@
       "generate-amount-exceeds-dai-yield-from-total-collateral": "The collateralization ratio for this Maker Vault is too low. Please generate less Dai",
       "generate-amount-exceeds-dai-yield-from-total-collateral-at-next-price": "The collateralization ratio for this Maker Vault is too low at the next price update. Please generate less Dai",
       "generate-amount-exceeds-debt-ceiling": "You are trying to generate more than the current debt ceiling allows. The amount of Dai that can be generated is {{maxGenerateAmount}} {{token}}",
-      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Debt floor <0>here</0>.",
+      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Minimum Vault Debt <0>here</0>.",
       "payback-amount-exceeds-dai-balance": "You cannot payback more Dai than the amount in your wallet",
       "payback-amount-exceeds-vault-debt": "You are trying to payback more than your Dai debt for this Maker Vault",
       "debt-will-be-less-than-debt-floor": "The Maker Vault debt amount either must be 0 or exceed {{debtFloor}} amount of Dai. Please change your payback amount",
@@ -233,7 +233,7 @@
       "custom-dai-allowance-amount-less-than-payback-amount": "You need at least an allowance of your payback amount to continue",
       "depositing-all-eth-balance": "You need some ETH to pay for the gas fees. Lower your deposit amount",
       "ledger-enable-contract-data": "Please enable Contract data on the Ledgers Ethereum app Settings",
-      "withdraw-collateral-on-vault-under-debt-floor": "You cannot withdraw from your vault while it is below the minimum required of {{debtFloor}} Dai. To withdraw your collateral, payback your debt fully. Learn more about the debt floor <0>here</0>."
+      "withdraw-collateral-on-vault-under-debt-floor": "You cannot withdraw from your vault while it is below the minimum required of {{debtFloor}} Dai. To withdraw your collateral, payback your debt fully. Learn more about the Minimum Vault Debt <0>here</0>."
     }
   },
   "max": "Max",
@@ -272,7 +272,7 @@
       "generate-amount-exceeds-dai-yield-from-depositing-collateral": "The collateralization ratio for this Maker Vault will be too low. Please generate less Dai",
       "generate-amount-exceeds-dai-yield-from-depositing-collateral-at-next-price": "The collateralization ratio for this Maker Vault will be too low at the next price update. Please generate less Dai",
       "generate-amount-exceeds-debt-ceiling": "You are trying to generate more than the current debt ceiling allows. The amount of Dai that can be generated is {{maxGenerateAmount}} {{token}}",
-      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Debt floor <0>here</0>.",
+      "generate-amount-less-than-debt-floor": "This vault type requires a minimum of {{debtFloor}} Dai to be generated. Read more about the Minimum Vault Debt <0>here</0>.",
       "debt-will-be-less-than-debt-floor": "The Maker Vault debt amount either must be 0 or exceed {{debtFloor}} amount of Dai. Please change your payback amount",
       "custom-allowance-amount-exceeds-maxuint256": "Allowance too large. Please decrease custom allowance amount",
       "custom-allowance-amount-less-than-deposit-amount": "You need at least an allowance of your deposit amount to continue",


### PR DESCRIPTION
# Fix
  
## Changes 👷‍♀️
- Added new error to prevent withdrawing assets before paying back debt
  
## How to test 🧪
- test in storybook story `/?path=/story/managevault-non-blocking--debt-is-less-than-debt-floor` 
- try withdraw some amount 
- then you should see error
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
