### PR TITLE
Story 2256 inform user about dust limit when trying to deposit below it

### DIFF
--- a/features/manageVault/ManageVaultErrors.tsx
+++ b/features/manageVault/ManageVaultErrors.tsx
@@ -89,6 +89,19 @@ export function ManageVaultErrors({
             ]}
           />
         )
+      case 'depositCollateralOnVaultUnderDebtFloor':
+        return (
+          <Trans
+            i18nKey="manage-vault.errors.deposit-collateral-on-vault-under-debt-floor"
+            values={{ debtFloor: formatCryptoBalance(debtFloor) }}
+            components={[
+              <AppLink
+                sx={{ color: 'onError' }}
+                href="https://kb.oasis.app/help/minimum-vault-debt-dust"
+              />,
+            ]}
+          />
+        )
 
       default:
         throw new UnreachableCaseError(message)

--- a/features/manageVault/manageVaultConditions.ts
+++ b/features/manageVault/manageVaultConditions.ts
@@ -195,6 +195,7 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
     maxWithdrawAmountAtNextPrice,
     maxGenerateAmountAtCurrentPrice,
     maxGenerateAmountAtNextPrice,
+    afterDebt,
   } = state
 
   const depositAndWithdrawAmountsEmpty = isNullish(depositAmount) && isNullish(withdrawAmount)
@@ -338,7 +339,7 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
     vault.debt.lt(ilkData.debtFloor) &&
     depositAmount !== undefined &&
     depositAmount.lt(ilkData.debtFloor) &&
-    (paybackAmount === undefined || paybackAmount.lt(vault.debt))
+    afterDebt.lt(ilkData.debtFloor)
 
   const editingProgressionDisabled =
     isEditingStage &&

--- a/features/manageVault/manageVaultConditions.ts
+++ b/features/manageVault/manageVaultConditions.ts
@@ -117,6 +117,7 @@ export interface ManageVaultConditions {
   customDaiAllowanceAmountExceedsMaxUint256: boolean
   customDaiAllowanceAmountLessThanPaybackAmount: boolean
   withdrawCollateralOnVaultUnderDebtFloor: boolean
+  depositCollateralOnVaultUnderDebtFloor: boolean
 }
 
 export const defaultManageVaultConditions: ManageVaultConditions = {
@@ -164,6 +165,7 @@ export const defaultManageVaultConditions: ManageVaultConditions = {
   customDaiAllowanceAmountLessThanPaybackAmount: false,
 
   withdrawCollateralOnVaultUnderDebtFloor: false,
+  depositCollateralOnVaultUnderDebtFloor: false,
 }
 
 export function applyManageVaultConditions(state: ManageVaultState): ManageVaultState {
@@ -331,6 +333,13 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
     withdrawAmount.gt(zero) &&
     (paybackAmount === undefined || paybackAmount.lt(vault.debt))
 
+  const depositCollateralOnVaultUnderDebtFloor =
+    vault.debt.gt(zero) &&
+    vault.debt.lt(ilkData.debtFloor) &&
+    depositAmount !== undefined &&
+    depositAmount.lt(ilkData.debtFloor) &&
+    (paybackAmount === undefined || paybackAmount.lt(vault.debt))
+
   const editingProgressionDisabled =
     isEditingStage &&
     (inputAmountsEmpty ||
@@ -347,7 +356,8 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
       generateAmountLessThanDebtFloor ||
       paybackAmountExceedsDaiBalance ||
       paybackAmountExceedsVaultDebt ||
-      withdrawCollateralOnVaultUnderDebtFloor)
+      withdrawCollateralOnVaultUnderDebtFloor ||
+      depositCollateralOnVaultUnderDebtFloor)
 
   const collateralAllowanceProgressionDisabled =
     isCollateralAllowanceStage &&
@@ -422,5 +432,6 @@ export function applyManageVaultConditions(state: ManageVaultState): ManageVault
     customDaiAllowanceAmountLessThanPaybackAmount,
 
     withdrawCollateralOnVaultUnderDebtFloor,
+    depositCollateralOnVaultUnderDebtFloor,
   }
 }

--- a/features/manageVault/manageVaultValidations.ts
+++ b/features/manageVault/manageVaultValidations.ts
@@ -21,6 +21,7 @@ export type ManageVaultErrorMessage =
   | 'depositingAllEthBalance'
   | 'ledgerWalletContractDataDisabled'
   | 'withdrawCollateralOnVaultUnderDebtFloor'
+  | 'depositCollateralOnVaultUnderDebtFloor'
 
 export type ManageVaultWarningMessage =
   | 'potentialGenerateAmountLessThanDebtFloor'
@@ -50,6 +51,7 @@ export function validateErrors(state: ManageVaultState): ManageVaultState {
     paybackAmountExceedsDaiBalance,
     paybackAmountExceedsVaultDebt,
     withdrawCollateralOnVaultUnderDebtFloor,
+    depositCollateralOnVaultUnderDebtFloor,
   } = state
 
   const errorMessages: ManageVaultErrorMessage[] = []
@@ -101,6 +103,9 @@ export function validateErrors(state: ManageVaultState): ManageVaultState {
 
     if (withdrawCollateralOnVaultUnderDebtFloor) {
       errorMessages.push('withdrawCollateralOnVaultUnderDebtFloor')
+    }
+    if (depositCollateralOnVaultUnderDebtFloor) {
+      errorMessages.push('depositCollateralOnVaultUnderDebtFloor')
     }
   }
 

--- a/features/manageVault/stories/ManageVaultErrors.stories.tsx
+++ b/features/manageVault/stories/ManageVaultErrors.stories.tsx
@@ -180,6 +180,21 @@ export const WithdrawOnVaultUnderDebtFloor = manageVaultStory({
   withdrawAmount: new BigNumber('1'),
 })
 
+export const DepositToVaultUnderDebtFloor = manageVaultStory({
+  title:
+    'Error is shown when a user is trying to deposit more collateral on a vault that is under debt floor. In this case user should first either payback all debt in order to withdraw any collateral or by depositing more collateral in order to generate this additional Dai - which must be done in the same transaction.',
+  vault: {
+    ilk: 'ETH-A',
+    collateral: new BigNumber('6'),
+    debt: new BigNumber(5000),
+  },
+  ilkData: { debtFloor: new BigNumber('10000') },
+  proxyAddress,
+})({
+  depositAmount: new BigNumber('6'),
+  stage: 'collateralEditing',
+})
+
 export const PaybackAmountExceedsDaiBalance = manageVaultStory({
   title: 'Error occurs when user is trying to pay back more DAI than they have in their wallet',
   vault: {

--- a/features/manageVault/tests/manageVaultValidations.test.ts
+++ b/features/manageVault/tests/manageVaultValidations.test.ts
@@ -29,18 +29,21 @@ describe('manageVaultValidations', () => {
   })
 
   it(`validates if generate doesn't exceeds debt ceiling, debt floor`, () => {
-    const depositAmount = new BigNumber('2')
-    const generateAmountAboveCeiling = new BigNumber('30')
+    const depositAmount = new BigNumber('2001')
+    const generateAmountAboveCeiling = new BigNumber('30000000')
     const generateAmountBelowFloor = new BigNumber('9')
 
     const state = getStateUnpacker(
       mockManageVault$({
+        balanceInfo: {
+          collateralBalance: new BigNumber('100000'),
+        },
         ilkData: {
           debtCeiling: new BigNumber('8000025'),
           debtFloor: new BigNumber('2000'),
         },
         vault: {
-          collateral: new BigNumber('3'),
+          collateral: new BigNumber('9999'),
           debt: new BigNumber('1990'),
           ilk: 'ETH-A',
         },
@@ -251,5 +254,29 @@ describe('manageVaultValidations', () => {
     state().toggle!()
     state().updatePaybackMax!()
     expect(state().errorMessages).to.deep.eq([])
+  })
+
+  it('should show meaningful message when trying to deposit to vault still being under dust limit (debt floor)', () => {
+    const depositAmount = new BigNumber('1')
+
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtFloor: new BigNumber(10000),
+        },
+        vault: {
+          debt: new BigNumber(5000),
+          collateral: new BigNumber(6),
+        },
+        balanceInfo: {
+          daiBalance: new BigNumber(1000),
+        },
+        proxyAddress: DEFAULT_PROXY_ADDRESS,
+        daiAllowance: zero,
+      }),
+    )
+
+    state().updateDeposit!(depositAmount)
+    expect(state().errorMessages).to.deep.eq(['depositCollateralOnVaultUnderDebtFloor'])
   })
 })

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -225,7 +225,7 @@
     "action": "Manage Vault",
     "warnings": {
       "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",
-      "debt-is-less-than-debt-floor": "Your current Dai debt is below the minimum of {{debtFloor}}. You cannot generate more Dai unless you go over this minimum",
+      "debt-is-less-than-debt-floor": "Your current Dai debt is below the minimum of {{debtFloor}}. Because of this some Vault actions are not possible. Please generate more Dai to take you above the minimum or payback all your debt",
       "vault-will-be-at-risk-level-danger": "With this action your vault will be at a collateralization ratio very close to the minimum required",
       "vault-will-be-at-risk-level-danger-at-next-price": "With this action your vault will be at a collateralization ratio very close to the minimum required at the next price update",
       "vault-will-be-at-risk-level-warning": "With this action your vault will be at a collateralization ratio near the minimum required",
@@ -248,7 +248,8 @@
       "custom-dai-allowance-amount-less-than-payback-amount": "You need at least an allowance of your payback amount to continue",
       "depositing-all-eth-balance": "You need some ETH to pay for the gas fees. Lower your deposit amount",
       "ledger-enable-contract-data": "Please enable Contract data on the Ledgers Ethereum app Settings",
-      "withdraw-collateral-on-vault-under-debt-floor": "You cannot withdraw from your vault while it is below the minimum required of {{debtFloor}} Dai. To withdraw your collateral, payback your debt fully. Learn more about the Minimum Vault Debt <0>here</0>."
+      "withdraw-collateral-on-vault-under-debt-floor": "You cannot withdraw from your vault while it is below the minimum required of {{debtFloor}} Dai. To withdraw your collateral, payback your debt fully. Learn more about the Minimum Vault Debt <0>here</0>.",
+      "deposit-collateral-on-vault-under-debt-floor": "You cannot deposit to your vault while it is below the minimum debt required of {{debtFloor}}. To add more collateral, generate Dai to get above the minimum required. Learn more about the Minimum Vault Debt here <0>here</0>)"
     }
   },
   "max": "Max",


### PR DESCRIPTION
# [inform user about dust limit when trying to deposit below it](https://app.clubhouse.io/oazo-apps/story/2256/bug-possible-to-continue-with-adding-collateral-for-vault-below-debt-floor)

  
## Changes 👷‍♀️
- Added new message with information about dust limit when user tries to deposit below it
- added new state which happens when user tries to deposit below dust limit
- added tests and modified also test for `it validates if generate doesn't exceeds debt ceiling, debt floor` because it started to fail as it had also condition for deposit-collateral-on-vault-under-debt-floor I added which was not scope of this test
- added story example to storybook

  
## How to test 🧪
- Have a vault below the debt floor
- Try to add collateral without generating dai to get above the debt floor
- The UI will allow you to continue, while the transaction will get reverted
    
## Definition of done ✔️

- [x] Acceptance criteria for each issue met
- [✔️ ] Unit tests written where needed and passing
- [ ✔️] End-to-end tests for happy path
- [ ✔️] Documentation updated <When applicable> (given the fact unit test and storybook is documentation)
- [✔️ ] Project builds without errors
- [ ✔️] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
