### PR TITLE
Fixed address if one paste url with addres with incorrect checksum

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,7 @@ module.exports = withBundleAnalyzer(
           etherscanAPIKey: process.env.ETHERSCAN_API_KEY,
         },
         webpack: function (config, { isServer }) {
-          // TODO: Figure out how to disable mangling partially without bresking the aplication.
+          // TODO: Figure out how to disable mangling partially without breaking the aplication.
           // To test if your changes break the app or no - go to /owner/<address> page for an account that has some vaults and see if they are displayed.
           config.optimization.minimizer[0].options.terserOptions.mangle = false
           config.module.rules.push({

--- a/pages/owner/[address]/index.tsx
+++ b/pages/owner/[address]/index.tsx
@@ -23,7 +23,11 @@ function Summary({ address }: { address: string }) {
     <WithErrorHandler error={[vaultsOverviewWithError.error, contextWithError.error]}>
       <WithLoadingIndicator value={[vaultsOverviewWithError.value, contextWithError.value]}>
         {([vaultsOverview, context]) => (
-          <VaultsOverviewView vaultsOverview={vaultsOverview} context={context} address={checksumAddress} />
+          <VaultsOverviewView
+            vaultsOverview={vaultsOverview}
+            context={context}
+            address={checksumAddress}
+          />
         )}
       </WithLoadingIndicator>
     </WithErrorHandler>

--- a/pages/owner/[address]/index.tsx
+++ b/pages/owner/[address]/index.tsx
@@ -1,6 +1,7 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { WithConnection } from 'components/connectWallet/ConnectWallet'
 import { AppLayout } from 'components/Layouts'
+import { getAddress } from 'ethers/lib/utils'
 import { VaultsOverviewView } from 'features/vaultsOverview/VaultsOverviewView'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
@@ -14,6 +15,7 @@ import { WithTermsOfService } from '../../../features/termsOfService/TermsOfServ
 // TODO Move this to /features
 function Summary({ address }: { address: string }) {
   const { vaultsOverview$, context$ } = useAppContext()
+  address = convertToAddressWithCorrectChecksum(address)
   const vaultsOverviewWithError = useObservableWithError(vaultsOverview$(address))
   const contextWithError = useObservableWithError(context$)
 
@@ -26,6 +28,10 @@ function Summary({ address }: { address: string }) {
       </WithLoadingIndicator>
     </WithErrorHandler>
   )
+
+  function convertToAddressWithCorrectChecksum(address: string) {
+    return getAddress(address.toLocaleLowerCase())
+  }
 }
 
 export async function getServerSideProps(ctx: any) {

--- a/pages/owner/[address]/index.tsx
+++ b/pages/owner/[address]/index.tsx
@@ -15,15 +15,15 @@ import { WithTermsOfService } from '../../../features/termsOfService/TermsOfServ
 // TODO Move this to /features
 function Summary({ address }: { address: string }) {
   const { vaultsOverview$, context$ } = useAppContext()
-  address = getAddress(address.toLocaleLowerCase())
-  const vaultsOverviewWithError = useObservableWithError(vaultsOverview$(address))
+  const checksumAddress = getAddress(address.toLocaleLowerCase())
+  const vaultsOverviewWithError = useObservableWithError(vaultsOverview$(checksumAddress))
   const contextWithError = useObservableWithError(context$)
 
   return (
     <WithErrorHandler error={[vaultsOverviewWithError.error, contextWithError.error]}>
       <WithLoadingIndicator value={[vaultsOverviewWithError.value, contextWithError.value]}>
         {([vaultsOverview, context]) => (
-          <VaultsOverviewView vaultsOverview={vaultsOverview} context={context} address={address} />
+          <VaultsOverviewView vaultsOverview={vaultsOverview} context={context} address={checksumAddress} />
         )}
       </WithLoadingIndicator>
     </WithErrorHandler>

--- a/pages/owner/[address]/index.tsx
+++ b/pages/owner/[address]/index.tsx
@@ -15,7 +15,7 @@ import { WithTermsOfService } from '../../../features/termsOfService/TermsOfServ
 // TODO Move this to /features
 function Summary({ address }: { address: string }) {
   const { vaultsOverview$, context$ } = useAppContext()
-  address = convertToAddressWithCorrectChecksum(address)
+  address = getAddress(address.toLocaleLowerCase())
   const vaultsOverviewWithError = useObservableWithError(vaultsOverview$(address))
   const contextWithError = useObservableWithError(context$)
 
@@ -28,10 +28,6 @@ function Summary({ address }: { address: string }) {
       </WithLoadingIndicator>
     </WithErrorHandler>
   )
-
-  function convertToAddressWithCorrectChecksum(address: string) {
-    return getAddress(address.toLocaleLowerCase())
-  }
 }
 
 export async function getServerSideProps(ctx: any) {


### PR DESCRIPTION
# [Fixed wrong checksum error](https://app.clubhouse.io/oazo-apps/story/1804/visiting-a-page-where-address-is-invalid-checksum-one-results-in-error)

  
## Changes 👷‍♀️

- If one will enter url with /owner/$address and addres has incorrect checksum checksum will be corrected by app
- Everywhere in oasis.app address is passed with correct checksum butt this issue occurs when redirected from other apps to oasis or when sb pastes adress into browser with wrong checksum
  
## How to test 🧪
Take any Ethereum address paste it into app url /owners endpoint for example:
https://staging.oasis.app/owner/0x81c8d249f2beEeAbdBd167b13aC94Ea2da4f4a61?network=kovan
https://localhost:3443/owner/0x81c8d249f2beEeAbdBd167b13aC94Ea2da4f4a61?network=kovan
Change some letters in addres from lowercase to upper case etc. to make incorrect checksum and it doesn't matter app will correct it out of box

## Definition of done ✔️

- [x] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [x] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [x] Project builds without errors
- [x] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
