### PR TITLE
Reset default states for inputs on toggling

### DIFF
--- a/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
@@ -235,6 +235,8 @@ export function applyManageVaultConditions(
     isCollateralAllowanceStage,
     isDaiAllowanceStage,
 
+    buyAmount,
+    sellAmount,
     paybackAmount,
     depositAmount,
     generateAmount,
@@ -255,6 +257,9 @@ export function applyManageVaultConditions(
   const generateAndPaybackAmountsEmpty = isNullish(generateAmount) && isNullish(paybackAmount)
 
   const inputAmountsEmpty =
+    paybackAmount === undefined &&
+    buyAmount === undefined &&
+    sellAmount === undefined &&
     paybackAmount === undefined &&
     depositAmount === undefined &&
     generateAmount === undefined &&

--- a/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
@@ -257,7 +257,6 @@ export function applyManageVaultConditions(
   const generateAndPaybackAmountsEmpty = isNullish(generateAmount) && isNullish(paybackAmount)
 
   const inputAmountsEmpty =
-    paybackAmount === undefined &&
     buyAmount === undefined &&
     sellAmount === undefined &&
     paybackAmount === undefined &&

--- a/features/manageMultiplyVault/manageMultiplyVaultForm.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultForm.ts
@@ -34,6 +34,10 @@ export type ManageVaultFormChange =
     }
 
 export const otherActionsDefaults: Partial<ManageMultiplyVaultState> = {
+  buyAmount: undefined,
+  buyAmountUSD: undefined,
+  sellAmount: undefined,
+  sellAmountUSD: undefined,
   depositAmount: undefined,
   depositAmountUSD: undefined,
   paybackAmount: undefined,
@@ -97,6 +101,7 @@ export function applyManageVaultForm(
   if (change.kind === 'toggleSliderController') {
     return {
       ...state,
+      ...otherActionsDefaults,
       showSliderController: !state.showSliderController,
     }
   }

--- a/features/manageMultiplyVault/manageMultiplyVaultForm.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultForm.ts
@@ -33,7 +33,7 @@ export type ManageVaultFormChange =
       closeVaultTo: CloseVaultTo
     }
 
-export const otherActionsDefaults: Partial<ManageMultiplyVaultState> = {
+export const manageInputsDefaults: Partial<ManageMultiplyVaultState> = {
   buyAmount: undefined,
   buyAmountUSD: undefined,
   sellAmount: undefined,
@@ -50,7 +50,7 @@ export const otherActionsDefaults: Partial<ManageMultiplyVaultState> = {
 
 export const manageVaultFormDefaults: Partial<ManageMultiplyVaultState> = {
   ...allowanceDefaults,
-  ...otherActionsDefaults,
+  ...manageInputsDefaults,
 }
 
 export function applyManageVaultForm(
@@ -101,7 +101,7 @@ export function applyManageVaultForm(
   if (change.kind === 'toggleSliderController') {
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       showSliderController: !state.showSliderController,
     }
   }
@@ -109,7 +109,7 @@ export function applyManageVaultForm(
   if (change.kind === 'mainAction') {
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       mainAction: change.mainAction,
     }
   }
@@ -117,7 +117,7 @@ export function applyManageVaultForm(
   if (change.kind === 'otherAction') {
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       otherAction: change.otherAction,
     }
   }

--- a/features/manageMultiplyVault/manageMultiplyVaultInput.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultInput.ts
@@ -2,7 +2,7 @@ import { BigNumber } from 'bignumber.js'
 import { zero } from 'helpers/zero'
 
 import { ManageMultiplyVaultChange, ManageMultiplyVaultState } from './manageMultiplyVault'
-import { otherActionsDefaults } from './manageMultiplyVaultForm'
+import { manageInputsDefaults } from './manageMultiplyVaultForm'
 
 interface DepositAmountChange {
   kind: 'depositAmount'
@@ -282,7 +282,7 @@ export function applyManageVaultInput(
   if (change.kind === 'requiredCollRatio') {
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       requiredCollRatio: change.requiredCollRatio,
     }
   }
@@ -294,12 +294,9 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       buyAmount,
       buyAmountUSD,
-
-      sellAmount: undefined,
-      sellAmountUSD: undefined,
     }
   }
 
@@ -310,12 +307,9 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       buyAmount,
       buyAmountUSD,
-
-      sellAmount: undefined,
-      sellAmountUSD: undefined,
     }
   }
 
@@ -325,12 +319,9 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       buyAmount: zero,
       buyAmountUSD: zero,
-
-      sellAmount: undefined,
-      sellAmountUSD: undefined,
     }
   }
 
@@ -341,12 +332,9 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       sellAmount,
       sellAmountUSD,
-
-      buyAmount: undefined,
-      buyAmountUSD: undefined,
     }
   }
 
@@ -361,12 +349,9 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       sellAmount,
       sellAmountUSD,
-
-      buyAmount: undefined,
-      buyAmountUSD: undefined,
     }
   }
 
@@ -380,12 +365,9 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       sellAmount: freeCollateral,
       sellAmountUSD: freeCollateralUSD,
-
-      buyAmount: undefined,
-      buyAmountUSD: undefined,
     }
   }
 
@@ -396,7 +378,7 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       depositAmount: change.depositAmount,
       depositAmountUSD: change.depositAmount?.times(currentCollateralPrice),
     }
@@ -409,7 +391,7 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       depositAmountUSD: change.depositAmountUSD,
       depositAmount: change.depositAmountUSD?.div(currentCollateralPrice),
     }
@@ -420,7 +402,7 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       depositAmount: maxDepositAmount,
       depositAmountUSD: maxDepositAmountUSD,
     }
@@ -429,7 +411,7 @@ export function applyManageVaultInput(
   if (change.kind === 'paybackAmount') {
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       paybackAmount: change.paybackAmount,
     }
   }
@@ -439,7 +421,7 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       paybackAmount: maxPaybackAmount,
     }
   }
@@ -448,7 +430,7 @@ export function applyManageVaultInput(
     const { priceInfo } = state
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       withdrawAmount: change.withdrawAmount,
       withdrawAmountUSD: change.withdrawAmount?.times(priceInfo.currentCollateralPrice),
     }
@@ -458,7 +440,7 @@ export function applyManageVaultInput(
     const { priceInfo } = state
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       withdrawAmountUSD: change.withdrawAmountUSD,
       withdrawAmount: change.withdrawAmountUSD?.div(priceInfo.currentCollateralPrice),
     }
@@ -469,7 +451,7 @@ export function applyManageVaultInput(
 
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       withdrawAmount: maxWithdrawAmount,
       withdrawAmountUSD: maxWithdrawAmountUSD,
     }
@@ -478,7 +460,7 @@ export function applyManageVaultInput(
   if (change.kind === 'generateAmount') {
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       generateAmount: change.generateAmount,
     }
   }
@@ -487,7 +469,7 @@ export function applyManageVaultInput(
     const { maxGenerateAmount } = state
     return {
       ...state,
-      ...otherActionsDefaults,
+      ...manageInputsDefaults,
       generateAmount: maxGenerateAmount,
     }
   }


### PR DESCRIPTION
Fixes:

```
Reported issue: When adjusting position the value set in "adjust position" doesn't reset when changing to "other actions". 
```

## Changes 👷‍♀️
- reset default values properly,
- rename const with defaults
- remove redundant resetting
  
## How to test 🧪
- test in UI toggling between states
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
