### PR TITLE
Fix BigNumber decimals issue when opening new multiply vault

### DIFF
--- a/blockchain/calls/proxyActions.ts
+++ b/blockchain/calls/proxyActions.ts
@@ -350,7 +350,7 @@ export const openMultiplyVault: TransactionDef<MultiplyData> = {
     return [dssMultiplyProxyActions.address, getOpenMultiplyCallData(data, context).encodeABI()]
   },
   options: ({ token, depositCollateral }) =>
-    token === 'ETH' ? { value: amountToWei(depositCollateral, 'ETH').toString() } : {},
+    token === 'ETH' ? { value: amountToWei(depositCollateral, 'ETH').toFixed(0) } : {},
 }
 
 export type ReclaimData = {


### PR DESCRIPTION
## Issue: 

 When I try to create a Vault with 20,000 USD and 200% coll. ratio, I receive this error. But then, when I try to use a ETH value directly, it goes trough. It seems to be an error related to the ETH calculation when I use USD.

## Changes 👷‍♀️
  changed BigNumber formatting from `.toString()` to `toFixed(0)` to avoid any decimals after conversion.
  
## How to test 🧪
  Try opening new vault and enter amount in USD not in collateral (e.g. $50,000). New vault should be created
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
