### PR TITLE
Display a card informating that user that it will take some time befo…

### DIFF
--- a/components/vault/VaultChangesWithADelayCard.tsx
+++ b/components/vault/VaultChangesWithADelayCard.tsx
@@ -1,0 +1,13 @@
+import { MessageCard } from 'components/MessageCard'
+import React from 'react'
+
+export function VaultChangesWithADelayCard() {
+  return (
+    <MessageCard
+      {...{
+        messages: ['Heads up! It can take up to 30 seconds for your Vault position to update.'],
+        type: 'warning',
+      }}
+    />
+  )
+}

--- a/features/manageMultiplyVault/components/ManageMultiplyVaultView.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultView.tsx
@@ -1,4 +1,5 @@
 import { VaultAllowanceStatus } from 'components/vault/VaultAllowance'
+import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
 import { VaultHeader } from 'components/vault/VaultHeader'
 import { VaultProxyStatusCard } from 'components/vault/VaultProxy'
@@ -33,6 +34,7 @@ function ManageMultiplyVaultForm(props: ManageMultiplyVaultState) {
     daiAllowanceTxHash,
     collateralAllowanceTxHash,
     vault: { token },
+    stage,
   } = props
 
   return (
@@ -46,6 +48,7 @@ function ManageMultiplyVaultForm(props: ManageMultiplyVaultState) {
         <>
           <ManageMultiplyVaultErrors {...props} />
           <ManageMultiplyVaultWarnings {...props} />
+          {stage === 'manageSuccess' && <VaultChangesWithADelayCard />}
           <ManageMultiplyVaultButton {...props} />
         </>
       )}

--- a/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
@@ -252,7 +252,7 @@ export function applyManageVaultConditions(
     swap,
     exchangeError,
     otherAction,
-    originalEditingStage
+    originalEditingStage,
   } = state
   const depositAndWithdrawAmountsEmpty = isNullish(depositAmount) && isNullish(withdrawAmount)
   const generateAndPaybackAmountsEmpty = isNullish(generateAmount) && isNullish(paybackAmount)

--- a/features/manageVault/ManageVaultView.tsx
+++ b/features/manageVault/ManageVaultView.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { VaultAllowanceStatus } from 'components/vault/VaultAllowance'
+import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
 import { VaultHeader } from 'components/vault/VaultHeader'
 import { VaultProxyStatusCard } from 'components/vault/VaultProxy'
@@ -84,6 +85,7 @@ function ManageVaultForm(props: ManageVaultState) {
     daiAllowanceTxHash,
     collateralAllowanceTxHash,
     vault: { token },
+    stage,
   } = props
 
   return (
@@ -98,6 +100,7 @@ function ManageVaultForm(props: ManageVaultState) {
         <>
           <ManageVaultErrors {...props} />
           <ManageVaultWarnings {...props} />
+          {stage === 'manageSuccess' && <VaultChangesWithADelayCard />}
           <ManageVaultButton {...props} />
         </>
       )}

--- a/features/openMultiplyVault/components/OpenMultiplyVaultView.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultView.tsx
@@ -1,6 +1,7 @@
 import { trackingEvents } from 'analytics/analytics'
 import { useAppContext } from 'components/AppContextProvider'
 import { VaultAllowance, VaultAllowanceStatus } from 'components/vault/VaultAllowance'
+import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultFormVaultTypeSwitch, WithVaultFormStepIndicator } from 'components/vault/VaultForm'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
 import { VaultHeader } from 'components/vault/VaultHeader'
@@ -65,7 +66,7 @@ function OpenMultiplyVaultTitle({
 }
 
 function OpenMultiplyVaultForm(props: OpenMultiplyVaultState) {
-  const { isEditingStage, isProxyStage, isAllowanceStage, isOpenStage, ilk } = props
+  const { isEditingStage, isProxyStage, isAllowanceStage, isOpenStage, ilk, stage } = props
 
   return (
     <VaultFormContainer toggleTitle="Open Vault">
@@ -75,6 +76,7 @@ function OpenMultiplyVaultForm(props: OpenMultiplyVaultState) {
       {isOpenStage && <OpenMultiplyVaultConfirmation {...props} />}
       <OpenMultiplyVaultErrors {...props} />
       <OpenMultiplyVaultWarnings {...props} />
+      {stage === 'openSuccess' && <VaultChangesWithADelayCard />}
       <OpenMultiplyVaultButton {...props} />
       {isProxyStage && <VaultProxyStatusCard {...props} />}
       {isAllowanceStage && <VaultAllowanceStatus {...props} />}

--- a/features/openVault/components/OpenVaultView.tsx
+++ b/features/openVault/components/OpenVaultView.tsx
@@ -1,6 +1,7 @@
 import { trackingEvents } from 'analytics/analytics'
 import { useAppContext } from 'components/AppContextProvider'
 import { VaultAllowance, VaultAllowanceStatus } from 'components/vault/VaultAllowance'
+import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultFormVaultTypeSwitch, WithVaultFormStepIndicator } from 'components/vault/VaultForm'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
 import { VaultHeader } from 'components/vault/VaultHeader'
@@ -62,7 +63,7 @@ function OpenVaultTitle({
 }
 
 function OpenVaultForm(props: OpenVaultState) {
-  const { isEditingStage, isProxyStage, isAllowanceStage, isOpenStage, ilk } = props
+  const { isEditingStage, isProxyStage, isAllowanceStage, isOpenStage, ilk, stage } = props
 
   return (
     <VaultFormContainer toggleTitle="Open Vault">
@@ -72,6 +73,7 @@ function OpenVaultForm(props: OpenVaultState) {
       {isOpenStage && <OpenVaultConfirmation {...props} />}
       <OpenVaultErrors {...props} />
       <OpenVaultWarnings {...props} />
+      {stage === 'openSuccess' && <VaultChangesWithADelayCard />}
       <OpenVaultButton {...props} />
       {isProxyStage && <VaultProxyStatusCard {...props} />}
       {isAllowanceStage && <VaultAllowanceStatus {...props} />}


### PR DESCRIPTION
Fixing: `UI values are updated much later than the tx is confirmed on the UI.
Expected behavior: short term solution - on the confirmation screens add a sentence to reflect that the changes are being loaded. `:

![1_Open Vault Heads UP](https://user-images.githubusercontent.com/23715025/132519692-2799a6b6-0c2b-4746-a441-5708484163aa.png)

![2_Manage Vault Changes](https://user-images.githubusercontent.com/23715025/132519769-19c15731-bb0d-4dd0-b1f7-e56b4dacbab0.png)
