### PR TITLE
fixed bug now total exposure and multiplier is shown on OpenMultiplyV…

### DIFF
--- a/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
@@ -1,4 +1,3 @@
-import { getToken } from 'blockchain/tokensMetadata'
 import {
   AfterPillProps,
   getAfterPillColors,
@@ -11,8 +10,9 @@ import {
   VaultDetailsSummaryContainer,
   VaultDetailsSummaryItem,
 } from 'components/vault/VaultDetails'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useModal } from 'helpers/modalHook'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Grid } from 'theme-ui'
@@ -20,15 +20,14 @@ import { Box, Grid } from 'theme-ui'
 import { ManageMultiplyVaultState } from '../manageMultiplyVault'
 
 function ManageMultiplyVaultDetailsSummary({
-  vault: { debt, token, freeCollateral, daiYieldFromLockedCollateral },
+  vault: { debt, token },
   afterDebt,
-  afterFreeCollateral,
-  daiYieldFromTotalCollateral,
   afterPillColors,
   showAfterPill,
+  multiply,
+  afterLockedCollateral,
 }: ManageMultiplyVaultState & AfterPillProps) {
   const { t } = useTranslation()
-  const { symbol } = getToken(token)
 
   return (
     <VaultDetailsSummaryContainer>
@@ -52,36 +51,34 @@ function ManageMultiplyVaultDetailsSummary({
       />
 
       <VaultDetailsSummaryItem
-        label={t('system.available-to-withdraw')}
+        label={t('system.total-exposure', { token })}
         value={
           <>
-            {formatAmount(freeCollateral, symbol)}
-            {` ${symbol}`}
+            {formatCryptoBalance(zero)} {token}
           </>
         }
         valueAfter={
           showAfterPill && (
             <>
-              {formatAmount(afterFreeCollateral, symbol)}
-              {` ${symbol}`}
+              {formatCryptoBalance(afterLockedCollateral || zero)} {token}
             </>
           )
         }
         afterPillColors={afterPillColors}
       />
       <VaultDetailsSummaryItem
-        label={t('system.available-to-generate')}
+        label={t('system.multiple')}
         value={
           <>
-            {formatAmount(daiYieldFromLockedCollateral, 'DAI')}
-            {` DAI`}
+            {(0.0).toFixed(2)}
+            {t('system.multiplier-exposure')}
           </>
         }
         valueAfter={
           showAfterPill && (
             <>
-              {formatAmount(daiYieldFromTotalCollateral, 'DAI')}
-              {` DAI`}
+              {multiply?.toFixed(2)}
+              {t('system.multiplier-exposure')}
             </>
           )
         }

--- a/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
@@ -20,12 +20,12 @@ import { Box, Grid } from 'theme-ui'
 import { ManageMultiplyVaultState } from '../manageMultiplyVault'
 
 function ManageMultiplyVaultDetailsSummary({
-  vault: { debt, token },
+  vault: { debt, token, lockedCollateral },
   afterDebt,
   afterPillColors,
   showAfterPill,
   multiply,
-  afterLockedCollateral,
+  afterLockedCollateral
 }: ManageMultiplyVaultState & AfterPillProps) {
   const { t } = useTranslation()
 
@@ -54,7 +54,7 @@ function ManageMultiplyVaultDetailsSummary({
         label={t('system.total-exposure', { token })}
         value={
           <>
-            {formatCryptoBalance(zero)} {token}
+            {formatCryptoBalance(lockedCollateral)} {token}
           </>
         }
         valueAfter={

--- a/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
@@ -25,6 +25,7 @@ function ManageMultiplyVaultDetailsSummary({
   afterPillColors,
   showAfterPill,
   multiply,
+  afterMultiply,
   afterLockedCollateral,
 }: ManageMultiplyVaultState & AfterPillProps) {
   const { t } = useTranslation()
@@ -70,14 +71,14 @@ function ManageMultiplyVaultDetailsSummary({
         label={t('system.multiple')}
         value={
           <>
-            {(0.0).toFixed(2)}
+            {multiply?.toFixed(2)}
             {t('system.multiplier-exposure')}
           </>
         }
         valueAfter={
           showAfterPill && (
             <>
-              {multiply?.toFixed(2)}
+              {afterMultiply?.toFixed(2)}
               {t('system.multiplier-exposure')}
             </>
           )

--- a/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultDetails.tsx
@@ -25,7 +25,7 @@ function ManageMultiplyVaultDetailsSummary({
   afterPillColors,
   showAfterPill,
   multiply,
-  afterLockedCollateral
+  afterLockedCollateral,
 }: ManageMultiplyVaultState & AfterPillProps) {
   const { t } = useTranslation()
 

--- a/features/openMultiplyVault/components/OpenMultiplyVaultChangesInformation.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultChangesInformation.tsx
@@ -15,6 +15,7 @@ import {
   formatPercent,
 } from 'helpers/formatters/format'
 import { zero } from 'helpers/zero'
+import { useTranslation } from 'next-i18next'
 import React, { useState } from 'react'
 
 import { OpenMultiplyVaultState } from '../openMultiplyVault'
@@ -42,6 +43,7 @@ export function OpenMultiplyVaultChangesInformation(props: OpenMultiplyVaultStat
 
   // starting zero balance for UI to show arrows
   const zeroBalance = formatCryptoBalance(zero)
+  const { t } = useTranslation()
 
   return !inputAmountsEmpty ? (
     <VaultChangesInformationContainer title="Order information">
@@ -89,7 +91,7 @@ export function OpenMultiplyVaultChangesInformation(props: OpenMultiplyVaultStat
         value={formatPercent(slippage.times(100), { precision: 2 })}
       />
       <VaultChangesInformationItem
-        label={'Multiply'}
+        label={t('system.multiple')}
         value={
           <Flex>
             {zeroBalance}x

--- a/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
@@ -54,17 +54,33 @@ function OpenMultiplyVaultDetailsSummary({
         label={t('system.total-exposure', { token })}
         value={
           <>
-            {formatCryptoBalance(totalExposure || zero)} {token}
+            {formatCryptoBalance(zero)} {token}
           </>
         }
+        valueAfter={
+          showAfterPill && (
+            <>
+              {formatCryptoBalance(totalExposure || zero)} {token}
+            </>
+          )
+        }
+        afterPillColors={afterPillColors}
       />
       <VaultDetailsSummaryItem
         label={t('system.multiply')}
         value={
           <>
-            {multiply?.toFixed(2)}
+            {(0.0).toFixed(2)}
             {t('system.multiplier-exposure')}
           </>
+        }
+        valueAfter={
+          showAfterPill && (
+            <>
+              {multiply?.toFixed(2)}
+              {t('system.multiplier-exposure')}
+            </>
+          )
         }
         afterPillColors={afterPillColors}
       />

--- a/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
@@ -81,8 +81,6 @@ export function OpenMultiplyVaultDetails(props: OpenMultiplyVaultState) {
     token,
     inputAmountsEmpty,
     stage,
-    multiply,
-    totalExposure,
   } = props
   const openModal = useModal()
 
@@ -95,10 +93,6 @@ export function OpenMultiplyVaultDetails(props: OpenMultiplyVaultState) {
   const afterCollRatioColor = getCollRatioColor(props, afterCollateralizationRatio)
   const afterPillColors = getAfterPillColors(afterCollRatioColor)
   const showAfterPill = !inputAmountsEmpty && stage !== 'openSuccess'
-  console.log('propsy')
-  console.log(props)
-  console.log(multiply)
-  console.log(totalExposure)
   return (
     <>
       <Grid variant="vaultDetailsCardsContainer">

--- a/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
@@ -1,5 +1,3 @@
-import BigNumber from 'bignumber.js'
-import { getToken } from 'blockchain/tokensMetadata'
 import {
   AfterPillProps,
   getAfterPillColors,
@@ -12,7 +10,7 @@ import {
   VaultDetailsSummaryContainer,
   VaultDetailsSummaryItem,
 } from 'components/vault/VaultDetails'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useModal } from 'helpers/modalHook'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
@@ -26,9 +24,10 @@ function OpenMultiplyVaultDetailsSummary({
   afterPillColors,
   showAfterPill,
   afterOutstandingDebt,
+  multiply,
+  totalExposure,
 }: OpenMultiplyVaultState & AfterPillProps) {
   const { t } = useTranslation()
-  const { symbol } = getToken(token)
 
   return (
     <VaultDetailsSummaryContainer>
@@ -52,42 +51,20 @@ function OpenMultiplyVaultDetailsSummary({
       />
 
       <VaultDetailsSummaryItem
-        label={t('system.available-to-withdraw')}
+        label={t('system.total-exposure', { token })}
         value={
           <>
-            {/* TO DO calculations */}
-            {formatAmount(new BigNumber(2), symbol)}
-            {` ${symbol}`}
+            {formatCryptoBalance(totalExposure || zero)} {token}
           </>
         }
-        valueAfter={
-          showAfterPill && (
-            <>
-              {/* TO DO calculations */}
-              {formatAmount(new BigNumber(3), 'DAI')}
-              {` DAI`}
-            </>
-          )
-        }
-        afterPillColors={afterPillColors}
       />
       <VaultDetailsSummaryItem
-        label={t('system.available-to-generate')}
+        label={t('system.multiply')}
         value={
           <>
-            {/* TO DO calculations */}
-            {formatAmount(new BigNumber(3), 'DAI')}
-            {` DAI`}
+            {multiply?.toFixed(2)}
+            {t('system.multiplier-exposure')}
           </>
-        }
-        valueAfter={
-          showAfterPill && (
-            <>
-              {/* TO DO calculations */}
-              {formatAmount(new BigNumber(4), 'DAI')}
-              {` DAI`}
-            </>
-          )
         }
         afterPillColors={afterPillColors}
       />
@@ -104,6 +81,8 @@ export function OpenMultiplyVaultDetails(props: OpenMultiplyVaultState) {
     token,
     inputAmountsEmpty,
     stage,
+    multiply,
+    totalExposure,
   } = props
   const openModal = useModal()
 
@@ -116,7 +95,10 @@ export function OpenMultiplyVaultDetails(props: OpenMultiplyVaultState) {
   const afterCollRatioColor = getCollRatioColor(props, afterCollateralizationRatio)
   const afterPillColors = getAfterPillColors(afterCollRatioColor)
   const showAfterPill = !inputAmountsEmpty && stage !== 'openSuccess'
-
+  console.log('propsy')
+  console.log(props)
+  console.log(multiply)
+  console.log(totalExposure)
   return (
     <>
       <Grid variant="vaultDetailsCardsContainer">

--- a/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultDetails.tsx
@@ -67,7 +67,7 @@ function OpenMultiplyVaultDetailsSummary({
         afterPillColors={afterPillColors}
       />
       <VaultDetailsSummaryItem
-        label={t('system.multiply')}
+        label={t('system.multiple')}
         value={
           <>
             {(0.0).toFixed(2)}

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -376,7 +376,7 @@
     "asset": "资产",
     "available-to-withdraw": "已取回数量",
     "total-exposure": "Total {{token}} exposure",
-    "multiply": "Multiply",
+    "multiple": "Multiple",
     "multiplier-exposure": "x exposure",
     "available-to-generate": "可生成数量",
     "coll-locked": "已存入",

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -375,6 +375,9 @@
   "system": {
     "asset": "资产",
     "available-to-withdraw": "已取回数量",
+    "total-exposure": "Total {{token}} exposure",
+    "multiply": "Multiply",
+    "multiplier-exposure": "x exposure",
     "available-to-generate": "可生成数量",
     "coll-locked": "已存入",
     "coll-ratio": "抵押率",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -399,6 +399,9 @@
   "system": {
     "asset": "Asset",
     "available-to-withdraw": "Available to Withdraw",
+    "total-exposure": "Total {{token}} exposure",
+    "multiplier-exposure": "x exposure",
+    "multiply": "Multiply",
     "available-to-generate": "Available to Generate",
     "coll-locked": "Coll. Locked",
     "coll-ratio": "Coll. Ratio",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -401,7 +401,7 @@
     "available-to-withdraw": "Available to Withdraw",
     "total-exposure": "Total {{token}} exposure",
     "multiplier-exposure": "x exposure",
-    "multiply": "Multiply",
+    "multiple": "Multiple",
     "available-to-generate": "Available to Generate",
     "coll-locked": "Coll. Locked",
     "coll-ratio": "Coll. Ratio",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -363,6 +363,9 @@
   "system": {
     "asset": "Activo",
     "available-to-withdraw": "Disponible para retirar",
+    "total-exposure": "Total {{token}} exposure",
+    "multiply": "Multiply",
+    "multiplier-exposure": "x exposure",
     "available-to-generate": "Disponible para generar",
     "coll-locked": "Colateral bloqueado",
     "coll-ratio": "Ratio de colateral",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -364,7 +364,7 @@
     "asset": "Activo",
     "available-to-withdraw": "Disponible para retirar",
     "total-exposure": "Total {{token}} exposure",
-    "multiply": "Multiply",
+    "multiple": "Multiple",
     "multiplier-exposure": "x exposure",
     "available-to-generate": "Disponible para generar",
     "coll-locked": "Colateral bloqueado",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -390,7 +390,7 @@
     "asset": "Ativo",
     "available-to-withdraw": "Disponível para Retirar",
     "total-exposure": "Total {{token}} exposure",
-    "multiply": "Multiply",
+    "multiple": "Multiple",
     "multiplier-exposure": "x exposure",
     "available-to-generate": "Disponível para Gerar",
     "coll-locked": "Colateral Travado",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -389,6 +389,9 @@
   "system": {
     "asset": "Ativo",
     "available-to-withdraw": "Disponível para Retirar",
+    "total-exposure": "Total {{token}} exposure",
+    "multiply": "Multiply",
+    "multiplier-exposure": "x exposure",
     "available-to-generate": "Disponível para Gerar",
     "coll-locked": "Colateral Travado",
     "coll-ratio": "Ratio de Colateralização",


### PR DESCRIPTION
…aultDetails

# [Title](https://www.notion.so/oazo/Multiply-MVP-tests-Feedback-bugs-2a776db8d0cf4acdb42717c96ccdf9d2#d466d439ce204927a7e0b955dd46d0d6)

<please insert a clubhouse link above>
  
## Changes 👷‍♀️
Fixed following error https://www.notion.so/oazo/Multiply-MVP-tests-Feedback-bugs-2a776db8d0cf4acdb42717c96ccdf9d2#d466d439ce204927a7e0b955dd46d0d6
 changed expected behavior of the summary box for multiply: available to withdraw becomes Total Collateral, available to Generate becomes the multiple

## How to test 🧪
  <Please explain how to test your changes>
- step 1 ...
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment

Result of fix:

![image](https://user-images.githubusercontent.com/6871923/132698408-7802cb6a-3dc8-4b65-8ec2-4492962d737b.png)
