### PR TITLE
Disabled converting to multiply vaults that contain unsupported token…

### DIFF
--- a/components/vault/VaultForm.tsx
+++ b/components/vault/VaultForm.tsx
@@ -4,8 +4,16 @@ import { AppLink } from 'components/Links'
 import { WithChildren } from 'helpers/types'
 import React, { ReactNode } from 'react'
 
-export function VaultFormVaultTypeSwitch({ href, title }: { href: string; title: ReactNode }) {
-  return (
+export function VaultFormVaultTypeSwitch({
+  href,
+  title,
+  visible,
+}: {
+  href: string
+  title: ReactNode
+  visible: boolean
+}) {
+  return visible ? (
     <>
       <Divider variant="styles.hrVaultFormBottom" />
       <Box>
@@ -32,6 +40,8 @@ export function VaultFormVaultTypeSwitch({ href, title }: { href: string; title:
         </AppLink>
       </Box>
     </>
+  ) : (
+    <></>
   )
 }
 

--- a/features/manageVault/ManageVaultButton.tsx
+++ b/features/manageVault/ManageVaultButton.tsx
@@ -1,4 +1,5 @@
 import { trackingEvents } from 'analytics/analytics'
+import { ALLOWED_MULTIPLY_TOKENS } from 'blockchain/tokensMetadata'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Button, Divider, Flex, Spinner, Text } from 'theme-ui'
@@ -81,7 +82,11 @@ function manageVaultButtonText(state: ManageVaultState): string {
       return t('changing-vault')
 
     case 'multiplyTransitionEditing':
-      return 'Multiply this Vault'
+      if (ALLOWED_MULTIPLY_TOKENS.includes(state.vault.token)) {
+        return 'Multiply this Vault'
+      } else {
+        return `Not supported for ${state.vault.token}`
+      }
 
     case 'multiplyTransitionWaitingForConfirmation':
       return 'Take me to the Multiply interface'
@@ -131,6 +136,7 @@ export function ManageVaultButton(props: ManageVaultState) {
     generateAmount,
     paybackAmount,
     withdrawAmount,
+    vault,
   } = props
 
   function handleProgress(e: React.SyntheticEvent<HTMLButtonElement>) {
@@ -178,7 +184,7 @@ export function ManageVaultButton(props: ManageVaultState) {
           trackEvents()
           handleProgress(e)
         }}
-        disabled={!canProgress}
+        disabled={!canProgress || !ALLOWED_MULTIPLY_TOKENS.includes(vault.token)}
       >
         {isLoadingStage ? (
           <Flex sx={{ justifyContent: 'center', alignItems: 'center' }}>

--- a/features/openMultiplyVault/components/OpenMultiplyVaultView.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultView.tsx
@@ -82,7 +82,11 @@ function OpenMultiplyVaultForm(props: OpenMultiplyVaultState) {
       {isAllowanceStage && <VaultAllowanceStatus {...props} />}
       {isOpenStage && <OpenMultiplyVaultStatus {...props} />}
       {isEditingStage ? (
-        <VaultFormVaultTypeSwitch href={`/vaults/open/${ilk}`} title="Switch to Borrow" />
+        <VaultFormVaultTypeSwitch
+          href={`/vaults/open/${ilk}`}
+          title="Switch to Borrow"
+          visible={true}
+        />
       ) : null}
     </VaultFormContainer>
   )

--- a/features/openVault/components/OpenVaultView.tsx
+++ b/features/openVault/components/OpenVaultView.tsx
@@ -1,4 +1,5 @@
 import { trackingEvents } from 'analytics/analytics'
+import { ALLOWED_MULTIPLY_TOKENS } from 'blockchain/tokensMetadata'
 import { useAppContext } from 'components/AppContextProvider'
 import { VaultAllowance, VaultAllowanceStatus } from 'components/vault/VaultAllowance'
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
@@ -82,6 +83,7 @@ function OpenVaultForm(props: OpenVaultState) {
         <VaultFormVaultTypeSwitch
           href={`/vaults/open-multiply/${ilk}`}
           title="Switch to Multiply"
+          visible={ALLOWED_MULTIPLY_TOKENS.includes(props.token)}
         />
       ) : null}
     </VaultFormContainer>


### PR DESCRIPTION
… as a collateral

# [Title](https://www.notion.so/oazo/Multiply-MVP-tests-Feedback-bugs-2a776db8d0cf4acdb42717c96ccdf9d2#20403022c7e04c1f98d1b0737bb47c1b)
Fix for following bug
"Switch to multiply" is available for every collateral type even those who are not supported at the moment. Click on "switch to multiply" leads to multiply interface and then "cannot fetch exchange prices" error stops the user from going forward.
  
## Changes 👷‍♀️
  <Please add short list of changes>
- item 1
  
## How to test 🧪
Get borrow vault with unsupported token (it's hard to create one I hardcoded different token in existing vault to test) 
See if it's possible to convert it to multiply
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment

![image](https://user-images.githubusercontent.com/6871923/132866138-8231f122-09af-48db-8e55-013cc37e1127.png)
