### PR TITLE
Make a simple announcement that will be visible on all app pages and …

### DIFF
--- a/components/Announcement.tsx
+++ b/components/Announcement.tsx
@@ -1,43 +1,9 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { WithChildren } from 'helpers/types'
-import { useTranslation } from 'next-i18next'
-import React from 'react'
-import { Box, Flex, SxProps, Text } from 'theme-ui'
+import React, { useLayoutEffect, useState } from 'react'
+import { Box, Flex, IconButton, SxProps, Text } from 'theme-ui'
 
 import { AppLink } from './Links'
-
-export function Announcement({ children, sx }: WithChildren & SxProps) {
-  return (
-    <Flex
-      sx={{
-        alignItems: 'center',
-        px: [3, 4],
-        py: [2, 3],
-        borderRadius: 'large',
-        background: 'rgba(255,255,255, 0.65)',
-        width: ['100%', 'fit-content'],
-        justifySelf: 'center',
-        ...sx,
-      }}
-    >
-      <Flex
-        sx={{
-          height: '36px',
-          width: ' 36px',
-          background: 'surface',
-          boxShadow: 'banner',
-          borderRadius: 'roundish',
-          mr: 3,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Icon name="announcement" height="25px" width="25px" />
-      </Flex>
-      {children}
-    </Flex>
-  )
-}
 
 function WithArrow({ children }: React.PropsWithChildren<{}>) {
   return (
@@ -64,36 +30,143 @@ function WithArrow({ children }: React.PropsWithChildren<{}>) {
   )
 }
 
-export function WelcomeAnnouncement() {
-  const { t } = useTranslation()
-
+function Separator() {
   return (
-    <Announcement sx={{ mb: 3, textAlign: 'left' }}>
-      <Flex sx={{ flexDirection: ['column', 'row'] }}>
-        <Text variant="paragraph3" sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3 }}>
-          {t('welcome')}
-        </Text>
-        <Flex sx={{ flexDirection: ['column', 'row'] }}>
-          <AppLink href="https://blog.oasis.app/introducing-the-redesigned-oasis-borrow/">
-            <WithArrow>{t('read-blog-post')}</WithArrow>
-          </AppLink>
-          <Text
-            variant="paragraph3"
+    <Text
+      variant="paragraph3"
+      sx={{
+        fontWeight: 'semiBold',
+        color: 'muted',
+        mx: 3,
+        ml: 4,
+        '@media screen and (max-width: 400px)': {
+          display: 'none',
+        },
+      }}
+    >
+      |
+    </Text>
+  )
+}
+
+function Closeable({ children, onClose }: { onClose?: () => void } & WithChildren) {
+  return (
+    <Box sx={{ position: 'relative' }}>
+      {children}
+      <IconButton
+        onClick={onClose}
+        sx={{
+          cursor: 'pointer',
+          height: 3,
+          width: 3,
+          padding: 0,
+          position: 'absolute',
+          top: 3,
+          right: 3,
+          zIndex: 1,
+          color: 'onSurface',
+          '&:hover': {
+            color: 'primary',
+          },
+        }}
+      >
+        <Icon name="close_squared" size={14} />
+      </IconButton>
+    </Box>
+  )
+}
+
+export function Announcement({ children, sx }: WithChildren & SxProps) {
+  return (
+    <Flex
+      sx={{
+        alignItems: 'center',
+        px: [3, 4],
+        py: [2, 3],
+        borderRadius: 'large',
+        background: 'rgba(255,255,255, 0.65)',
+        width: ['100%', 'fit-content'],
+        justifySelf: 'center',
+        ...sx,
+      }}
+    >
+      <Flex
+        sx={{
+          height: '36px',
+          width: ' 36px',
+          background: 'surface',
+          boxShadow: 'banner',
+          borderRadius: 'roundish',
+          mr: 3,
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Icon name="announcement" height="25px" width="25px" />
+      </Flex>
+      {children}
+    </Flex>
+  )
+}
+
+interface GenericAnnouncementProps {
+  text: string
+  discordLink: string
+  link?: string
+  linkText?: string
+}
+
+export function GenericAnnouncement({
+  text,
+  discordLink,
+  link,
+  linkText,
+}: GenericAnnouncementProps) {
+  const [shouldRender, setShouldRender] = useState(true)
+
+  useLayoutEffect(() => {
+    setShouldRender(!sessionStorage.getItem('isAnnouncementHidden'))
+  }, [])
+
+  return shouldRender ? (
+    <Closeable
+      onClose={() => {
+        setShouldRender(false)
+        sessionStorage.setItem('isAnnouncementHidden', 'true')
+      }}
+    >
+      <Announcement sx={{ mb: 3, textAlign: 'left' }}>
+        <Box>
+          <Box sx={{ mb: 2 }}>
+            <Text
+              variant="paragraph3"
+              sx={{ fontWeight: 'semiBold', fontSize: [1, 2], mr: 3, pr: 2 }}
+            >
+              {text}
+            </Text>
+          </Box>
+          <Flex
             sx={{
-              fontWeight: 'semiBold',
-              color: 'muted',
-              mx: 3,
-              ml: 4,
-              display: ['none', 'block'],
+              '@media screen and (max-width: 400px)': {
+                flexDirection: 'column',
+              },
             }}
           >
-            |
-          </Text>
-          <AppLink href={`${window.location.origin}/borrow-old`}>
-            <WithArrow>{t('visit-old-oasis')}</WithArrow>
-          </AppLink>
-        </Flex>
-      </Flex>
-    </Announcement>
-  )
+            <AppLink href={discordLink}>
+              <WithArrow>Visit Discord</WithArrow>
+            </AppLink>
+            {link && linkText && (
+              <>
+                <Separator />
+                <AppLink href={link}>
+                  <WithArrow>{linkText}</WithArrow>
+                </AppLink>
+              </>
+            )}
+          </Flex>
+        </Box>
+      </Announcement>
+    </Closeable>
+  ) : null
 }

--- a/components/Layouts.tsx
+++ b/components/Layouts.tsx
@@ -9,11 +9,17 @@ import { Background } from 'theme/Background'
 import { BackgroundLight } from 'theme/BackgroundLight'
 import { BackgroundLighter } from 'theme/BackgroundLighter'
 
+import { GenericAnnouncement } from './Announcement'
+
 interface BasicLayoutProps extends WithChildren {
   header: JSX.Element
   footer?: JSX.Element
   sx?: SxStyleProp
   variant?: string
+}
+
+interface WithAnnouncementLayoutProps extends BasicLayoutProps {
+  showAnnouncement: boolean
 }
 
 export function BasicLayout({ header, footer, children, sx, variant }: BasicLayoutProps) {
@@ -35,6 +41,43 @@ export function BasicLayout({ header, footer, children, sx, variant }: BasicLayo
   )
 }
 
+export function WithAnnouncementLayout({
+  header,
+  footer,
+  children,
+  showAnnouncement,
+  sx,
+  variant,
+}: WithAnnouncementLayoutProps) {
+  return (
+    <Flex
+      sx={{
+        bg: 'none',
+        flexDirection: 'column',
+        minHeight: '100%',
+        ...sx,
+      }}
+    >
+      {header}
+      {showAnnouncement && (
+        <Container variant="announcement">
+          <GenericAnnouncement
+            text="Welcome to the new Oasis.app. We are thrilled to have you here. Please check the new stuff. How long can it go is that I
+        m curious"
+            discordLink="https://discord.com/channels/837076147694207067/846839026651889675"
+            link="https://blog.ethereum.org/2015/11/15/merkling-in-ethereum/"
+            linkText="Check blog post"
+          />
+        </Container>
+      )}
+      <Container variant={variant || 'appContainer'} sx={{ flex: 2, mb: 5 }} as="main">
+        <Flex sx={{ width: '100%', height: '100%' }}>{children}</Flex>
+      </Container>
+      {footer}
+    </Flex>
+  )
+}
+
 export function AppLayout({ children }: WithChildren) {
   if (!isAppContextAvailable()) {
     return null
@@ -42,9 +85,14 @@ export function AppLayout({ children }: WithChildren) {
 
   return (
     <>
-      <BasicLayout sx={{ zIndex: 2 }} footer={<Footer />} header={<AppHeader />}>
+      <WithAnnouncementLayout
+        sx={{ zIndex: 2 }}
+        showAnnouncement={false}
+        footer={<Footer />}
+        header={<AppHeader />}
+      >
         {children}
-      </BasicLayout>
+      </WithAnnouncementLayout>
     </>
   )
 }
@@ -54,6 +102,27 @@ const marketingBackgrounds = {
   light: <BackgroundLight />,
   lighter: <BackgroundLighter />,
   none: null,
+}
+
+export function LandingPageLayout({ children }: WithChildren) {
+  if (!isAppContextAvailable()) {
+    return null
+  }
+
+  return (
+    <>
+      {marketingBackgrounds['default']}
+      <WithAnnouncementLayout
+        header={<AppHeader />}
+        footer={<Footer />}
+        showAnnouncement={false}
+        variant="landingContainer"
+        sx={{ position: 'relative' }}
+      >
+        {children}
+      </WithAnnouncementLayout>
+    </>
+  )
 }
 
 export interface MarketingLayoutProps extends WithChildren {

--- a/components/Layouts.tsx
+++ b/components/Layouts.tsx
@@ -64,7 +64,7 @@ export function WithAnnouncementLayout({
           <GenericAnnouncement
             text="Welcome to the new Oasis.app. We are thrilled to have you here. Please check the new stuff. How long can it go is that I
         m curious"
-            discordLink="https://discord.com/channels/837076147694207067/846839026651889675"
+            discordLink="https://discord.gg/Kc2bBB59GC"
             link="https://blog.ethereum.org/2015/11/15/merkling-in-ethereum/"
             linkText="Check blog post"
           />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { WithConnection } from 'components/connectWallet/ConnectWallet'
-import { MarketingLayout } from 'components/Layouts'
+import { LandingPageLayout } from 'components/Layouts'
 import { LandingView } from 'features/landing/LandingView'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
@@ -18,8 +18,5 @@ export default function LandingPage() {
   )
 }
 
-LandingPage.layout = MarketingLayout
-LandingPage.layoutProps = {
-  variant: 'landingContainer',
-}
+LandingPage.layout = LandingPageLayout
 LandingPage.theme = 'Landing'

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -260,6 +260,11 @@ const oasisBaseTheme = {
       position: 'relative',
       ...slideInAnimation,
     },
+    announcement: {
+      maxWidth: '792px',
+      alignSelf: 'center',
+      zIndex: 4,
+    },
   },
   metadata: {
     fontLinkHref: 'https://rsms.me/inter/inter.css',


### PR DESCRIPTION
According to a requirement we should have a very easy to configure announcement that anyone can active.
- The announcement **MUST** contain a text.
- The announcement **MUST** contain link to discord.  
  - This link should be configurable because the invitation links expire so the person who 
    configures the announcement should be able easily provide a new link.
- The announcement **COULD** have another **OPTIONAL** link. 
- The announcement **MUST** be closeable per session. 
  - If the user during his session closed the announcement on any page, they shouldn't see it on any other pages during that session. 
  - If the user has announcement dismissed and closes the tab where the application is loading and then opens the application in a new tab, the announcement MUST be visible, even thought they have closed it in a previous session.
 - The announcement **MUST** be visible only on the Landing page  + All application related pages.
 - The announcement **MUST NOT** be visible on Connect Page, Team Page, Terms page, Support page and these sort of pages.
 - The announcement **MUST** look nice on mobile devices and everything should be rendered without any overlapping elements.
