### PR TITLE
Close modal window only when you click outside of it and not inside.

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -80,7 +80,9 @@ function overflowClickHandler(onClick: () => void, event: MouseEvent) {
       (node: any) => node.id === 'modalContainer',
     )
     if (hasClickedOnOverlay) {
-      onClick()
+      if (onClick) {
+        onClick()
+      }
     }
   }
 }

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@makerdao/dai-ui-icons'
 import { ModalProps } from 'helpers/modalHook'
 import { WithChildren } from 'helpers/types'
 import { useTranslation } from 'next-i18next'
+import { curry } from 'ramda'
 import React, { useCallback, useEffect, useState } from 'react'
 import { TRANSITIONS } from 'theme'
 import { Box, Card, Container, Flex, IconButton, SxStyleProp, Text } from 'theme-ui'
@@ -54,15 +55,51 @@ export function ModalCloseIcon({ close, sx, size = 26, color = 'onSurface' }: Mo
   )
 }
 
+// This will recursively look down to every single child of the target element.
+function iterateAllNodes(target: Node, container: Node[] = [], id = 0) {
+  let nodes = [...container, target]
+  target.childNodes.forEach((node) => {
+    if (node.childNodes.length) {
+      nodes = [...iterateAllNodes(node, nodes, ++id)]
+    } else {
+      nodes.push(node)
+    }
+  })
+
+  return nodes
+}
+
+// The logic is as follows:
+// Whenever we click on an element, the event.target is the element where the event was fired on.
+// If the modal container id is part of the children then that means we clicked outside of it.
+// If the modal container is is not part of the chilren then that means we clicked inside of it.
+function overflowClickHandler(onClick: () => void, event: MouseEvent) {
+  event.stopPropagation()
+  if (event.target) {
+    const hasClickedOnOverlay = iterateAllNodes(event.target as Node).find(
+      (node: any) => node.id === 'modalContainer',
+    )
+    if (hasClickedOnOverlay) {
+      onClick()
+    }
+  }
+}
+
 // Helper component to compensate jumping of window upon opening Modal
-export function ModalHTMLOverflow() {
+export function ModalHTMLOverflow({ close }: { close: () => void }) {
   const [compensateWidth, setCompensateWidth] = useState(false)
+
   useEffect(() => {
     document.body.style.width = `${document.body.clientWidth}px`
     setCompensateWidth(true)
 
+    const curriedOverflowClickHandler = curry(overflowClickHandler)(close)
+
+    document.body.addEventListener('click', curriedOverflowClickHandler)
+
     return () => {
       document.body.removeAttribute('style')
+      document.body.removeEventListener('click', curriedOverflowClickHandler)
     }
   }, [])
 
@@ -80,7 +117,6 @@ export function ModalHTMLOverflow() {
 function ModalWrapper({ children, close }: WithChildren & { close: () => void }) {
   return (
     <Box
-      onClick={close}
       sx={{
         position: 'fixed',
         width: '100%',
@@ -95,7 +131,7 @@ function ModalWrapper({ children, close }: WithChildren & { close: () => void })
         overflow: 'auto',
       }}
     >
-      <ModalHTMLOverflow />
+      <ModalHTMLOverflow close={close} />
       {children}
     </Box>
   )
@@ -113,8 +149,8 @@ export function Modal({ children, variant, sx, close }: ModalProps) {
           ...sx,
         }}
       >
-        <Container variant={variant || 'modalHalf'} m="auto" py={2}>
-          <Card p={0} sx={{ position: 'relative' }}>
+        <Container id="modalContainer" variant={variant || 'modalHalf'} m="auto" py={2}>
+          <Card id="modalCard" p={0} sx={{ position: 'relative' }}>
             {children}
           </Card>
         </Container>

--- a/components/vault/VaultFormContainer.tsx
+++ b/components/vault/VaultFormContainer.tsx
@@ -26,6 +26,8 @@ export function VaultFormContainer({
     }
   }, [])
 
+  const onClose = () => setVaultFormOpened(false);
+
   return (
     <VaultFormPortal mobile={breakpoint === 0}>
       <Box
@@ -47,7 +49,7 @@ export function VaultFormContainer({
       >
         {breakpoint === 0 && (
           <Box>
-            {vaultFormOpened && <ModalHTMLOverflow />}
+            {vaultFormOpened && <ModalHTMLOverflow close={onClose}/>}
             <Box
               sx={{
                 display: ['flex', 'none'],
@@ -58,7 +60,7 @@ export function VaultFormContainer({
               }}
             >
               <ModalCloseIcon
-                close={() => setVaultFormOpened(false)}
+                close={onClose}
                 sx={{ top: 0, right: 0, color: 'primary', position: 'relative' }}
                 size={3}
               />

--- a/components/vault/VaultFormContainer.tsx
+++ b/components/vault/VaultFormContainer.tsx
@@ -26,7 +26,7 @@ export function VaultFormContainer({
     }
   }, [])
 
-  const onClose = () => setVaultFormOpened(false);
+  const onClose = () => setVaultFormOpened(false)
 
   return (
     <VaultFormPortal mobile={breakpoint === 0}>
@@ -49,7 +49,7 @@ export function VaultFormContainer({
       >
         {breakpoint === 0 && (
           <Box>
-            {vaultFormOpened && <ModalHTMLOverflow close={onClose}/>}
+            {vaultFormOpened && <ModalHTMLOverflow close={onClose} />}
             <Box
               sx={{
                 display: ['flex', 'none'],

--- a/features/account/Account.tsx
+++ b/features/account/Account.tsx
@@ -169,7 +169,7 @@ export function AccountModal({ close }: ModalProps) {
   const { account, connectionKind } = web3Context
 
   return (
-    <Modal close={close} sx={{ maxWidth: '530px', margin: '0px auto' }}>
+    <Modal id="AccountModal" close={close} sx={{ maxWidth: '530px', margin: '0px auto' }}>
       <ModalCloseIcon {...{ close }} />
       <Grid gap={2} pt={3} mt={1}>
         <Box

--- a/features/openVaultOverview/SelectVaultTypeModal.tsx
+++ b/features/openVaultOverview/SelectVaultTypeModal.tsx
@@ -38,13 +38,15 @@ export function SelectVaultTypeModal({ ilk, token, liquidationRatio, close }: Mo
               token,
             })}
           </Text>
-          <AppLink
-            variant="primary"
-            href={`/vaults/open-multiply/${ilk}`}
-            sx={{ display: 'block', textAlign: 'center', mb: 3 }}
-          >
-            {t('select-vault-type.multiply.button', { token })}
-          </AppLink>
+          <Box onClick={close}>
+            <AppLink
+              variant="primary"
+              href={`/vaults/open-multiply/${ilk}`}
+              sx={{ display: 'block', textAlign: 'center', mb: 3 }}
+            >
+              {t('select-vault-type.multiply.button', { token })}
+            </AppLink>
+          </Box>
         </Box>
         <Divider />
 
@@ -58,13 +60,15 @@ export function SelectVaultTypeModal({ ilk, token, liquidationRatio, close }: Mo
               token,
             })}
           </Text>
-          <AppLink
-            variant="primary"
-            href={`/vaults/open/${ilk}`}
-            sx={{ display: 'block', textAlign: 'center' }}
-          >
-            {t('select-vault-type.borrow.button', { token })}
-          </AppLink>
+          <Box onClick={close}>
+            <AppLink
+              variant="primary"
+              href={`/vaults/open/${ilk}`}
+              sx={{ display: 'block', textAlign: 'center' }}
+            >
+              {t('select-vault-type.borrow.button', { token })}
+            </AppLink>
+          </Box>
         </Box>
       </Grid>
     </Modal>


### PR DESCRIPTION
https://www.notion.so/oazo/Multiply-MVP-tests-Feedback-bugs-2a776db8d0cf4acdb42717c96ccdf9d2#b0d8445e1ac34e2197147c5154cab5d2

The modal windows `MUST BE` closed:
 - Clicking outside the modal container itself
 - Pressing `ESC` button
 - Clicking `close` button in the top right corner.
 
 The modal windows `MUST NOT BE` closed:
 - Click inside on any part of the modal itself.


Modals to test:
 - `Error`
 - `Account`
 - `Selecting Vault Type`
 - `Signing ToS`