### PR TITLE
Change button label

### DIFF
--- a/features/manageMultiplyVault/components/ManageMultiplyVaultButton.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultButton.tsx
@@ -13,7 +13,9 @@ function manageMultiplyVaultButtonText(state: ManageMultiplyVaultState): string 
     case 'adjustPosition':
     case 'otherActions':
       return state.inputAmountsEmpty
-        ? t('enter-an-amount')
+        ? state.stage === 'adjustPosition'
+          ? t('adjust-your-position')
+          : t('enter-an-amount')
         : !state.proxyAddress
         ? t('setup-proxy')
         : state.insufficientCollateralAllowance

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -17,6 +17,7 @@
   "activity": "历史记录",
   "address": "地址",
   "address-invalid": "找不到地址",
+  "adjust-your-position": "Adjust your position",
   "after": "继续",
   "after-next": "继续 + 下一步",
   "all-assets": "所有资产",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -17,6 +17,7 @@
   "activity": "Activity",
   "address": "Address",
   "address-invalid": "Address not found",
+  "adjust-your-position": "Adjust your position",
   "after": "After",
   "after-next": "After + Next",
   "all-assets": "All Assets",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -17,6 +17,7 @@
   "activity": "Actividad",
   "address": "Dirección",
   "address-invalid": "Dirección no encontrada",
+  "adjust-your-position": "Adjust your position",
   "after": "Después",
   "after-next": "After + Next",
   "all-assets": "Todos los activos",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -17,6 +17,7 @@
   "activity": "Atividade",
   "address": "Endereço",
   "address-invalid": "Endereço não encontrado",
+  "adjust-your-position": "Adjust your position",
   "after": "Depois",
   "after-next": "Depois + Próximo",
   "all-assets": "Todos Ativos",


### PR DESCRIPTION
https://www.notion.so/oazo/Multiply-MVP-tests-Feedback-bugs-2a776db8d0cf4acdb42717c96ccdf9d2#9cc7609c2a2248938ed81fcd9bfbf0f7

![adjust your position](https://user-images.githubusercontent.com/23715025/133584456-81d5d13b-9eca-4cf2-9fe9-81989b321aca.png)

My understanding of the expected version:
 - `Adjust your position` label **MUST BE** only on existing multiply vaults.
 - `Enter an amount` label **MUST BE** visible when the user creates new multiply vault
 - `Enter an amount` label **MUST BE** visible when the user manages an existing multiply vault through `Other Actions` tab.
 - `Enter an amount` label **MUST BE** visible when the user creates new  ordinary vault
 - `Enter an amount` label **MUST BE** visible when the user manages an existing ordinary vault ( all operations )