### PR TITLE
Fix displaying 1inch data on summary screen

### DIFF
--- a/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultConditions.ts
@@ -270,7 +270,8 @@ export function applyManageVaultConditions(
     !(originalEditingStage === 'otherActions' && otherAction === 'depositCollateral')
 
   const exchangeDataRequired =
-    stage === 'adjustPosition' || (stage === 'otherActions' && otherAction === 'closeVault')
+    originalEditingStage === 'adjustPosition' ||
+    (originalEditingStage === 'otherActions' && otherAction === 'closeVault')
 
   const shouldShowExchangeError = exchangeDataRequired && exchangeError
 


### PR DESCRIPTION
## Changes 👷‍♀️
- hide 1inch data only on relevant summary screens, not all of them
  
## How to test 🧪
- test in UI/Storybook
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
