### PR TITLE
Summary screen should not update the change information after the cha…

### DIFF
--- a/features/manageMultiplyVault/components/ManageMultiplyVaultConfirmation.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultConfirmation.tsx
@@ -1,19 +1,25 @@
 import { Divider } from '@theme-ui/components'
 import { TxStatusCardSuccess } from 'components/vault/TxStatusCard'
 import { useTranslation } from 'next-i18next'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { OpenVaultAnimation } from 'theme/animations'
 
 import { ManageMultiplyVaultState } from '../manageMultiplyVault'
 import { ManageMultiplyVaultChangesInformation } from './ManageMultiplyVaultChangesInformation'
 
 export function ManageMultiplyVaultConfirmation(props: ManageMultiplyVaultState) {
+  const [vaultChange, setVaultChanges] = useState<ManageMultiplyVaultState>(props)
+  useEffect(() => {
+    if (props.stage !== 'manageSuccess') {
+      setVaultChanges(props)
+    }
+  }, [props.stage])
   return props.stage === 'manageInProgress' ? (
     <OpenVaultAnimation />
   ) : (
     <>
       <Divider />
-      <ManageMultiplyVaultChangesInformation {...props} />
+      <ManageMultiplyVaultChangesInformation {...vaultChange} />
     </>
   )
 }

--- a/features/manageVault/ManageVaultConfirmation.tsx
+++ b/features/manageVault/ManageVaultConfirmation.tsx
@@ -1,19 +1,25 @@
 import { Divider } from '@theme-ui/components'
 import { TxStatusCardSuccess } from 'components/vault/TxStatusCard'
 import { useTranslation } from 'next-i18next'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { OpenVaultAnimation } from 'theme/animations'
 
 import { ManageVaultState } from './manageVault'
 import { ManageVaultChangesInformation } from './ManageVaultChangesInformation'
 
 export function ManageVaultConfirmation(props: ManageVaultState) {
+  const [vaultChange, setVaultChanges] = useState<ManageVaultState>(props)
+  useEffect(() => {
+    if (props.stage !== 'manageSuccess') {
+      setVaultChanges(props)
+    }
+  }, [props.stage])
   return props.stage === 'manageInProgress' ? (
     <OpenVaultAnimation />
   ) : (
     <>
       <Divider />
-      <ManageVaultChangesInformation {...props} />
+      <ManageVaultChangesInformation {...vaultChange} />
     </>
   )
 }


### PR DESCRIPTION
https://app.shortcut.com/oazo-apps/story/2691/vault-changes-after-the-change-are-overwritten-where-prior-data

The changes shouldn't be updated when the user is on the success screen. This applies for Managing Vault only and also it applies for both Multiply and Normal vaults.