### PR TITLE
Increase DECIMAL_PLACES for RAY and RAD numbers

### DIFF
--- a/blockchain/utils.ts
+++ b/blockchain/utils.ts
@@ -7,10 +7,12 @@ import ethAbi from 'web3-eth-abi'
 import { getToken } from './tokensMetadata'
 
 export function amountFromRay(amount: BigNumber): BigNumber {
+  BigNumber.config({ DECIMAL_PLACES: RAY.toString().length })
   return amount.div(RAY)
 }
 
 export function amountFromRad(amount: BigNumber): BigNumber {
+  BigNumber.config({ DECIMAL_PLACES: RAD.toString().length })
   return amount.div(RAD)
 }
 


### PR DESCRIPTION
https://app.shortcut.com/oazo-apps/story/2686/precision-error-sets-a-vault-into-limited-mode-when-the-vault-is-not-under-the-dust-limit-this-breaks-current-standard-vaults


`rate` is of 'type' `RAY` which is `1e27` so
So let's say the current `ilk.rate` is `1064998962605983256332145468` which is `28 digits` long.
Now by `default` the `DECIMAL_PLACES` for `BigNumber` is `20`  - taken from the documentation  - https://mikemcl.github.io/bignumber.js/#decimal-places
If you check the code  where we fetch the needed information `ilk.rate` and `urn.art`  which is respectively in `vatUrns` and `varIlk` which is in the file `vat.ts` we use the utility functions `amountTFromRay` and `amountFromWei`.
When we parse the numbers for the rate used in this example we get the following value: `1.06499896260598325633` . IF you check the length for the decimal digits it's exactly `20`. That happens because of the default value for `DECIMAL_PLACES` .
As you can see there is lost of digits between `1.06499896260598325633` and `1064998962605983256332145468`
My values for the vault are the following:

```
DEBUG:ART 28169.041523375712444976
DEBUG:RATE 1.06499896260598325633
DEBUG:DEBT 29999.99999999999999994012015635226242869808
```

Now if we  make `amountToRay` to actually utilize more digits for the decimal part and apply it over the same value, we get the following: 
```
DEBUG:ART 28169.041523375712444976
DEBUG:RATE 1.064998962605983256332145468
DEBUG:DEBT 30000.000000000000000000555933531336271725977768768
```
