### PR TITLE
Add network and wallet type for confirmTransaction mixpanel events

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -1,3 +1,4 @@
+import { ConnectionKind } from '@oasisdex/web3-context'
 import * as mixpanelBrowser from 'mixpanel-browser'
 import getConfig from 'next/config'
 
@@ -181,6 +182,8 @@ export const trackingEvents = {
     daiAmount: string,
     firstCDP: boolean | undefined,
     txHash: string,
+    network: string,
+    walletType: ConnectionKind,
   ) => {
     mixpanel.track('btn-click', {
       id: 'ConfirmTransaction',
@@ -190,6 +193,8 @@ export const trackingEvents = {
       daiAmount,
       firstCDP,
       txHash,
+      network,
+      walletType,
       page: Pages.VaultCreate,
       section: 'ConfirmVault',
     })
@@ -341,6 +346,8 @@ export const trackingEvents = {
     collateralAmount: string,
     daiAmount: string,
     txHash: string,
+    network: string,
+    walletType: ConnectionKind,
   ) => {
     mixpanel.track('btn-click', {
       id: 'ConfirmTransaction',
@@ -349,6 +356,8 @@ export const trackingEvents = {
       collateralAmount,
       daiAmount,
       txHash,
+      network,
+      walletType,
       page,
       section: 'ConfirmVault',
     })

--- a/features/generalManageVault/GeneralManageVaultView.tsx
+++ b/features/generalManageVault/GeneralManageVaultView.tsx
@@ -21,15 +21,6 @@ export function GeneralManageVaultView({ id }: { id: BigNumber }) {
   const vaultHistoryWithError = useObservableWithError(vaultHistory$(id))
   const vaultMultiplyHistoryWithError = useObservableWithError(vaultMultiplyHistory$(id))
 
-  // TO DO bring back analytics
-  // useEffect(() => {
-  //   const subscription = createManageVaultAnalytics$(manageVaultWithId$, trackingEvents).subscribe()
-
-  //   return () => {
-  //     subscription.unsubscribe()
-  //   }
-  // }, [])
-
   function prepareMultiplyHistory(vaultHistory: any[], vaultMultiplyHistory: any[]) {
     let outstandingDebt = new BigNumber(0)
     let collateral = new BigNumber(0)

--- a/features/manageVault/ManageVaultView.tsx
+++ b/features/manageVault/ManageVaultView.tsx
@@ -1,4 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import { trackingEvents } from 'analytics/analytics'
+import { useAppContext } from 'components/AppContextProvider'
 import { VaultAllowanceStatus } from 'components/vault/VaultAllowance'
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
@@ -13,6 +15,7 @@ import React, { useEffect } from 'react'
 import { Box, Divider, Flex, Grid, Text } from 'theme-ui'
 
 import { ManageVaultState } from './manageVault'
+import { createManageVaultAnalytics$ } from './manageVaultAnalytics'
 import { ManageVaultButton } from './ManageVaultButton'
 import { ManageVaultCollateralAllowance } from './ManageVaultCollateralAllowance'
 import { ManageVaultConfirmation, ManageVaultConfirmationStatus } from './ManageVaultConfirmation'
@@ -129,6 +132,7 @@ export function ManageVaultContainer({
   manageVault: ManageVaultState
   vaultHistory: VaultHistoryEvent[]
 }) {
+  const { manageVault$, context$ } = useAppContext()
   const {
     vault: { id, ilk },
     clear,
@@ -136,8 +140,15 @@ export function ManageVaultContainer({
   const { t } = useTranslation()
 
   useEffect(() => {
+    const subscription = createManageVaultAnalytics$(
+      manageVault$(id),
+      context$,
+      trackingEvents,
+    ).subscribe()
+
     return () => {
       clear()
+      subscription.unsubscribe()
     }
   }, [])
 

--- a/features/manageVault/manageVaultAnalytics.ts
+++ b/features/manageVault/manageVaultAnalytics.ts
@@ -1,8 +1,10 @@
 import { INPUT_DEBOUNCE_TIME, Pages, Tracker } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
+import { networksById } from 'blockchain/config'
+import { Context } from 'blockchain/network'
 import { zero } from 'helpers/zero'
 import { isEqual } from 'lodash'
-import { merge, Observable, zip } from 'rxjs'
+import { combineLatest, merge, Observable, zip } from 'rxjs'
 import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators'
 
 import { ManageVaultState } from './manageVault'
@@ -58,6 +60,7 @@ type ManageVaultConfirmTransaction = {
 
 export function createManageVaultAnalytics$(
   manageVaultState$: Observable<ManageVaultState>,
+  context$: Observable<Context>,
   tracker: Tracker,
 ) {
   const stageChanges = manageVaultState$.pipe(
@@ -220,9 +223,9 @@ export function createManageVaultAnalytics$(
     distinctUntilChanged(isEqual),
   )
 
-  return stageChanges
+  return combineLatest(context$, stageChanges)
     .pipe(
-      switchMap((stage) =>
+      switchMap(([context, stage]) =>
         merge(
           merge(
             depositAmountChanges,
@@ -235,6 +238,8 @@ export function createManageVaultAnalytics$(
           merge(manageVaultConfirm, manageVaultConfirmTransaction),
         ).pipe(
           tap((event) => {
+            console.log(event)
+
             const page = stage === 'daiEditing' ? Pages.ManageDai : Pages.ManageCollateral
             switch (event.kind) {
               case 'depositAmountChange':
@@ -286,12 +291,17 @@ export function createManageVaultAnalytics$(
                 )
                 break
               case 'manageVaultConfirmTransaction':
+                const network = networksById[context.chainId].name
+                const walletType = context.connectionKind
+
                 tracker.manageVaultConfirmTransaction(
                   page,
                   event.value.ilk,
                   event.value.collateralAmount.toString(),
                   event.value.daiAmount.toString(),
                   event.value.txHash,
+                  network,
+                  walletType,
                 )
                 break
               default:

--- a/features/openVault/components/OpenVaultView.tsx
+++ b/features/openVault/components/OpenVaultView.tsx
@@ -116,7 +116,7 @@ export function OpenVaultContainer(props: OpenVaultState) {
 }
 
 export function OpenVaultView({ ilk }: { ilk: string }) {
-  const { openVault$, accountData$ } = useAppContext()
+  const { openVault$, accountData$, context$ } = useAppContext()
   const openVaultWithIlk$ = openVault$(ilk)
   const openVaultWithError = useObservableWithError(openVaultWithIlk$)
 
@@ -124,6 +124,7 @@ export function OpenVaultView({ ilk }: { ilk: string }) {
     const subscription = createOpenVaultAnalytics$(
       accountData$,
       openVaultWithIlk$,
+      context$,
       trackingEvents,
     ).subscribe()
 

--- a/features/openVault/openVaultAnalytics.ts
+++ b/features/openVault/openVaultAnalytics.ts
@@ -1,9 +1,11 @@
 import { INPUT_DEBOUNCE_TIME, Tracker } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
+import { networksById } from 'blockchain/config'
+import { Context } from 'blockchain/network'
 import { AccountDetails } from 'features/account/AccountData'
 import { zero } from 'helpers/zero'
 import { isEqual } from 'lodash'
-import { merge, Observable, zip } from 'rxjs'
+import { combineLatest, merge, Observable, zip } from 'rxjs'
 import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators'
 
 import { MutableOpenVaultState, OpenVaultState } from './openVault'
@@ -48,6 +50,7 @@ type OpenVaultConfirmTransaction = {
 export function createOpenVaultAnalytics$(
   accountDetails$: Observable<AccountDetails>,
   openVaultState$: Observable<OpenVaultState>,
+  context$: Observable<Context>,
   tracker: Tracker,
 ) {
   const firstCDPChange: Observable<boolean | undefined> = accountDetails$.pipe(
@@ -133,8 +136,8 @@ export function createOpenVaultAnalytics$(
     distinctUntilChanged(isEqual),
   )
 
-  return firstCDPChange.pipe(
-    switchMap((firstCDP) =>
+  return combineLatest(context$, firstCDPChange).pipe(
+    switchMap(([context, firstCDP]) =>
       merge(
         depositAmountChanges,
         generateAmountChanges,
@@ -166,12 +169,17 @@ export function createOpenVaultAnalytics$(
               )
               break
             case 'openVaultConfirmTransaction':
+              const network = networksById[context.chainId].name
+              const walletType = context.connectionKind
+
               tracker.confirmVaultConfirmTransaction(
                 event.value.ilk,
                 event.value.collateralAmount.toString(),
                 event.value.daiAmount.toString(),
                 firstCDP,
                 event.value.txHash,
+                network,
+                walletType,
               )
               break
             default:


### PR DESCRIPTION
# [Add network and wallet type for confirmTransaction mixpanel events](https://app.shortcut.com/oazo-apps/story/2351/mixpanel-story-add-firstcdp-network-and-wallettype-parameters-to-confirmtransaction-mixpanel-event)

## Changes 👷‍♀️
- add network and walletType params to `confirmTransaction` mixpanel's events
- bring back manage analytics
  
## How to test 🧪
- test in UI's console to see if proper data is sent for open and manage vaults

Open:
![open](https://user-images.githubusercontent.com/19193499/134178767-2298e88f-43d4-4ca3-8797-4dbb175a579d.png)

Manage:
![manage1](https://user-images.githubusercontent.com/19193499/134178800-7ad707c8-5545-4818-919d-9dbf9c36249c.png)

    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
