### PR TITLE
Add multiply confirm button and transaction events

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -1,4 +1,5 @@
 import { ConnectionKind } from '@oasisdex/web3-context'
+import { CloseVaultTo } from 'features/manageMultiplyVault/manageMultiplyVault'
 import * as mixpanelBrowser from 'mixpanel-browser'
 import getConfig from 'next/config'
 
@@ -26,6 +27,10 @@ export enum Pages {
   VaultsOverview = 'VaultsOverview',
   ManageCollateral = 'ManageCollateral',
   ManageDai = 'ManageDai',
+  OpenMultiply = 'OpenMultiply',
+  AdjustPosition = 'AdjustPosition',
+  OtherActions = 'OtherActions',
+  CloseVault = 'CloseVault',
 }
 
 export const trackingEvents = {
@@ -441,6 +446,149 @@ export const trackingEvents = {
       page: Pages.ManageDai,
       section: 'Payback',
     })
+  },
+
+  multiply: {
+    confirmOpenMultiplyConfirm: (
+      ilk: string,
+      firstCDP: boolean | undefined,
+      collAmount: string,
+      multiply: string,
+    ) => {
+      mixpanel.track('btn-click', {
+        id: 'Confirm',
+        product,
+        ilk,
+        firstCDP,
+        collAmount,
+        multiply,
+        page: Pages.OpenMultiply,
+        section: 'ConfirmVault',
+      })
+    },
+
+    confirmOpenMultiplyConfirmTransaction: (
+      ilk: string,
+      firstCDP: boolean | undefined,
+      collAmount: string,
+      multiply: string,
+      txHash: string,
+      network: string,
+      walletType: ConnectionKind,
+    ) => {
+      mixpanel.track('btn-click', {
+        id: 'ConfirmTransaction',
+        product,
+        ilk,
+        firstCDP,
+        collAmount,
+        multiply,
+        txHash,
+        network,
+        walletType,
+        page: Pages.OpenMultiply,
+        section: 'ConfirmVault',
+      })
+    },
+
+    adjustPositionConfirm: (ilk: string, multiply: string) => {
+      mixpanel.track('btn-click', {
+        id: 'Confirm',
+        product,
+        ilk,
+        multiply,
+        page: Pages.AdjustPosition,
+        section: 'ConfirmVault',
+      })
+    },
+
+    adjustPositionConfirmTransaction: (
+      ilk: string,
+      multiply: string,
+      txHash: string,
+      network: string,
+      walletType: ConnectionKind,
+    ) => {
+      mixpanel.track('btn-click', {
+        id: 'ConfirmTransaction',
+        product,
+        ilk,
+        multiply,
+        txHash,
+        network,
+        walletType,
+        page: Pages.AdjustPosition,
+        section: 'ConfirmVault',
+      })
+    },
+
+    otherActionsConfirm: (ilk: string, collateralAmount: string, daiAmount: string) => {
+      mixpanel.track('btn-click', {
+        id: 'Confirm',
+        product,
+        ilk,
+        collateralAmount,
+        daiAmount,
+        page: Pages.OtherActions,
+        section: 'ConfirmVault',
+      })
+    },
+
+    otherActionsConfirmTransaction: (
+      ilk: string,
+      collateralAmount: string,
+      daiAmount: string,
+      txHash: string,
+      network: string,
+      walletType: ConnectionKind,
+    ) => {
+      mixpanel.track('btn-click', {
+        id: 'ConfirmTransaction',
+        product,
+        ilk,
+        collateralAmount,
+        daiAmount,
+        txHash,
+        network,
+        walletType,
+        page: Pages.OtherActions,
+        section: 'ConfirmVault',
+      })
+    },
+
+    closeVaultConfirm: (ilk: string, debt: string, closeTo: CloseVaultTo) => {
+      mixpanel.track('btn-click', {
+        id: 'Confirm',
+        product,
+        ilk,
+        debt,
+        closeTo,
+        page: Pages.CloseVault,
+        section: 'ConfirmVault',
+      })
+    },
+
+    closeVaultConfirmTransaction: (
+      ilk: string,
+      debt: string,
+      closeTo: CloseVaultTo,
+      txHash: string,
+      network: string,
+      walletType: ConnectionKind,
+    ) => {
+      mixpanel.track('btn-click', {
+        id: 'ConfirmTransaction',
+        product,
+        ilk,
+        debt,
+        closeTo,
+        txHash,
+        network,
+        walletType,
+        page: Pages.CloseVault,
+        section: 'ConfirmVault',
+      })
+    },
   },
 }
 

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -415,6 +415,7 @@ export function setupAppContext() {
     landing$,
     openVault$,
     manageVault$,
+    manageMultiplyVault$,
     vaultsOverview$,
     vaultBanners$,
     redirectState$,

--- a/features/manageMultiplyVault/components/ManageMultiplyVaultView.tsx
+++ b/features/manageMultiplyVault/components/ManageMultiplyVaultView.tsx
@@ -1,3 +1,5 @@
+import { trackingEvents } from 'analytics/analytics'
+import { useAppContext } from 'components/AppContextProvider'
 import { VaultAllowanceStatus } from 'components/vault/VaultAllowance'
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
@@ -10,6 +12,7 @@ import React, { useEffect } from 'react'
 import { Box, Grid } from 'theme-ui'
 
 import { ManageMultiplyVaultState } from '../manageMultiplyVault'
+import { createManageMultiplyVaultAnalytics$ } from '../manageMultiplyVaultAnalytics'
 import { ManageMultiplyVaultButton } from './ManageMultiplyVaultButton'
 import { ManageMultiplyVaultCollateralAllowance } from './ManageMultiplyVaultCollateralAllowance'
 import {
@@ -83,6 +86,7 @@ export function ManageMultiplyVaultContainer({
   manageVault: ManageMultiplyVaultState
   vaultHistory: VaultHistoryEvent[]
 }) {
+  const { manageMultiplyVault$, context$ } = useAppContext()
   const {
     vault: { id, ilk },
     clear,
@@ -90,8 +94,15 @@ export function ManageMultiplyVaultContainer({
   const { t } = useTranslation()
 
   useEffect(() => {
+    const subscription = createManageMultiplyVaultAnalytics$(
+      manageMultiplyVault$(id),
+      context$,
+      trackingEvents,
+    ).subscribe()
+
     return () => {
       clear()
+      subscription.unsubscribe()
     }
   }, [])
 

--- a/features/manageMultiplyVault/manageMultiplyVaultAnalytics.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultAnalytics.ts
@@ -1,303 +1,246 @@
-import { INPUT_DEBOUNCE_TIME } from 'analytics/analytics'
+import { Tracker } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
+import { networksById } from 'blockchain/config'
+import { Context } from 'blockchain/network'
+import { zero } from 'helpers/zero'
 import { isEqual } from 'lodash'
-import { merge, Observable, zip } from 'rxjs'
-import { debounceTime, distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators'
+import { merge, Observable } from 'rxjs'
+import { distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators'
 
-import { ManageMultiplyVaultState } from './manageMultiplyVault'
+import { CloseVaultTo, ManageMultiplyVaultState } from './manageMultiplyVault'
 
-// type GenerateAmountChange = {
-//   kind: 'generateAmountChange'
-//   value: { amount: BigNumber; setMax: boolean }
-// }
-
-// type DepositAmountChange = {
-//   kind: 'depositAmountChange'
-//   value: { amount: BigNumber; setMax: boolean }
-// }
-
-// type PaybackAmountChange = {
-//   kind: 'paybackAmountChange'
-//   value: { amount: BigNumber; setMax: boolean }
-// }
-
-// type WithdrawAmountChange = {
-//   kind: 'withdrawAmountChange'
-//   value: { amount: BigNumber; setMax: boolean }
-// }
-
-type AllowanceChange = {
-  kind: 'collateralAllowanceChange' | 'daiAllowanceChange'
+type AdjustPositionConfirm = {
+  kind: 'adjustPositionConfirm'
   value: {
-    type:
-      | Pick<ManageMultiplyVaultState, 'selectedDaiAllowanceRadio'>
-      | Pick<ManageMultiplyVaultState, 'selectedCollateralAllowanceRadio'>
-    amount: BigNumber
+    ilk: string
+    multiply: BigNumber
   }
 }
 
-// type ManageVaultConfirm = {
-//   kind: 'manageVaultConfirm'
-//   value: {
-//     ilk: string
-//     collateralAmount: BigNumber
-//     daiAmount: BigNumber
-//   }
-// }
+type AdjustPositionConfirmTransaction = {
+  kind: 'adjustPositionConfirmTransaction'
+  value: {
+    ilk: string
+    multiply: BigNumber
+    txHash: string
+  }
+}
 
-// type ManageVaultConfirmTransaction = {
-//   kind: 'manageVaultConfirmTransaction'
-//   value: {
-//     ilk: string
-//     collateralAmount: BigNumber
-//     daiAmount: BigNumber
-//     txHash: string
-//   }
-// }
+type OtherActionsConfirm = {
+  kind: 'otherActionsConfirm'
+  value: {
+    ilk: string
+    collateralAmount: BigNumber
+    daiAmount: BigNumber
+  }
+}
 
-export function createManageVaultAnalytics$(
-  manageVaultState$: Observable<ManageMultiplyVaultState>,
-  // tracker: Tracker,
+type OtherActionsConfirmTransaction = {
+  kind: 'otherActionsConfirmTransaction'
+  value: {
+    ilk: string
+    collateralAmount: BigNumber
+    daiAmount: BigNumber
+    txHash: string
+  }
+}
+
+type CloseVaultConfirm = {
+  kind: 'closeVaultConfirm'
+  value: {
+    ilk: string
+    debt: BigNumber
+    closeTo: CloseVaultTo
+    txHash: string
+  }
+}
+
+type CloseVaultConfirmTransaction = {
+  kind: 'closeVaultConfirmTransaction'
+  value: {
+    ilk: string
+    debt: BigNumber
+    closeTo: CloseVaultTo
+    txHash: string
+  }
+}
+
+type ManageMultiplyConfirmTransaction =
+  | AdjustPositionConfirmTransaction
+  | OtherActionsConfirmTransaction
+  | CloseVaultConfirmTransaction
+
+type ManageMultiplyConfirm = AdjustPositionConfirm | OtherActionsConfirm | CloseVaultConfirm
+
+export function createManageMultiplyVaultAnalytics$(
+  manageMultiplyVaultState$: Observable<ManageMultiplyVaultState>,
+  context$: Observable<Context>,
+  tracker: Tracker,
 ) {
-  const stageChanges = manageVaultState$.pipe(
-    map((state) => state.stage),
-    filter((stage) => stage === 'otherActions' || stage === 'adjustPosition'),
-    distinctUntilChanged(isEqual),
-  )
-
-  // const depositAmountChanges: Observable<DepositAmountChange> = manageVaultState$.pipe(
-  //   map(({ depositAmount, maxDepositAmount }) => ({
-  //     amount: depositAmount,
-  //     setMax: depositAmount?.eq(maxDepositAmount),
-  //   })),
-  //   filter((value) => !!value.amount),
-  //   distinctUntilChanged(isEqual),
-  //   debounceTime(INPUT_DEBOUNCE_TIME),
-  //   map((value) => ({
-  //     kind: 'depositAmountChange',
-  //     value,
-  //   })),
-  // )
-
-  // const generateAmountChanges: Observable<GenerateAmountChange> = manageVaultState$.pipe(
-  //   map(({ generateAmount, maxGenerateAmount }) => ({
-  //     amount: generateAmount,
-  //     setMax: generateAmount?.eq(maxGenerateAmount),
-  //   })),
-  //   filter((value) => !!value.amount),
-  //   distinctUntilChanged(isEqual),
-  //   debounceTime(INPUT_DEBOUNCE_TIME),
-  //   map((value) => ({
-  //     kind: 'generateAmountChange',
-  //     value,
-  //   })),
-  // )
-
-  // const paybackAmountChanges: Observable<PaybackAmountChange> = manageVaultState$.pipe(
-  //   map(({ paybackAmount, maxPaybackAmount }) => ({
-  //     amount: paybackAmount,
-  //     setMax: paybackAmount?.eq(maxPaybackAmount),
-  //   })),
-  //   filter((value) => !!value.amount),
-  //   distinctUntilChanged(isEqual),
-  //   debounceTime(INPUT_DEBOUNCE_TIME),
-  //   map((value) => ({
-  //     kind: 'paybackAmountChange',
-  //     value,
-  //   })),
-  // )
-
-  // const withdrawAmountChanges: Observable<WithdrawAmountChange> = manageVaultState$.pipe(
-  //   map(({ withdrawAmount, maxWithdrawAmount }) => ({
-  //     amount: withdrawAmount,
-  //     setMax: withdrawAmount?.eq(maxWithdrawAmount),
-  //   })),
-  //   filter((value) => !!value.amount),
-  //   distinctUntilChanged(isEqual),
-  //   debounceTime(INPUT_DEBOUNCE_TIME),
-  //   map((value) => ({
-  //     kind: 'withdrawAmountChange',
-  //     value,
-  //   })),
-  // )
-
-  const collateralAllowanceTypeChanges: Observable<Pick<
-    ManageMultiplyVaultState,
-    'selectedCollateralAllowanceRadio'
-  >> = manageVaultState$.pipe(
-    filter((state) => state.stage === 'collateralAllowanceWaitingForConfirmation'),
-    map((state) => state.selectedCollateralAllowanceRadio),
-    distinctUntilChanged(isEqual),
-  )
-
-  const collateralAllowanceAmountChanges: Observable<BigNumber> = manageVaultState$.pipe(
-    map((state) => state.collateralAllowanceAmount),
-    filter((amount) => !!amount),
-    distinctUntilChanged(isEqual),
-    debounceTime(INPUT_DEBOUNCE_TIME),
-  )
-
-  const collateralAllowanceChanges: Observable<AllowanceChange> = zip(
-    collateralAllowanceTypeChanges,
-    collateralAllowanceAmountChanges,
-  ).pipe(
-    map(([type, amount]) => ({
-      kind: 'collateralAllowanceChange',
-      value: {
-        type,
-        amount,
+  const manageMultiplyConfirmTransaction: Observable<ManageMultiplyConfirmTransaction> = manageMultiplyVaultState$.pipe(
+    filter((state) => state.stage === 'manageInProgress'),
+    map(
+      ({
+        vault: { ilk, debt },
+        manageTxHash,
+        multiply,
+        afterMultiply,
+        originalEditingStage,
+        otherAction,
+        depositAmount,
+        withdrawAmount,
+        generateAmount,
+        paybackAmount,
+        closeVaultTo,
+      }) => {
+        if (originalEditingStage === 'adjustPosition') {
+          return {
+            kind: 'adjustPositionConfirmTransaction',
+            value: {
+              ilk,
+              multiply: afterMultiply.minus(multiply),
+              txHash: manageTxHash,
+            },
+          } as AdjustPositionConfirmTransaction
+        } else if (otherAction !== 'closeVault') {
+          return {
+            kind: 'otherActionsConfirmTransaction',
+            value: {
+              ilk,
+              collateralAmount:
+                depositAmount || (withdrawAmount ? withdrawAmount.times(new BigNumber(-1)) : zero),
+              daiAmount:
+                generateAmount || (paybackAmount ? paybackAmount.times(new BigNumber(-1)) : zero),
+              txHash: manageTxHash,
+            },
+          } as OtherActionsConfirmTransaction
+        } else {
+          return {
+            kind: 'closeVaultConfirmTransaction',
+            value: {
+              ilk,
+              debt,
+              closeTo: closeVaultTo,
+              txHash: manageTxHash,
+            },
+          } as CloseVaultConfirmTransaction
+        }
       },
-    })),
-  )
-
-  const daiAllowanceTypeChanges: Observable<Pick<
-    ManageMultiplyVaultState,
-    'selectedDaiAllowanceRadio'
-  >> = manageVaultState$.pipe(
-    filter((state) => state.stage === 'daiAllowanceWaitingForConfirmation'),
-    map((state) => state.selectedDaiAllowanceRadio),
+    ),
     distinctUntilChanged(isEqual),
   )
 
-  const daiAllowanceAmountChanges: Observable<BigNumber> = manageVaultState$.pipe(
-    map((state) => state.daiAllowanceAmount),
-    filter((amount) => !!amount),
-    distinctUntilChanged(isEqual),
-    debounceTime(INPUT_DEBOUNCE_TIME),
-  )
-
-  const daiAllowanceChanges: Observable<AllowanceChange> = zip(
-    daiAllowanceTypeChanges,
-    daiAllowanceAmountChanges,
-  ).pipe(
-    map(([type, amount]) => ({
-      kind: 'daiAllowanceChange',
-      value: {
-        type,
-        amount,
+  const manageMultiplyConfirm: Observable<ManageMultiplyConfirm> = manageMultiplyVaultState$.pipe(
+    filter((state) => state.stage === 'manageWaitingForApproval'),
+    map(
+      ({
+        vault: { ilk, debt },
+        multiply,
+        afterMultiply,
+        originalEditingStage,
+        otherAction,
+        depositAmount,
+        withdrawAmount,
+        generateAmount,
+        paybackAmount,
+        closeVaultTo,
+      }) => {
+        if (originalEditingStage === 'adjustPosition') {
+          return {
+            kind: 'adjustPositionConfirm',
+            value: {
+              ilk,
+              multiply: afterMultiply.minus(multiply),
+            },
+          } as AdjustPositionConfirm
+        } else if (otherAction !== 'closeVault') {
+          return {
+            kind: 'otherActionsConfirm',
+            value: {
+              ilk,
+              collateralAmount:
+                depositAmount || (withdrawAmount ? withdrawAmount.times(new BigNumber(-1)) : zero),
+              daiAmount:
+                generateAmount || (paybackAmount ? paybackAmount.times(new BigNumber(-1)) : zero),
+            },
+          } as OtherActionsConfirm
+        } else {
+          return {
+            kind: 'closeVaultConfirm',
+            value: {
+              ilk,
+              debt,
+              closeTo: closeVaultTo,
+            },
+          } as CloseVaultConfirm
+        }
       },
-    })),
+    ),
+    distinctUntilChanged(isEqual),
   )
 
-  // const manageVaultConfirm: Observable<ManageVaultConfirm> = manageVaultState$.pipe(
-  //   filter((state) => state.stage === 'manageWaitingForApproval'),
-  //   map(({ vault: { ilk }, depositAmount, withdrawAmount, generateAmount, paybackAmount }) => ({
-  //     kind: 'manageVaultConfirm',
-  //     value: {
-  //       ilk: ilk,
-  //       collateralAmount:
-  //         depositAmount || (withdrawAmount ? withdrawAmount.times(new BigNumber(-1)) : zero),
-  //       daiAmount:
-  //         generateAmount || (paybackAmount ? paybackAmount.times(new BigNumber(-1)) : zero),
-  //     },
-  //   })),
-  //   distinctUntilChanged(isEqual),
-  // )
+  return context$.pipe(
+    switchMap((context) =>
+      merge(merge(manageMultiplyConfirm, manageMultiplyConfirmTransaction)).pipe(
+        tap((event) => {
+          const network = networksById[context.chainId].name
+          const walletType = context.connectionKind
 
-  // const manageVaultConfirmTransaction: Observable<ManageVaultConfirmTransaction> = manageVaultState$.pipe(
-  //   filter((state) => state.stage === 'manageInProgress'),
-  //   map(
-  //     ({
-  //       vault: { ilk },
-  //       depositAmount,
-  //       withdrawAmount,
-  //       generateAmount,
-  //       paybackAmount,
-  //       manageTxHash,
-  //     }) => ({
-  //       kind: 'manageVaultConfirmTransaction',
-  //       value: {
-  //         ilk: ilk,
-  //         collateralAmount:
-  //           depositAmount || (withdrawAmount ? withdrawAmount.times(new BigNumber(-1)) : zero),
-  //         daiAmount:
-  //           generateAmount || (paybackAmount ? paybackAmount.times(new BigNumber(-1)) : zero),
-  //         txHash: manageTxHash,
-  //       },
-  //     }),
-  //   ),
-  //   distinctUntilChanged(isEqual),
-  // )
-
-  return stageChanges.pipe(
-    switchMap((_stage) =>
-      merge(
-        merge(
-          // depositAmountChanges,
-          // generateAmountChanges,
-          // paybackAmountChanges,
-          // withdrawAmountChanges,
-          collateralAllowanceChanges,
-          daiAllowanceChanges,
-        ),
-        // merge(manageVaultConfirm, manageVaultConfirmTransaction),
-      )
-        .pipe
-        // tap((event) => {
-        //   const page = stage === 'daiEditing' ? Pages.ManageDai : Pages.ManageCollateral
-        //   switch (event.kind) {
-        //     case 'depositAmountChange':
-        //       tracker.manageVaultDepositAmount(
-        //         page,
-        //         event.value.amount.toString(),
-        //         event.value.setMax,
-        //       )
-        //       break
-        //     case 'generateAmountChange':
-        //       tracker.manageVaultGenerateAmount(
-        //         page,
-        //         event.value.amount.toString(),
-        //         event.value.setMax,
-        //       )
-        //       break
-        //     case 'paybackAmountChange':
-        //       tracker.manageVaultPaybackAmount(
-        //         page,
-        //         event.value.amount.toString(),
-        //         event.value.setMax,
-        //       )
-        //       break
-        //     case 'withdrawAmountChange':
-        //       tracker.manageVaultWithdrawAmount(
-        //         page,
-        //         event.value.amount.toString(),
-        //         event.value.setMax,
-        //       )
-        //       break
-        //     case 'collateralAllowanceChange':
-        //       tracker.manageCollateralPickAllowance(
-        //         event.value.type.toString(),
-        //         event.value.amount.toString(),
-        //       )
-        //       break
-        //     case 'daiAllowanceChange':
-        //       tracker.manageDaiPickAllowance(
-        //         event.value.type.toString(),
-        //         event.value.amount.toString(),
-        //       )
-        //       break
-        //     case 'manageVaultConfirm':
-        //       tracker.manageVaultConfirm(
-        //         page,
-        //         event.value.ilk,
-        //         event.value.collateralAmount.toString(),
-        //         event.value.daiAmount.toString(),
-        //       )
-        //       break
-        //     case 'manageVaultConfirmTransaction':
-        //       tracker.manageVaultConfirmTransaction(
-        //         page,
-        //         event.value.ilk,
-        //         event.value.collateralAmount.toString(),
-        //         event.value.daiAmount.toString(),
-        //         event.value.txHash,
-        //       )
-        //       break
-        //     default:
-        //       throw new Error('Unhandled Scenario')
-        //   }
-        // }),
-        (),
+          switch (event.kind) {
+            case 'adjustPositionConfirm':
+              tracker.multiply.adjustPositionConfirm(
+                event.value.ilk,
+                event.value.multiply.toString(),
+              )
+              break
+            case 'adjustPositionConfirmTransaction':
+              tracker.multiply.adjustPositionConfirmTransaction(
+                event.value.ilk,
+                event.value.multiply.toString(),
+                event.value.txHash,
+                network,
+                walletType,
+              )
+              break
+            case 'otherActionsConfirm':
+              tracker.multiply.otherActionsConfirm(
+                event.value.ilk,
+                event.value.collateralAmount.toString(),
+                event.value.daiAmount.toString(),
+              )
+              break
+            case 'otherActionsConfirmTransaction':
+              tracker.multiply.otherActionsConfirmTransaction(
+                event.value.ilk,
+                event.value.collateralAmount.toString(),
+                event.value.daiAmount.toString(),
+                event.value.txHash,
+                network,
+                walletType,
+              )
+              break
+            case 'closeVaultConfirm':
+              tracker.multiply.closeVaultConfirm(
+                event.value.ilk,
+                event.value.debt.toString(),
+                event.value.closeTo,
+              )
+              break
+            case 'closeVaultConfirmTransaction':
+              tracker.multiply.closeVaultConfirmTransaction(
+                event.value.ilk,
+                event.value.debt.toString(),
+                event.value.closeTo,
+                event.value.txHash,
+                network,
+                walletType,
+              )
+              break
+            default:
+              throw new Error('Unhandled Scenario')
+          }
+        }),
+      ),
     ),
   )
 }

--- a/features/manageMultiplyVault/manageMultiplyVaultAnalytics.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultAnalytics.ts
@@ -190,13 +190,13 @@ export function createManageMultiplyVaultAnalytics$(
             case 'adjustPositionConfirm':
               tracker.multiply.adjustPositionConfirm(
                 event.value.ilk,
-                event.value.multiply.toString(),
+                event.value.multiply.toFixed(3),
               )
               break
             case 'adjustPositionConfirmTransaction':
               tracker.multiply.adjustPositionConfirmTransaction(
                 event.value.ilk,
-                event.value.multiply.toString(),
+                event.value.multiply.toFixed(3),
                 event.value.txHash,
                 network,
                 walletType,
@@ -222,14 +222,14 @@ export function createManageMultiplyVaultAnalytics$(
             case 'closeVaultConfirm':
               tracker.multiply.closeVaultConfirm(
                 event.value.ilk,
-                event.value.debt.toString(),
+                event.value.debt.toFixed(3),
                 event.value.closeTo,
               )
               break
             case 'closeVaultConfirmTransaction':
               tracker.multiply.closeVaultConfirmTransaction(
                 event.value.ilk,
-                event.value.debt.toString(),
+                event.value.debt.toFixed(3),
                 event.value.closeTo,
                 event.value.txHash,
                 network,

--- a/features/manageMultiplyVault/manageMultiplyVaultAnalytics.ts
+++ b/features/manageMultiplyVault/manageMultiplyVaultAnalytics.ts
@@ -13,7 +13,7 @@ type AdjustPositionConfirm = {
   kind: 'adjustPositionConfirm'
   value: {
     ilk: string
-    multiply: BigNumber
+    multiply: string
   }
 }
 
@@ -21,7 +21,7 @@ type AdjustPositionConfirmTransaction = {
   kind: 'adjustPositionConfirmTransaction'
   value: {
     ilk: string
-    multiply: BigNumber
+    multiply: string
     txHash: string
   }
 }
@@ -49,7 +49,7 @@ type CloseVaultConfirm = {
   kind: 'closeVaultConfirm'
   value: {
     ilk: string
-    debt: BigNumber
+    debt: string
     closeTo: CloseVaultTo
     txHash: string
   }
@@ -59,7 +59,7 @@ type CloseVaultConfirmTransaction = {
   kind: 'closeVaultConfirmTransaction'
   value: {
     ilk: string
-    debt: BigNumber
+    debt: string
     closeTo: CloseVaultTo
     txHash: string
   }
@@ -98,7 +98,7 @@ export function createManageMultiplyVaultAnalytics$(
             kind: 'adjustPositionConfirmTransaction',
             value: {
               ilk,
-              multiply: afterMultiply.minus(multiply),
+              multiply: afterMultiply.minus(multiply).toFixed(3),
               txHash: manageTxHash,
             },
           } as AdjustPositionConfirmTransaction
@@ -119,7 +119,7 @@ export function createManageMultiplyVaultAnalytics$(
             kind: 'closeVaultConfirmTransaction',
             value: {
               ilk,
-              debt,
+              debt: debt.toFixed(3),
               closeTo: closeVaultTo,
               txHash: manageTxHash,
             },
@@ -150,7 +150,7 @@ export function createManageMultiplyVaultAnalytics$(
             kind: 'adjustPositionConfirm',
             value: {
               ilk,
-              multiply: afterMultiply.minus(multiply),
+              multiply: afterMultiply.minus(multiply).toFixed(3),
             },
           } as AdjustPositionConfirm
         } else if (otherAction !== 'closeVault') {
@@ -169,7 +169,7 @@ export function createManageMultiplyVaultAnalytics$(
             kind: 'closeVaultConfirm',
             value: {
               ilk,
-              debt,
+              debt: debt.toFixed(3),
               closeTo: closeVaultTo,
             },
           } as CloseVaultConfirm
@@ -188,15 +188,12 @@ export function createManageMultiplyVaultAnalytics$(
 
           switch (event.kind) {
             case 'adjustPositionConfirm':
-              tracker.multiply.adjustPositionConfirm(
-                event.value.ilk,
-                event.value.multiply.toFixed(3),
-              )
+              tracker.multiply.adjustPositionConfirm(event.value.ilk, event.value.multiply)
               break
             case 'adjustPositionConfirmTransaction':
               tracker.multiply.adjustPositionConfirmTransaction(
                 event.value.ilk,
-                event.value.multiply.toFixed(3),
+                event.value.multiply,
                 event.value.txHash,
                 network,
                 walletType,
@@ -222,14 +219,14 @@ export function createManageMultiplyVaultAnalytics$(
             case 'closeVaultConfirm':
               tracker.multiply.closeVaultConfirm(
                 event.value.ilk,
-                event.value.debt.toFixed(3),
+                event.value.debt,
                 event.value.closeTo,
               )
               break
             case 'closeVaultConfirmTransaction':
               tracker.multiply.closeVaultConfirmTransaction(
                 event.value.ilk,
-                event.value.debt.toFixed(3),
+                event.value.debt,
                 event.value.closeTo,
                 event.value.txHash,
                 network,

--- a/features/openMultiplyVault/components/OpenMultiplyVaultView.tsx
+++ b/features/openMultiplyVault/components/OpenMultiplyVaultView.tsx
@@ -118,7 +118,7 @@ export function OpenMultiplyVaultContainer(props: OpenMultiplyVaultState) {
 }
 
 export function OpenMultiplyVaultView({ ilk }: { ilk: string }) {
-  const { openMultiplyVault$, accountData$ } = useAppContext()
+  const { openMultiplyVault$, accountData$, context$ } = useAppContext()
   const multiplyVaultWithIlk$ = openMultiplyVault$(ilk)
 
   const openVaultWithError = useObservableWithError(openMultiplyVault$(ilk))
@@ -127,6 +127,7 @@ export function OpenMultiplyVaultView({ ilk }: { ilk: string }) {
     const subscription = createOpenMultiplyVaultAnalytics$(
       accountData$,
       multiplyVaultWithIlk$,
+      context$,
       trackingEvents,
     ).subscribe()
 

--- a/features/openMultiplyVault/openMultiplyVaultAnalytics.ts
+++ b/features/openMultiplyVault/openMultiplyVaultAnalytics.ts
@@ -1,8 +1,10 @@
 import { INPUT_DEBOUNCE_TIME, Tracker } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
+import { networksById } from 'blockchain/config'
+import { Context } from 'blockchain/network'
 import { AccountDetails } from 'features/account/AccountData'
 import { isEqual } from 'lodash'
-import { merge, Observable, zip } from 'rxjs'
+import { combineLatest, merge, Observable, zip } from 'rxjs'
 import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators'
 
 import { MutableOpenMultiplyVaultState, OpenMultiplyVaultState } from './openMultiplyVault'
@@ -20,9 +22,29 @@ type AllowanceChange = {
   }
 }
 
+type OpenMultiplyVaultConfirm = {
+  kind: 'openMultiplyVaultConfirm'
+  value: {
+    ilk: string
+    collateralAmount: BigNumber
+    multiply: BigNumber
+  }
+}
+
+type OpenMultiplyVaultConfirmTransaction = {
+  kind: 'openMultiplyVaultConfirmTransaction'
+  value: {
+    ilk: string
+    collateralAmount: BigNumber
+    multiply: BigNumber
+    txHash: string
+  }
+}
+
 export function createOpenMultiplyVaultAnalytics$(
   accountDetails$: Observable<AccountDetails>,
   openVaultState$: Observable<OpenMultiplyVaultState>,
+  context$: Observable<Context>,
   tracker: Tracker,
 ) {
   const firstCDPChange: Observable<boolean | undefined> = accountDetails$.pipe(
@@ -31,6 +53,7 @@ export function createOpenMultiplyVaultAnalytics$(
   )
 
   const depositAmountChanges: Observable<DepositAmountChange> = openVaultState$.pipe(
+    filter((state) => state.stage === 'editing'),
     map((state) => state.depositAmount),
     filter((amount) => !!amount),
     distinctUntilChanged(isEqual),
@@ -69,9 +92,41 @@ export function createOpenMultiplyVaultAnalytics$(
     })),
   )
 
-  return firstCDPChange.pipe(
-    switchMap((firstCDP) =>
-      merge(depositAmountChanges, allowanceChanges).pipe(
+  const openMultiplyVaultConfirm: Observable<OpenMultiplyVaultConfirm> = openVaultState$.pipe(
+    filter((state) => state.stage === 'openWaitingForApproval'),
+    map(({ ilk, depositAmount, multiply }) => ({
+      kind: 'openMultiplyVaultConfirm',
+      value: {
+        ilk: ilk,
+        collateralAmount: depositAmount,
+        multiply,
+      },
+    })),
+    distinctUntilChanged(isEqual),
+  )
+
+  const openMultiplyVaultConfirmTransaction: Observable<OpenMultiplyVaultConfirmTransaction> = openVaultState$.pipe(
+    filter((state) => state.stage === 'openInProgress'),
+    map(({ ilk, depositAmount, openTxHash, multiply }) => ({
+      kind: 'openMultiplyVaultConfirmTransaction',
+      value: {
+        ilk: ilk,
+        collateralAmount: depositAmount,
+        multiply,
+        txHash: openTxHash,
+      },
+    })),
+    distinctUntilChanged(isEqual),
+  )
+
+  return combineLatest(context$, firstCDPChange).pipe(
+    switchMap(([context, firstCDP]) =>
+      merge(
+        depositAmountChanges,
+        allowanceChanges,
+        openMultiplyVaultConfirm,
+        openMultiplyVaultConfirmTransaction,
+      ).pipe(
         tap((event) => {
           switch (event.kind) {
             case 'depositAmountChange':
@@ -82,6 +137,28 @@ export function createOpenMultiplyVaultAnalytics$(
                 firstCDP,
                 event.value.type.toString(),
                 event.value.amount.toString(),
+              )
+              break
+            case 'openMultiplyVaultConfirm':
+              tracker.multiply.confirmOpenMultiplyConfirm(
+                event.value.ilk,
+                firstCDP,
+                event.value.collateralAmount.toString(),
+                event.value.multiply.toString(),
+              )
+              break
+            case 'openMultiplyVaultConfirmTransaction':
+              const network = networksById[context.chainId].name
+              const walletType = context.connectionKind
+
+              tracker.multiply.confirmOpenMultiplyConfirmTransaction(
+                event.value.ilk,
+                firstCDP,
+                event.value.collateralAmount.toString(),
+                event.value.multiply.toString(),
+                event.value.txHash,
+                network,
+                walletType,
               )
               break
             default:

--- a/features/openMultiplyVault/openMultiplyVaultAnalytics.ts
+++ b/features/openMultiplyVault/openMultiplyVaultAnalytics.ts
@@ -144,7 +144,7 @@ export function createOpenMultiplyVaultAnalytics$(
                 event.value.ilk,
                 firstCDP,
                 event.value.collateralAmount.toString(),
-                event.value.multiply.toString(),
+                event.value.multiply.toFixed(3),
               )
               break
             case 'openMultiplyVaultConfirmTransaction':
@@ -155,7 +155,7 @@ export function createOpenMultiplyVaultAnalytics$(
                 event.value.ilk,
                 firstCDP,
                 event.value.collateralAmount.toString(),
-                event.value.multiply.toString(),
+                event.value.multiply.toFixed(3),
                 event.value.txHash,
                 network,
                 walletType,

--- a/features/openMultiplyVault/openMultiplyVaultAnalytics.ts
+++ b/features/openMultiplyVault/openMultiplyVaultAnalytics.ts
@@ -99,7 +99,9 @@ export function createOpenMultiplyVaultAnalytics$(
       value: {
         ilk: ilk,
         collateralAmount: depositAmount,
-        multiply,
+        // slight movements on market price are causing change of multiply
+        // to counter that we round passed multiply to not have retriggered events
+        multiply: multiply?.toFixed(3),
       },
     })),
     distinctUntilChanged(isEqual),
@@ -112,7 +114,7 @@ export function createOpenMultiplyVaultAnalytics$(
       value: {
         ilk: ilk,
         collateralAmount: depositAmount,
-        multiply,
+        multiply: multiply?.toFixed(3),
         txHash: openTxHash,
       },
     })),
@@ -144,7 +146,7 @@ export function createOpenMultiplyVaultAnalytics$(
                 event.value.ilk,
                 firstCDP,
                 event.value.collateralAmount.toString(),
-                event.value.multiply.toFixed(3),
+                event.value.multiply.toString(),
               )
               break
             case 'openMultiplyVaultConfirmTransaction':
@@ -155,7 +157,7 @@ export function createOpenMultiplyVaultAnalytics$(
                 event.value.ilk,
                 firstCDP,
                 event.value.collateralAmount.toString(),
-                event.value.multiply.toFixed(3),
+                event.value.multiply.toString(),
                 event.value.txHash,
                 network,
                 walletType,


### PR DESCRIPTION
# [Multiply Vault Mixpanel events](https://app.shortcut.com/oazo-apps/story/2320/add-mixpanel-confirmtransaction-events-to-multiply-flows)

Spreadsheet with agreed events:
https://docs.google.com/spreadsheets/d/1Jie1SX_5i4-jDZLMKnCUkq4lhchkPKonIOVPNNJtsA8/edit#gid=149360134
  
## Changes 👷‍♀️
- add events to track confirm and confirm transaction for opening and managing multiply vault
- toFixed(3) for `multiply` and `debt` are used to prevent resending multiple events if user eg left browser open for longer time. Those values are dynamic, small fluctuations of marketPrice or calling `drip` by someone were causing small differences at 5+ decimal places on those 2 values and events were resent as `distincUntilChange(isEqual)` wasn't applied due to those differences
  
## How to test 🧪
- test in UI (hardhat) opening and managing multiply vault and see events in console on confirm button click and confirm tx in wallet

eg:
on confirm button click on Confirm screen:
![image](https://user-images.githubusercontent.com/19193499/134347740-b9601a24-f720-4546-8dea-93ee40df644c.png)

on confirming transaction:
![image](https://user-images.githubusercontent.com/19193499/134347585-7f84f9fa-7bf1-4572-ac99-e093a21a614e.png)

 
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
