### PR TITLE
Increase type safety 

### DIFF
--- a/features/exchange/exchange.ts
+++ b/features/exchange/exchange.ts
@@ -47,7 +47,7 @@ type TokenMetadata = {
 }
 
 export type QuoteResult = {
-  status: string
+  status: 'SUCCESS'
   fromTokenAddress: string
   toTokenAddress: string
   collateralAmount: BigNumber
@@ -76,7 +76,7 @@ export function getQuote$(
   amount: BigNumber, // This is always the receiveAtLeast amount of tokens we want to exchange from
   slippage: BigNumber,
   action: ExchangeAction,
-): Observable<QuoteResult> {
+) {
   const fromTokenAddress = action === 'BUY_COLLATERAL' ? dai.address : collateral.address
   const toTokenAddress = action === 'BUY_COLLATERAL' ? collateral.address : dai.address
 
@@ -155,7 +155,7 @@ export function getQuote$(
       }
     }),
     retry(3),
-    catchError(() => of({ status: 'ERROR' } as QuoteResult)),
+    catchError(() => of({ status: 'ERROR' } as const)),
   )
 }
 


### PR DESCRIPTION
# Increase type safety

Before change it is possible to check whether the quote is defined and Typescript will allow us to read all properties even though they might be not there, e.g. in case of error
![image](https://user-images.githubusercontent.com/15217169/135824742-141d8ceb-227c-43b2-8a46-f124aedd4597.png)

After the fix developer needs to check also the status of the quote in order to read it. 
![image](https://user-images.githubusercontent.com/15217169/135824644-8a8a46aa-deb9-43e2-9150-4131bf076bf6.png)
