### PR TITLE
saving guni as multiply vault

### DIFF
--- a/features/manageVault/ManageVaultFormHeader.tsx
+++ b/features/manageVault/ManageVaultFormHeader.tsx
@@ -43,8 +43,6 @@ function ManageVaultEditingController({
       trackingEvents.switchToCollateral(accountIsController)
     }
   }
-  // TODO REMOVE IT AS SOON AS MANAGE FOR GUNI WILL BE READY
-  const multiplyDisabled = token === 'GUNIV3DAIUSDC1'
 
   return (
     <Grid gap={4}>
@@ -55,15 +53,9 @@ function ManageVaultEditingController({
         <Button onClick={() => handleToggle('daiEditing')} variant={daiVariant}>
           {t('system.dai')}
         </Button>
-        {/* TODO REMOVE IT AS SOON AS MANAGE FOR GUNI WILL BE READY */}
-        {!multiplyDisabled && (
-          <Button
-            onClick={() => handleToggle('multiplyTransitionEditing')}
-            variant={multiplyVariant}
-          >
-            Multiply
-          </Button>
-        )}
+        <Button onClick={() => handleToggle('multiplyTransitionEditing')} variant={multiplyVariant}>
+          Multiply
+        </Button>
       </Grid>
       {isEditingStage && (
         <WithVaultFormStepIndicator {...{ totalSteps, currentStep }}>

--- a/features/openGuniVault/guniActionsCalls.ts
+++ b/features/openGuniVault/guniActionsCalls.ts
@@ -14,6 +14,10 @@ import { catchError, startWith } from 'rxjs/operators'
 import { DssGuniProxyActions as GuniProxyActions } from 'types/ethers-contracts/DssGuniProxyActions'
 import { GuniToken } from 'types/ethers-contracts/GuniToken'
 
+import { VaultType } from '../generalManageVault/generalManageVault'
+import { saveVaultUsingApi$ } from '../shared/vaultApi'
+import { jwtAuthGetToken } from '../termsOfService/jwt'
+
 type TxChange =
   | { kind: 'txWaitingForApproval' }
   | {
@@ -142,16 +146,15 @@ export function openGuniVault<S extends TxStateDependencies>(
             txState.status === TxStatus.Success && txState.receipt,
           )
 
-          // TODO: save in db that vault is multiply
-          // const jwtToken = jwtAuthGetToken(account as string)
-          // if (id && jwtToken) {
-          //   saveVaultUsingApi$(
-          //     id,
-          //     jwtToken,
-          //     VaultType.Multiply,
-          //     parseInt(txState.networkId),
-          //   ).subscribe()
-          // }
+          const jwtToken = jwtAuthGetToken(account as string)
+          if (id && jwtToken) {
+            saveVaultUsingApi$(
+              id,
+              jwtToken,
+              VaultType.Multiply,
+              parseInt(txState.networkId),
+            ).subscribe()
+          }
 
           return of({
             kind: 'txSuccess',


### PR DESCRIPTION
# [Saving GUNI as multiply vault](https://app.shortcut.com/oazo-apps/story/3098/set-guni-to-multiply-type-when-opening-guni-add-migration-scripts-for-all-mainnet-guni-vaults-to-set-to-multiply)

<please insert a clubhouse link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- GUNI vault is saved as multiple vault
- removed condition that causes that multiple button is not visible for guni in manage vault
  
## How to test 🧪
  <Please explain how to test your changes>
- test using hardhat
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
