### PR TITLE
Release v2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oasis-borrow",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "Apache-2.0",
   "scripts": {
     "start": "ts-node --project ./tsconfig.dev.json -r tsconfig-paths/register -r dotenv-flow/config ./server/server.ts",


### PR DESCRIPTION
## Changes 👷‍♀️
- vault card details blurred by default - unblur when entering deposit amount
  
## How to test 🧪
- For all GUNI, Borrow, Multiply check that the cards values unblur after a value is entered into the deposit amount.