### PR TITLE
Increase calculation buffer for Guni

### DIFF
--- a/features/openGuniVault/openGuniVault.ts
+++ b/features/openGuniVault/openGuniVault.ts
@@ -220,7 +220,7 @@ function applyCalculations<S extends { ilkData: IlkData; depositAmount?: BigNumb
 ): S & GuniCalculations {
   // TODO: missing fees
   const leveragedAmount = state.depositAmount
-    ? state.depositAmount.div(state.ilkData.liquidationRatio.minus(one).plus(0.001))
+    ? state.depositAmount.div(state.ilkData.liquidationRatio.minus(one).plus(0.002))
     : zero
   const flAmount = state.depositAmount ? leveragedAmount.minus(state.depositAmount) : zero
 


### PR DESCRIPTION
Due to the failing open Guni vault transactions buffer is increased from `0.001` to `0.002`