### PR TITLE
Form switch

### DIFF
--- a/components/vault/DefaultVaultLayout.tsx
+++ b/components/vault/DefaultVaultLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Grid } from 'theme-ui'
+import { Card, Grid } from 'theme-ui'
 
 export function DefaultVaultLayout({
   detailsViewControl,
@@ -20,7 +20,16 @@ export function DefaultVaultLayout({
           {detailsViewControl}
           {listControl}
         </Grid>
-        <Box>{editForm}</Box>
+        <Card
+          sx={{
+            borderRadius: 'large',
+            border: 'lightMuted',
+            boxShadow: 'vaultDetailsCard',
+            padding: '24px',
+          }}
+        >
+          {editForm}
+        </Card>
       </Grid>
     </>
   )

--- a/features/automation/common/enums/TriggersTypes.ts
+++ b/features/automation/common/enums/TriggersTypes.ts
@@ -2,3 +2,8 @@ export enum TriggersTypes {
   StopLossToCollateral = 1,
   StopLossToDai = 2,
 }
+
+export enum AutomationFromKind {
+  ADJUST,
+  CANCEL,
+}

--- a/features/automation/controls/AdjustSlFormControl.tsx
+++ b/features/automation/controls/AdjustSlFormControl.tsx
@@ -270,8 +270,15 @@ export function AdjustSlFormControl({ id }: { id: BigNumber }) {
         ]}
         customLoader={<VaultContainerSpinner />}
       >
-        {([v, c, i, s, tx, ctx]) => {
-          return renderLayout(v, c, i, extractSLData(s), tx, ctx.account !== v.controller)
+        {([vault, collateralPrice, ilksData, triggerData, tx, ctx]) => {
+          return renderLayout(
+            vault,
+            collateralPrice,
+            ilksData,
+            extractSLData(triggerData),
+            tx,
+            ctx.account !== vault.controller,
+          )
         }}
       </WithLoadingIndicator>
     </WithErrorHandler>

--- a/features/automation/controls/AdjustSlFormControl.tsx
+++ b/features/automation/controls/AdjustSlFormControl.tsx
@@ -270,8 +270,8 @@ export function AdjustSlFormControl({ id }: { id: BigNumber }) {
         ]}
         customLoader={<VaultContainerSpinner />}
       >
-        {([vault, collateralPrice, ilksData, triggerData, tx, ctx]) => {
-          return renderLayout(
+        {([vault, collateralPrice, ilksData, triggerData, tx, ctx]) =>
+          renderLayout(
             vault,
             collateralPrice,
             ilksData,
@@ -279,7 +279,7 @@ export function AdjustSlFormControl({ id }: { id: BigNumber }) {
             tx,
             ctx.account !== vault.controller,
           )
-        }}
+        }
       </WithLoadingIndicator>
     </WithErrorHandler>
   )

--- a/features/automation/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/controls/AdjustSlFormLayout.tsx
@@ -1,5 +1,5 @@
 import { TxState } from '@oasisdex/transactions'
-import { Box,  Grid } from '@theme-ui/components'
+import { Box, Grid } from '@theme-ui/components'
 import { AutomationBotAddTriggerData } from 'blockchain/calls/automationBot'
 import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseState'
 import { SliderValuePicker, SliderValuePickerProps } from 'components/dumb/SliderValuePicker'

--- a/features/automation/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/controls/AdjustSlFormLayout.tsx
@@ -20,28 +20,19 @@ export interface AdjustSlFormLayoutProps {
 
 export function AdjustSlFormLayout(props: AdjustSlFormLayoutProps) {
   return (
-    <Card
-      sx={{
-        borderRadius: 'large',
-        border: 'lightMuted',
-        boxShadow: 'vaultDetailsCard',
-        padding: '24px',
-      }}
-    >
-      <Grid columns={[1]}>
-        <Box>
-          <SliderValuePicker {...props.slValuePickerConfig} />
-        </Box>
-        <Box>
-          <PickCloseState {...props.closePickerConfig} />
-        </Box>
-        <Box>
-          <TxStatusSection txState={props.txState} />
-        </Box>
-        <Box>
-          <RetryableLoadingButton {...props.addTriggerConfig} />
-        </Box>
-      </Grid>
-    </Card>
+    <Grid columns={[1]}>
+      <Box>
+        <SliderValuePicker {...props.slValuePickerConfig} />
+      </Box>
+      <Box>
+        <PickCloseState {...props.closePickerConfig} />
+      </Box>
+      <Box>
+        <TxStatusSection txState={props.txState} />
+      </Box>
+      <Box>
+        <RetryableLoadingButton {...props.addTriggerConfig} />
+      </Box>
+    </Grid>
   )
 }

--- a/features/automation/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/controls/AdjustSlFormLayout.tsx
@@ -1,5 +1,5 @@
 import { TxState } from '@oasisdex/transactions'
-import { Box, Card, Grid } from '@theme-ui/components'
+import { Box,  Grid } from '@theme-ui/components'
 import { AutomationBotAddTriggerData } from 'blockchain/calls/automationBot'
 import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseState'
 import { SliderValuePicker, SliderValuePickerProps } from 'components/dumb/SliderValuePicker'

--- a/features/automation/controls/ProtectionFormControl.tsx
+++ b/features/automation/controls/ProtectionFormControl.tsx
@@ -8,21 +8,23 @@ interface Props {
   cancelForm: JSX.Element
 }
 
-export enum Forms {
+export enum ProtectionForms {
   ADJUST,
   CANCEL,
 }
 
 export function ProtectionFormControl({ adjustForm, cancelForm }: Props) {
-  const [currentForm, setForm] = useState(Forms.ADJUST)
+  const [currentForm, setForm] = useState(ProtectionForms.ADJUST)
 
   const toggleForms = useCallback(() => {
-    setForm(currentForm === Forms.ADJUST ? Forms.CANCEL : Forms.ADJUST)
+    setForm((prevState) =>
+      prevState === ProtectionForms.ADJUST ? ProtectionForms.CANCEL : ProtectionForms.ADJUST,
+    )
   }, [currentForm])
 
   return (
     <ProtectionFormLayout currentForm={currentForm} toggleForm={toggleForms}>
-      {currentForm === Forms.ADJUST ? adjustForm : cancelForm}
+      {currentForm === ProtectionForms.ADJUST ? adjustForm : cancelForm}
     </ProtectionFormLayout>
   )
 }

--- a/features/automation/controls/ProtectionFormControl.tsx
+++ b/features/automation/controls/ProtectionFormControl.tsx
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react'
+import React from 'react'
+import { ProtectionFormLayout } from './ProtectionFormLayout'
+
+interface Props {
+  adjustForm: JSX.Element
+  cancelForm: JSX.Element
+}
+
+export enum Forms {
+  ADJUST,
+  CANCEL,
+}
+
+export function ProtectionFormControl({ adjustForm, cancelForm }: Props) {
+  const [currentForm, setForm] = useState(Forms.ADJUST)
+
+  const toggleForms = useCallback(() => {
+    setForm(currentForm === Forms.ADJUST ? Forms.CANCEL : Forms.ADJUST)
+  }, [currentForm])
+
+  return (
+    <ProtectionFormLayout currentForm={currentForm} toggleForm={toggleForms}>
+      {currentForm === Forms.ADJUST ? adjustForm : cancelForm}
+    </ProtectionFormLayout>
+  )
+}

--- a/features/automation/controls/ProtectionFormControl.tsx
+++ b/features/automation/controls/ProtectionFormControl.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import React from 'react'
+
 import { ProtectionFormLayout } from './ProtectionFormLayout'
 
 interface Props {

--- a/features/automation/controls/ProtectionFormControl.tsx
+++ b/features/automation/controls/ProtectionFormControl.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import React from 'react'
 
+import { AutomationFromKind } from '../common/enums/TriggersTypes'
 import { ProtectionFormLayout } from './ProtectionFormLayout'
 
 interface Props {
@@ -8,23 +9,20 @@ interface Props {
   cancelForm: JSX.Element
 }
 
-export enum ProtectionForms {
-  ADJUST,
-  CANCEL,
-}
-
 export function ProtectionFormControl({ adjustForm, cancelForm }: Props) {
-  const [currentForm, setForm] = useState(ProtectionForms.ADJUST)
+  const [currentForm, setForm] = useState(AutomationFromKind.ADJUST)
 
   const toggleForms = useCallback(() => {
     setForm((prevState) =>
-      prevState === ProtectionForms.ADJUST ? ProtectionForms.CANCEL : ProtectionForms.ADJUST,
+      prevState === AutomationFromKind.ADJUST
+        ? AutomationFromKind.CANCEL
+        : AutomationFromKind.ADJUST,
     )
   }, [currentForm])
 
   return (
     <ProtectionFormLayout currentForm={currentForm} toggleForm={toggleForms}>
-      {currentForm === ProtectionForms.ADJUST ? adjustForm : cancelForm}
+      {currentForm === AutomationFromKind.ADJUST ? adjustForm : cancelForm}
     </ProtectionFormLayout>
   )
 }

--- a/features/automation/controls/ProtectionFormLayout.tsx
+++ b/features/automation/controls/ProtectionFormLayout.tsx
@@ -1,0 +1,27 @@
+import { Button, Divider, Grid } from '@theme-ui/components'
+import React from 'react'
+import { useTranslation } from 'react-i18next/*'
+import { Forms } from './ProtectionFormControl'
+
+export function ProtectionFormLayout({
+  toggleForm,
+  currentForm,
+  children,
+}: React.PropsWithChildren<{ toggleForm: () => void; currentForm: Forms }>) {
+  const { t } = useTranslation()
+
+  return (
+    <Grid columns={1}>
+      {children}
+      <Divider
+        sx={{ width: 'calc(100% + 48px)', left: '-24px' }}
+        variant="styles.hrVaultFormBottom"
+      />
+      <Button sx={{ mt: 3 }} variant="textualSmall" onClick={toggleForm}>
+        {currentForm === Forms.ADJUST
+          ? t('protection.navigate-cancel')
+          : t('protection.navigate-adjust')}
+      </Button>
+    </Grid>
+  )
+}

--- a/features/automation/controls/ProtectionFormLayout.tsx
+++ b/features/automation/controls/ProtectionFormLayout.tsx
@@ -2,13 +2,13 @@ import { Button, Divider, Grid } from '@theme-ui/components'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ProtectionForms } from './ProtectionFormControl'
+import { AutomationFromKind } from '../common/enums/TriggersTypes'
 
 export function ProtectionFormLayout({
   toggleForm,
   currentForm,
   children,
-}: React.PropsWithChildren<{ toggleForm: () => void; currentForm: ProtectionForms }>) {
+}: React.PropsWithChildren<{ toggleForm: () => void; currentForm: AutomationFromKind }>) {
   const { t } = useTranslation()
 
   return (
@@ -19,7 +19,7 @@ export function ProtectionFormLayout({
         variant="styles.hrVaultFormBottom"
       />
       <Button sx={{ mt: 3 }} variant="textualSmall" onClick={toggleForm}>
-        {currentForm === ProtectionForms.ADJUST
+        {currentForm === AutomationFromKind.ADJUST
           ? t('protection.navigate-cancel')
           : t('protection.navigate-adjust')}
       </Button>

--- a/features/automation/controls/ProtectionFormLayout.tsx
+++ b/features/automation/controls/ProtectionFormLayout.tsx
@@ -1,6 +1,7 @@
 import { Button, Divider, Grid } from '@theme-ui/components'
 import React from 'react'
-import { useTranslation } from 'react-i18next/*'
+import { useTranslation } from 'react-i18next'
+
 import { Forms } from './ProtectionFormControl'
 
 export function ProtectionFormLayout({

--- a/features/automation/controls/ProtectionFormLayout.tsx
+++ b/features/automation/controls/ProtectionFormLayout.tsx
@@ -2,13 +2,13 @@ import { Button, Divider, Grid } from '@theme-ui/components'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Forms } from './ProtectionFormControl'
+import { ProtectionForms } from './ProtectionFormControl'
 
 export function ProtectionFormLayout({
   toggleForm,
   currentForm,
   children,
-}: React.PropsWithChildren<{ toggleForm: () => void; currentForm: Forms }>) {
+}: React.PropsWithChildren<{ toggleForm: () => void; currentForm: ProtectionForms }>) {
   const { t } = useTranslation()
 
   return (
@@ -19,7 +19,7 @@ export function ProtectionFormLayout({
         variant="styles.hrVaultFormBottom"
       />
       <Button sx={{ mt: 3 }} variant="textualSmall" onClick={toggleForm}>
-        {currentForm === Forms.ADJUST
+        {currentForm === ProtectionForms.ADJUST
           ? t('protection.navigate-cancel')
           : t('protection.navigate-adjust')}
       </Button>

--- a/pages/[vault]/index.tsx
+++ b/pages/[vault]/index.tsx
@@ -6,6 +6,7 @@ import { DefaultVaultHeaderControl } from 'components/vault/DefaultVaultHeaderCo
 import { DefaultVaultLayout } from 'components/vault/DefaultVaultLayout'
 import { AdjustSlFormControl } from 'features/automation/controls/AdjustSlFormControl'
 import { ProtectionDetailsControl } from 'features/automation/controls/ProtectionDetailsControl'
+import { ProtectionFormControl } from 'features/automation/controls/ProtectionFormControl'
 import { VaultBannersView } from 'features/banners/VaultsBannersView'
 import { GeneralManageVaultView } from 'features/generalManageVault/GeneralManageVaultView'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -44,7 +45,12 @@ export default function Vault({ id }: { id: string }) {
               protectionControl={
                 <DefaultVaultLayout
                   detailsViewControl={<ProtectionDetailsControl id={vaultId} />}
-                  editForm={<AdjustSlFormControl id={vaultId} />}
+                  editForm={
+                    <ProtectionFormControl
+                      adjustForm={<AdjustSlFormControl id={vaultId} />}
+                      cancelForm={<div>Cancel form</div>}
+                    />
+                  }
                   headerControl={<DefaultVaultHeaderControl vaultId={vaultId} />}
                 />
               }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -484,22 +484,22 @@
   "setup-proxy": "Setup Proxy",
   "setup-wallet": "Setup your wallet",
   "show-more": "Show more",
-  "slider":{
-    "adjust-multiply":{
-      "introduction-header":"Adjust your multiply",
-      "introduction-content":"",
-      "left-label":"Liquidation Price",
-      "right-label":"Collateral Ratio",
-      "left-footer":"Decrease risk",
-      "right-footer":"Increase risk"
+  "slider": {
+    "adjust-multiply": {
+      "introduction-header": "Adjust your multiply",
+      "introduction-content": "",
+      "left-label": "Liquidation Price",
+      "right-label": "Collateral Ratio",
+      "left-footer": "Decrease risk",
+      "right-footer": "Increase risk"
     },
-    "set-stoploss":{
-      "introduction-header":"Set downside protection",
-      "introduction-content":"Some intro text. Some more text, even more, even more, even more, even more, even more, even more, even more {{ link }}",
-      "left-label":"Stop loss coll.ratio",
-      "right-label":"Dynamic stop price",
-      "left-footer":"Bigger loss",
-      "right-footer":"More likely execution"
+    "set-stoploss": {
+      "introduction-header": "Set downside protection",
+      "introduction-content": "Some intro text. Some more text, even more, even more, even more, even more, even more, even more, even more {{ link }}",
+      "left-label": "Stop loss coll.ratio",
+      "right-label": "Dynamic stop price",
+      "left-footer": "Bigger loss",
+      "right-footer": "More likely execution"
     }
   },
   "spots-remaining": "{{ spots }} spots remaining",
@@ -728,6 +728,10 @@
       "subtext": "Borrow up to {{maxBorrow}} DAI for every $100,000 worth of {{token}}",
       "button": "Borrow against {{token}}"
     }
+  },
+  "protection": {
+    "navigate-cancel": "Cancel downside protection",
+    "navigate-adjust": "Return to adjusting stop loss"
   },
   "modal-trezor-eip1559-title": "Trezor with Metamask does not support EIP-1559",
   "modal-trezor-eip1559-paragraph1": "Oasis.app has recently updated all transactions to support EIP-1559. Doing EIP-1559 transactions with Trezor through metamask is currently not supported, see <0>here</0>.",


### PR DESCRIPTION
# [Implement form switch](https://app.shortcut.com/oazo-apps/story/3206/create-control-switching-between-cancel-protection-and-add-protection-form)

![image](https://user-images.githubusercontent.com/15217169/145990717-985f3586-9a06-491c-94ec-cd89f141e4ac.png)
  
## Changes 👷‍♀️
- Added functionality to switch forms
  
## How to test 🧪
- Go to protection tab 
- You should be able to switch between implemented adjust form and mocked cancel form (to be implemented in separate PR)
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
