### PR TITLE
removing feature toggle

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -3,12 +3,11 @@ export const FT_LOCAL_STORAGE_KEY = 'features'
 
 type ConfiguredFeatures = Record<Features, boolean>
 
-type Features = 'TestFeature' | 'AnotherTestFeature' | 'AssetLandingPages' | 'MultiplyAndBorrowPage'
+type Features = 'TestFeature' | 'AnotherTestFeature' | 'AssetLandingPages'
 const configuredFeatures: Record<Features, boolean> = {
   TestFeature: false, // used in unit tests
   AnotherTestFeature: true, // used in unit tests
   AssetLandingPages: false,
-  MultiplyAndBorrowPage: false,
   // your feature here....
 }
 

--- a/pages/borrow.tsx
+++ b/pages/borrow.tsx
@@ -21,9 +21,7 @@ export default function BorrowPage() {
       void router.push('/')
     }
   }
-
-  const enabled = useFeatureToggle('MultiplyAndBorrowPage')
-  const view = enabled ? <BorrowView /> : null
+  const view = assetLandingPagesEnabled ? <BorrowView /> : null
 
   return <WithConnection>{view}</WithConnection>
 }

--- a/pages/multiply.tsx
+++ b/pages/multiply.tsx
@@ -13,7 +13,7 @@ export const getStaticProps = async ({ locale }: { locale: string }) => ({
 })
 
 export default function MultiplyPage() {
-  const enabled = useFeatureToggle('MultiplyAndBorrowPage')
+  const enabled = useFeatureToggle('AssetLandingPages')
   const view = enabled ? <MultiplyView /> : null
 
   return <WithConnection>{view}</WithConnection>


### PR DESCRIPTION
## Changes 👷‍♀️
- removes feature toggle and uses `AssetLandingPages` feature toggle
  
## How to test 🧪
- AssetsLandingPages feature toggle enabled - expect to see borrow and multiply pages
- AssetsLandingPages feature toggle disabled - borrow doesn't display and redirects to /, multiply doesn't display
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
