### PR TITLE
Add /earn page behind feature toggle

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -138,6 +138,7 @@ function ConnectedHeader() {
   const accountData = useObservable(accountData$)
   const context = useObservable(context$)
   const assetLandingPagesFeatureEnabled = useFeatureToggle('AssetLandingPages')
+  const earnEnabled = useFeatureToggle('EarnProduct')
 
   const numberOfVaults =
     accountData?.numberOfVaults !== undefined ? accountData.numberOfVaults : undefined
@@ -186,10 +187,19 @@ function ConnectedHeader() {
                 <AppLink
                   variant="links.navHeader"
                   href={HEADER_LINKS.borrow}
-                  sx={{ color: navLinkColor(pathname.includes(HEADER_LINKS.borrow)) }}
+                  sx={{ mr: 4, color: navLinkColor(pathname.includes(HEADER_LINKS.borrow)) }}
                 >
                   {t('nav.borrow')}
                 </AppLink>
+                {earnEnabled && (
+                  <AppLink
+                    variant="links.navHeader"
+                    href={HEADER_LINKS.earn}
+                    sx={{ color: navLinkColor(pathname.includes(HEADER_LINKS.earn)) }}
+                  >
+                    {t('nav.earn')}
+                  </AppLink>
+                )}
               </Flex>
             </Flex>
             <UserAccount position="relative" />
@@ -289,6 +299,7 @@ const HEADER_LINKS = {
   blog: 'https://blog.oasis.app',
   multiply: `/multiply`,
   borrow: `/borrow`,
+  earn: '/earn',
 }
 
 function HeaderDropdown({
@@ -424,64 +435,36 @@ const LangSelectMobileComponents: Partial<SelectComponents<{
   ),
 }
 
-const MOBILE_MENU_SECTIONS_PRE_ASSET_LANDING_PAGES = [
-  {
-    titleKey: 'nav.products',
-    links: [
-      { labelKey: 'nav.dai-wallet', url: HEADER_LINKS['dai-wallet'] },
-      { labelKey: 'nav.oasis-borrow' },
-    ],
-  },
-  {
-    titleKey: 'nav.resources',
-    links: [
-      { labelKey: 'nav.learn', url: HEADER_LINKS['learn'] },
-      { labelKey: 'nav.blog', url: HEADER_LINKS['blog'] },
-    ],
-  },
-]
-
-const MOBILE_MENU_DISCONNECTED_SECTIONS = [
-  {
-    titleKey: 'nav.products',
-    links: [
-      { labelKey: 'nav.multiply', url: HEADER_LINKS.multiply },
-      { labelKey: 'nav.borrow', url: HEADER_LINKS.borrow },
-      { labelKey: 'nav.dai-wallet', url: HEADER_LINKS['dai-wallet'] },
-    ],
-  },
-  {
-    titleKey: 'nav.resources',
-    links: [
-      { labelKey: 'nav.learn', url: HEADER_LINKS['learn'] },
-      { labelKey: 'nav.blog', url: HEADER_LINKS['blog'] },
-    ],
-  },
-]
-
-const MOBILE_MENU_CONNECTED_SECTIONS = [
-  {
-    titleKey: 'nav.products',
-    links: [
-      { labelKey: 'nav.multiply', url: HEADER_LINKS.multiply },
-      { labelKey: 'nav.borrow', url: HEADER_LINKS.borrow },
-    ],
-  },
-]
-
 function MobileMenu() {
   const { t } = useTranslation()
   const { pathname } = useRouter()
   const assetLandingPagesFeatureEnabled = useFeatureToggle('AssetLandingPages')
+  const earnProductEnabled = useFeatureToggle('EarnProduct')
   const [isOpen, setIsOpen] = useState(false)
-  const { context$ } = useAppContext()
-  const context = useObservable(context$)
 
-  const isConnected = !!(context as ContextConnected)?.account
-
-  const mobileMenuEntries = assetLandingPagesFeatureEnabled
-    ? MOBILE_MENU_DISCONNECTED_SECTIONS
-    : MOBILE_MENU_SECTIONS_PRE_ASSET_LANDING_PAGES
+  const mobileMenuEntries = [
+    {
+      titleKey: 'nav.products',
+      links: assetLandingPagesFeatureEnabled
+        ? [
+            { labelKey: 'nav.multiply', url: HEADER_LINKS.multiply },
+            { labelKey: 'nav.borrow', url: HEADER_LINKS.borrow },
+            ...(earnProductEnabled ? [{ labelKey: 'nav.earn', url: HEADER_LINKS.earn }] : []),
+            { labelKey: 'nav.dai-wallet', url: HEADER_LINKS['dai-wallet'] },
+          ]
+        : [
+            { labelKey: 'nav.multiply', url: HEADER_LINKS.multiply },
+            { labelKey: 'nav.borrow', url: HEADER_LINKS.borrow },
+          ],
+    },
+    {
+      titleKey: 'nav.resources',
+      links: [
+        { labelKey: 'nav.learn', url: HEADER_LINKS['learn'] },
+        { labelKey: 'nav.blog', url: HEADER_LINKS['blog'] },
+      ],
+    },
+  ]
 
   const closeMenu = useCallback(() => setIsOpen(false), [])
   return (
@@ -515,67 +498,35 @@ function MobileMenu() {
         }}
       >
         <Grid sx={{ rowGap: 5, mt: 3, mx: 'auto', maxWidth: 7 }}>
-          {!isConnected &&
-            mobileMenuEntries.map((section) => (
-              <Grid key={section.titleKey}>
-                <Text variant="links.navHeader">{t(section.titleKey)}</Text>
-                {section.links.map((link) =>
-                  link.url ? (
-                    <AppLink
-                      key={link.labelKey}
-                      variant="text.paragraph1"
-                      sx={{
-                        textDecoration: 'none',
-                        color: navLinkColor(pathname.includes(link.url)),
-                      }}
-                      href={link.url}
-                      onClick={closeMenu}
-                    >
-                      {t(link.labelKey)}
-                    </AppLink>
-                  ) : (
-                    <Text
-                      key={link.labelKey}
-                      variant="text.paragraph1"
-                      sx={{ fontWeight: 'semiBold' }}
-                    >
-                      {t(link.labelKey)}
-                    </Text>
-                  ),
-                )}
-              </Grid>
-            ))}
-          {isConnected &&
-            assetLandingPagesFeatureEnabled &&
-            MOBILE_MENU_CONNECTED_SECTIONS.map((section) => (
-              <Grid key={section.titleKey}>
-                <Text variant="links.navHeader">{t(section.titleKey)}</Text>
-                {section.links.map((link) =>
-                  link.url ? (
-                    <AppLink
-                      key={link.labelKey}
-                      variant="text.paragraph1"
-                      sx={{
-                        textDecoration: 'none',
-                        color: navLinkColor(pathname.includes(link.url)),
-                      }}
-                      href={link.url}
-                      onClick={closeMenu}
-                    >
-                      {t(link.labelKey)}
-                    </AppLink>
-                  ) : (
-                    <Text
-                      key={link.labelKey}
-                      variant="text.paragraph1"
-                      sx={{ fontWeight: 'semiBold' }}
-                    >
-                      {t(link.labelKey)}
-                    </Text>
-                  ),
-                )}
-              </Grid>
-            ))}
+          {mobileMenuEntries.map((section) => (
+            <Grid key={section.titleKey}>
+              <Text variant="links.navHeader">{t(section.titleKey)}</Text>
+              {section.links.map((link) =>
+                link.url ? (
+                  <AppLink
+                    key={link.labelKey}
+                    variant="text.paragraph1"
+                    sx={{
+                      textDecoration: 'none',
+                      color: navLinkColor(pathname.includes(link.url)),
+                    }}
+                    href={link.url}
+                    onClick={closeMenu}
+                  >
+                    {t(link.labelKey)}
+                  </AppLink>
+                ) : (
+                  <Text
+                    key={link.labelKey}
+                    variant="text.paragraph1"
+                    sx={{ fontWeight: 'semiBold' }}
+                  >
+                    {t(link.labelKey)}
+                  </Text>
+                ),
+              )}
+            </Grid>
+          ))}
           <Grid>
             <Text variant="links.navHeader">{t('languages')}</Text>
             <LanguageSelect components={LangSelectMobileComponents} />
@@ -596,6 +547,7 @@ function DisconnectedHeader() {
   const { t } = useTranslation()
   const { pathname } = useRouter()
   const assetLandingPagesEnabled = useFeatureToggle('AssetLandingPages')
+  const earnEnabled = useFeatureToggle('EarnProduct')
   const menuBarLandingPagesDisabled = (
     <>
       <HeaderDropdown title={t('nav.products')}>
@@ -630,6 +582,15 @@ function DisconnectedHeader() {
       >
         {t('nav.borrow')}
       </AppLink>
+      {earnEnabled && (
+        <AppLink
+          variant="links.navHeader"
+          href={HEADER_LINKS.earn}
+          sx={{ color: navLinkColor(pathname.includes(HEADER_LINKS.earn)) }}
+        >
+          {t('nav.earn')}
+        </AppLink>
+      )}
       <HeaderDropdown title={t('nav.more')}>
         <AppLink variant="links.nav" sx={{ fontWeight: 'body' }} href={HEADER_LINKS['dai-wallet']}>
           {t('nav.dai-wallet')}

--- a/features/earn/EarnView.tsx
+++ b/features/earn/EarnView.tsx
@@ -4,13 +4,12 @@ import { Flex, Grid } from 'theme-ui'
 
 import { useAppContext } from '../../components/AppContextProvider'
 import { ProductCardMultiply } from '../../components/ProductCardMultiply'
-import { ProductCardsFilter } from '../../components/ProductCardsFilter'
 import { ProductCardsWrapper } from '../../components/ProductCardsWrapper'
 import { ProductHeader } from '../../components/ProductHeader'
 import { AppSpinner, WithLoadingIndicator } from '../../helpers/AppSpinner'
 import { WithErrorHandler } from '../../helpers/errorHandlers/WithErrorHandler'
 import { useObservableWithError } from '../../helpers/observableHook'
-import { multiplyPageCardsData, productCardsConfig } from '../../helpers/productCards'
+import { earnPageCardsData } from '../../helpers/productCards'
 
 export function EarnView() {
   const { t } = useTranslation()
@@ -46,19 +45,11 @@ export function EarnView() {
           }
         >
           {([productCardsData]) => (
-            <ProductCardsFilter filters={productCardsConfig.multiply.cardsFilters}>
-              {(cardsFilter) => {
-                const filteredCards = multiplyPageCardsData({ productCardsData, cardsFilter })
-
-                return (
-                  <ProductCardsWrapper>
-                    {filteredCards.map((cardData) => (
-                      <ProductCardMultiply cardData={cardData} key={cardData.ilk} />
-                    ))}
-                  </ProductCardsWrapper>
-                )
-              }}
-            </ProductCardsFilter>
+            <ProductCardsWrapper>
+              {earnPageCardsData({ productCardsData }).map((cardData) => (
+                <ProductCardMultiply cardData={cardData} key={cardData.ilk} />
+              ))}
+            </ProductCardsWrapper>
           )}
         </WithLoadingIndicator>
       </WithErrorHandler>

--- a/features/earn/EarnView.tsx
+++ b/features/earn/EarnView.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Flex, Grid } from 'theme-ui'
+
+import { useAppContext } from '../../components/AppContextProvider'
+import { ProductCardMultiply } from '../../components/ProductCardMultiply'
+import { ProductCardsFilter } from '../../components/ProductCardsFilter'
+import { ProductCardsWrapper } from '../../components/ProductCardsWrapper'
+import { ProductHeader } from '../../components/ProductHeader'
+import { AppSpinner, WithLoadingIndicator } from '../../helpers/AppSpinner'
+import { WithErrorHandler } from '../../helpers/errorHandlers/WithErrorHandler'
+import { useObservableWithError } from '../../helpers/observableHook'
+import { multiplyPageCardsData, productCardsConfig } from '../../helpers/productCards'
+
+export function EarnView() {
+  const { t } = useTranslation()
+  const { productCardsData$ } = useAppContext()
+  const { error: productCardsDataError, value: productCardsDataValue } = useObservableWithError(
+    productCardsData$,
+  )
+
+  return (
+    <Grid
+      sx={{
+        flex: 1,
+        position: 'relative',
+        mb: ['123px', '187px'],
+      }}
+    >
+      <ProductHeader
+        title={t('product-page.earn.title')}
+        description={t('product-page.earn.description')}
+        link={{
+          href: 'https://kb.oasis.app/help/earn-with-dai-and-g-uni-multiply',
+          text: t('product-page.earn.link'),
+        }}
+      />
+
+      <WithErrorHandler error={[productCardsDataError]}>
+        <WithLoadingIndicator
+          value={[productCardsDataValue]}
+          customLoader={
+            <Flex sx={{ alignItems: 'flex-start', justifyContent: 'center', height: '500px' }}>
+              <AppSpinner sx={{ mt: 5 }} variant="styles.spinner.large" />
+            </Flex>
+          }
+        >
+          {([productCardsData]) => (
+            <ProductCardsFilter filters={productCardsConfig.multiply.cardsFilters}>
+              {(cardsFilter) => {
+                const filteredCards = multiplyPageCardsData({ productCardsData, cardsFilter })
+
+                return (
+                  <ProductCardsWrapper>
+                    {filteredCards.map((cardData) => (
+                      <ProductCardMultiply cardData={cardData} key={cardData.ilk} />
+                    ))}
+                  </ProductCardsWrapper>
+                )
+              }}
+            </ProductCardsFilter>
+          )}
+        </WithLoadingIndicator>
+      </WithErrorHandler>
+    </Grid>
+  )
+}

--- a/features/multiply/MultiplyView.tsx
+++ b/features/multiply/MultiplyView.tsx
@@ -51,7 +51,7 @@ export function MultiplyView() {
           {([productCardsData]) => (
             <ProductCardsFilter
               filters={productCardsConfig.multiply.cardsFilters.filter(
-                (f) => !(earnEnabled && f.name == 'UNI LP'),
+                (f) => !(earnEnabled && f.name === 'UNI LP'),
               )}
             >
               {(cardsFilter) => {

--- a/features/multiply/MultiplyView.tsx
+++ b/features/multiply/MultiplyView.tsx
@@ -11,6 +11,7 @@ import { AppSpinner, WithLoadingIndicator } from '../../helpers/AppSpinner'
 import { WithErrorHandler } from '../../helpers/errorHandlers/WithErrorHandler'
 import { useObservableWithError } from '../../helpers/observableHook'
 import { multiplyPageCardsData, productCardsConfig } from '../../helpers/productCards'
+import { useFeatureToggle } from '../../helpers/useFeatureToggle'
 
 export function MultiplyView() {
   const { t } = useTranslation()
@@ -18,6 +19,8 @@ export function MultiplyView() {
   const { error: productCardsDataError, value: productCardsDataValue } = useObservableWithError(
     productCardsData$,
   )
+
+  const earnEnabled = useFeatureToggle('EarnProduct')
 
   return (
     <Grid
@@ -46,9 +49,16 @@ export function MultiplyView() {
           }
         >
           {([productCardsData]) => (
-            <ProductCardsFilter filters={productCardsConfig.multiply.cardsFilters}>
+            <ProductCardsFilter
+              filters={productCardsConfig.multiply.cardsFilters.filter(
+                (f) => !(earnEnabled && f.name == 'UNI LP'),
+              )}
+            >
               {(cardsFilter) => {
-                const filteredCards = multiplyPageCardsData({ productCardsData, cardsFilter })
+                const filteredCards = multiplyPageCardsData({
+                  productCardsData,
+                  cardsFilter,
+                })
 
                 return (
                   <ProductCardsWrapper>

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -278,6 +278,10 @@ function sortCards(
   return productCardsData
 }
 
+export function earnPageCardsData({ productCardsData }: { productCardsData: ProductCardData[] }) {
+  return productCardsData.filter((data) => data.ilk === 'GUNIV3DAIUSDC2-A')
+}
+
 export function multiplyPageCardsData({
   productCardsData,
   cardsFilter,

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -3,11 +3,12 @@ export const FT_LOCAL_STORAGE_KEY = 'features'
 
 type ConfiguredFeatures = Record<Features, boolean>
 
-type Features = 'TestFeature' | 'AnotherTestFeature' | 'AssetLandingPages'
+type Features = 'TestFeature' | 'AnotherTestFeature' | 'AssetLandingPages' | 'EarnProduct'
 const configuredFeatures: Record<Features, boolean> = {
   TestFeature: false, // used in unit tests
   AnotherTestFeature: true, // used in unit tests
   AssetLandingPages: true,
+  EarnProduct: false,
   // your feature here....
 }
 

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -7,8 +7,6 @@ type Features = 'TestFeature' | 'AnotherTestFeature' | 'AssetLandingPages' | 'Ea
 const configuredFeatures: Record<Features, boolean> = {
   TestFeature: false, // used in unit tests
   AnotherTestFeature: true, // used in unit tests
-
-  EarnProduct: false,
   AssetLandingPages: true,
   EarnProduct: false,
   // your feature here....

--- a/pages/earn.tsx
+++ b/pages/earn.tsx
@@ -14,7 +14,6 @@ export const getStaticProps = async ({ locale }: { locale: string }) => ({
 })
 
 export default function EarnPage() {
-  console.log('hi')
   const enabled = useFeatureToggle('EarnProduct')
 
   if (!enabled) {

--- a/pages/earn.tsx
+++ b/pages/earn.tsx
@@ -1,0 +1,33 @@
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+import React from 'react'
+
+import { WithConnection } from '../components/connectWallet/ConnectWallet'
+import { ProductPagesLayout } from '../components/Layouts'
+import { EarnView } from '../features/earn/EarnView'
+import { useFeatureToggle } from '../helpers/useFeatureToggle'
+
+export const getStaticProps = async ({ locale }: { locale: string }) => ({
+  props: {
+    ...(await serverSideTranslations(locale, ['common'])),
+  },
+})
+
+export default function EarnPage() {
+  console.log('hi')
+  const enabled = useFeatureToggle('EarnProduct')
+
+  if (!enabled) {
+    const router = useRouter()
+    if (typeof window !== 'undefined') {
+      void router.push('/')
+    }
+  }
+
+  const view = enabled ? <EarnView /> : null
+
+  return <WithConnection>{view}</WithConnection>
+}
+
+EarnPage.layout = ProductPagesLayout
+EarnPage.theme = 'Landing'

--- a/sitemapGenerator.js
+++ b/sitemapGenerator.js
@@ -5,7 +5,8 @@ try {
     baseUrl: 'https://oasis.app',
     pagesDirectory: `.next/server/pages`,
     targetDirectory: 'public/',
-    ignoredPaths: ['/api', '404', '/[address]', '/terms', '/privacy', '/save'],
+    // TODO: remove '/earn' exclusion below when enabling EarnProduct feature
+    ignoredPaths: ['/api', '404', '/[address]', '/terms', '/privacy', '/save', '/earn'],
     // other apps routes from Oasis Suite
     extraPaths: ['/blog'],
     nextConfigPath: `${__dirname}/next.config.js`,


### PR DESCRIPTION
# [Title](https://app.shortcut.com/oazo-apps/story/3333/create-earn-page)
  
## Changes 👷‍♀️
- added new /earn page
- new tab in menu
- tidied up mobile header a little
- 
  
## How to test 🧪

### Feature enabled

1. enable feature `EarnPages`
2. observe Earn tab in menu bar (mobile & desktop; connected & disconnected)
3. Navigate to /earn page and observe GUNI card
4. Navigate to /multiply page and observe UNI LP filter not present.

### Feature disabled

1. disable feature `EarnPages`
2. observe missing Earn tab in menu bar (mobile & desktop; connected & disconnected)
3. Navigate to /earn page and observe redirect to /
4. Navigate to /multiply page and observe UNI LP filter is present and shows GUNI card

    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
