### PR TITLE
adding NODE_ENV as build arg for docker build

### DIFF
--- a/.github/workflows/aws-prod.yaml
+++ b/.github/workflows/aws-prod.yaml
@@ -60,6 +60,7 @@ jobs:
                      --build-arg ETHERSCAN_API_KEY=${{ secrets.ETHERSCAN_API_KEY }} \
                      --build-arg BLOCKNATIVE_API_KEY=${{ secrets.BLOCKNATIVE_API_KEY }} \
                      --build-arg SHOW_BUILD_INFO=0 \
+                     --build-arg NODE_ENV=production \
                      --cache-from=$ECR_REGISTRY/$ECR_REPO_NAME:$ENVIRONMENT_TAG \
                      -t $ECR_REGISTRY/$ECR_REPO_NAME:$SHA_TAG \
                      -t $ECR_REGISTRY/$ECR_REPO_NAME:$LATEST_TAG \


### PR DESCRIPTION
- Adding `NODE_ENV=production` to `docker build`, for generating some of the static assets at build time instead of on-demand