### PR TITLE
added readonly view of protection for vaults

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -557,7 +557,7 @@ export function setupAppContext() {
   const accountData$ = createAccountData(web3Context$, balance$, vaults$, ensName$)
 
   const automationTriggersData$ = memoize(
-    curry(createAutomationTriggersData)(connectedContext$, onEveryBlock$, vault$),
+    curry(createAutomationTriggersData)(context$, onEveryBlock$, vault$),
   )
 
   const openVaultOverview$ = createOpenVaultOverview$(ilksWithBalance$)

--- a/features/automation/controls/AdjustSlFormControl.tsx
+++ b/features/automation/controls/AdjustSlFormControl.tsx
@@ -246,7 +246,7 @@ export function AdjustSlFormControl({ id }: { id: BigNumber }) {
             ilksData,
             extractSLData(triggerData),
             txHelpersWithError.value,
-            ctx.status === 'connected' ? ctx.account !== vault.controller : false,
+            ctx.status === 'connected' && ctx.account !== vault.controller,
           )
         }
       </WithLoadingIndicator>

--- a/features/automation/triggers/AutomationTriggersData.ts
+++ b/features/automation/triggers/AutomationTriggersData.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { networksById } from 'blockchain/config'
-import { ContextConnected } from 'blockchain/network'
+import { Context } from 'blockchain/network'
 import { Vault } from 'blockchain/vaults'
 import { GraphQLClient } from 'graphql-request'
 import { List } from 'lodash'
@@ -18,8 +18,6 @@ async function loadTriggerDataFromCache(vaultId: number, cacheApi: string): Prom
     vaultId.toFixed(0),
   )
 
-  console.log('activeTriggersForVault in loadTriggerDataFromCache')
-  console.log(activeTriggersForVault)
   return {
     isAutomationEnabled: activeTriggersForVault.length > 0,
     triggers: activeTriggersForVault,
@@ -38,7 +36,7 @@ export interface TriggersData {
 }
 
 export function createAutomationTriggersData(
-  context$: Observable<ContextConnected>,
+  context$: Observable<Context>,
   onEveryBlock$: Observable<number>,
   vauit$: (id: BigNumber) => Observable<Vault>,
   id: BigNumber,


### PR DESCRIPTION
# [Added readonly view of stoplosses and protection tab](https://app.shortcut.com/oazo-apps/story/3596/fix-view-of-protection-tab-when-web3-wallet-is-not-connected)

  
## Changes 👷‍♀️
- Protectred vault details can be viewed when vault owner is not connected
  
  
![image](https://user-images.githubusercontent.com/6871923/153007519-d75aac7f-9f3d-430a-a8bc-8fcd8ff90f12.png)


## How to test 🧪
- Go to any protected vault for ex. 55 on goerli
- View it in incognito mode or when connected with another wallet which is not owner of this one
- See some details about this vault's stoploss etc
- also try for vault that don't have protection
    
## Definition of done ✔️

- [x] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [x ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [x ] Project builds without errors
- [ x] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
