### PR TITLE
Added wordBreak for Banner component

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -43,7 +43,7 @@ export function Banner({ children, close, sx }: BannerProps) {
       >
         <Icon name="close_squared" size={14} />
       </IconButton>
-      <Box>{children}</Box>
+      <Box sx={{ wordBreak: 'break-all' }}>{children}</Box>
     </Box>
   )
 }


### PR DESCRIPTION
# [Added wordBreak for Banner component](https://clubhouseLink)

<please insert a clubhouse link above>
This PR fixes issue with banners with long strings (hashes) on mobile  

## Changes 👷‍♀️
  <Please add short list of changes>
- added wordBreak for Banner component
  
## How to test 🧪
  <Please explain how to test your changes>
- heroku / locally, use `54?network=goerli`
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
