### PR TITLE
Added ZeroDebtProtectionBanner when vault debt is 0

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -6,10 +6,11 @@ import { Box, IconButton, SxProps } from 'theme-ui'
 type Closable = {
   close: React.MouseEventHandler<any>
   sx?: SxProps
+  withClose?: boolean
 }
 type BannerProps = WithChildren & Closable
 
-export function Banner({ children, close, sx }: BannerProps) {
+export function Banner({ children, close, sx, withClose = true }: BannerProps) {
   return (
     <Box
       sx={{
@@ -24,25 +25,27 @@ export function Banner({ children, close, sx }: BannerProps) {
         ...sx,
       }}
     >
-      <IconButton
-        onClick={close}
-        sx={{
-          cursor: 'pointer',
-          height: 3,
-          width: 3,
-          padding: 0,
-          position: 'absolute',
-          top: 3,
-          right: 3,
-          zIndex: 1,
-          color: 'onSurface',
-          '&:hover': {
-            color: 'primary',
-          },
-        }}
-      >
-        <Icon name="close_squared" size={14} />
-      </IconButton>
+      {withClose && (
+        <IconButton
+          onClick={close}
+          sx={{
+            cursor: 'pointer',
+            height: 3,
+            width: 3,
+            padding: 0,
+            position: 'absolute',
+            top: 3,
+            right: 3,
+            zIndex: 1,
+            color: 'onSurface',
+            '&:hover': {
+              color: 'primary',
+            },
+          }}
+        >
+          <Icon name="close_squared" size={14} />
+        </IconButton>
+      )}
       <Box>{children}</Box>
     </Box>
   )

--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -1,14 +1,40 @@
+import { Icon } from '@makerdao/dai-ui-icons'
+import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 import { IlkDataList } from '../../blockchain/ilks'
 import { Vault } from '../../blockchain/vaults'
 import { ProtectionDetailsControl } from '../../features/automation/controls/ProtectionDetailsControl'
 import { ProtectionFormControl } from '../../features/automation/controls/ProtectionFormControl'
+import { VaultBanner } from '../../features/banners/VaultsBannersView'
 import { VaultContainerSpinner, WithLoadingIndicator } from '../../helpers/AppSpinner'
 import { WithErrorHandler } from '../../helpers/errorHandlers/WithErrorHandler'
 import { useObservableWithError } from '../../helpers/observableHook'
 import { useAppContext } from '../AppContextProvider'
+import { AppLink } from '../Links'
 import { DefaultVaultLayout } from './DefaultVaultLayout'
+
+function ZeroDebtProtectionBanner() {
+  const { t } = useTranslation()
+
+  return (
+    <VaultBanner
+      status={<Icon size="34px" name="warning" />}
+      withClose={false}
+      header={t('protection.zero-debt-heading')}
+      subheader={
+        <>
+          {t('protection.zero-debt-description')}
+          {', '}
+          <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 3 }}>
+            {t('here')}.
+          </AppLink>
+        </>
+      }
+      color="primary"
+    />
+  )
+}
 
 interface ProtectionControlProps {
   vault: Vault
@@ -21,7 +47,7 @@ export function ProtectionControl({ vault, ilkDataList }: ProtectionControlProps
   const automationTriggersDataWithError = useObservableWithError(autoTriggersData$)
   const collateralPricesWithError = useObservableWithError(collateralPrices$)
 
-  return (
+  return !vault.debt.isZero() ? (
     <WithErrorHandler
       error={[automationTriggersDataWithError.error, collateralPricesWithError.error]}
     >
@@ -53,5 +79,7 @@ export function ProtectionControl({ vault, ilkDataList }: ProtectionControlProps
         }}
       </WithLoadingIndicator>
     </WithErrorHandler>
+  ) : (
+    <ZeroDebtProtectionBanner />
   )
 }

--- a/features/banners/VaultsBannersView.tsx
+++ b/features/banners/VaultsBannersView.tsx
@@ -21,6 +21,7 @@ type VaultBannerProps = {
   status?: JSX.Element
   header: JSX.Element | string
   subheader?: JSX.Element | string | false
+  withClose?: boolean
 }
 
 function StatusFrame({ children, sx }: WithChildren & { sx?: SxStyleProp }) {
@@ -45,12 +46,14 @@ export function VaultBanner({
   header,
   subheader,
   color,
+  withClose = true,
 }: VaultBannerProps & { color: string }) {
   const [isVisible, setIsVisible] = useState(true)
+
   return (
     <>
       {isVisible && (
-        <Banner close={() => setIsVisible(false)}>
+        <Banner close={() => setIsVisible(false)} withClose={withClose}>
           <Flex sx={{ py: 2, pr: 5 }}>
             {status && <Box sx={{ mr: 4, flexShrink: 0 }}>{status}</Box>}
             <Grid gap={2} sx={{ alignItems: 'center' }}>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -800,7 +800,9 @@
     "banner-button": "Set up Vault Protection ->",
     "edit-vault-protection": "Edit Vault Protection",
     "dynamic-stop-loss-price": "Dynamic Stop Loss Price",
-    "stop-loss-coll-ratio": "Stop Loss Collateral Ratio"
+    "stop-loss-coll-ratio": "Stop Loss Collateral Ratio",
+    "zero-debt-heading": "You need to generate DAI before you can set up Stop Loss Protection",
+    "zero-debt-description": "Oasis Protection allows you to set up a stop loss for your vault. In the case of a sharp downturn in collateralisation ratio, while you are unavailable to manage your vault, the protection set at your desired collateralisation level will sell some of your collateral to cover your complete debt. Learn more about how it works under the hood"
   },
   "newsletter": {
     "title": "Stay up to date with Oasis.app",


### PR DESCRIPTION
# [Added ZeroDebtProtectionBanner when vault debt is 0](https://app.shortcut.com/oazo-apps/story/3466/changing-view-of-protection-tab-if-user-has-no-dai-debt)

<please insert a clubhouse link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added ZeroDebtProtectionBanner when vault debt is 0
  
## How to test 🧪
  <Please explain how to test your changes>
- locally / heroku
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
