### PR TITLE
Tally Wallet Support

### DIFF
--- a/components/connectWallet/ConnectWallet.tsx
+++ b/components/connectWallet/ConnectWallet.tsx
@@ -53,9 +53,17 @@ export async function getConnector(
   assert(rpcUrls[network], 'Unsupported chainId!')
   switch (connectorKind) {
     case 'injected': {
-      const connector = new InjectedConnector({
+      let connector = new InjectedConnector({
         supportedChainIds: Object.values(networksById).map(({ id }) => Number.parseInt(id)),
       })
+      const injectedKind = getInjectedWalletKind();
+
+      if (injectedKind === 'Tally') {
+        connector = new InjectedConnector({
+          supportedChainIds: [1]
+        })
+        return connector;
+      }
       const connectorChainId = Number.parseInt((await connector.getChainId()) as string)
       if (network !== connectorChainId) {
         alert('Browser ethereum provider and URL network param do not match!')
@@ -232,6 +240,7 @@ export function getInjectedWalletKind() {
   if (w.imToken) return 'IMToken'
 
   if (w.ethereum?.isMetaMask) return 'MetaMask'
+  if (w.ethereum?.isTally) return 'Tally'
 
   if (!w.web3 || typeof w.web3.currentProvider === 'undefined') return undefined
 


### PR DESCRIPTION
# Tally Wallet support

Following an ETHDenver Bounty to integrate Tally wallet into an existing Dapp.
  
## Changes 👷‍♀️
- add tally wallet to Injected provider list
- set injectedConnector if Tally wallet since Tally only supports mainnet
- add support for custom injected icons


## Dependencies
- depends on https://github.com/makerdao/dai-ui/pull/88
  
## How to test 🧪
- In a fresh browser [install Tally wallet](https://chrome.google.com/webstore/detail/tally/eajafomhmkipbjmfmhebemolkcicgfmd)
- click connect on oasis app
    
## Preview
![272841780_322803759656683_3649109090989556370_n](https://user-images.githubusercontent.com/29347276/154766811-51c4723a-c63e-46a2-b554-7950cc407a00.png)

## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
