### PR TITLE
Added distinction between closing to dai and collateral on ui

### DIFF
--- a/components/vault/stories/VaultDetailsCard.stories.tsx
+++ b/components/vault/stories/VaultDetailsCard.stories.tsx
@@ -80,6 +80,8 @@ export const MaxTokenOnStopLossTrigger = ({ hasAfter, isProtected }: CardsContro
         liquidationRatio={new BigNumber(1.3)}
         token="ETH"
         showAfterPill={hasAfter}
+        isCollateralActive={true}
+        tokenPrice={new BigNumber(2000)}
       />
     </MaxWidthWrapper>
   )

--- a/features/automation/controls/AdjustSlFormControl.tsx
+++ b/features/automation/controls/AdjustSlFormControl.tsx
@@ -73,7 +73,7 @@ export function AdjustSlFormControl({
 }: AdjustSlFormControlProps) {
   const uiSubjectName = 'AdjustSlForm'
   const validOptions: FixedSizeArray<string, 2> = ['collateral', 'dai']
-  const [collateralActive, setCloseToCollateral] = useState(true)
+  const [collateralActive, setCloseToCollateral] = useState(false)
   const [selectedSLValue, setSelectedSLValue] = useState(new BigNumber(0))
 
   const isOwner = ctx.status === 'connected' && ctx.account === vault.controller
@@ -129,7 +129,7 @@ export function AdjustSlFormControl({
   const token = vault.token
   const tokenData = getToken(token)
   const currentCollateralData = collateralPrice.data.find((x) => x.token === vault.token)
-  const ethPrice = collateralPrice.data.find((x) => x.token === 'ETH')?.currentPrice!
+  const tokenPrice = collateralPrice.data.find((x) => x.token === token)?.currentPrice!
   const startingSlRatio = isStopLossEnabled
     ? stopLossLevel
     : new BigNumber(
@@ -294,7 +294,7 @@ export function AdjustSlFormControl({
     stopLossLevel,
     dynamicStopLossPrice,
     amountOnStopLossTrigger,
-    ethPrice,
+    tokenPrice,
     vault,
     ilkData,
     isEditing,

--- a/features/automation/controls/ProtectionDetailsControl.tsx
+++ b/features/automation/controls/ProtectionDetailsControl.tsx
@@ -32,7 +32,8 @@ function renderLayout(
     token: vaultData.token,
 
     afterSlRatio: lastUIState ? lastUIState.selectedSLValue.dividedBy(100) : new BigNumber(0),
-    isEditing: lastUIState ? lastUIState.isEditing : false,
+    isEditing: !!lastUIState?.isEditing,
+    isCollateralActive: !!lastUIState?.collateralActive,
   }
   return <ProtectionDetailsLayout {...props} />
 }

--- a/features/automation/controls/ProtectionDetailsLayout.tsx
+++ b/features/automation/controls/ProtectionDetailsLayout.tsx
@@ -21,6 +21,7 @@ export interface ProtectionDetailsLayoutProps {
   liquidationRatio: BigNumber
   afterSlRatio: BigNumber
   isEditing: boolean
+  isCollateralActive: boolean
 }
 
 export function ProtectionDetailsLayout({
@@ -35,6 +36,7 @@ export function ProtectionDetailsLayout({
   liquidationRatio,
   afterSlRatio,
   isEditing,
+  isCollateralActive,
 }: ProtectionDetailsLayoutProps) {
   const showAfterPill = isEditing
 
@@ -83,6 +85,8 @@ export function ProtectionDetailsLayout({
           lockedCollateral={lockedCollateral}
           afterSlRatio={afterSlRatio}
           afterPillColors={afterPillColors}
+          isCollateralActive={isCollateralActive}
+          tokenPrice={currentOraclePrice}
         />
       </Grid>
     </Box>


### PR DESCRIPTION
# [Added distinction between closing to dai and collateral on ui](https://app.shortcut.com/oazo-apps/story/3640/stop-loss-to-dai)

<please insert a clubhouse link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added distinction between closing to dai and collateral on ui
  
## How to test 🧪
  <Please explain how to test your changes>
- heroku / goerli
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
