### PR TITLE
added stop loss validation to borrow and  multiply vaults

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -577,6 +577,7 @@ export function setupAppContext() {
         vaultHistory$,
         withdrawPaybackDepositGenerateLogicFactory(StandardDssProxyActionsContractWrapper),
         StandardBorrowManageVaultViewStateProvider,
+        automationTriggersData$,
         id,
       ),
     bigNumberTostring,
@@ -600,6 +601,7 @@ export function setupAppContext() {
         // comment out above and uncomment below to test insti vault flows + UI against standard borrow vault
         // withdrawPaybackDepositGenerateLogicFactory(StandardDssProxyActionsContractWrapper),
         InstitutionalBorrowManageVaultViewStateProvider,
+        automationTriggersData$,
         id,
       ),
     bigNumberTostring,

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -621,6 +621,7 @@ export function setupAppContext() {
         userSettings$,
         vaultMultiplyHistory$,
         saveVaultUsingApi$,
+        automationTriggersData$,
         id,
       ),
     bigNumberTostring,

--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -124,6 +124,8 @@ export function VaultErrors({
         )
       case 'invalidSlippage':
         return translate('invalid-slippage')
+      case 'afterCollRatioBelowStopLossRatio':
+        return translate('after-coll-ratio-below-stop-loss-ratio')
 
       default:
         throw new UnreachableCaseError(message)

--- a/features/automation/triggers/AutomationTriggersData.ts
+++ b/features/automation/triggers/AutomationTriggersData.ts
@@ -5,9 +5,10 @@ import { Vault } from 'blockchain/vaults'
 import { GraphQLClient } from 'graphql-request'
 import { List } from 'lodash'
 import { Observable } from 'rxjs'
-import { distinctUntilChanged, mergeMap, shareReplay, withLatestFrom } from 'rxjs/operators'
+import { distinctUntilChanged, map, mergeMap, shareReplay, withLatestFrom } from 'rxjs/operators'
 
 import { getAllActiveTriggers } from '../common/service/allActiveTriggers'
+import { extractStopLossData, StopLossTriggerData } from '../common/StopLossTriggerDataExtractor'
 
 // TODO - ŁW - Implement tests for this file
 
@@ -54,4 +55,21 @@ export function createAutomationTriggersData(
     }),
     shareReplay(1),
   )
+}
+
+export function createStopLossDataChange$(
+  automationTriggersData$: (id: BigNumber) => Observable<TriggersData>,
+  id: BigNumber,
+) {
+  return automationTriggersData$(id).pipe(
+    map((triggerData) => ({
+      kind: 'stopLossData',
+      stopLossData: extractStopLossData(triggerData),
+    })),
+  )
+}
+
+export interface StopLossChange {
+  kind: 'stopLossData'
+  stopLossData: StopLossTriggerData
 }

--- a/features/borrow/manage/pipes/manageVault.ts
+++ b/features/borrow/manage/pipes/manageVault.ts
@@ -20,6 +20,11 @@ import { WithdrawPaybackDepositGenerateLogicInterface } from '../../../../blockc
 import { InstiVault } from '../../../../blockchain/instiVault'
 import { SelectedDaiAllowanceRadio } from '../../../../components/vault/commonMultiply/ManageVaultDaiAllowance'
 import { TxError } from '../../../../helpers/types'
+import { StopLossTriggerData } from '../../../automation/common/StopLossTriggerDataExtractor'
+import {
+  createStopLossDataChange$,
+  TriggersData,
+} from '../../../automation/triggers/AutomationTriggersData'
 import { VaultErrorMessage } from '../../../form/errorMessagesHandler'
 import { VaultWarningMessage } from '../../../form/warningMessagesHandler'
 import { BalanceInfo, balanceInfoChange$ } from '../../../shared/balanceInfo'
@@ -160,6 +165,7 @@ type GenericManageBorrowVaultState<V extends Vault> = MutableManageVaultState &
     initialTotalSteps: number
     totalSteps: number
     currentStep: number
+    stopLossData?: StopLossTriggerData
   } & HasGasEstimation
 
 export type ManageStandardBorrowVaultState = GenericManageBorrowVaultState<Vault>
@@ -365,6 +371,7 @@ export function createManageVault$<V extends Vault, VS extends ManageStandardBor
   vaultHistory$: (id: BigNumber) => Observable<VaultHistoryEvent[]>,
   proxyActions: WithdrawPaybackDepositGenerateLogicInterface,
   vaultViewStateProvider: BorrowManageVaultViewStateProviderInterface<V, VS>,
+  automationTriggersData$: (id: BigNumber) => Observable<TriggersData>,
   id: BigNumber,
 ): Observable<VS> {
   return context$.pipe(
@@ -430,6 +437,7 @@ export function createManageVault$<V extends Vault, VS extends ManageStandardBor
                     createIlkDataChange$(ilkData$, vault.ilk),
                     createVaultChange$(vault$, id, context.chainId),
                     createHistoryChange$(vaultHistory$, id),
+                    createStopLossDataChange$(automationTriggersData$, id),
                   )
 
                   const connectedProxyAddress$ = account ? proxyAddress$(account) : of(undefined)

--- a/features/borrow/manage/pipes/manageVaultValidations.ts
+++ b/features/borrow/manage/pipes/manageVaultValidations.ts
@@ -26,6 +26,7 @@ export function validateErrors(
     withdrawCollateralOnVaultUnderDebtFloor,
     depositCollateralOnVaultUnderDebtFloor,
     ledgerWalletContractDataDisabled,
+    afterCollRatioBelowStopLossRatio,
   } = state
 
   const errorMessages: VaultErrorMessage[] = []
@@ -46,6 +47,7 @@ export function validateErrors(
         debtWillBeLessThanDebtFloor,
         withdrawCollateralOnVaultUnderDebtFloor,
         depositCollateralOnVaultUnderDebtFloor,
+        afterCollRatioBelowStopLossRatio,
       }),
     )
   }

--- a/features/borrow/manage/pipes/viewStateProviders/standardBorrowManageVaultViewStateProvider.ts
+++ b/features/borrow/manage/pipes/viewStateProviders/standardBorrowManageVaultViewStateProvider.ts
@@ -72,8 +72,9 @@ export const StandardBorrowManageVaultViewStateProvider: BorrowManageVaultViewSt
       currentStep: 1,
       clear: () => change({ kind: 'clear' }),
       gasEstimationStatus: GasEstimationStatus.unset,
-      injectStateOverride,
       vaultHistory: [],
+      stopLossData: undefined,
+      injectStateOverride,
     }
     return initialState
   },

--- a/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
+++ b/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
@@ -2,6 +2,7 @@ import { IlkDataChange } from 'blockchain/ilks'
 import { VaultChange } from 'blockchain/vaults'
 import { PriceInfoChange } from 'features/shared/priceInfo'
 
+import { StopLossChange } from '../../../../automation/triggers/AutomationTriggersData'
 import { BalanceInfoChange } from '../../../../shared/balanceInfo'
 import { VaultHistoryChange } from '../../../../vaultHistory/vaultHistory'
 import { ManageStandardBorrowVaultState, ManageVaultChange } from '../manageVault'
@@ -12,6 +13,7 @@ export type ManageVaultEnvironmentChange =
   | IlkDataChange
   | VaultChange
   | VaultHistoryChange
+  | StopLossChange
 
 export function applyManageVaultEnvironment<VaultState extends ManageStandardBorrowVaultState>(
   change: ManageVaultChange,
@@ -49,6 +51,13 @@ export function applyManageVaultEnvironment<VaultState extends ManageStandardBor
     return {
       ...state,
       vaultHistory: change.vaultHistory,
+    }
+  }
+
+  if (change.kind === 'stopLossData') {
+    return {
+      ...state,
+      stopLossData: change.stopLossData,
     }
   }
 

--- a/features/borrow/manage/tests/manageVaultValidations.test.ts
+++ b/features/borrow/manage/tests/manageVaultValidations.test.ts
@@ -5,6 +5,9 @@ import { mockManageVault, mockManageVault$ } from 'helpers/mocks/manageVault.moc
 import { DEFAULT_PROXY_ADDRESS } from 'helpers/mocks/vaults.mock'
 import { getStateUnpacker } from 'helpers/testHelpers'
 import { zero } from 'helpers/zero'
+import { of } from 'rxjs'
+
+import { mockedStopLossTrigger } from '../../../../helpers/mocks/stopLoss.mock'
 
 describe('manageVaultValidations', () => {
   it('validates if deposit amount exceeds collateral balance or depositing all ETH', () => {
@@ -285,5 +288,50 @@ describe('manageVaultValidations', () => {
 
     state().updateDeposit!(depositAmount)
     expect(state().errorMessages).to.deep.eq(['depositCollateralOnVaultUnderDebtFloor'])
+  })
+
+  it('validates if next coll ratio on dai generate action is below stop loss level', () => {
+    const generateAmountStopLossError = new BigNumber(500)
+
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtFloor: new BigNumber(1500),
+        },
+        vault: {
+          collateral: new BigNumber(4.5),
+          debt: new BigNumber(1990),
+          ilk: 'ETH-A',
+        },
+        _automationTriggersData$: of(mockedStopLossTrigger),
+      }),
+    )
+
+    state().toggle!('daiEditing')
+    state().setMainAction!('depositGenerate')
+    state().updateGenerate!(generateAmountStopLossError)
+    expect(state().errorMessages).to.deep.equal(['afterCollRatioBelowStopLossRatio'])
+  })
+
+  it('validates if next coll ratio on collateral withdraw action is below stop loss level', () => {
+    const withdrawCollateralStopLossError = new BigNumber(0.5)
+
+    const state = getStateUnpacker(
+      mockManageVault$({
+        ilkData: {
+          debtFloor: new BigNumber(1500),
+        },
+        vault: {
+          collateral: new BigNumber(4.5),
+          debt: new BigNumber(1990),
+          ilk: 'ETH-A',
+        },
+        _automationTriggersData$: of(mockedStopLossTrigger),
+      }),
+    )
+
+    state().setMainAction!('withdrawPayback')
+    state().updateWithdraw!(withdrawCollateralStopLossError)
+    expect(state().errorMessages).to.deep.equal(['afterCollRatioBelowStopLossRatio'])
   })
 })

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -393,3 +393,18 @@ export function daiAllowanceProgressionDisabledValidator({
       customDaiAllowanceAmountLessThanPaybackAmount)
   )
 }
+
+export function afterCollRatioBelowStopLossRatioValidator({
+  afterCollateralizationRatio,
+  afterCollateralizationRatioAtNextPrice,
+  stopLossRatio,
+}: {
+  afterCollateralizationRatio: BigNumber
+  afterCollateralizationRatioAtNextPrice: BigNumber
+  stopLossRatio: BigNumber
+}) {
+  return (
+    afterCollateralizationRatio.lt(stopLossRatio) ||
+    afterCollateralizationRatioAtNextPrice.lt(stopLossRatio)
+  )
+}

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -26,6 +26,7 @@ export type VaultErrorMessage =
   | 'hasToDepositCollateralOnEmptyVault'
   | 'depositCollateralOnVaultUnderDebtFloor'
   | 'invalidSlippage'
+  | 'afterCollRatioBelowStopLossRatio'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -55,6 +56,7 @@ interface ErrorMessagesHandler {
   hasToDepositCollateralOnEmptyVault?: boolean
   shouldShowExchangeError?: boolean
   invalidSlippage?: boolean
+  afterCollRatioBelowStopLossRatio?: boolean
 }
 
 export function errorMessagesHandler({
@@ -85,6 +87,7 @@ export function errorMessagesHandler({
   hasToDepositCollateralOnEmptyVault,
   shouldShowExchangeError,
   invalidSlippage,
+  afterCollRatioBelowStopLossRatio,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -194,6 +197,10 @@ export function errorMessagesHandler({
 
   if (invalidSlippage) {
     errorMessages.push('invalidSlippage')
+  }
+
+  if (afterCollRatioBelowStopLossRatio) {
+    errorMessages.push('afterCollRatioBelowStopLossRatio')
   }
 
   return errorMessages

--- a/features/multiply/manage/pipes/manageMultiplyVault.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVault.ts
@@ -21,6 +21,11 @@ import { first, map, scan, shareReplay, switchMap, tap } from 'rxjs/operators'
 
 import { SelectedDaiAllowanceRadio } from '../../../../components/vault/commonMultiply/ManageVaultDaiAllowance'
 import { TxError } from '../../../../helpers/types'
+import { StopLossTriggerData } from '../../../automation/common/StopLossTriggerDataExtractor'
+import {
+  createStopLossDataChange$,
+  TriggersData,
+} from '../../../automation/triggers/AutomationTriggersData'
 import { VaultErrorMessage } from '../../../form/errorMessagesHandler'
 import { VaultWarningMessage } from '../../../form/warningMessagesHandler'
 import { BalanceInfo, balanceInfoChange$ } from '../../../shared/balanceInfo'
@@ -250,6 +255,7 @@ export type ManageMultiplyVaultState = MutableManageMultiplyVaultState &
     initialTotalSteps: number
     totalSteps: number
     currentStep: number
+    stopLossData?: StopLossTriggerData
   } & HasGasEstimation
 
 function addTransitions(
@@ -471,6 +477,7 @@ export function createManageMultiplyVault$(
   slippageLimit$: Observable<UserSettingsState>,
   vaultMultiplyHistory$: (id: BigNumber) => Observable<VaultHistoryEvent[]>,
   saveVaultType$: SaveVaultType,
+  automationTriggersData$: (id: BigNumber) => Observable<TriggersData>,
   id: BigNumber,
 ): Observable<ManageMultiplyVaultState> {
   return context$.pipe(
@@ -524,6 +531,7 @@ export function createManageMultiplyVault$(
                     vault,
                     priceInfo,
                     vaultHistory: [],
+                    stopLossData: undefined,
                     balanceInfo,
                     ilkData,
                     account,
@@ -556,6 +564,7 @@ export function createManageMultiplyVault$(
                     createExchangeChange$(exchangeQuote$, stateSubject$),
                     slippageChange$(slippageLimit$),
                     createMultiplyHistoryChange$(vaultMultiplyHistory$, id),
+                    createStopLossDataChange$(automationTriggersData$, id),
                   )
 
                   const connectedProxyAddress$ = account ? proxyAddress$(account) : of(undefined)

--- a/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
@@ -7,6 +7,7 @@ import { zero } from 'helpers/zero'
 import {
   accountIsConnectedValidator,
   accountIsControllerValidator,
+  afterCollRatioBelowStopLossRatioValidator,
   collateralAllowanceProgressionDisabledValidator,
   customCollateralAllowanceAmountEmptyValidator,
   customCollateralAllowanceAmountExceedsMaxUint256Validator,
@@ -216,6 +217,7 @@ export interface ManageVaultConditions {
   highSlippage: boolean
   invalidSlippage: boolean
   stopLossTriggered: boolean
+  afterCollRatioBelowStopLossRatio: boolean
 }
 
 export const defaultManageMultiplyVaultConditions: ManageVaultConditions = {
@@ -276,6 +278,7 @@ export const defaultManageMultiplyVaultConditions: ManageVaultConditions = {
   highSlippage: false,
   invalidSlippage: false,
   stopLossTriggered: false,
+  afterCollRatioBelowStopLossRatio: false,
 }
 
 export function applyManageVaultConditions(
@@ -331,6 +334,7 @@ export function applyManageVaultConditions(
 
     invalidSlippage,
     vaultHistory,
+    stopLossData,
   } = state
 
   const depositAndWithdrawAmountsEmpty = depositAndWithdrawAmountsEmptyValidator({
@@ -531,6 +535,14 @@ export function applyManageVaultConditions(
 
   const highSlippage = exchangeDataRequired && slippage.gt(SLIPPAGE_WARNING_THRESHOLD)
 
+  const afterCollRatioBelowStopLossRatio =
+    !!stopLossData?.isStopLossEnabled &&
+    afterCollRatioBelowStopLossRatioValidator({
+      afterCollateralizationRatio,
+      afterCollateralizationRatioAtNextPrice,
+      stopLossRatio: stopLossData.stopLossLevel,
+    })
+
   const editingProgressionDisabled =
     isEditingStage &&
     (inputAmountsEmpty ||
@@ -551,7 +563,8 @@ export function applyManageVaultConditions(
       withdrawCollateralOnVaultUnderDebtFloor ||
       shouldShowExchangeError ||
       hasToDepositCollateralOnEmptyVault ||
-      invalidSlippage)
+      invalidSlippage ||
+      afterCollRatioBelowStopLossRatio)
 
   const collateralAllowanceProgressionDisabled = collateralAllowanceProgressionDisabledValidator({
     isCollateralAllowanceStage,
@@ -651,5 +664,6 @@ export function applyManageVaultConditions(
 
     highSlippage,
     stopLossTriggered,
+    afterCollRatioBelowStopLossRatio,
   }
 }

--- a/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
@@ -3,6 +3,7 @@ import { VaultChange } from 'blockchain/vaults'
 import { PriceInfoChange } from 'features/shared/priceInfo'
 import { SlippageChange } from 'features/userSettings/userSettings'
 
+import { StopLossChange } from '../../../automation/triggers/AutomationTriggersData'
 import { BalanceInfoChange } from '../../../shared/balanceInfo'
 import { VaultHistoryChange } from '../../../vaultHistory/vaultHistory'
 import { ManageMultiplyVaultChange, ManageMultiplyVaultState } from './manageMultiplyVault'
@@ -14,6 +15,7 @@ export type ManageVaultEnvironmentChange =
   | VaultChange
   | VaultHistoryChange
   | SlippageChange
+  | StopLossChange
 
 export function applyManageVaultEnvironment(
   change: ManageMultiplyVaultChange,
@@ -58,6 +60,13 @@ export function applyManageVaultEnvironment(
     return {
       ...state,
       vaultHistory: change.vaultHistory,
+    }
+  }
+
+  if (change.kind === 'stopLossData') {
+    return {
+      ...state,
+      stopLossData: change.stopLossData,
     }
   }
 

--- a/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
@@ -27,6 +27,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
     shouldShowExchangeError,
     ledgerWalletContractDataDisabled,
     invalidSlippage,
+    afterCollRatioBelowStopLossRatio,
   } = state
 
   const errorMessages: VaultErrorMessage[] = []
@@ -50,6 +51,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
         hasToDepositCollateralOnEmptyVault,
         shouldShowExchangeError,
         invalidSlippage,
+        afterCollRatioBelowStopLossRatio,
       }),
     )
   }

--- a/features/multiply/manage/tests/manageMultiplyVaultAdjustPositionValidations.test.ts
+++ b/features/multiply/manage/tests/manageMultiplyVaultAdjustPositionValidations.test.ts
@@ -3,7 +3,9 @@ import { expect } from 'chai'
 import { mockManageMultiplyVault$ } from 'helpers/mocks/manageMultiplyVault.mock'
 import { getStateUnpacker } from 'helpers/testHelpers'
 import { zero } from 'helpers/zero'
+import { of } from 'rxjs'
 
+import { mockedStopLossTrigger } from '../../../../helpers/mocks/stopLoss.mock'
 import { legacyToggle } from './legacyToggle'
 
 describe('manageVaultAdjustPositionValidations', () => {
@@ -96,6 +98,18 @@ describe('manageVaultAdjustPositionValidations', () => {
     expect(state().errorMessages).to.deep.eq([])
     legacyToggle(state())
     expect(state().errorMessages).to.deep.eq(['hasToDepositCollateralOnEmptyVault'])
+    expect(state().canProgress).to.deep.eq(false)
+  })
+
+  it('validates if next coll ratio is below stop loss level', () => {
+    const state = getStateUnpacker(
+      mockManageMultiplyVault$({ _automationTriggersData$: of(mockedStopLossTrigger) }),
+    )
+
+    // state().stopLossData = extractStopLossData(mockedStopLossTrigger)
+    state().updateRequiredCollRatio!(new BigNumber(2))
+
+    expect(state().errorMessages).to.deep.eq(['afterCollRatioBelowStopLossRatio'])
     expect(state().canProgress).to.deep.eq(false)
   })
 })

--- a/features/multiply/manage/tests/manageMultiplyVaultAdjustPositionValidations.test.ts
+++ b/features/multiply/manage/tests/manageMultiplyVaultAdjustPositionValidations.test.ts
@@ -102,12 +102,12 @@ describe('manageVaultAdjustPositionValidations', () => {
   })
 
   it('validates if next coll ratio is below stop loss level', () => {
+    const requiredCollRatioBelowStopLoss = new BigNumber(2)
     const state = getStateUnpacker(
       mockManageMultiplyVault$({ _automationTriggersData$: of(mockedStopLossTrigger) }),
     )
 
-    // state().stopLossData = extractStopLossData(mockedStopLossTrigger)
-    state().updateRequiredCollRatio!(new BigNumber(2))
+    state().updateRequiredCollRatio!(requiredCollRatioBelowStopLoss)
 
     expect(state().errorMessages).to.deep.eq(['afterCollRatioBelowStopLossRatio'])
     expect(state().canProgress).to.deep.eq(false)

--- a/helpers/mocks/manageMultiplyVault.mock.ts
+++ b/helpers/mocks/manageMultiplyVault.mock.ts
@@ -15,6 +15,7 @@ import { one, zero } from 'helpers/zero'
 import { Observable, of } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 
+import { TriggersData } from '../../features/automation/triggers/AutomationTriggersData'
 import { VaultHistoryEvent } from '../../features/vaultHistory/vaultHistory'
 import { mockedMultiplyEvents } from '../multiply/calculations.test'
 import { mockBalanceInfo$, MockBalanceInfoProps } from './balanceInfo.mock'
@@ -24,6 +25,7 @@ import { mockIlkData$, MockIlkDataProps } from './ilks.mock'
 import { addGasEstimationMock } from './openVault.mock'
 import { mockPriceInfo$, MockPriceInfoProps } from './priceInfo.mock'
 import { slippageLimitMock } from './slippageLimit.mock'
+import { mockedEmptyStopLossTrigger } from './stopLoss.mock'
 import { mockVault$, MockVaultProps } from './vaults.mock'
 
 export const MOCK_VAULT_ID = one
@@ -37,6 +39,7 @@ export interface MockManageMultiplyVaultProps {
   _balanceInfo$?: Observable<BalanceInfo>
   _proxyAddress$?: Observable<string | undefined>
   _vaultMultiplyHistory$?: Observable<VaultHistoryEvent[]>
+  _automationTriggersData$?: Observable<TriggersData>
   _collateralAllowance$?: Observable<BigNumber>
   _daiAllowance$?: Observable<BigNumber>
   _vault$?: Observable<Vault>
@@ -63,6 +66,7 @@ export function mockManageMultiplyVault$({
   _balanceInfo$,
   _proxyAddress$,
   _vaultMultiplyHistory$,
+  _automationTriggersData$,
   _collateralAllowance$,
   _daiAllowance$,
   _vault$,
@@ -115,6 +119,10 @@ export function mockManageMultiplyVault$({
     return _vaultMultiplyHistory$ || of(mockedMultiplyEvents)
   }
 
+  function automationTriggersData$() {
+    return _automationTriggersData$ || of(mockedEmptyStopLossTrigger)
+  }
+
   function allowance$(_token: string) {
     return _token === 'DAI'
       ? _daiAllowance$ || daiAllowance
@@ -158,6 +166,7 @@ export function mockManageMultiplyVault$({
     slippageLimitMock(),
     vaultMultiplyHistory$,
     saveVaultType$,
+    automationTriggersData$,
     MOCK_VAULT_ID,
   )
 }

--- a/helpers/mocks/manageVault.mock.ts
+++ b/helpers/mocks/manageVault.mock.ts
@@ -19,6 +19,7 @@ import { switchMap } from 'rxjs/operators'
 import { withdrawPaybackDepositGenerateLogicFactory } from '../../blockchain/calls/proxyActions/proxyActions'
 import { StandardDssProxyActionsContractWrapper } from '../../blockchain/calls/proxyActions/standardDssProxyActionsContractWrapper'
 import { createInstiVault$, InstiVault } from '../../blockchain/instiVault'
+import { TriggersData } from '../../features/automation/triggers/AutomationTriggersData'
 import { InstitutionalBorrowManageVaultViewStateProvider } from '../../features/borrow/manage/pipes/viewStateProviders/institutionalBorrowManageVaultViewStateProvider'
 import { StandardBorrowManageVaultViewStateProvider } from '../../features/borrow/manage/pipes/viewStateProviders/standardBorrowManageVaultViewStateProvider'
 import { VaultHistoryEvent } from '../../features/vaultHistory/vaultHistory'
@@ -27,6 +28,7 @@ import { mockContext$ } from './context.mock'
 import { mockIlkData$, MockIlkDataProps } from './ilks.mock'
 import { addGasEstimationMock } from './openVault.mock'
 import { mockPriceInfo$, MockPriceInfoProps } from './priceInfo.mock'
+import { mockedEmptyStopLossTrigger } from './stopLoss.mock'
 import { mockVault$, MockVaultProps } from './vaults.mock'
 
 export const MOCK_VAULT_ID = one
@@ -76,6 +78,7 @@ export interface MockManageVaultProps {
   _balanceInfo$?: Observable<BalanceInfo>
   _proxyAddress$?: Observable<string | undefined>
   _vaultHistory$?: Observable<VaultHistoryEvent[]>
+  _automationTriggersData$?: Observable<TriggersData>
   _collateralAllowance$?: Observable<BigNumber>
   _daiAllowance$?: Observable<BigNumber>
   _vault$?: Observable<Vault>
@@ -101,6 +104,7 @@ function buildMockDependencies({
   _balanceInfo$,
   _proxyAddress$,
   _vaultHistory$,
+  _automationTriggersData$,
   _collateralAllowance$,
   _daiAllowance$,
   _vault$,
@@ -152,6 +156,10 @@ function buildMockDependencies({
     return _vaultHistory$ || of(mockedBorrowEvents)
   }
 
+  function automationTriggersData$() {
+    return _automationTriggersData$ || of(mockedEmptyStopLossTrigger)
+  }
+
   function allowance$(_token: string) {
     return _token === 'DAI'
       ? _daiAllowance$ || daiAllowance
@@ -193,6 +201,7 @@ function buildMockDependencies({
     vault$,
     saveVaultType$,
     vaultHistory$,
+    automationTriggersData$,
   }
 }
 
@@ -210,6 +219,7 @@ export function mockManageVault$(
     vault$,
     saveVaultType$,
     vaultHistory$,
+    automationTriggersData$,
   } = buildMockDependencies(args)
 
   return createManageVault$<Vault, ManageStandardBorrowVaultState>(
@@ -226,6 +236,7 @@ export function mockManageVault$(
     vaultHistory$,
     withdrawPaybackDepositGenerateLogicFactory(StandardDssProxyActionsContractWrapper),
     StandardBorrowManageVaultViewStateProvider,
+    automationTriggersData$,
     MOCK_VAULT_ID,
   )
 }
@@ -247,6 +258,7 @@ export function mockManageInstiVault$(
     ilkData$,
     saveVaultType$,
     vaultHistory$,
+    automationTriggersData$,
   } = buildMockDependencies(args)
 
   function instiVault$(): Observable<InstiVault> {
@@ -284,6 +296,7 @@ export function mockManageInstiVault$(
     vaultHistory$,
     withdrawPaybackDepositGenerateLogicFactory(StandardDssProxyActionsContractWrapper),
     InstitutionalBorrowManageVaultViewStateProvider,
+    automationTriggersData$,
     MOCK_VAULT_ID,
   )
 }

--- a/helpers/mocks/stopLoss.mock.ts
+++ b/helpers/mocks/stopLoss.mock.ts
@@ -1,5 +1,6 @@
 import { TriggersData } from '../../features/automation/triggers/AutomationTriggersData'
 
+// mock with 300% stop loss level
 export const mockedStopLossTrigger: TriggersData = {
   isAutomationEnabled: true,
   triggers: [

--- a/helpers/mocks/stopLoss.mock.ts
+++ b/helpers/mocks/stopLoss.mock.ts
@@ -1,0 +1,17 @@
+import { TriggersData } from '../../features/automation/triggers/AutomationTriggersData'
+
+export const mockedStopLossTrigger: TriggersData = {
+  isAutomationEnabled: true,
+  triggers: [
+    {
+      triggerId: 290,
+      executionParams:
+        '0x00000000000000000000000000000000000000000000000000000000000000870000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000012c',
+    },
+  ],
+}
+
+export const mockedEmptyStopLossTrigger: TriggersData = {
+  isAutomationEnabled: false,
+  triggers: [],
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -663,7 +663,8 @@
     "withdraw-collateral-on-vault-under-debt-floor": "You cannot withdraw from your vault while it is below the minimum required of {{debtFloor}} Dai. To withdraw your collateral, payback your debt fully. Learn more about the Minimum Vault Debt <0>here</0>.",
     "has-to-deposit-collateral-on-empty-vault": "There is no collateral in this vault. Please first add collateral in the 'Other actions' tab, with the 'deposit collateral' action",
     "deposit-collateral-on-vault-under-debt-floor": "You cannot deposit to your vault while it is below the minimum debt required of {{debtFloor}}. To add more collateral, generate Dai to get above the minimum required. Learn more about the Minimum Vault Debt here <0>here</0>)",
-    "invalid-slippage": "Custom slippage set too high for this transaction, please reduce your slippage setting"
+    "invalid-slippage": "Custom slippage set too high for this transaction, please reduce your slippage setting",
+    "after-coll-ratio-below-stop-loss-ratio": "You cannot make adjustments to your Vault which take it below your Stop Loss Col. Ratio at current or next collateral price"
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",


### PR DESCRIPTION
# [Added stop loss validation to borrow vaults](https://app.shortcut.com/oazo-apps/story/3709/add-validation-to-block-users-from-triggering-their-automation-by-adjustment-actions-borrow-flow)

# [Added stop loss validation to multiply vaults](https://app.shortcut.com/oazo-apps/story/3710/add-validation-to-block-users-from-triggering-their-automation-by-adjustment-actions-multiply-flow)

<please insert a clubhouse link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added stop loss validation to borrow and multiply flows
  
## How to test 🧪
  <Please explain how to test your changes>
- locally / heroku
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
