### PR TITLE
disable steCRV button when user has a vault already

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -121,15 +121,7 @@ import { createVaultsOverview$ } from 'features/vaultsOverview/vaultsOverview'
 import { isEqual, mapValues, memoize } from 'lodash'
 import { curry } from 'ramda'
 import { combineLatest, iif, Observable, of, Subject } from 'rxjs'
-import {
-  distinctUntilChanged,
-  filter,
-  map,
-  mergeMap,
-  shareReplay,
-  switchMap,
-  tap,
-} from 'rxjs/operators'
+import { distinctUntilChanged, filter, map, mergeMap, shareReplay, switchMap } from 'rxjs/operators'
 
 import { cropperUrnProxy } from '../blockchain/calls/cropper'
 import { dogIlk } from '../blockchain/calls/dog'
@@ -175,9 +167,9 @@ import { BalanceInfo, createBalanceInfo$ } from '../features/shared/balanceInfo'
 import { createCheckVaultType$, VaultIdToTypeMapping } from '../features/shared/checkVaultType'
 import { jwtAuthSetupToken$ } from '../features/termsOfService/jwt'
 import { createTermsAcceptance$ } from '../features/termsOfService/termsAcceptance'
+import { createCanCreateVaultForIlk$ } from '../helpers/createCanCreateVaultForIlk'
 import { doGasEstimation, HasGasEstimation } from '../helpers/form'
 import { createProductCardsData$ } from '../helpers/productCards'
-import { createCanCreateVaultForIlk$ } from '../helpers/createCanCreateVaultForIlk'
 
 export type TxData =
   | OpenData
@@ -753,14 +745,7 @@ export function setupAppContext() {
 
   const collateralPrices$ = createCollateralPrices$(collateralTokens$, oraclePriceData$)
 
-  const canCreateVaultForIlkMock = () => of(true)
-
-  const productCardsData$ = createProductCardsData$(
-    ilkDataList$,
-    priceInfo$,
-    // canCreateVaultForIlkMock,
-    canCreateVaultForIlk$,
-  )
+  const productCardsData$ = createProductCardsData$(ilkDataList$, priceInfo$, canCreateVaultForIlk$)
 
   const automationTriggersData$ = memoize(
     curry(createAutomationTriggersData)(context$, onEveryBlock$, vault$),

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -121,7 +121,15 @@ import { createVaultsOverview$ } from 'features/vaultsOverview/vaultsOverview'
 import { isEqual, mapValues, memoize } from 'lodash'
 import { curry } from 'ramda'
 import { combineLatest, iif, Observable, of, Subject } from 'rxjs'
-import { distinctUntilChanged, filter, map, mergeMap, shareReplay, switchMap } from 'rxjs/operators'
+import {
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeMap,
+  shareReplay,
+  startWith,
+  switchMap,
+} from 'rxjs/operators'
 
 import { cropperUrnProxy } from '../blockchain/calls/cropper'
 import { dogIlk } from '../blockchain/calls/dog'
@@ -503,10 +511,9 @@ export function setupAppContext() {
     ]),
   )
 
-  const userVaults$: Observable<VaultWithType[]> = context$.pipe(
-    switchMap((ctx) =>
-      iif(() => ctx.status === 'connected', vaults$((ctx as ContextConnected).account), of([])),
-    ),
+  const userVaults$: Observable<VaultWithType[]> = connectedContext$.pipe(
+    switchMap((ctx) => vaults$(ctx.account)),
+    startWith([]),
     shareReplay(1),
   )
 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from 'next-i18next'
 import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { Box, Button, Card, Flex, Heading, Image, Spinner, Text } from 'theme-ui'
 
+import { CanOpenVaultResult } from '../helpers/createCanCreateVaultForIlk'
 import { useWindowSize } from '../helpers/useWindowSize'
 import { fadeInAnimation } from '../theme/animations'
 import { FloatingLabel } from './FloatingLabel'
 import { AppLink } from './Links'
-import { CanOpenVaultResult } from '../helpers/createCanCreateVaultForIlk'
 
 function InactiveCard() {
   return (

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -7,6 +7,7 @@ import { useWindowSize } from '../helpers/useWindowSize'
 import { fadeInAnimation } from '../theme/animations'
 import { FloatingLabel } from './FloatingLabel'
 import { AppLink } from './Links'
+import { CanOpenVaultResult } from '../helpers/createCanCreateVaultForIlk'
 
 function InactiveCard() {
   return (
@@ -126,7 +127,7 @@ export interface ProductCardProps {
   rightSlot: { title: string; value: ReactNode }
   button: { link: string; text: string }
   background: string
-  isFull: boolean
+  canCreateVault: CanOpenVaultResult
   floatingLabelText?: string
   inactive?: boolean
 }
@@ -141,7 +142,7 @@ export function ProductCard({
   rightSlot,
   button,
   background,
-  isFull,
+  canCreateVault,
   floatingLabelText,
   inactive,
 }: ProductCardProps) {
@@ -220,7 +221,7 @@ export function ProductCard({
             <Flex>
               <AppLink
                 href={button.link}
-                disabled={isFull}
+                disabled={!canCreateVault.canOpen}
                 sx={{ width: '100%' }}
                 onClick={handleClick}
               >
@@ -234,16 +235,20 @@ export function ProductCard({
                     alignItems: 'center',
                     justifyContent: 'center',
                     boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.13)',
-                    backgroundColor: inactive || isFull ? '#80818A' : 'primary',
+                    backgroundColor: inactive || !canCreateVault.canOpen ? '#80818A' : 'primary',
                     '&:hover': {
                       boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.15)',
                       transition: '0.2s ease-in',
-                      backgroundColor: isFull ? '#80818A' : 'primary',
-                      cursor: isFull ? 'default' : 'pointer',
+                      backgroundColor: !canCreateVault.canOpen ? '#80818A' : 'primary',
+                      cursor: !canCreateVault.canOpen ? 'default' : 'pointer',
                     },
                   }}
                 >
-                  {isFull ? t('full') : !clicked ? button.text : ''}
+                  {!canCreateVault.canOpen
+                    ? t(`product-card.${canCreateVault.excuse}`)
+                    : !clicked
+                    ? button.text
+                    : ''}
                   {clicked && (
                     <Spinner
                       variant="styles.spinner.medium"

--- a/components/ProductCardBorrow.tsx
+++ b/components/ProductCardBorrow.tsx
@@ -90,7 +90,7 @@ export function ProductCardBorrow(props: { cardData: ProductCardData }) {
       button={{ link: `/vaults/open/${cardData.ilk}`, text: t('nav.borrow') }}
       background={cardData.background}
       inactive={productCardsConfig.borrow.inactiveIlks.includes(cardData.ilk)}
-      isFull={cardData.isFull}
+      canCreateVault={cardData.canCreateVault}
       floatingLabelText={tagKey ? t(`product-card.tags.${tagKey}`) : ''}
     />
   )

--- a/components/ProductCardEarn.tsx
+++ b/components/ProductCardEarn.tsx
@@ -108,7 +108,7 @@ export function ProductCardEarn({ cardData }: ProductCardEarnProps) {
       }}
       background={cardData.background}
       inactive={productCardsConfig.earn.inactiveIlks.includes(cardData.ilk)}
-      isFull={cardData.isFull}
+      canCreateVault={cardData.canCreateVault}
       floatingLabelText={tagKey ? t(`product-card.tags.${tagKey}`, { token: cardData.token }) : ''}
     />
   )

--- a/components/ProductCardMultiply.tsx
+++ b/components/ProductCardMultiply.tsx
@@ -71,7 +71,7 @@ export function ProductCardMultiply(props: { cardData: ProductCardData }) {
       }}
       background={cardData.background}
       inactive={productCardsConfig.multiply.inactiveIlks.includes(cardData.ilk)}
-      isFull={cardData.isFull}
+      canCreateVault={cardData.canCreateVault}
       floatingLabelText={tagKey ? t(`product-card.tags.${tagKey}`, { token: cardData.token }) : ''}
     />
   )

--- a/components/stories/ProductCard.stories.tsx
+++ b/components/stories/ProductCard.stories.tsx
@@ -24,7 +24,7 @@ export const Borrow = () => {
       rightSlot={{ title: t(t('system.stability-fee')), value: '2.0%' }}
       background="linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF"
       button={{ link: '/vaults/open/ETH-A', text: t('nav.borrow') }}
-      isFull={false}
+      canCreateVault={{ canOpen: true }}
     />
   )
 }
@@ -50,7 +50,7 @@ export const Multiply = () => {
       background="linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF"
       button={{ link: '/vaults/open-multiply/ETH-A', text: t('nav.multiply') }}
       floatingLabelText="Get up to 3.3x ETH exposure"
-      isFull={false}
+      canCreateVault={{ canOpen: true }}
     />
   )
 }

--- a/helpers/canCreateVaultForIlk.test.ts
+++ b/helpers/canCreateVaultForIlk.test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai'
+
+import { createCanCreateVaultForIlk$ } from './createCanCreateVaultForIlk'
+import { mockVaults$ } from './mocks/vaults.mock'
+import { getStateUnpacker } from './testHelpers'
+import { mockIlkData, mockIlkData$ } from './mocks/ilks.mock'
+import BigNumber from 'bignumber.js'
+
+describe('create can create vault', () => {
+  it('lets the user create a sethCRV vault if they do not already have one', () => {
+    const vaults$ = mockVaults$([
+      {
+        ilk: 'ETH-A',
+      },
+    ])
+    const obs = createCanCreateVaultForIlk$(vaults$, mockIlkData({ ilk: 'CRVV1ETHSTETH-A' })())
+    const state = getStateUnpacker(obs)
+    expect(state().canOpen).to.eq(true)
+  })
+
+  it('blocks the user from creating a sethCRV vault if they already have one', () => {
+    const vaults$ = mockVaults$([
+      {
+        ilk: 'CRVV1ETHSTETH-A',
+      },
+    ])
+
+    const mockIlk = mockIlkData({ ilk: 'CRVV1ETHSTETH-A' })()
+
+    const obs = createCanCreateVaultForIlk$(vaults$, mockIlk)
+    const state = getStateUnpacker(obs)
+    expect(state()).to.eql({ canOpen: false, excuse: 'user-already-has-vault' })
+  })
+
+  it('lets the user create an ETH vault if they already have one', () => {
+    const vaults$ = mockVaults$([
+      {
+        ilk: 'ETH-A',
+      },
+    ])
+    const obs = createCanCreateVaultForIlk$(vaults$, mockIlkData({ ilk: 'ETH-A' })())
+    const state = getStateUnpacker(obs)
+    expect(state().canOpen).to.eq(true)
+  })
+
+  it('blocks a user from creating a vault when the ilk debt available is less than the debt floor', () => {
+    const vaults$ = mockVaults$([
+      {
+        ilk: 'ETH-A',
+      },
+    ])
+
+    const ilkData = mockIlkData({
+      ilk: 'ETH-A',
+      debtCeiling: new BigNumber(0), // bring ilkDebtAvailable down to zero
+    })()
+    const obs = createCanCreateVaultForIlk$(vaults$, ilkData)
+    const state = getStateUnpacker(obs)
+    expect(state()).to.eql({ canOpen: false, excuse: 'vault-full' })
+  })
+})

--- a/helpers/canCreateVaultForIlk.test.ts
+++ b/helpers/canCreateVaultForIlk.test.ts
@@ -1,10 +1,10 @@
+import BigNumber from 'bignumber.js'
 import { expect } from 'chai'
 
 import { createCanCreateVaultForIlk$ } from './createCanCreateVaultForIlk'
+import { mockIlkData } from './mocks/ilks.mock'
 import { mockVaults$ } from './mocks/vaults.mock'
 import { getStateUnpacker } from './testHelpers'
-import { mockIlkData, mockIlkData$ } from './mocks/ilks.mock'
-import BigNumber from 'bignumber.js'
 
 describe('create can create vault', () => {
   it('lets the user create a sethCRV vault if they do not already have one', () => {

--- a/helpers/createCanCreateVaultForIlk.ts
+++ b/helpers/createCanCreateVaultForIlk.ts
@@ -1,8 +1,8 @@
 import { Observable, of } from 'rxjs'
-import { map, tap } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 
-import { Vault } from '../blockchain/vaults'
 import { IlkData } from '../blockchain/ilks'
+import { Vault } from '../blockchain/vaults'
 
 function userAlreadyHasSethCRVVault(usersVaults: Vault[], ilk: IlkData) {
   return (

--- a/helpers/createCanCreateVaultForIlk.ts
+++ b/helpers/createCanCreateVaultForIlk.ts
@@ -1,0 +1,47 @@
+import { Observable, of } from 'rxjs'
+import { map, tap } from 'rxjs/operators'
+
+import { Vault } from '../blockchain/vaults'
+import { IlkData } from '../blockchain/ilks'
+
+function userAlreadyHasSethCRVVault(usersVaults: Vault[], ilk: IlkData) {
+  return (
+    ilk.ilk === 'CRVV1ETHSTETH-A' && usersVaults.some((vault) => vault.ilk === 'CRVV1ETHSTETH-A')
+  )
+}
+
+function noDebtAvailableOnIlk(ilk: IlkData) {
+  return ilk.ilkDebtAvailable.lt(ilk.debtFloor)
+}
+
+export function createCanCreateVaultForIlk$(
+  usersVaults$: Observable<Vault[]>,
+  ilk: IlkData,
+): Observable<CanOpenVaultResult> {
+  return usersVaults$.pipe(
+    map((usersVaults) => {
+      if (userAlreadyHasSethCRVVault(usersVaults, ilk)) {
+        return { canOpen: false, excuse: 'user-already-has-vault' }
+      }
+
+      if (noDebtAvailableOnIlk(ilk)) {
+        return { canOpen: false, excuse: 'vault-full' }
+      }
+
+      return { canOpen: true }
+    }),
+  )
+}
+
+export type CanOpenVaultResult =
+  | {
+      canOpen: true
+    }
+  | {
+      canOpen: false
+      excuse: 'vault-full' | 'user-already-has-vault'
+    }
+
+export function mockCanCreateVaultForIlk$(): Observable<CanOpenVaultResult> {
+  return of({ canOpen: true })
+}

--- a/helpers/mocks/vaults.mock.ts
+++ b/helpers/mocks/vaults.mock.ts
@@ -6,7 +6,7 @@ import { createVault$, Vault } from 'blockchain/vaults'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { getStateUnpacker } from 'helpers/testHelpers'
 import { one, zero } from 'helpers/zero'
-import { Observable, of } from 'rxjs'
+import { combineLatest, Observable, of } from 'rxjs'
 import { first, switchMap } from 'rxjs/operators'
 
 import { mockContextConnected$ } from './context.mock'
@@ -113,4 +113,8 @@ export function mockVault$({
 
 export function mockVaults(props: MockVaultProps = {}) {
   return getStateUnpacker(mockVault$(props))
+}
+
+export function mockVaults$(vaultData: MockVaultProps[]): Observable<Vault[]> {
+  return combineLatest(vaultData.map((vd) => mockVault$(vd)))
 }

--- a/helpers/productCards.test.ts
+++ b/helpers/productCards.test.ts
@@ -4,6 +4,7 @@ import { mockIlkData } from 'helpers/mocks/ilks.mock'
 import { getStateUnpacker } from 'helpers/testHelpers'
 import { of } from 'rxjs'
 
+import { mockCanCreateVaultForIlk$ } from './createCanCreateVaultForIlk'
 import { mockPriceInfo$ } from './mocks/priceInfo.mock'
 import {
   borrowPageCardsData,
@@ -11,7 +12,6 @@ import {
   landingPageCardsData,
   multiplyPageCardsData,
 } from './productCards'
-import { mockCanCreateVaultForIlk$ } from './createCanCreateVaultForIlk'
 
 const wbtcA = mockIlkData({
   token: 'WTBC',

--- a/helpers/productCards.test.ts
+++ b/helpers/productCards.test.ts
@@ -11,6 +11,7 @@ import {
   landingPageCardsData,
   multiplyPageCardsData,
 } from './productCards'
+import { mockCanCreateVaultForIlk$ } from './createCanCreateVaultForIlk'
 
 const wbtcA = mockIlkData({
   token: 'WTBC',
@@ -91,7 +92,9 @@ const crv = mockIlkData({
 
 describe('createProductCardsData$', () => {
   it('should return correct product data', () => {
-    const state = getStateUnpacker(createProductCardsData$(of([wbtcA]), () => mockPriceInfo$()))
+    const state = getStateUnpacker(
+      createProductCardsData$(of([wbtcA]), () => mockPriceInfo$(), mockCanCreateVaultForIlk$),
+    )
 
     expect(state()[0]).to.eql({
       background: 'linear-gradient(147.66deg, #FEF1E1 0%, #FDF2CA 88.25%)',
@@ -103,13 +106,17 @@ describe('createProductCardsData$', () => {
       name: 'Wrapped Bitcoin',
       stabilityFee: new BigNumber(0.045),
       token: 'WBTC',
-      isFull: false,
+      canCreateVault: { canOpen: true },
     })
   })
 
   it('should return correct landing page product data', () => {
     const state = getStateUnpacker(
-      createProductCardsData$(of([wbtcB, ethB, guni, wsteth]), () => mockPriceInfo$()),
+      createProductCardsData$(
+        of([wbtcB, ethB, guni, wsteth]),
+        () => mockPriceInfo$(),
+        mockCanCreateVaultForIlk$,
+      ),
     )
 
     const landingPageData = landingPageCardsData({ productCardsData: state() })
@@ -125,7 +132,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/wbtc.gif',
         background: 'linear-gradient(147.66deg, #FEF1E1 0%, #FDF2CA 88.25%)',
         name: 'Wrapped Bitcoin',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: ethB.token,
@@ -137,7 +144,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/eth.gif',
         background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
         name: 'Ether',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: guni.token,
@@ -149,14 +156,18 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/uni_old_dai_usdc.gif',
         background: 'linear-gradient(171.29deg, #FDDEF0 -2.46%, #FFF0F9 -2.45%, #FFF6F1 99.08%)',
         name: 'GUNIV3 DAI/USDC 0.01%',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
     ])
   })
 
   it('should return correct multiple page product data', () => {
     const state = getStateUnpacker(
-      createProductCardsData$(of([wbtcB, ethB, guni, wsteth]), () => mockPriceInfo$()),
+      createProductCardsData$(
+        of([wbtcB, ethB, guni, wsteth]),
+        () => mockPriceInfo$(),
+        mockCanCreateVaultForIlk$,
+      ),
     )
 
     const multiplyPageData = multiplyPageCardsData({
@@ -175,7 +186,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/wbtc.gif',
         background: 'linear-gradient(147.66deg, #FEF1E1 0%, #FDF2CA 88.25%)',
         name: 'Wrapped Bitcoin',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: ethB.token,
@@ -187,7 +198,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/eth.gif',
         background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
         name: 'Ether',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: guni.token,
@@ -199,14 +210,18 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/uni_old_dai_usdc.gif',
         background: 'linear-gradient(171.29deg, #FDDEF0 -2.46%, #FFF0F9 -2.45%, #FFF6F1 99.08%)',
         name: 'GUNIV3 DAI/USDC 0.01%',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
     ])
   })
 
   it('should return correct multiple page token product data', () => {
     const state = getStateUnpacker(
-      createProductCardsData$(of([wbtcA, ethA, linkA, wsteth]), () => mockPriceInfo$()),
+      createProductCardsData$(
+        of([wbtcA, ethA, linkA, wsteth]),
+        () => mockPriceInfo$(),
+        mockCanCreateVaultForIlk$,
+      ),
     )
 
     const multiplyPageData = multiplyPageCardsData({
@@ -225,7 +240,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/eth.gif',
         background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
         name: 'Ether',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: wsteth.token,
@@ -237,14 +252,18 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/wstETH.gif',
         background: 'linear-gradient(158.87deg, #E2F7F9 0%, #D3F3F5 100%), #FFFFFF',
         name: 'WSTETH',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
     ])
   })
 
   it('should return correct borrow page product data', () => {
     const state = getStateUnpacker(
-      createProductCardsData$(of([wbtcC, ethA, ethC, linkA, wsteth, crv]), () => mockPriceInfo$()),
+      createProductCardsData$(
+        of([wbtcC, ethA, ethC, linkA, wsteth, crv]),
+        () => mockPriceInfo$(),
+        mockCanCreateVaultForIlk$,
+      ),
     )
 
     const borrowPageData = borrowPageCardsData({
@@ -263,7 +282,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/wbtc.gif',
         background: 'linear-gradient(147.66deg, #FEF1E1 0%, #FDF2CA 88.25%)',
         name: 'Wrapped Bitcoin',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: ethC.token,
@@ -275,7 +294,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/eth.gif',
         background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
         name: 'Ether',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: crv.token,
@@ -287,15 +306,17 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/crv_steth_eth.gif',
         background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
         name: 'stETH/ETH CRV',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
     ])
   })
 
   it('should return correct borrow page token product data', () => {
     const state = getStateUnpacker(
-      createProductCardsData$(of([wbtcA, ethA, ethC, linkA, wsteth, renbtc]), () =>
-        mockPriceInfo$(),
+      createProductCardsData$(
+        of([wbtcA, ethA, ethC, linkA, wsteth, renbtc]),
+        () => mockPriceInfo$(),
+        mockCanCreateVaultForIlk$,
       ),
     )
 
@@ -312,7 +333,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/renBTC.gif',
         background: 'linear-gradient(160.47deg, #F1F5F5 0.35%, #E5E7E8 99.18%), #FFFFFF',
         name: 'renBTC',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
       {
         token: wbtcA.token,
@@ -324,7 +345,7 @@ describe('createProductCardsData$', () => {
         bannerGif: '/static/img/tokens/wbtc.gif',
         background: 'linear-gradient(147.66deg, #FEF1E1 0%, #FDF2CA 88.25%)',
         name: 'Wrapped Bitcoin',
-        isFull: false,
+        canCreateVault: { canOpen: true },
       },
     ])
   })
@@ -334,6 +355,7 @@ describe('createProductCardsData$', () => {
       createProductCardsData$(
         of([wbtcA, ethA, ethC, linkA, wsteth, renbtc, ethB, wbtcB, wbtcC]),
         () => mockPriceInfo$(),
+        mockCanCreateVaultForIlk$,
       ),
     )
 
@@ -355,5 +377,15 @@ describe('createProductCardsData$', () => {
     expect(multiplyCardData[3].ilk).to.eql(wbtcC.ilk)
   })
 
-  it('does not sort product cards that have no custom ordering')
+  it('shows steCRV ilk as full when the user already has one', () => {
+    const state = getStateUnpacker(
+      createProductCardsData$(
+        of([wbtcA, crv]),
+        () => mockPriceInfo$(),
+        () => of({ canOpen: false, excuse: 'user-already-has-vault' }),
+      ),
+    )
+
+    expect(state()[0].canCreateVault.canOpen).to.eq(false)
+  })
 })

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -176,7 +176,6 @@
   "get-started": "Get Started",
   "go-to-vault": "Go to Vault #{{id}}",
   "here": "here",
-  "full": "Full",
   "history": {
     "auction_finished_v2": "Auction <0>#{{auctionId}}</0> finished, <0>{{remainingCollateral}} {{token}}</0> remained",
     "auction_started": "Auction started, <0>{{collateralAmount}} {{token}}</0> taken to cover <0>{{daiAmount}} Dai</0>",
@@ -940,7 +939,9 @@
       "staking-rewards": "Staking rewards",
       "max-exposure": "Max {{token}} exposure"
     },
-    "unprofitable-position": "This position is currently likely unprofitable. Proceed if you know what you are doing."
+    "unprofitable-position": "This position is currently likely unprofitable. Proceed if you know what you are doing.",
+    "vault-full": "Full",
+    "user-already-has-vault": "You already have this"
   },
   "product-card-banner": {
     "with": "With {{value}} {{token}} \uD83D\uDC47",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -169,7 +169,6 @@
   "get-started": "Comenzar",
   "go-to-vault": "Ir al Vault #{{id}}",
   "here": "aquí",
-  "full": "Completo",
   "history": {
     "auction_finished_v2": "Subasta <0>#{{auctionId}}</0> finalizada, <0>{{remainingCollateral}} {{token}}</0> restantes",
     "auction_started": "Subasta iniciada, <0>{{collateralAmount}} {{token}}</0> tomado para cubrir <0>{{daiAmount}} Dai</0>",
@@ -995,7 +994,8 @@
       "staking-rewards": "Recompensas de staking",
       "max-exposure": "Máxima exposición a {{token}}"
     },
-    "unprofitable-position": "Esta posición probablemente no sea rentable en este momento. Continúe si está seguro sobre lo que está haciendo."
+    "unprofitable-position": "Esta posición probablemente no sea rentable en este momento. Continúe si está seguro sobre lo que está haciendo.",
+    "vault-full": "Completo"
   },
   "product-card-banner": {
     "with": "Con {{value}} {{token}} 👇",


### PR DESCRIPTION
Disables steCRV when the user already has a steCRV vault, because a wallet can only have one.

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/3783198/158643664-1605014a-5aff-405a-8d12-8cf309101da7.png">

Creates a pipe `canCreateVaultForIlk$` which is consumed by `productCardData$` provides an excuse if the user cannot open the vault.

Testing:

- create a full vault where the debt ceiling is zero - ensure button disabled and shows as `full`
- ensure you can create a steCRV borrow position (both connected and disconnected wallet) if you don't already have one
- ensure you button is disabled when you go to create another steCRV borrow position