### PR TITLE
Add rollback GHA

### DIFF
--- a/.github/workflows/aws-prod-rollback.yaml
+++ b/.github/workflows/aws-prod-rollback.yaml
@@ -1,0 +1,78 @@
+name: Rollback Production
+
+on:
+  workflow_dispatch:
+    branches: [ main ]
+    inputs:
+      commit_hash:
+        description: 'Enter the commit hash you want to roll back to.'
+        default: '<hash>'
+        required: true
+        type: string
+
+jobs:
+  rollback-deployment:
+    env:
+      AWS_REGION: us-east-1
+      ECR_REPO_NAME: oasis-borrow-prod
+      SERVICE_NAME: oasis-borrow-prod
+      CLUSTER_NAME: oasis-borrow-prod
+      COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout Repo History
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate commit_hash
+        run: |
+          VALID_HASH=$(env -i git log --max-count=10 --no-walk --tags --pretty='%h' --decorate=full | grep ${{ env.COMMIT_HASH }})
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.OAZO_PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.OAZO_PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Retrieve Docker Image Tagged :${{ env.COMMIT_HASH }}
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker pull $ECR_REGISTRY/$ECR_REPO_NAME:${{ env.COMMIT_HASH }}
+
+      - name: Tag Image as ':latest'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker image tag $ECR_REGISTRY/$ECR_REPO_NAME:${{ env.COMMIT_HASH }} $ECR_REGISTRY/$ECR_REPO_NAME:latest
+
+      - name: Push New ':latest' Tag To Repo
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker push $ECR_REGISTRY/$ECR_REPO_NAME:latest
+
+      - name: Update ECS service with Rollback Docker image
+        id: service-update
+        run: |
+          aws ecs update-service --cluster $CLUSTER_NAME --service ${{ env.SERVICE_NAME }} --force-new-deployment --region $AWS_REGION
+
+      - name: Wait for all services to become stable
+        uses: oryanmoshe/ecs-wait-action@v1.3
+        with:
+          ecs-cluster: ${{ env.CLUSTER_NAME }}
+          ecs-services: '["${{ env.SERVICE_NAME }}"]'
+
+      - name: Invalidate CloudFront
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DIST_ID_PROD }} --paths "/*"
+

--- a/.github/workflows/aws-prod-rollback.yaml
+++ b/.github/workflows/aws-prod-rollback.yaml
@@ -17,7 +17,6 @@ jobs:
       ECR_REPO_NAME: oasis-borrow-prod
       SERVICE_NAME: oasis-borrow-prod
       CLUSTER_NAME: oasis-borrow-prod
-      COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
 
     runs-on: ubuntu-latest
 
@@ -31,7 +30,7 @@ jobs:
 
       - name: Validate commit_hash
         run: |
-          VALID_HASH=$(env -i git log --max-count=10 --no-walk --tags --pretty='%h' --decorate=full | grep ${{ env.COMMIT_HASH }})
+          VALID_HASH=$(env -i git log --max-count=10 --no-walk --tags --pretty='%h' --decorate=full | grep ${{ github.event.inputs.commit_hash }})
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -44,23 +43,10 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Retrieve Docker Image Tagged :${{ env.COMMIT_HASH }}
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      - name: Tag Image as latest
         run: |
-          docker pull $ECR_REGISTRY/$ECR_REPO_NAME:${{ env.COMMIT_HASH }}
-
-      - name: Tag Image as ':latest'
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker image tag $ECR_REGISTRY/$ECR_REPO_NAME:${{ env.COMMIT_HASH }} $ECR_REGISTRY/$ECR_REPO_NAME:latest
-
-      - name: Push New ':latest' Tag To Repo
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker push $ECR_REGISTRY/$ECR_REPO_NAME:latest
+          MANIFEST=$(aws ecr batch-get-image --repository-name $ECR_REPO_NAME --image-ids imageTag=${{ github.event.inputs.commit_hash }} --query 'images[].imageManifest' --output text)
+          aws ecr put-image --repository-name $ECR_REPO_NAME --image-tag latest --image-manifest "$MANIFEST"
 
       - name: Update ECS service with Rollback Docker image
         id: service-update


### PR DESCRIPTION
CICD to allow Devs to roll production back to a previously released version.
This is a **manual** trigger job, and requires the user to input the short commit hash, of a previously released tag.
The docker image will then be re-tagged as **_latest_**, and deployed to prod.
This way dev's can deploy any release tag that they choose, and not disrupt normal workflows, as all deployed images will be tagged with **_:latest_** .
cc: @peculiarity 