### PR TITLE
Add GHA WF to dev branch

### DIFF
--- a/.github/workflows/aws-prod-rollback.yaml
+++ b/.github/workflows/aws-prod-rollback.yaml
@@ -1,0 +1,64 @@
+name: Rollback Production
+
+on:
+  workflow_dispatch:
+    branches: [ main ]
+    inputs:
+      commit_hash:
+        description: 'Enter the commit hash you want to roll back to.'
+        default: '<hash>'
+        required: true
+        type: string
+
+jobs:
+  rollback-deployment:
+    env:
+      AWS_REGION: us-east-1
+      ECR_REPO_NAME: oasis-borrow-prod
+      SERVICE_NAME: oasis-borrow-prod
+      CLUSTER_NAME: oasis-borrow-prod
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout Repo History
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate commit_hash
+        run: |
+          VALID_HASH=$(env -i git log --max-count=10 --no-walk --tags --pretty='%h' --decorate=full | grep ${{ github.event.inputs.commit_hash }})
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.OAZO_PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.OAZO_PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Tag Image as latest
+        run: |
+          MANIFEST=$(aws ecr batch-get-image --repository-name $ECR_REPO_NAME --image-ids imageTag=${{ github.event.inputs.commit_hash }} --query 'images[].imageManifest' --output text)
+          aws ecr put-image --repository-name $ECR_REPO_NAME --image-tag latest --image-manifest "$MANIFEST"
+
+      - name: Update ECS service with Rollback Docker image
+        id: service-update
+        run: |
+          aws ecs update-service --cluster $CLUSTER_NAME --service ${{ env.SERVICE_NAME }} --force-new-deployment --region $AWS_REGION
+
+      - name: Wait for all services to become stable
+        uses: oryanmoshe/ecs-wait-action@v1.3
+        with:
+          ecs-cluster: ${{ env.CLUSTER_NAME }}
+          ecs-services: '["${{ env.SERVICE_NAME }}"]'
+
+      - name: Invalidate CloudFront
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DIST_ID_PROD }} --paths "/*"
+


### PR DESCRIPTION
Workaround for GHA bug.
GHA only shows workflows from the "default" branch, which in this case is **dev**, so when the new GHA WF was merged to main branch, it did not show up in the Actions Tab.
Adding the new "rollback" workflow to DEV branch.