### PR TITLE
Career offers manual order and new offer

### DIFF
--- a/features/careers/listings/full-stack-developer.mdx
+++ b/features/careers/listings/full-stack-developer.mdx
@@ -5,9 +5,9 @@ export const meta = {
 };
 
 ## About Us
-We are the company behind [Oasis.app](https://oasis.app/), the app to deploy your capital into the Maker Protocol and DeFi. With [Oasis.app](https://oasis.app/) you can borrow Dai or increase your exposure to your favourite crypto. Our mission is to provide the best and most trusted entry point to DeFi. 
+We are the company behind [Oasis.app](https://oasis.app/), the app to deploy your capital into the Maker Protocol and DeFi. With [Oasis.app](https://oasis.app/) you can borrow Dai or increase your exposure to your favourite crypto. Our mission is to provide the best and most trusted entry point to DeFi.
 
-We are a team of passionate thinkers and builders. You can decide to either work remotely or from our fantastic offices in Warsaw. The team is mostly allocated across Europe. 
+We are a team of passionate thinkers and builders. We are spread across Europe, and a few of us come from the Americas and Asia. Our engineering team is mostly allocated in Europe. You can decide to either work remotely or from our fantastic offices in Warsaw. 
 
 We operate under Oazo Apps Limited, a company incorporated and registered in the United Kingdom.
 

--- a/features/careers/listings/full-stack-developer.mdx
+++ b/features/careers/listings/full-stack-developer.mdx
@@ -1,7 +1,8 @@
 export const meta = {
   title: 'Full-Stack Developer',
   location: 'Remote',
-  area: 'Engineering'
+  area: 'Engineering',
+  order: 2
 };
 
 ## About Us

--- a/features/careers/listings/smart-contract-developer.mdx
+++ b/features/careers/listings/smart-contract-developer.mdx
@@ -1,7 +1,8 @@
 export const meta = {
   title: 'Smart Contract Developer',
   location: 'Remote',
-  area: 'Engineering'
+  area: 'Engineering',
+  order: 1
 };
 
 ## About us

--- a/features/careers/listings/software-Engineer-in-test.mdx
+++ b/features/careers/listings/software-Engineer-in-test.mdx
@@ -1,0 +1,61 @@
+export const meta = {
+  title: 'Software Engineer in Test',
+  location: 'Remote',
+  area: 'Engineering'
+};
+
+## About Us
+We are the company behind [Oasis.app](https://oasis.app/), the app to deploy your capital into the Maker Protocol and DeFi. With [Oasis.app](https://oasis.app/) you can borrow Dai or increase your exposure to your favourite crypto. Our mission is to provide the best and most trusted entry point to DeFi.
+
+We are a team of passionate thinkers and builders. We are spread across Europe, and a few of us come from the Americas and Asia. Our engineering team is mostly allocated in Europe. You can decide to either work remotely or from our fantastic offices in Warsaw. 
+
+We operate under Oazo Apps Limited, a company incorporated and registered in the United Kingdom.
+
+## The technology
+Our software is coded in JavaScript and TypeScript using RX.js, React (including hooks), Postgres, SQL, NoSQL, and GraphQL. While creating our apps, we also use blockchain-related technologies: Ethereum blockchain principles, Solidity, test-nets, and contract deployment scripts. Other tools and technologies we use include Bash scripting & DApp tools; Node.js, express, Next.js; Docker; CircleCI, CypressJS, Mocha, and Jest. We use Github actions for managing deploys, and Heroku for preview apps.
+
+## The role
+You would be a valued member of our engineering team, focusing on ensuring our software quality and collaborating with Product and Techops. This is both a technical role and a people role, and would likely include:
+
+- Very close collaboration within the engineering team, mentoring, designing and advocating a modern testing approach towards confident, trivial, and quick production deploys.
+- Setting up and maintaining testing infrastructure and environments, including deterministic blockchain testnets, and possibly UI and snapshot testing.
+- Supporting tooling to engineers to write their own functional tests alongside new features. Mentoring, listening to their feedback and adjusting if necessary.
+- Understanding when refactoring might require more targeted regression testing, leading those efforts, and maintaining a suite of regression tests that anyone can run.
+- Bringing a testing mindset into our team, system and application design.
+- Providing input and expertise into the approach to automated software testing - helping the team decide when different levels of tests are appropriate for given test coverage. Keeping an eye on the PRs.
+-Developing and maintaining dashboards to give a view of our system health from a functional perspective.
+
+There will be more things - roll your own. Throughout all of this is a healthy dose of “facilitating self-serve” - we want you to scale your efforts by providing tooling and knowledge to others. As a company, we want to ensure that the effort required to maintain software quality scales sub-linearly with the functionality.
+
+For clarity - this is not a QA role.
+
+## About you
+The ideal candidate will have operated as a Software Engineer in Test before in a Web2 environment and is curious about applying these techniques to blockchain development (Web3) both on the front-end and the backend.
+
+- You’re excited about automated testing; an advocate and collaborator at heart who loves to share knowledge with others.
+- You’re curious about leading-edge technologies and new models of financial markets.
+- You’re curious about DeFi and Blockchain.
+
+## What you’ll need
+- Minimum 3 years of working as a Software Engineer in Test, or a cool project you can talk about that was successful.
+- Experience with advocating and mentoring the testing approach of the engineering team.
+- Interest in and knowledge of application and system design, particularly from an automated-testing perspective.
+
+## The nice to haves
+- Experience in using Ethereum tools and building DApps accessing Ethereum blockchain
+- Understanding of Blockchain primitives and applied cryptography
+- Basic knowledge of DeFi and financial concepts and markets
+- Degree in Engineering or Computer Science
+
+## Compensation package
+- Competitive fixed annual salary and yearly Dai bonus
+- Employee share options and performance equity
+- Paid time off - 5 weeks per year (or more if you need it), public holidays and 2-weeks end-of-year break
+- Monthly subscription perks - can be anything you choose, from gym membership, fresh flower or fruit delivery, Netflix/Spotify/gaming subscription, etc.
+- Annual company retreats and participation in industry conferences fully covered by us
+- Freedom to choose the best-suited place for you in our company with the ability to develop vertically (seniority) and horizontally (new areas of expertise)
+- Engineering tools of your choice 
+
+<br/>
+
+**If this sounds like this could be the role for you, we would love to hear from you! Please reach out to [work@oasis.app](mailto:work@oasis.app).**

--- a/features/careers/listings/software-Engineer-in-test.mdx
+++ b/features/careers/listings/software-Engineer-in-test.mdx
@@ -1,7 +1,8 @@
 export const meta = {
   title: 'Software Engineer in Test',
   location: 'Remote',
-  area: 'Engineering'
+  area: 'Engineering',
+  order: 0
 };
 
 ## About Us

--- a/pages/careers/index.tsx
+++ b/pages/careers/index.tsx
@@ -3,7 +3,7 @@ import { PageSEOTags } from 'components/HeadTags'
 import { MarketingLayout } from 'components/Layouts'
 import { AppLink } from 'components/Links'
 import { Career, getCareerByFileName, getCareerFileNames } from 'features/careers/careers'
-import { groupBy } from 'lodash'
+import { groupBy, orderBy } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
@@ -48,7 +48,7 @@ function CareersPage({ careers }: { careers: Career[] }) {
                 />
               </Flex>
               <Grid>
-                {careers.map((career) => (
+                {orderBy(careers, ['order']).map((career) => (
                   <AppLink
                     key={career.slug}
                     href={`/careers/${career.slug}`}


### PR DESCRIPTION
# Career offers manual order and new offer

Two stories on one branch:
- https://app.shortcut.com/oazo-apps/story/3986/careers-add-software-engineer-in-test-job-ad-to-careers
- https://app.shortcut.com/oazo-apps/story/3987/careers-update-the-about-us-section-in-the-full-stack-job-ad

<please insert a clubhouse link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- Add mechanism for manually sorting offers,
- Add new offer: **Software Engineer in Test**,
- Update **About us** section for **Full-Stack Developer**.
  
## How to test 🧪
  <Please explain how to test your changes>

- See if sorting works and how its behave when e.g. there are more than one offers category or some offer doesn't have `order` field filled.
- No need to test content changes.
    
## Definition of done ✔️

- [ ] Acceptance criteria for each issue met
- [ ] Unit tests written where needed and passing
- [ ] End-to-end tests for happy path
- [ ] Documentation updated <When applicable>
- [ ] Project builds without errors
- [ ] Non-functional requirements met
- [ ] Code reviewed and functionality tested by the reviewer (locally, Heroku, etc.)
- [ ] Feature verified and accepted by Product Owner
- [ ] Project deployed to production environment
