### PR TITLE
Fixed warning with potential debt less than debt floor

### DIFF
--- a/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
@@ -584,7 +584,9 @@ export function applyManageVaultConditions(
   })
 
   const potentialGenerateAmountLessThanDebtFloor =
-    !isNullish(depositAmount) && maxGenerateAmountAtCurrentPrice.lt(debtFloor)
+    !isNullish(depositAmount) &&
+    maxGenerateAmountAtCurrentPrice.lt(debtFloor) &&
+    !debt.gt(debtFloor)
 
   const debtIsLessThanDebtFloor = debtIsLessThanDebtFloorValidator({ debtFloor, debt })
 


### PR DESCRIPTION
# [Fixed warning with potential debt less than debt floor](https://app.shortcut.com/oazo-apps/story/3851/bug-fix-warning-with-minimal-debt-required-to-open-vault)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- adjusted condition for checking if generate amount is less than debt flow
  
## How to test 🧪
  <Please explain how to test your changes>
- test it using multiply vault, try to deposit collateral / dai when debt is above dust limit and see if this warning will popup (should not)
