### PR TITLE
Fixed issue with stop loss summary section

### DIFF
--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -284,7 +284,6 @@ export function AdjustSlFormControl({
     txHash: uiState?.txDetails?.txHash,
     gasEstimation,
     accountIsController,
-    stopLossLevel,
     dynamicStopLossPrice,
     amountOnStopLossTrigger,
     tokenPrice,

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -30,7 +30,7 @@ import { AutomationFormHeader } from '../common/components/AutomationFormHeader'
 
 interface AdjustSlFormInformationProps {
   tokenPrice: BigNumber
-  stopLossLevel: BigNumber
+  afterStopLossRatio: BigNumber
   vault: Vault
   ilkData: IlkData
   token: string
@@ -40,7 +40,7 @@ interface AdjustSlFormInformationProps {
 }
 
 function ProtectionCompleteInformation({
-  stopLossLevel,
+  afterStopLossRatio,
   vault,
   ilkData,
   token,
@@ -52,7 +52,7 @@ function ProtectionCompleteInformation({
 
   const dynamicStopLossPrice = vault.liquidationPrice
     .div(ilkData.liquidationRatio)
-    .times(stopLossLevel)
+    .times(afterStopLossRatio.div(100))
 
   const maxToken = vault.lockedCollateral
     .times(dynamicStopLossPrice)
@@ -69,7 +69,7 @@ function ProtectionCompleteInformation({
         label={`${t('protection.stop-loss-coll-ratio')}`}
         value={
           <Flex>
-            {formatPercent(stopLossLevel.times(100), {
+            {formatPercent(afterStopLossRatio, {
               precision: 2,
               roundMode: BigNumber.ROUND_DOWN,
             })}
@@ -198,7 +198,6 @@ export interface AdjustSlFormLayoutProps {
   txState?: TxStatus
   txHash?: string
   txCost?: BigNumber
-  stopLossLevel: BigNumber
   dynamicStopLossPrice: BigNumber
   amountOnStopLossTrigger: BigNumber
   tokenPrice: BigNumber
@@ -222,7 +221,6 @@ export function AdjustSlFormLayout({
   closePickerConfig,
   accountIsController,
   addTriggerConfig,
-  stopLossLevel,
   tokenPrice,
   ethPrice,
   vault,
@@ -301,7 +299,7 @@ export function AdjustSlFormLayout({
             <ProtectionCompleteInformation
               token={token}
               txState={txState}
-              stopLossLevel={stopLossLevel}
+              afterStopLossRatio={selectedSLValue}
               tokenPrice={tokenPrice}
               vault={vault}
               ilkData={ilkData}


### PR DESCRIPTION
# [Fixed issue with stop loss summary section](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- in calculations in stop loss summary section we will now use value from slider as it has the same value as stop loss level which is available after some delay. This delay led to situation where in summary for couple of seconds zeros and inifity values were present (not always but from time to time).
  
## How to test 🧪
  <Please explain how to test your changes>
- using vault on goerli network add stop loss trigger for couple of times and check whether summary section has zero / infinity values.
