### PR TITLE
Hide stop-loss banner setup on zero debt vaults

### DIFF
--- a/features/automation/protection/controls/GetProtectionBannerControl.tsx
+++ b/features/automation/protection/controls/GetProtectionBannerControl.tsx
@@ -16,10 +16,16 @@ import { GetProtectionBannerLayout } from './GetProtectionBannerLayout'
 interface GetProtectionBannerProps {
   vaultId: BigNumber
   ilk: string
+  debt: BigNumber
   token?: string
 }
 
-export function GetProtectionBannerControl({ vaultId, token, ilk }: GetProtectionBannerProps) {
+export function GetProtectionBannerControl({
+  vaultId,
+  token,
+  ilk,
+  debt,
+}: GetProtectionBannerProps) {
   const { t } = useTranslation()
   const { uiChanges, automationTriggersData$ } = useAppContext()
   const [isBannerClosed, setIsBannerClosed] = useSessionStorage('overviewProtectionBanner', false)
@@ -32,7 +38,10 @@ export function GetProtectionBannerControl({ vaultId, token, ilk }: GetProtectio
 
   const handleClose = useCallback(() => setIsBannerClosed(true), [])
 
-  return !slData?.isStopLossEnabled && !isBannerClosed && isAllowedForAutomation ? (
+  return !slData?.isStopLossEnabled &&
+    !isBannerClosed &&
+    isAllowedForAutomation &&
+    !debt.isZero() ? (
     <>
       {!automationBasicBuyAndSellEnabled ? (
         <GetProtectionBannerLayout

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -147,7 +147,7 @@ export function ManageVaultDetails(
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
           {!automationBasicBuyAndSellEnabled && (
-            <GetProtectionBannerControl vaultId={id} ilk={ilk} />
+            <GetProtectionBannerControl vaultId={id} ilk={ilk} debt={debt} />
           )}
           <StopLossBannerControl
             vaultId={id}
@@ -238,7 +238,7 @@ export function ManageVaultDetails(
       )}
       {automationEnabled && automationBasicBuyAndSellEnabled && (
         <Box sx={{ mt: 3 }}>
-          <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} />
+          <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>
       )}
     </Box>

--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -132,7 +132,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
           {!automationBasicBuyAndSellEnabled && (
-            <GetProtectionBannerControl vaultId={id} ilk={ilk} />
+            <GetProtectionBannerControl vaultId={id} ilk={ilk} debt={debt} />
           )}
           <StopLossBannerControl
             vaultId={id}
@@ -242,7 +242,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
       )}
       {automationEnabled && automationBasicBuyAndSellEnabled && (
         <Box sx={{ mt: 3 }}>
-          <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} />
+          <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>
       )}
     </Box>


### PR DESCRIPTION
# Hide stop-loss banner setup on zero debt vaults
  
## Changes 👷‍♀️

Added checking debt value in `GetProtectionBannerControl` component.
  
## How to test 🧪

Check if this banner:
![image](https://user-images.githubusercontent.com/16230404/166705658-87402ec7-f550-485a-9ba6-5a5e69aa3042.png)
is visible on vaults with generated debt and is not visible on those without.
