### PR TITLE
Hide stop-loss pill on zero debt vaults in vaults list

### DIFF
--- a/features/vaultsOverview/VaultsOverviewView.tsx
+++ b/features/vaultsOverview/VaultsOverviewView.tsx
@@ -31,7 +31,7 @@ const vaultsColumns: ColumnDef<Vault & StopLossTriggerData, VaultsFilterState>[]
   {
     headerLabel: 'system.asset',
     header: ({ label }) => <Text variant="tableHead">{label}</Text>,
-    cell: ({ ilk, token, isStopLossEnabled }) => {
+    cell: ({ ilk, token, isStopLossEnabled, debt }) => {
       const tokenInfo = getToken(token)
       const { t } = useTranslation()
 
@@ -39,7 +39,7 @@ const vaultsColumns: ColumnDef<Vault & StopLossTriggerData, VaultsFilterState>[]
         <Flex>
           <Icon name={tokenInfo.iconCircle} size="26px" sx={{ verticalAlign: 'sub', mr: 2 }} />
           <Box sx={{ whiteSpace: 'nowrap' }}>{ilk}</Box>
-          {isStopLossEnabled && (
+          {isStopLossEnabled && !debt.isZero() && (
             <Box ml={2}>
               <VaultDetailsAfterPill
                 afterPillColors={{ color: 'onSuccess', bg: 'success' }}


### PR DESCRIPTION
# Hide stop-loss pill on zero debt vaults in vaults list
  
## Changes 👷‍♀️

Added checking debt value in `vaultsColumns` in vaults list. Vaults with SL enabled, but no debt shouldn't have SL pill visible.
  
## How to test 🧪
Test it on your own vaults OR go to `/owner/0xd0612c759fC6C512B7C3abceB2366C4f4096451C`/ on mainnet and check vault `27644` and vaults above. `27644` has SL enabled and zero debt.
![image](https://user-images.githubusercontent.com/16230404/166907220-90c2e994-ce5a-41b0-9bc7-6484041be404.png)

