### PR TITLE
Update stop-loss related links to knowledge base

### DIFF
--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -27,7 +27,7 @@ function ZeroDebtProtectionBanner() {
         <>
           {t('protection.zero-debt-description')}
           {', '}
-          <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 3 }}>
+          <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 3 }}>
             {t('here')}.
           </AppLink>
         </>

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -178,7 +178,10 @@ function SetDownsideProtectionInformation({
         <Text sx={{ mt: 3, fontWeight: 'semiBold' }}>{t('protection.not-guaranteed')}</Text>
         <Text sx={{ mb: 3 }}>
           {t('protection.guarantee-factors')}{' '}
-          <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontWeight: 'body' }}>
+          <AppLink
+            href="https://kb.oasis.app/help/stop-loss-protection"
+            sx={{ fontWeight: 'body' }}
+          >
             {t('protection.learn-more-about-automation')}
           </AppLink>
         </Text>

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -178,7 +178,7 @@ function SetDownsideProtectionInformation({
         <Text sx={{ mt: 3, fontWeight: 'semiBold' }}>{t('protection.not-guaranteed')}</Text>
         <Text sx={{ mb: 3 }}>
           {t('protection.guarantee-factors')}{' '}
-          <AppLink href="https://kb.oasis.app/help" sx={{ fontWeight: 'body' }}>
+          <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontWeight: 'body' }}>
             {t('protection.learn-more-about-automation')}
           </AppLink>
         </Text>
@@ -245,7 +245,7 @@ export function AdjustSlFormLayout({
             description: (
               <>
                 {t('protection.set-downside-protection-desc')}{' '}
-                <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 2 }}>
+                <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 2 }}>
                   {t('here')}.
                 </AppLink>
               </>
@@ -264,7 +264,7 @@ export function AdjustSlFormLayout({
             description: (
               <>
                 {t('protection.downside-protection-complete-desc')}{' '}
-                <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 2 }}>
+                <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 2 }}>
                   {t('here')}.
                 </AppLink>
               </>

--- a/features/automation/protection/controls/CancelSlFormLayout.tsx
+++ b/features/automation/protection/controls/CancelSlFormLayout.tsx
@@ -124,7 +124,7 @@ export function CancelSlFormLayout(props: CancelSlFormLayoutProps) {
                 <Text variant="paragraph3" sx={{ mb: '24px', color: 'lavender' }}>
                   {t('protection.cancel-protection-complete-desc')}
                 </Text>
-                <AppLink href="https://kb.oasis.app/help" sx={{ fontWeight: 'body' }}>
+                <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontWeight: 'body' }}>
                   {t('protection.find-more-about-setting-stop-loss')}
                 </AppLink>
               </>

--- a/features/automation/protection/controls/CancelSlFormLayout.tsx
+++ b/features/automation/protection/controls/CancelSlFormLayout.tsx
@@ -124,7 +124,10 @@ export function CancelSlFormLayout(props: CancelSlFormLayoutProps) {
                 <Text variant="paragraph3" sx={{ mb: '24px', color: 'lavender' }}>
                   {t('protection.cancel-protection-complete-desc')}
                 </Text>
-                <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontWeight: 'body' }}>
+                <AppLink
+                  href="https://kb.oasis.app/help/stop-loss-protection"
+                  sx={{ fontWeight: 'body' }}
+                >
                   {t('protection.find-more-about-setting-stop-loss')}
                 </AppLink>
               </>


### PR DESCRIPTION
# Update stop-loss related links to knowledge base
  
## Changes 👷‍♀️

Updated link from general https://kb.oasis.app/help to https://kb.oasis.app/help/stop-loss-protection into below places:
![image](https://user-images.githubusercontent.com/16230404/167106354-4a816476-91e2-4f3d-b434-29bc6e2323df.png)
![image](https://user-images.githubusercontent.com/16230404/167106376-e6829a91-804c-49db-91d3-fabd5d4f0415.png)
![image](https://user-images.githubusercontent.com/16230404/167106391-85e1db50-bb6b-44b3-8803-9278017bb68a.png)
![image](https://user-images.githubusercontent.com/16230404/167106405-b209e3fd-28ab-4ee9-bfd7-45b4935b94a5.png)
![image](https://user-images.githubusercontent.com/16230404/167106420-72de0507-4e30-41ff-aaff-a00e42b232b7.png)

