### PR TITLE
created banner and validation for vault below dust limit

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -946,6 +946,7 @@
     "token-on-stop-loss-trigger": "{{token}} on stop loss trigger",
     "zero-debt-heading": "You need to generate Dai before you can set up Stop-Loss Protection",
     "zero-debt-description": "Oasis Stop-Loss Protection allows you to set up a dynamic Stop-Loss for your Vault based on the Collateralisation Ratio. In the case of a sharp downturn in the price of the Vaults collateral, have your Vault automatically closed to collateral or Dai by Oasis.app's advanced automation features to help protect your Vault from liquidation or big losses. Learn more about how it works",
+    "below-dust-limit-heading": "You need to generate Dai above the minimum debt limit to set up Stop Loss Protection",
     "summary-of-protection": "Summary of protection",
     "on-stop-loss-trigger": "On Stop-Loss trigger",
     "estimated-to-receive": "Estimated to receive",


### PR DESCRIPTION
# [Added validation and banner preventing from setting sl on vault below dust limit](https://app.shortcut.com/oazo-apps/story/4298/add-validation-to-prevent-stop-loss-protection-being-added-on-vaults-with-0-debt-or-below-dust-limit)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

Added new banner and validation for vault below dust limit
  
## How to test 🧪
  <Please explain how to test your changes>
- Create vault below dust limit, see if it's possible to set stop loss and if labels are correct
