### PR TITLE
Add Warning when Stop loss is set to 3% of current collateral Ratio based on next price

### DIFF
--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -28,7 +28,13 @@ export function GeneralManageLayout({
   autoTriggersData,
 }: GeneralManageLayoutProps) {
   const { t } = useTranslation()
-  const { ilkData, vault, account, priceInfo } = generalManageVault.state
+  const {
+    ilkData,
+    vault,
+    account,
+    priceInfo,
+    collateralizationRatioAtNextPrice,
+  } = generalManageVault.state
   const showProtectionTab = ALLOWED_AUTOMATION_ILKS.includes(vault.ilk)
   const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
   const isStopLossEnabled = useStopLossStateInitializator(ilkData, vault, autoTriggersData)
@@ -71,7 +77,14 @@ export function GeneralManageLayout({
           <GeneralManageVaultViewAutomation generalManageVault={generalManageVault} />
         }
         historyControl={<HistoryControl generalManageVault={generalManageVault} />}
-        protectionControl={<ProtectionControl vault={vault} ilkData={ilkData} account={account} />}
+        protectionControl={
+          <ProtectionControl
+            vault={vault}
+            ilkData={ilkData}
+            account={account}
+            collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
+          />
+        }
         vaultInfo={<VaultInformationControl generalManageVault={generalManageVault} />}
         showProtectionTab={showProtectionTab}
         protectionEnabled={isStopLossEnabled}

--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import BigNumber from 'bignumber.js'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Container } from 'theme-ui'
@@ -41,9 +42,15 @@ interface ProtectionControlProps {
   vault: Vault
   ilkData: IlkData
   account?: string
+  collateralizationRatioAtNextPrice: BigNumber
 }
 
-export function ProtectionControl({ vault, ilkData, account }: ProtectionControlProps) {
+export function ProtectionControl({
+  vault,
+  ilkData,
+  account,
+  collateralizationRatioAtNextPrice,
+}: ProtectionControlProps) {
   const { automationTriggersData$, collateralPrices$ } = useAppContext()
   const autoTriggersData$ = automationTriggersData$(vault.id)
   const [automationTriggersData, automationTriggersError] = useObservable(autoTriggersData$)
@@ -73,6 +80,7 @@ export function ProtectionControl({ vault, ilkData, account }: ProtectionControl
                   collateralPrices={collateralPrices}
                   vault={vault}
                   account={account}
+                  collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
                 />
               }
             />

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -55,6 +55,7 @@ interface AdjustSlFormControlProps {
   triggerData: TriggersData
   ctx: Context
   accountIsController: boolean
+  collateralizationRatioAtNextPrice: BigNumber
   toggleForms: () => void
   tx?: TxHelpers
 }
@@ -66,6 +67,7 @@ export function AdjustSlFormControl({
   triggerData,
   ctx,
   accountIsController,
+  collateralizationRatioAtNextPrice,
   toggleForms,
   tx,
 }: AdjustSlFormControlProps) {
@@ -295,6 +297,7 @@ export function AdjustSlFormControl({
     toggleForms,
     firstStopLossSetup,
     isEditing,
+    collateralizationRatioAtNextPrice,
   }
 
   return <AdjustSlFormLayout {...props} />

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect } from 'react'
@@ -27,6 +28,7 @@ interface Props {
   collateralPrices: CollateralPricesWithFilters
   vault: Vault
   account?: string
+  collateralizationRatioAtNextPrice: BigNumber
 }
 
 export function ProtectionFormControl({
@@ -35,6 +37,7 @@ export function ProtectionFormControl({
   collateralPrices,
   vault,
   account,
+  collateralizationRatioAtNextPrice,
 }: Props) {
   const { txHelpers$, context$, uiChanges } = useAppContext()
   const { t } = useTranslation()
@@ -91,6 +94,7 @@ export function ProtectionFormControl({
                 tx={txHelpers}
                 ctx={context}
                 accountIsController={accountIsController}
+                collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
                 toggleForms={() => {
                   uiChanges.publish(PROTECTION_MODE_CHANGE_SUBJECT, {
                     type: 'change-mode',

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -969,7 +969,8 @@
     "find-more-about-setting-stop-loss": "Find out more about setting Stop-Loss →",
     "set-stop-loss-again": "Set up Stop-Loss again",
     "sl-triggered-gas-estimation": "These estimated fees are based on the approximate price you will get from selling your collateral to cover your debt when automation is executed and covers the Oasis fee.",
-    "stop-loss-on": "Stop-Loss On"
+    "stop-loss-on": "Stop-Loss On",
+    "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change."
   },
   "newsletter": {
     "title": "Stay up to date with Oasis.app",


### PR DESCRIPTION
# [Add Warning when Stop loss is set to 3% of current collateral Ratio based on next price](https://app.shortcut.com/oazo-apps/story/4310/add-warning-when-stop-loss-is-set-to-3-of-current-collateral-ratio-based-on-next-price)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

Added box with warning when SL ratio is set in range between (NEXT_COLL_RATIO - 3) and (MAX_COLL_RATIO).
![image](https://user-images.githubusercontent.com/16230404/167627120-d4bd39c4-6520-4678-9c4a-44c94441daf7.png)

## How to test 🧪

Try setting up SL in vault and check if warning is visible. Ideal conditions are when next price is different than current, because in that case gap on which warning is displayed is different than three.