### PR TITLE
Temporary remove SL UI changes

### DIFF
--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -13,7 +13,7 @@ import { VaultContainerSpinner, WithLoadingIndicator } from '../../helpers/AppSp
 import { WithErrorHandler } from '../../helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from '../../helpers/observableHook'
 import { useAppContext } from '../AppContextProvider'
-import { AppLink } from '../Links'
+// import { AppLink } from '../Links'
 import { DefaultVaultLayout } from './DefaultVaultLayout'
 
 interface ZeroDebtProtectionBannerProps {
@@ -35,10 +35,10 @@ function ZeroDebtProtectionBanner({
       subheader={
         <>
           {t(descriptionTranslationKey)}
-          {', '}
+          {/* {', '}
           <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 3 }}>
             {t('here')}.
-          </AppLink>
+          </AppLink> */}
         </>
       }
       color="primary"
@@ -65,7 +65,9 @@ export function ProtectionControl({
   const [collateralPrices, collateralPricesError] = useObservable(collateralPrices$)
   const dustLimit = ilkData.debtFloor
 
-  return !vault.debt.isZero() && vault.debt > dustLimit ? (
+  return !vault.debt.isZero() &&
+    vault.debt > dustLimit &&
+    automationTriggersData?.triggers?.length ? (
     <WithErrorHandler error={[automationTriggersError, collateralPricesError]}>
       <WithLoadingIndicator
         value={[automationTriggersData, collateralPrices]}
@@ -97,19 +99,27 @@ export function ProtectionControl({
         }}
       </WithLoadingIndicator>
     </WithErrorHandler>
-  ) : vault.debt.isZero() ? (
-    <Container variant="vaultPageContainer" sx={{ zIndex: 0 }}>
-      <ZeroDebtProtectionBanner
-        headerTranslationKey={'protection.zero-debt-heading'}
-        descriptionTranslationKey={'protection.zero-debt-description'}
-      />
-    </Container>
   ) : (
     <Container variant="vaultPageContainer" sx={{ zIndex: 0 }}>
       <ZeroDebtProtectionBanner
-        headerTranslationKey={'protection.below-dust-limit-heading'}
-        descriptionTranslationKey={'protection.zero-debt-description'}
+        headerTranslationKey="Creation of the new stop loss trigger is currently disabled."
+        descriptionTranslationKey="To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW stop loss triggers, as they might not result in the expected outcome. Please use the 'close vault' option if you want to close your vault right now."
       />
     </Container>
   )
+  // ) : vault.debt.isZero() ? (
+  //   <Container variant="vaultPageContainer" sx={{ zIndex: 0 }}>
+  //     <ZeroDebtProtectionBanner
+  //       headerTranslationKey={'protection.zero-debt-heading'}
+  //       descriptionTranslationKey={'protection.zero-debt-description'}
+  //     />
+  //   </Container>
+  // ) : (
+  //   <Container variant="vaultPageContainer" sx={{ zIndex: 0 }}>
+  //     <ZeroDebtProtectionBanner
+  //       headerTranslationKey={'protection.below-dust-limit-heading'}
+  //       descriptionTranslationKey={'protection.zero-debt-description'}
+  //     />
+  //   </Container>
+  // )
 }

--- a/features/automation/protection/common/components/AutomationFormButtons.tsx
+++ b/features/automation/protection/common/components/AutomationFormButtons.tsx
@@ -46,7 +46,7 @@ export function AutomationFormButtons({
 
   return (
     <>
-      {!txSuccess && (
+      {!txSuccess && type === 'cancel' && (
         <Box>
           <RetryableLoadingButton {...triggerConfig} />
         </Box>

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -255,7 +255,6 @@ export function AdjustSlFormControl({
     isRetry: false,
     isEditing,
     disabled:
-      !replacedTriggerId|| //if we are not replacing anything then disable button
       !isOwner ||
       (!isEditing && uiState?.txDetails?.txStatus !== TxStatus.Success) ||
       (!isEditing && !uiState?.txDetails),

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -1,8 +1,8 @@
 import { TxStatus } from '@oasisdex/transactions'
 import { Box, Grid } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
-import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseState'
-import { SliderValuePicker, SliderValuePickerProps } from 'components/dumb/SliderValuePicker'
+import { PickCloseStateProps } from 'components/dumb/PickCloseState'
+import { SliderValuePickerProps } from 'components/dumb/SliderValuePicker'
 import { MessageCard } from 'components/MessageCard'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
@@ -108,6 +108,7 @@ interface SetDownsideProtectionInformationProps {
   selectedSLValue: BigNumber
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function SetDownsideProtectionInformation({
   vault,
   ilkData,
@@ -240,22 +241,22 @@ export function AdjustSlFormLayout({
   txState,
   txHash,
   txCost,
-  slValuePickerConfig,
+  // slValuePickerConfig,
   closePickerConfig,
   accountIsController,
   addTriggerConfig,
   tokenPrice,
-  ethPrice,
+  // ethPrice,
   vault,
   ilkData,
-  gasEstimation,
+  // gasEstimation,
   etherscan,
   toggleForms,
   selectedSLValue,
   firstStopLossSetup,
-  isEditing,
-  collateralizationRatioAtNextPrice,
-}: AdjustSlFormLayoutProps) {
+}: // isEditing,
+// collateralizationRatioAtNextPrice,
+AdjustSlFormLayoutProps) {
   const { t } = useTranslation()
 
   return (
@@ -266,14 +267,8 @@ export function AdjustSlFormLayout({
         translations={{
           editing: {
             header: t('protection.set-downside-protection'),
-            description: (
-              <>
-                {t('protection.set-downside-protection-desc')}{' '}
-                <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 2 }}>
-                  {t('here')}.
-                </AppLink>
-              </>
-            ),
+            description:
+              "Due to extreme adversarial market conditions we have currently disabled setting up new stop loss triggers, as they might not result in the expected outcome for our users. Please use the 'close vault' option if you want to close your vault right now.",
           },
           progressing: {
             header: t('protection.setting-downside-protection'),
@@ -297,7 +292,7 @@ export function AdjustSlFormLayout({
         }}
       />
       {txProgressing && <OpenVaultAnimation />}
-      {!txProgressing && txState !== TxStatus.Success && (
+      {/* {!txProgressing && txState !== TxStatus.Success && (
         <>
           <Box mt={3}>
             <SliderValuePicker {...slValuePickerConfig} />
@@ -327,7 +322,7 @@ export function AdjustSlFormLayout({
             </>
           )}
         </>
-      )}
+      )} */}
 
       {txState === TxStatus.Success && (
         <>

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -144,7 +144,7 @@ export function ManageVaultDetails(
 
   return (
     <Box>
-      {false && (
+      {automationEnabled && (
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
           {!automationBasicBuyAndSellEnabled && (
@@ -237,7 +237,7 @@ export function ManageVaultDetails(
           }
         />
       )}
-      {false && automationBasicBuyAndSellEnabled && (
+      {automationEnabled && automationBasicBuyAndSellEnabled && (
         <Box sx={{ mt: 3 }}>
           <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -26,7 +26,7 @@ import React from 'react'
 import { Box, Grid } from 'theme-ui'
 
 import { useFeatureToggle } from '../../../../helpers/useFeatureToggle'
-import { GetProtectionBannerControl } from '../../../automation/protection/controls/GetProtectionBannerControl'
+// import { GetProtectionBannerControl } from '../../../automation/protection/controls/GetProtectionBannerControl'
 import { StopLossBannerControl } from '../../../automation/protection/controls/StopLossBannerControl'
 import { StopLossTriggeredBannerControl } from '../../../automation/protection/controls/StopLossTriggeredBannerControl'
 import { BonusContainer } from '../../../bonus/BonusContainer'
@@ -118,7 +118,7 @@ export function ManageVaultDetails(
       lockedCollateral,
       lockedCollateralUSD,
       collateralizationRatio,
-      ilk,
+      // ilk,
     },
     ilkData: { liquidationRatio },
     liquidationPriceCurrentPriceDifference,
@@ -147,9 +147,9 @@ export function ManageVaultDetails(
       {automationEnabled && (
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
-          {!automationBasicBuyAndSellEnabled && (
+          {/* {!automationBasicBuyAndSellEnabled && (
             <GetProtectionBannerControl vaultId={id} ilk={ilk} debt={debt} />
-          )}
+          )} */}
           <StopLossBannerControl
             vaultId={id}
             liquidationPrice={liquidationPrice}
@@ -237,11 +237,11 @@ export function ManageVaultDetails(
           }
         />
       )}
-      {automationEnabled && automationBasicBuyAndSellEnabled && (
+      {/* {automationEnabled && automationBasicBuyAndSellEnabled && (
         <Box sx={{ mt: 3 }}>
           <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>
-      )}
+      )} */}
       <BonusContainer cdpId={props.vault.id} />
     </Box>
   )

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -139,7 +139,7 @@ export function ManageVaultDetails(
   const afterPillColors = getAfterPillColors(afterCollRatioColor)
   const showAfterPill = !inputAmountsEmpty && stage !== 'manageSuccess'
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
-  // const automationEnabled = useFeatureToggle('Automation')
+  const automationEnabled = useFeatureToggle('Automation')
   const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
 
   return (

--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -128,7 +128,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
 
   return (
     <Box>
-      {false && (
+      {automationEnabled && (
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
           {!automationBasicBuyAndSellEnabled && (
@@ -240,7 +240,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
           }
         />
       )}
-      {false && automationBasicBuyAndSellEnabled && (
+      {automationEnabled && automationBasicBuyAndSellEnabled && (
         <Box sx={{ mt: 3 }}>
           <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>

--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -121,7 +121,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
   const afterCollRatioColor = getCollRatioColor(props, afterCollateralizationRatio)
   const afterPillColors = getAfterPillColors(afterCollRatioColor)
   const showAfterPill = !inputAmountsEmpty && stage !== 'manageSuccess'
-  // const automationEnabled = useFeatureToggle('Automation')
+  const automationEnabled = useFeatureToggle('Automation')
   const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
   const oraclePrice = priceInfo.currentCollateralPrice

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -15,7 +15,7 @@ const configuredFeatures: Record<Features, boolean> = {
   TestFeature: false, // used in unit tests
   AnotherTestFeature: true, // used in unit tests
   EarnProduct: false,
-  Automation: false,
+  Automation: true,
   Exchange: true,
   AutomationBasicBuyAndSell: false,
   // your feature here....


### PR DESCRIPTION
# Temporary remove SL UI changes

Some of the changes are made dirty like commenting or disabling eslint lines, but that was faster and it's just temporary.

SL UI is available only for users that already have any triggers.
In other cases users will see banner with proper message.
Also removed banner from overview tab that is suppose to encourage to set up new SL, because there's no point in it right now.
