### PR TITLE
Hide "Get protection" banner from multiply vault page

### DIFF
--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -28,7 +28,7 @@ import { ContentCardBuyingPower } from '../../../../components/vault/detailsSect
 import { ContentCardLiquidationPrice } from '../../../../components/vault/detailsSection/ContentCardLiquidationPrice'
 import { ContentCardNetValue } from '../../../../components/vault/detailsSection/ContentCardNetValue'
 import { useFeatureToggle } from '../../../../helpers/useFeatureToggle'
-import { GetProtectionBannerControl } from '../../../automation/protection/controls/GetProtectionBannerControl'
+// import { GetProtectionBannerControl } from '../../../automation/protection/controls/GetProtectionBannerControl'
 import { StopLossBannerControl } from '../../../automation/protection/controls/StopLossBannerControl'
 import { StopLossTriggeredBannerControl } from '../../../automation/protection/controls/StopLossTriggeredBannerControl'
 import { ManageMultiplyVaultState } from '../pipes/manageMultiplyVault'
@@ -93,7 +93,7 @@ function DefaultManageMultiplyVaultDetailsSummary({
 
 export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
   const {
-    vault: { token, liquidationPrice, id, debt, lockedCollateral, lockedCollateralUSD, ilk },
+    vault: { token, liquidationPrice, id, debt, lockedCollateral, lockedCollateralUSD /* , ilk */ },
     ilkData: { liquidationRatio },
     afterDebt,
     afterLockedCollateral,
@@ -131,9 +131,9 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
       {automationEnabled && (
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
-          {!automationBasicBuyAndSellEnabled && (
+          {/* {!automationBasicBuyAndSellEnabled && (
             <GetProtectionBannerControl vaultId={id} ilk={ilk} debt={debt} />
-          )}
+          )} */}
           <StopLossBannerControl
             vaultId={id}
             liquidationPrice={liquidationPrice}
@@ -240,11 +240,11 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
           }
         />
       )}
-      {automationEnabled && automationBasicBuyAndSellEnabled && (
+      {/* {automationEnabled && automationBasicBuyAndSellEnabled && (
         <Box sx={{ mt: 3 }}>
           <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>
-      )}
+      )} */}
     </Box>
   )
 }


### PR DESCRIPTION
# Hide "Get protection" banner from multiply vault page

Follow up to https://github.com/OasisDEX/oasis-borrow/pull/1017.
  
## Changes 👷‍♀️

Hide get protection banner from multiply vault overview tab.
  
## How to test 🧪

Check if you can see this banner anywhere on vault pages. If not, then it's all good.

![image](https://user-images.githubusercontent.com/16230404/168250206-6b76ad08-955b-4395-bd98-cdf763326f0a.png)