### PR TITLE
Added 0.05 offset to liquidation ratio when setting SL

### DIFF
--- a/features/automation/protection/common/consts/calculations.ts
+++ b/features/automation/protection/common/consts/calculations.ts
@@ -1,0 +1,3 @@
+import BigNumber from 'bignumber.js'
+
+export const STOP_LOSS_LIQUIDATION_OFFSET = new BigNumber(0.05)

--- a/features/automation/protection/common/helpers.ts
+++ b/features/automation/protection/common/helpers.ts
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js'
 
+import { STOP_LOSS_LIQUIDATION_OFFSET } from './consts/calculations'
+
 export function getInitialVaultCollRatio({
   liquidationRatio,
   collateralizationRatio,
@@ -8,7 +10,11 @@ export function getInitialVaultCollRatio({
   collateralizationRatio: BigNumber
 }) {
   return new BigNumber(
-    liquidationRatio.plus(collateralizationRatio).dividedBy(2).toFixed(2, BigNumber.ROUND_CEIL),
+    liquidationRatio
+      .plus(collateralizationRatio)
+      .plus(STOP_LOSS_LIQUIDATION_OFFSET)
+      .dividedBy(2)
+      .toFixed(2, BigNumber.ROUND_CEIL),
   )
 }
 


### PR DESCRIPTION
# [Added 0.05 offset to liquidation ratio when setting SL](https://app.shortcut.com/oazo-apps/story/4374/ui-limit-sl-range-to-at-elast-5-from-liquidation-ratio)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added 0.05 offset to liquidation ratio when setting SL
  
## How to test 🧪
  <Please explain how to test your changes>
- minimum slider value in Protection tab should be `liquidationRatio + 0.05`, for example if liquidation ratio is 1.30 then minimum value should be 1.35 (135%) 
