### PR TITLE
Added newComponents feature toggle key

### DIFF
--- a/components/VaultTabSwitch.tsx
+++ b/components/VaultTabSwitch.tsx
@@ -50,22 +50,21 @@ function VaultTabButton({ onClick, variant, children }: VaultTabButtonProps) {
 }
 
 const InputWithTag = ({ data }: SingleValueProps<VaultTabSwitchOption>) => {
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
   return (
     <Flex sx={{ alignItems: 'center' }}>
       {(data as VaultTabSwitchOption).label}
-      {(data as VaultTabSwitchOptionAutomationBasicBuyAndSell).withTag &&
-        automationBasicBuyAndSellEnabled && (
-          <VaultTabTag
-            isEnabled={(data as VaultTabSwitchOptionAutomationBasicBuyAndSell).isTagEnabled}
-          />
-        )}
+      {(data as VaultTabSwitchOptionNewComponentDesignEnabled).withTag && newComponentsEnabled && (
+        <VaultTabTag
+          isEnabled={(data as VaultTabSwitchOptionNewComponentDesignEnabled).isTagEnabled}
+        />
+      )}
     </Flex>
   )
 }
 
 function Option({ innerProps, isSelected, data }: OptionProps<VaultTabSwitchOption>) {
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   return (
     <Box
@@ -82,9 +81,7 @@ function Option({ innerProps, isSelected, data }: OptionProps<VaultTabSwitchOpti
     >
       <Flex sx={{ fontWeight: isSelected ? 'semiBold' : 'body', alignItems: 'center' }}>
         {data.label}
-        {data.withTag && automationBasicBuyAndSellEnabled && (
-          <VaultTabTag isEnabled={data.isTagEnabled} />
-        )}
+        {data.withTag && newComponentsEnabled && <VaultTabTag isEnabled={data.isTagEnabled} />}
       </Flex>
     </Box>
   )
@@ -95,7 +92,7 @@ type VaultTabSwitchOption = {
   label: keyof typeof VaultViewMode
 }
 
-type VaultTabSwitchOptionAutomationBasicBuyAndSell = {
+type VaultTabSwitchOptionNewComponentDesignEnabled = {
   value: VaultViewMode
   label: keyof typeof VaultViewMode
   withTag: boolean
@@ -128,7 +125,7 @@ export function VaultTabSwitch({
   const [mode, setMode] = useState<VaultViewMode>(defaultMode)
   const { uiChanges } = useAppContext()
   const { t } = useTranslation()
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   useEffect(() => {
     const uiChanges$ = uiChanges.subscribe<TabChange>(TAB_CHANGE_SUBJECT)
@@ -141,7 +138,7 @@ export function VaultTabSwitch({
   }, [])
 
   function getVariant(currentMode: VaultViewMode, activeMode: VaultViewMode) {
-    if (automationBasicBuyAndSellEnabled) {
+    if (newComponentsEnabled) {
       return currentMode === activeMode ? 'vaultTab' : 'vaultTabInactive'
     }
     return currentMode === activeMode ? 'tab' : 'tabInactive'
@@ -158,13 +155,13 @@ export function VaultTabSwitch({
       [VaultViewMode.Protection]: protectionEnabled,
     } as Record<VaultViewMode, boolean>
 
-    return automationBasicBuyAndSellEnabled
+    return newComponentsEnabled
       ? (vaultViewModeTuples.map(([label, value]) => ({
           value,
           label,
           withTag: Object.keys(tagMap).includes(value.toString()),
           isTagEnabled: tagMap[value as VaultViewMode],
-        })) as VaultTabSwitchOptionAutomationBasicBuyAndSell[])
+        })) as VaultTabSwitchOptionNewComponentDesignEnabled[])
       : (vaultViewModeTuples.map(([label, value]) => ({
           value,
           label,
@@ -184,7 +181,7 @@ export function VaultTabSwitch({
 
   return (
     <Grid gap={0} sx={{ width: '100%', mt: 4 }}>
-      {automationBasicBuyAndSellEnabled ? (
+      {newComponentsEnabled ? (
         <Box sx={{ zIndex: 0 }}>{headline}</Box>
       ) : (
         <Flex mt={2} mb={3} sx={{ zIndex: 0 }}>
@@ -211,7 +208,7 @@ export function VaultTabSwitch({
         />
       </Box>
       <Box sx={{ display: ['none', 'block'], zIndex: 1 }}>
-        {automationBasicBuyAndSellEnabled ? (
+        {newComponentsEnabled ? (
           <Flex
             sx={{
               borderBottom: '3px solid',

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -35,7 +35,7 @@ export function GeneralManageLayout({
     collateralizationRatioAtNextPrice,
   } = generalManageVault.state
   const showProtectionTab = ALLOWED_AUTOMATION_ILKS.includes(vault.ilk)
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
   const isStopLossEnabled = useStopLossStateInitializator(ilkData, vault, autoTriggersData)
 
   const vaultHeadingKey =
@@ -54,9 +54,9 @@ export function GeneralManageLayout({
             priceInfo={priceInfo}
           />
         }
-        // TODO this prop to be removed when automationBasicBuyAndSellEnabled wont be needed anymore
+        // TODO this prop to be removed when newComponentsEnabled wont be needed anymore
         headerControl={
-          !automationBasicBuyAndSellEnabled ? (
+          !newComponentsEnabled ? (
             <DefaultVaultHeaderControl vault={vault} ilkData={ilkData} />
           ) : (
             <></>

--- a/components/vault/VaultHeaderContainer.tsx
+++ b/components/vault/VaultHeaderContainer.tsx
@@ -17,11 +17,11 @@ export function VaultHeaderContainer({
   token: string
   priceInfo: PriceInfo
 }) {
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   return (
     <Grid mt={4}>
-      {automationBasicBuyAndSellEnabled ? (
+      {newComponentsEnabled ? (
         <VaultHeadline header={header} token={token} priceInfo={priceInfo} />
       ) : (
         <>

--- a/features/automation/protection/controls/GetProtectionBannerControl.tsx
+++ b/features/automation/protection/controls/GetProtectionBannerControl.tsx
@@ -31,7 +31,7 @@ export function GetProtectionBannerControl({
   const [isBannerClosed, setIsBannerClosed] = useSessionStorage('overviewProtectionBanner', false)
   const autoTriggersData$ = automationTriggersData$(vaultId)
   const [automationTriggersData] = useObservable(autoTriggersData$)
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
   const isAllowedForAutomation = ALLOWED_AUTOMATION_ILKS.includes(ilk)
 
   const slData = automationTriggersData ? extractStopLossData(automationTriggersData) : null
@@ -43,7 +43,7 @@ export function GetProtectionBannerControl({
     isAllowedForAutomation &&
     !debt.isZero() ? (
     <>
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <GetProtectionBannerLayout
           handleClick={() => {
             uiChanges.publish(TAB_CHANGE_SUBJECT, {

--- a/features/automation/protection/controls/ProtectionDetailsLayout.tsx
+++ b/features/automation/protection/controls/ProtectionDetailsLayout.tsx
@@ -49,7 +49,7 @@ export function ProtectionDetailsLayout({
 }: ProtectionDetailsLayoutProps) {
   const { t } = useTranslation()
   const afterPillColors = getAfterPillColors('onSuccess')
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   const percentageChange = calculatePricePercentageChange(currentOraclePrice, nextOraclePrice)
   const collateralizationRatio = lockedCollateral.times(currentOraclePrice).div(vaultDebt)
@@ -58,7 +58,7 @@ export function ProtectionDetailsLayout({
 
   return (
     <Box>
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <Grid variant="vaultDetailsCardsContainer">
           <VaultDetailsCardStopLossCollRatio
             slRatio={slRatio}

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -140,14 +140,14 @@ export function ManageVaultDetails(
   const showAfterPill = !inputAmountsEmpty && stage !== 'manageSuccess'
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
   const automationEnabled = useFeatureToggle('Automation')
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   return (
     <Box>
       {automationEnabled && (
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
-          {/* {!automationBasicBuyAndSellEnabled && (
+          {/* {!newComponentsEnabled && (
             <GetProtectionBannerControl vaultId={id} ilk={ilk} debt={debt} />
           )} */}
           <StopLossBannerControl
@@ -159,7 +159,7 @@ export function ManageVaultDetails(
           />
         </>
       )}
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <>
           <Grid variant="vaultDetailsCardsContainer">
             <VaultDetailsCardLiquidationPrice
@@ -237,7 +237,7 @@ export function ManageVaultDetails(
           }
         />
       )}
-      {/* {automationEnabled && automationBasicBuyAndSellEnabled && (
+      {/* {automationEnabled && newComponentsEnabled && (
         <Box sx={{ mt: 3 }}>
           <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>

--- a/features/borrow/open/containers/OpenVaultDetails.tsx
+++ b/features/borrow/open/containers/OpenVaultDetails.tsx
@@ -134,11 +134,11 @@ export function OpenVaultDetails(props: OpenVaultState) {
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
   const inputAmountWasChanged = useHasChangedSinceFirstRender(inputAmountsEmpty)
   const daiYieldFromTotalCollateral = maxGenerateAmountCurrentPrice.minus(generateAmount || zero)
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   return (
     <>
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <>
           <Grid variant="vaultDetailsCardsContainer">
             <VaultDetailsCardLiquidationPrice

--- a/features/earn/guni/manage/containers/GuniManageMultiplyVaultDetails.tsx
+++ b/features/earn/guni/manage/containers/GuniManageMultiplyVaultDetails.tsx
@@ -107,11 +107,11 @@ export function GuniManageMultiplyVaultDetails(props: ManageMultiplyVaultState) 
   const showAfterPill = !inputAmountsEmpty && stage !== 'manageSuccess'
   const oraclePrice = priceInfo.currentCollateralPrice
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   return (
     <Box>
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <>
           <Grid variant="vaultDetailsCardsContainer">
             <VaultDetailsCardNetValue

--- a/features/earn/guni/open/containers/GuniOpenMultiplyVaultDetails.tsx
+++ b/features/earn/guni/open/containers/GuniOpenMultiplyVaultDetails.tsx
@@ -107,11 +107,11 @@ export function GuniOpenMultiplyVaultDetails(props: OpenGuniVaultState) {
   const inputAmountChangedSinceFirstRender = useHasChangedSinceFirstRender(inputAmountsEmpty)
   const oraclePrice = priceInfo.currentCollateralPrice
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
   return (
     <>
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <>
           <Grid variant="vaultDetailsCardsContainer">
             <VaultDetailsCardNetValue

--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -122,7 +122,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
   const afterPillColors = getAfterPillColors(afterCollRatioColor)
   const showAfterPill = !inputAmountsEmpty && stage !== 'manageSuccess'
   const automationEnabled = useFeatureToggle('Automation')
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
   const oraclePrice = priceInfo.currentCollateralPrice
 
@@ -131,7 +131,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
       {automationEnabled && (
         <>
           {stopLossTriggered && <StopLossTriggeredBannerControl />}
-          {/* {!automationBasicBuyAndSellEnabled && (
+          {/* {!newComponentsEnabled && (
             <GetProtectionBannerControl vaultId={id} ilk={ilk} debt={debt} />
           )} */}
           <StopLossBannerControl
@@ -143,7 +143,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
           />
         </>
       )}
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <>
           <Grid variant="vaultDetailsCardsContainer">
             <VaultDetailsCardLiquidationPrice
@@ -240,7 +240,7 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
           }
         />
       )}
-      {/* {automationEnabled && automationBasicBuyAndSellEnabled && (
+      {/* {automationEnabled && newComponentsEnabled && (
         <Box sx={{ mt: 3 }}>
           <GetProtectionBannerControl vaultId={id} token={token} ilk={ilk} debt={debt} />
         </Box>

--- a/features/multiply/open/containers/OpenMultiplyVaultDetails.tsx
+++ b/features/multiply/open/containers/OpenMultiplyVaultDetails.tsx
@@ -119,11 +119,11 @@ export function OpenMultiplyVaultDetails(props: OpenMultiplyVaultState) {
   const afterPillColors = getAfterPillColors(afterCollRatioColor)
   const showAfterPill = !inputAmountsEmpty && stage !== 'txSuccess'
   const inputAmountChangedSinceFirstRender = useHasChangedSinceFirstRender(inputAmountsEmpty)
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
   const oraclePrice = priceInfo.currentCollateralPrice
 
-  return !automationBasicBuyAndSellEnabled ? (
+  return !newComponentsEnabled ? (
     <>
       <Grid variant="vaultDetailsCardsContainer">
         <VaultDetailsCardLiquidationPrice

--- a/features/vaultHistory/VaultHistoryView.tsx
+++ b/features/vaultHistory/VaultHistoryView.tsx
@@ -298,13 +298,13 @@ export function VaultHistoryView({ vaultHistory }: { vaultHistory: VaultHistoryE
   const [context] = useObservable(context$)
   const { t } = useTranslation()
 
-  const automationBasicBuyAndSellEnabled = useFeatureToggle('AutomationBasicBuyAndSell')
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
   const spitedEvents = flatten(vaultHistory.map(splitEvents))
 
   return (
     <>
       {/* TODO: remove VaultHistoryItem, MultiplyHistoryEventDetails and MultiplyHistoryEventDetailsItem components when this flag is no longer needed */}
-      {!automationBasicBuyAndSellEnabled ? (
+      {!newComponentsEnabled ? (
         <Box>
           <Heading variant="header3" sx={{ mb: [4, 3] }}>
             {t('vault-history')}

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -10,6 +10,7 @@ type Features =
   | 'Automation'
   | 'Exchange'
   | 'AutomationBasicBuyAndSell'
+  | 'NewComponents'
 
 const configuredFeatures: Record<Features, boolean> = {
   TestFeature: false, // used in unit tests
@@ -18,6 +19,7 @@ const configuredFeatures: Record<Features, boolean> = {
   Automation: true,
   Exchange: true,
   AutomationBasicBuyAndSell: false,
+  NewComponents: false,
   // your feature here....
 }
 


### PR DESCRIPTION
# [Added NewComponents feature toggle key](https://app.shortcut.com/oazo-apps/story/4223/display-hide-new-redesigned-views-behind-new-feature-flag)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added NewComponents feature toggle key
- replaced usage of AutomationBasicBuyAndSell to NewComponents key 
  
## How to test 🧪
  <Please explain how to test your changes>
- in order to see new designs use new feature toggle key `NewComponents`
