### PR TITLE
Lock Set Stop-loss button disabled if SL is set on collateral ratio, …

### DIFF
--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -65,7 +65,7 @@ export function ProtectionControl({
   const [collateralPrices, collateralPricesError] = useObservable(collateralPrices$)
   const dustLimit = ilkData.debtFloor
 
-  return !vault.debt.isZero() && vault.debt > dustLimit ? (
+  return !vault.debt.isZero() && vault.debt.isGreaterThan(dustLimit) ? (
     <WithErrorHandler error={[automationTriggersError, collateralPricesError]}>
       <WithLoadingIndicator
         value={[automationTriggersData, collateralPrices]}

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -31,7 +31,7 @@ import { getIsEditingProtection } from '../common/helpers'
 import { extractStopLossData, prepareTriggerData } from '../common/StopLossTriggerDataExtractor'
 import { ADD_FORM_CHANGE, AddFormChange } from '../common/UITypes/AddFormChange'
 import { TriggersData } from '../triggers/AutomationTriggersData'
-import { AdjustSlFormLayout, AdjustSlFormLayoutProps } from './AdjustSlFormLayout'
+import { AdjustSlFormLayout, AdjustSlFormLayoutProps, slCollRatioIsAtLiquidationRatio } from './AdjustSlFormLayout'
 
 function prepareAddTriggerData(
   vaultData: Vault,
@@ -257,7 +257,7 @@ export function AdjustSlFormControl({
     disabled:
       !isOwner ||
       (!isEditing && uiState?.txDetails?.txStatus !== TxStatus.Success) ||
-      (!isEditing && !uiState?.txDetails),
+      (!isEditing && !uiState?.txDetails) || slCollRatioIsAtLiquidationRatio(selectedSLValue, ilkData),
   }
 
   const dynamicStopLossPrice = vault.liquidationPrice

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -205,6 +205,13 @@ function SetDownsideProtectionInformation({
           withBullet={false}
         />
       )}
+      {slCollRatioIsAtLiquidationRatio(selectedSLValue, ilkData) && (
+        <MessageCard
+          messages={[t('protection.coll-ratio-liquidation')]}
+          type="error"
+          withBullet={false}
+        />
+      )}
     </VaultChangesInformationContainer>
   )
 }
@@ -232,6 +239,10 @@ export interface AdjustSlFormLayoutProps {
   firstStopLossSetup: boolean
   isEditing: boolean
   collateralizationRatioAtNextPrice: BigNumber
+}
+
+export function slCollRatioIsAtLiquidationRatio(selectedSLValue: BigNumber, ilkData: IlkData) {
+  return selectedSLValue.isLessThanOrEqualTo(ilkData.liquidationRatio.multipliedBy(100))
 }
 
 export function AdjustSlFormLayout({

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -969,7 +969,8 @@
     "set-stop-loss-again": "Set up Stop-Loss again",
     "sl-triggered-gas-estimation": "These estimated fees are based on the approximate price you will get from selling your collateral to cover your debt when automation is executed and covers the Oasis fee.",
     "stop-loss-on": "Stop-Loss On",
-    "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change."
+    "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change.",
+    "coll-ratio-liquidation": "Your Stop-Loss Trigger Col. Ratio would cause closing vault immediately. If this is intended, close your vault."
   },
   "newsletter": {
     "title": "Stay up to date with Oasis.app",


### PR DESCRIPTION
…display message to close vault

# [Lock Set Stop-loss button disabled if SL is set on collateral ratio, display message to close vault](https://app.shortcut.com/oazo-apps/story/4400/lock-set-stop-loss-button-disabled-if-sl-is-set-on-collateral-ratio-display-message-to-close-vault)

  
## Changes 👷‍♀️
 
- Disabled adding stop loss on liquidation ratio
  
## How to test 🧪
  Try to set stop loss on liquidationRatio
See if you will see message and add stop-loss button will be disabled
![image](https://user-images.githubusercontent.com/6871923/168826327-bfac6dd5-97b8-458d-b566-fd7e1099debf.png)

