### PR TITLE
Fix balances on featuredcards when no card balance filters available

### DIFF
--- a/components/ProductCardBorrow.tsx
+++ b/components/ProductCardBorrow.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { formatCryptoBalance, formatPercent } from '../helpers/formatters/format'
 import { ProductCardData, productCardsConfig } from '../helpers/productCards'
 import { roundToThousand } from '../helpers/roundToThousand'
-import { one } from '../helpers/zero'
+import { one, zero } from '../helpers/zero'
 import { calculateTokenAmount, ProductCard, ProductCardProtocolLink } from './ProductCard'
 
 function personaliseCardData({
@@ -65,9 +65,10 @@ function makeCardData(singleTokenMaxBorrow: BigNumber) {
 
 function bannerValues(props: ProductCardData) {
   const { liquidationRatio, currentCollateralPrice, balance } = props
+
   const singleTokenMaxBorrow = one.div(liquidationRatio).multipliedBy(currentCollateralPrice)
 
-  if (balance) {
+  if (balance?.gt(zero)) {
     return personaliseCardData({ productCardData: props, singleTokenMaxBorrow })
   }
 

--- a/components/ProductCardMultiply.tsx
+++ b/components/ProductCardMultiply.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { formatCryptoBalance, formatPercent } from '../helpers/formatters/format'
 import { ProductCardData, productCardsConfig } from '../helpers/productCards'
-import { one } from '../helpers/zero'
+import { one, zero } from '../helpers/zero'
 import { calculateTokenAmount, ProductCard, ProductCardProtocolLink } from './ProductCard'
 
 function personaliseCardData({
@@ -30,7 +30,7 @@ function bannerValues(props: ProductCardData, maxMultiple: BigNumber) {
   const roundedMaxMultiple = new BigNumber(maxMultiple.toFixed(2, 3))
   const roundedTokenAmount = new BigNumber(tokenAmount.toFixed(0, 3))
 
-  if (balance) {
+  if (balance?.gt(zero)) {
     return personaliseCardData({ productCardData: props, roundedMaxMultiple })
   }
 


### PR DESCRIPTION
<img width="416" alt="Screenshot 2022-05-17 at 15 11 28" src="https://user-images.githubusercontent.com/5372463/168831605-5e18c009-1f72-418b-a9c3-0da9919f6629.png">

Featured cards showing nil balances when user wallet is returning a balance but that balances is zero.