### PR TITLE
set slippage to zero

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -769,7 +769,6 @@ export function setupAppContext() {
         addGasEstimation$,
         getProportions$,
         vaultHistory$,
-        userSettings$,
         id,
       ),
     bigNumberTostring,


### PR DESCRIPTION
# [Slippage to zero](https://app.shortcut.com/oazo-apps/story/4426/bug-closing-guni-shows-dai-returned-including-slippage-which-is-false)

  
## Changes 👷‍♀️
- hardcode slippage to zero
  
## How to test 🧪
- try to close your multiply vault and look at slippage 
