### PR TITLE
Open multiply new design sidebar

### DIFF
--- a/components/vault/VaultAllowance.tsx
+++ b/components/vault/VaultAllowance.tsx
@@ -1,9 +1,6 @@
 import { getToken } from 'blockchain/tokensMetadata'
 import { Radio } from 'components/forms/Radio'
 import { TxStatusCardProgress, TxStatusCardSuccess } from 'components/vault/TxStatusCard'
-import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
-import { OpenGuniVaultState } from 'features/earn/guni/open/pipes/openGuniVault'
-import { OpenMultiplyVaultState } from 'features/multiply/open/pipes/openMultiplyVault'
 import { BigNumberInput } from 'helpers/BigNumberInput'
 import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { handleNumericInput } from 'helpers/input'
@@ -12,6 +9,8 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { createNumberMask } from 'text-mask-addons'
 import { Grid, Text } from 'theme-ui'
+
+import { HasAllowanceData } from '../../helpers/extractSidebarHelpers'
 
 export function VaultAllowance({
   stage,
@@ -23,7 +22,7 @@ export function VaultAllowance({
   setAllowanceAmountToDepositAmount,
   setAllowanceAmountCustom,
   selectedAllowanceRadio,
-}: OpenVaultState | OpenMultiplyVaultState | OpenGuniVaultState) {
+}: HasAllowanceData) {
   const canSelectRadio = stage === 'allowanceWaitingForConfirmation'
 
   const isUnlimited = selectedAllowanceRadio === 'unlimited'

--- a/components/vault/sidebar/SidebarOpenBorrowVault.tsx
+++ b/components/vault/sidebar/SidebarOpenBorrowVault.tsx
@@ -14,16 +14,21 @@ import {
   regressTrackingEvent,
 } from 'features/sidebar/trackingEventOpenVault'
 import { extractGasDataFromState } from 'helpers/extractGasDataFromState'
-import { extractSidebarButtonLabelParams } from 'helpers/extractSidebarHelpers'
+import {
+  extractAllowanceDataFromOpenVaultState,
+  extractSidebarButtonLabelParams,
+  extractSidebarTxData,
+} from 'helpers/extractSidebarHelpers'
 import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
 
-import { SidebarOpenBorrowVaultAllowanceStage } from './SidebarOpenBorrowVaultAllowanceStage'
+import { isFirstCdp } from '../../../helpers/isFirstCdp'
 import { SidebarOpenBorrowVaultEditingStage } from './SidebarOpenBorrowVaultEditingStage'
 import { SidebarOpenBorrowVaultOpenStage } from './SidebarOpenBorrowVaultOpenStage'
-import { SidebarOpenBorrowVaultProxyStage } from './SidebarOpenBorrowVaultProxyStage'
+import { SidebarOpenVaultAllowanceStage } from './SidebarOpenVaultAllowanceStage'
+import { SidebarOpenVaultProxyStage } from './SidebarOpenVaultProxyStage'
 
 export function SidebarOpenBorrowVault(props: OpenVaultState) {
   const { t } = useTranslation()
@@ -56,7 +61,9 @@ export function SidebarOpenBorrowVault(props: OpenVaultState) {
     flow: 'openBorrow',
     ...props,
   })
-  const firstCDP = accountData?.numberOfVaults ? accountData.numberOfVaults === 0 : undefined
+  const firstCDP = isFirstCdp(accountData)
+  const allowanceData = extractAllowanceDataFromOpenVaultState(props)
+  const sidebarTxData = extractSidebarTxData(props)
 
   const sidebarSectionProps: SidebarSectionProps = {
     title: getSidebarTitle({ flow: 'openBorrow', stage, token }),
@@ -75,8 +82,8 @@ export function SidebarOpenBorrowVault(props: OpenVaultState) {
     content: (
       <Grid gap={3}>
         {isEditingStage && <SidebarOpenBorrowVaultEditingStage {...props} />}
-        {isProxyStage && <SidebarOpenBorrowVaultProxyStage stage={stage} gasData={gasData} />}
-        {isAllowanceStage && <SidebarOpenBorrowVaultAllowanceStage {...props} />}
+        {isProxyStage && <SidebarOpenVaultProxyStage stage={stage} gasData={gasData} />}
+        {isAllowanceStage && <SidebarOpenVaultAllowanceStage {...allowanceData} />}
         {isOpenStage && <SidebarOpenBorrowVaultOpenStage {...props} />}
         <VaultErrors {...props} />
         <VaultWarnings {...props} />
@@ -100,8 +107,8 @@ export function SidebarOpenBorrowVault(props: OpenVaultState) {
           url: `/vaults/open-multiply/${ilk}`,
         },
       }),
-    progress: getSidebarProgress(props),
-    success: getSidebarSuccess(props),
+    progress: getSidebarProgress(sidebarTxData),
+    success: getSidebarSuccess(sidebarTxData),
   }
 
   return <SidebarSection {...sidebarSectionProps} />

--- a/components/vault/sidebar/SidebarOpenVaultAllowanceStage.tsx
+++ b/components/vault/sidebar/SidebarOpenVaultAllowanceStage.tsx
@@ -1,8 +1,8 @@
+import { HasAllowanceData } from 'helpers/extractSidebarHelpers'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid, Text } from 'theme-ui'
 
-import { HasAllowanceData } from '../../../helpers/extractSidebarHelpers'
 import { VaultAllowance } from '../VaultAllowance'
 
 export function SidebarOpenVaultAllowanceStage(props: HasAllowanceData) {

--- a/components/vault/sidebar/SidebarOpenVaultAllowanceStage.tsx
+++ b/components/vault/sidebar/SidebarOpenVaultAllowanceStage.tsx
@@ -1,11 +1,11 @@
-import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid, Text } from 'theme-ui'
 
+import { HasAllowanceData } from '../../../helpers/extractSidebarHelpers'
 import { VaultAllowance } from '../VaultAllowance'
 
-export function SidebarOpenBorrowVaultAllowanceStage(props: OpenVaultState) {
+export function SidebarOpenVaultAllowanceStage(props: HasAllowanceData) {
   const { t } = useTranslation()
   const { stage } = props
 

--- a/components/vault/sidebar/SidebarOpenVaultProxyStage.tsx
+++ b/components/vault/sidebar/SidebarOpenVaultProxyStage.tsx
@@ -1,12 +1,12 @@
 import { AppLink } from 'components/Links'
 import { ListWithIcon } from 'components/ListWithIcon'
+import { SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
 import { HasGasEstimation } from 'helpers/form'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Image, Text } from 'theme-ui'
 
-import { SidebarVaultStages } from '../../../features/types/vaults/sidebarLabels'
 import {
   getEstimatedGasFeeText,
   VaultChangesInformationContainer,

--- a/components/vault/sidebar/SidebarOpenVaultProxyStage.tsx
+++ b/components/vault/sidebar/SidebarOpenVaultProxyStage.tsx
@@ -1,29 +1,24 @@
 import { AppLink } from 'components/Links'
 import { ListWithIcon } from 'components/ListWithIcon'
-import { ManageBorrowVaultStage } from 'features/borrow/manage/pipes/manageVault'
-import { OpenVaultStage } from 'features/borrow/open/pipes/openVault'
-import { ManageMultiplyVaultStage } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { HasGasEstimation } from 'helpers/form'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Image, Text } from 'theme-ui'
 
+import { SidebarVaultStages } from '../../../features/types/vaults/sidebarLabels'
 import {
   getEstimatedGasFeeText,
   VaultChangesInformationContainer,
   VaultChangesInformationItem,
 } from '../VaultChangesInformation'
 
-interface SidebarOpenBorrowVaultProxyStageProps {
-  stage: OpenVaultStage | ManageBorrowVaultStage | ManageMultiplyVaultStage
+interface SidebarOpenVaultProxyStageProps {
+  stage: SidebarVaultStages
   gasData: HasGasEstimation
 }
 
-export function SidebarOpenBorrowVaultProxyStage({
-  stage,
-  gasData,
-}: SidebarOpenBorrowVaultProxyStageProps) {
+export function SidebarOpenVaultProxyStage({ stage, gasData }: SidebarOpenVaultProxyStageProps) {
   const { t } = useTranslation()
 
   const isProxyInfoStage = [

--- a/features/multiply/open/containers/OpenMultiplyVaultForm.tsx
+++ b/features/multiply/open/containers/OpenMultiplyVaultForm.tsx
@@ -1,3 +1,9 @@
+import { OpenMultiplyVaultButton } from 'components/vault/commonMultiply/OpenMultiplyVaultButton'
+import {
+  OpenMultiplyVaultConfirmation,
+  OpenMultiplyVaultStatus,
+} from 'components/vault/commonMultiply/OpenMultiplyVaultConfirmation'
+import { OpenMultiplyVaultTitle } from 'components/vault/commonMultiply/OpenMultiplyVaultTitle'
 import { VaultAllowance, VaultAllowanceStatus } from 'components/vault/VaultAllowance'
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { VaultErrors } from 'components/vault/VaultErrors'
@@ -5,17 +11,11 @@ import { VaultFormVaultTypeSwitch } from 'components/vault/VaultForm'
 import { VaultFormContainer } from 'components/vault/VaultFormContainer'
 import { VaultProxyContentBox, VaultProxyStatusCard } from 'components/vault/VaultProxy'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { extractGasDataFromState } from 'helpers/extractGasDataFromState'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { OpenMultiplyVaultButton } from '../../../../components/vault/commonMultiply/OpenMultiplyVaultButton'
-import {
-  OpenMultiplyVaultConfirmation,
-  OpenMultiplyVaultStatus,
-} from '../../../../components/vault/commonMultiply/OpenMultiplyVaultConfirmation'
-import { OpenMultiplyVaultTitle } from '../../../../components/vault/commonMultiply/OpenMultiplyVaultTitle'
-import { extractGasDataFromState } from '../../../../helpers/extractGasDataFromState'
-import { useFeatureToggle } from '../../../../helpers/useFeatureToggle'
 import { OpenMultiplyVaultState } from '../pipes/openMultiplyVault'
 import { OpenMultiplyVaultChangesInformation } from './OpenMultiplyVaultChangesInformation'
 import { OpenMultiplyVaultEditing } from './OpenMultiplyVaultEditing'

--- a/features/multiply/open/containers/OpenMultiplyVaultForm.tsx
+++ b/features/multiply/open/containers/OpenMultiplyVaultForm.tsx
@@ -15,16 +15,21 @@ import {
 } from '../../../../components/vault/commonMultiply/OpenMultiplyVaultConfirmation'
 import { OpenMultiplyVaultTitle } from '../../../../components/vault/commonMultiply/OpenMultiplyVaultTitle'
 import { extractGasDataFromState } from '../../../../helpers/extractGasDataFromState'
+import { useFeatureToggle } from '../../../../helpers/useFeatureToggle'
 import { OpenMultiplyVaultState } from '../pipes/openMultiplyVault'
 import { OpenMultiplyVaultChangesInformation } from './OpenMultiplyVaultChangesInformation'
 import { OpenMultiplyVaultEditing } from './OpenMultiplyVaultEditing'
+import { SidebarOpenMultiplyVault } from './sidebar/SidebarOpenMultiplyVault'
 
 export function OpenMultiplyVaultForm(props: OpenMultiplyVaultState) {
   const { isEditingStage, isProxyStage, isAllowanceStage, isOpenStage, ilk, stage } = props
   const { t } = useTranslation()
   const gasData = extractGasDataFromState(props)
+  const newComponentsEnabled = useFeatureToggle('NewComponents')
 
-  return (
+  return newComponentsEnabled ? (
+    <SidebarOpenMultiplyVault {...props} />
+  ) : (
     <VaultFormContainer toggleTitle="Open Vault">
       <OpenMultiplyVaultTitle
         {...props}

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVault.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVault.tsx
@@ -1,33 +1,30 @@
-import { useTranslation } from 'next-i18next'
-import React from 'react'
-import { Grid } from 'theme-ui'
-
-import { useAppContext } from '../../../../../components/AppContextProvider'
+import { useAppContext } from 'components/AppContextProvider'
+import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
+import { SidebarOpenVaultAllowanceStage } from 'components/vault/sidebar/SidebarOpenVaultAllowanceStage'
+import { SidebarOpenVaultProxyStage } from 'components/vault/sidebar/SidebarOpenVaultProxyStage'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { getHeaderButton } from 'features/sidebar/getHeaderButton'
+import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
+import { getSidebarProgress } from 'features/sidebar/getSidebarProgress'
+import { getSidebarSuccess } from 'features/sidebar/getSidebarSuccess'
+import { getSidebarTitle } from 'features/sidebar/getSidebarTitle'
 import {
-  SidebarSection,
-  SidebarSectionProps,
-} from '../../../../../components/sidebar/SidebarSection'
-import { SidebarOpenVaultAllowanceStage } from '../../../../../components/vault/sidebar/SidebarOpenVaultAllowanceStage'
-import { SidebarOpenVaultProxyStage } from '../../../../../components/vault/sidebar/SidebarOpenVaultProxyStage'
-import { VaultErrors } from '../../../../../components/vault/VaultErrors'
-import { VaultWarnings } from '../../../../../components/vault/VaultWarnings'
-import { extractGasDataFromState } from '../../../../../helpers/extractGasDataFromState'
+  progressTrackingEvent,
+  regressTrackingEvent,
+} from 'features/sidebar/trackingEventOpenVault'
+import { extractGasDataFromState } from 'helpers/extractGasDataFromState'
 import {
   extractAllowanceDataFromOpenVaultState,
   extractSidebarButtonLabelParams,
   extractSidebarTxData,
-} from '../../../../../helpers/extractSidebarHelpers'
-import { isFirstCdp } from '../../../../../helpers/isFirstCdp'
-import { useObservable } from '../../../../../helpers/observableHook'
-import { getHeaderButton } from '../../../../sidebar/getHeaderButton'
-import { getPrimaryButtonLabel } from '../../../../sidebar/getPrimaryButtonLabel'
-import { getSidebarProgress } from '../../../../sidebar/getSidebarProgress'
-import { getSidebarSuccess } from '../../../../sidebar/getSidebarSuccess'
-import { getSidebarTitle } from '../../../../sidebar/getSidebarTitle'
-import {
-  progressTrackingEvent,
-  regressTrackingEvent,
-} from '../../../../sidebar/trackingEventOpenVault'
+} from 'helpers/extractSidebarHelpers'
+import { isFirstCdp } from 'helpers/isFirstCdp'
+import { useObservable } from 'helpers/observableHook'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Grid } from 'theme-ui'
+
 import { OpenMultiplyVaultState } from '../../pipes/openMultiplyVault'
 import { SidebarOpenMultiplyVaultEditingState } from './SidebarOpenMultiplyVaultEditingState'
 import { SidebarOpenMultiplyVaultOpenStage } from './SidebarOpenMultiplyVaultOpenStage'

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVault.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVault.tsx
@@ -1,0 +1,116 @@
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Grid } from 'theme-ui'
+
+import { useAppContext } from '../../../../../components/AppContextProvider'
+import {
+  SidebarSection,
+  SidebarSectionProps,
+} from '../../../../../components/sidebar/SidebarSection'
+import { SidebarOpenVaultAllowanceStage } from '../../../../../components/vault/sidebar/SidebarOpenVaultAllowanceStage'
+import { SidebarOpenVaultProxyStage } from '../../../../../components/vault/sidebar/SidebarOpenVaultProxyStage'
+import { VaultErrors } from '../../../../../components/vault/VaultErrors'
+import { VaultWarnings } from '../../../../../components/vault/VaultWarnings'
+import { extractGasDataFromState } from '../../../../../helpers/extractGasDataFromState'
+import {
+  extractAllowanceDataFromOpenVaultState,
+  extractSidebarButtonLabelParams,
+  extractSidebarTxData,
+} from '../../../../../helpers/extractSidebarHelpers'
+import { isFirstCdp } from '../../../../../helpers/isFirstCdp'
+import { useObservable } from '../../../../../helpers/observableHook'
+import { getHeaderButton } from '../../../../sidebar/getHeaderButton'
+import { getPrimaryButtonLabel } from '../../../../sidebar/getPrimaryButtonLabel'
+import { getSidebarProgress } from '../../../../sidebar/getSidebarProgress'
+import { getSidebarSuccess } from '../../../../sidebar/getSidebarSuccess'
+import { getSidebarTitle } from '../../../../sidebar/getSidebarTitle'
+import {
+  progressTrackingEvent,
+  regressTrackingEvent,
+} from '../../../../sidebar/trackingEventOpenVault'
+import { OpenMultiplyVaultState } from '../../pipes/openMultiplyVault'
+import { SidebarOpenMultiplyVaultEditingState } from './SidebarOpenMultiplyVaultEditingState'
+import { SidebarOpenMultiplyVaultOpenStage } from './SidebarOpenMultiplyVaultOpenStage'
+
+export function SidebarOpenMultiplyVault(props: OpenMultiplyVaultState) {
+  const { t } = useTranslation()
+  const { accountData$ } = useAppContext()
+  const [accountData] = useObservable(accountData$)
+
+  const {
+    id,
+    stage,
+    canProgress,
+    progress,
+    canRegress,
+    regress,
+    isEditingStage,
+    isProxyStage,
+    isAllowanceStage,
+    isOpenStage,
+    isLoadingStage,
+    isSuccessStage,
+    token,
+    totalSteps,
+    currentStep,
+    ilk,
+    updateDeposit,
+    inputAmountsEmpty,
+  } = props
+
+  const gasData = extractGasDataFromState(props)
+  const firstCDP = isFirstCdp(accountData)
+  const allowanceData = extractAllowanceDataFromOpenVaultState(props)
+  const sidebarPrimaryButtonLabelParams = extractSidebarButtonLabelParams({
+    flow: 'openMultiply',
+    ...props,
+  })
+  const sidebarTxData = extractSidebarTxData(props)
+
+  const sidebarSectionProps: SidebarSectionProps = {
+    title: getSidebarTitle({ flow: 'openMultiply', stage, token }),
+    headerButton: getHeaderButton({
+      stage,
+      canResetForm: isEditingStage && !inputAmountsEmpty,
+      resetForm: () => {
+        updateDeposit!(undefined)
+      },
+      canRegress,
+      regress,
+      regressCallback: () => {
+        regressTrackingEvent({ props, firstCDP })
+      },
+    }),
+    content: (
+      <Grid gap={3}>
+        {isEditingStage && <SidebarOpenMultiplyVaultEditingState {...props} />}
+        {isProxyStage && <SidebarOpenVaultProxyStage stage={stage} gasData={gasData} />}
+        {isAllowanceStage && <SidebarOpenVaultAllowanceStage {...allowanceData} />}
+        {isOpenStage && <SidebarOpenMultiplyVaultOpenStage {...props} />}
+        <VaultErrors {...props} />
+        <VaultWarnings {...props} />
+      </Grid>
+    ),
+    primaryButton: {
+      label: getPrimaryButtonLabel(sidebarPrimaryButtonLabelParams),
+      steps: !isSuccessStage ? [currentStep, totalSteps] : undefined,
+      disabled: !canProgress,
+      isLoading: isLoadingStage,
+      action: () => {
+        if (!isSuccessStage) progress!()
+        progressTrackingEvent({ props, firstCDP })
+      },
+      url: isSuccessStage ? `/${id}` : undefined,
+    },
+    ...(isEditingStage && {
+      textButton: {
+        label: t('system.actions.multiply.switch-to-borrow'),
+        url: `/vaults/open/${ilk}`,
+      },
+    }),
+    progress: getSidebarProgress(sidebarTxData),
+    success: getSidebarSuccess(sidebarTxData),
+  }
+
+  return <SidebarSection {...sidebarSectionProps} />
+}

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultEditingState.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultEditingState.tsx
@@ -1,0 +1,143 @@
+import BigNumber from 'bignumber.js'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Box, Divider, Flex, Grid, Slider, Text, useThemeUI } from 'theme-ui'
+
+import { VaultActionInput } from '../../../../../components/vault/VaultActionInput'
+import { getCollRatioColor } from '../../../../../components/vault/VaultDetails'
+import { formatAmount, formatPercent } from '../../../../../helpers/formatters/format'
+import { handleNumericInput } from '../../../../../helpers/input'
+import { zero } from '../../../../../helpers/zero'
+import { OpenMultiplyVaultState } from '../../pipes/openMultiplyVault'
+import { OpenMultiplyVaultChangesInformation } from '../OpenMultiplyVaultChangesInformation'
+
+export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultState) {
+  const {
+    theme: { colors },
+  } = useThemeUI()
+  const { t } = useTranslation()
+
+  const {
+    token,
+    depositAmount,
+    maxDepositAmount,
+    updateDeposit,
+    updateDepositMax,
+    updateDepositUSD,
+    depositAmountUSD,
+    maxDepositAmountUSD,
+    updateRequiredCollRatio,
+    multiply,
+    priceInfo: { currentCollateralPrice },
+    canAdjustRisk,
+    afterLiquidationPrice,
+    afterCollateralizationRatio,
+    requiredCollRatio,
+
+    ilkData: { liquidationRatio },
+    maxCollRatio,
+    inputAmountsEmpty,
+  } = props
+
+  const slider = requiredCollRatio
+    ? maxCollRatio?.minus(requiredCollRatio)?.div(maxCollRatio.minus(liquidationRatio)).times(100)
+    : zero
+
+  const collRatioColor = getCollRatioColor(props, afterCollateralizationRatio)
+  const sliderBackground =
+    multiply && !multiply.isNaN() && slider
+      ? `linear-gradient(to right, ${colors?.sliderTrackFill} 0%, ${
+          colors?.sliderTrackFill
+        } ${slider.toNumber()}%, ${colors?.primaryAlt} ${slider.toNumber()}%, ${
+          colors?.primaryAlt
+        } 100%)`
+      : 'primaryAlt'
+
+  return (
+    <Grid gap={4}>
+      <Grid gap={2}>
+        <Text variant="strong">Deposit your {token}</Text>
+        <VaultActionInput
+          action="Deposit"
+          token={token}
+          tokenUsdPrice={currentCollateralPrice}
+          showMax={true}
+          hasAuxiliary={true}
+          onSetMax={updateDepositMax!}
+          amount={depositAmount}
+          auxiliaryAmount={depositAmountUSD}
+          onChange={handleNumericInput(updateDeposit!)}
+          onAuxiliaryChange={handleNumericInput(updateDepositUSD!)}
+          maxAmount={maxDepositAmount}
+          maxAuxiliaryAmount={maxDepositAmountUSD}
+          maxAmountLabel={t('balance')}
+          hasError={false}
+        />
+      </Grid>
+      <Grid gap={2}>
+        <Text variant="strong" mb={2}>
+          {t('slider.adjust-multiply.introduction-header')}
+        </Text>
+        <Box>
+          <Flex
+            sx={{
+              variant: 'text.paragraph4',
+              justifyContent: 'space-between',
+              fontWeight: 'semiBold',
+              color: 'text.subtitle',
+            }}
+          >
+            <Grid gap={2}>
+              <Text>Liquidation Price</Text>
+              <Text variant="paragraph1" sx={{ fontWeight: 'semiBold' }}>
+                ${formatAmount(afterLiquidationPrice, 'USD')}
+              </Text>
+            </Grid>
+            <Grid gap={2}>
+              <Text>{t('system.collateral-ratio')}</Text>
+              <Text
+                variant="paragraph1"
+                sx={{ fontWeight: 'semiBold', textAlign: 'right', color: collRatioColor }}
+              >
+                {formatPercent(afterCollateralizationRatio.times(100), {
+                  precision: 2,
+                  roundMode: BigNumber.ROUND_DOWN,
+                })}
+              </Text>
+            </Grid>
+          </Flex>
+        </Box>
+        <Box my={1}>
+          <Slider
+            sx={{
+              background: sliderBackground,
+              direction: 'rtl',
+            }}
+            disabled={!canAdjustRisk}
+            step={0.05}
+            min={liquidationRatio.toNumber()}
+            max={maxCollRatio?.toNumber()}
+            value={canAdjustRisk && requiredCollRatio ? requiredCollRatio.toNumber() : 100}
+            onChange={(e) => {
+              updateRequiredCollRatio && updateRequiredCollRatio(new BigNumber(e.target.value))
+            }}
+          />
+        </Box>
+        <Box>
+          <Flex
+            sx={{
+              variant: 'text.paragraph4',
+              justifyContent: 'space-between',
+              color: 'text.subtitle',
+            }}
+          >
+            <Text>{t('slider.adjust-multiply.left-footer')}</Text>
+            <Text>{t('slider.adjust-multiply.right-footer')}</Text>
+          </Flex>
+        </Box>
+      </Grid>
+      {!inputAmountsEmpty && <Divider />}
+      <OpenMultiplyVaultChangesInformation {...props} />
+    </Grid>
+  )
+}

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultEditingState.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultEditingState.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Box, Divider, Flex, Grid, Slider, Text, useThemeUI } from 'theme-ui'
+import { Box, Flex, Grid, Slider, Text, useThemeUI } from 'theme-ui'
 
 import { VaultActionInput } from '../../../../../components/vault/VaultActionInput'
 import { getCollRatioColor } from '../../../../../components/vault/VaultDetails'
@@ -36,7 +36,6 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
 
     ilkData: { liquidationRatio },
     maxCollRatio,
-    inputAmountsEmpty,
   } = props
 
   const slider = requiredCollRatio
@@ -56,7 +55,6 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
   return (
     <Grid gap={4}>
       <Grid gap={2}>
-        <Text variant="strong">Deposit your {token}</Text>
         <VaultActionInput
           action="Deposit"
           token={token}
@@ -75,9 +73,6 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
         />
       </Grid>
       <Grid gap={2}>
-        <Text variant="strong" mb={2}>
-          {t('slider.adjust-multiply.introduction-header')}
-        </Text>
         <Box>
           <Flex
             sx={{
@@ -88,7 +83,7 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
             }}
           >
             <Grid gap={2}>
-              <Text>Liquidation Price</Text>
+              <Text>{t('system.liquidation-price')}</Text>
               <Text variant="paragraph1" sx={{ fontWeight: 'semiBold' }}>
                 ${formatAmount(afterLiquidationPrice, 'USD')}
               </Text>
@@ -136,7 +131,6 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
           </Flex>
         </Box>
       </Grid>
-      {!inputAmountsEmpty && <Divider />}
       <OpenMultiplyVaultChangesInformation {...props} />
     </Grid>
   )

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultEditingState.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultEditingState.tsx
@@ -1,13 +1,13 @@
 import BigNumber from 'bignumber.js'
+import { VaultActionInput } from 'components/vault/VaultActionInput'
+import { getCollRatioColor } from 'components/vault/VaultDetails'
+import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { handleNumericInput } from 'helpers/input'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Flex, Grid, Slider, Text, useThemeUI } from 'theme-ui'
 
-import { VaultActionInput } from '../../../../../components/vault/VaultActionInput'
-import { getCollRatioColor } from '../../../../../components/vault/VaultDetails'
-import { formatAmount, formatPercent } from '../../../../../helpers/formatters/format'
-import { handleNumericInput } from '../../../../../helpers/input'
-import { zero } from '../../../../../helpers/zero'
 import { OpenMultiplyVaultState } from '../../pipes/openMultiplyVault'
 import { OpenMultiplyVaultChangesInformation } from '../OpenMultiplyVaultChangesInformation'
 

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultOpenStage.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultOpenStage.tsx
@@ -1,9 +1,9 @@
+import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Text } from 'theme-ui'
 import { OpenVaultAnimation } from 'theme/animations'
 
-import { VaultChangesWithADelayCard } from '../../../../../components/vault/VaultChangesWithADelayCard'
 import { OpenMultiplyVaultState } from '../../pipes/openMultiplyVault'
 import { OpenMultiplyVaultChangesInformation } from '../OpenMultiplyVaultChangesInformation'
 

--- a/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultOpenStage.tsx
+++ b/features/multiply/open/containers/sidebar/SidebarOpenMultiplyVaultOpenStage.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Text } from 'theme-ui'
+import { OpenVaultAnimation } from 'theme/animations'
+
+import { VaultChangesWithADelayCard } from '../../../../../components/vault/VaultChangesWithADelayCard'
+import { OpenMultiplyVaultState } from '../../pipes/openMultiplyVault'
+import { OpenMultiplyVaultChangesInformation } from '../OpenMultiplyVaultChangesInformation'
+
+export function SidebarOpenMultiplyVaultOpenStage(props: OpenMultiplyVaultState) {
+  const { t } = useTranslation()
+  const { stage } = props
+
+  switch (stage) {
+    case 'txInProgress':
+      return <OpenVaultAnimation />
+    case 'txSuccess':
+      return (
+        <>
+          <OpenMultiplyVaultChangesInformation {...props} />
+          <VaultChangesWithADelayCard />
+        </>
+      )
+    default:
+      return (
+        <>
+          <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
+            {t('vault-form.subtext.review-manage')}
+          </Text>
+          <OpenMultiplyVaultChangesInformation {...props} />
+        </>
+      )
+  }
+}

--- a/features/multiply/open/pipes/openMultiplyVaultConditions.ts
+++ b/features/multiply/open/pipes/openMultiplyVaultConditions.ts
@@ -115,6 +115,7 @@ export interface OpenMultiplyVaultConditions {
   insufficientAllowance: boolean
 
   isLoadingStage: boolean
+  isSuccessStage: boolean
   canProgress: boolean
   canRegress: boolean
   canAdjustRisk: boolean
@@ -152,6 +153,7 @@ export const defaultOpenMultiplyVaultConditions: OpenMultiplyVaultConditions = {
   insufficientAllowance: false,
 
   isLoadingStage: false,
+  isSuccessStage: false,
   canProgress: false,
   canRegress: false,
   isExchangeLoading: false,
@@ -275,6 +277,8 @@ export function applyOpenVaultConditions(state: OpenMultiplyVaultState): OpenMul
     'txWaitingForApproval',
   ] as OpenMultiplyVaultStage[]).some((s) => s === stage)
 
+  const isSuccessStage = stage === 'txSuccess'
+
   const customAllowanceAmountEmpty = customAllowanceAmountEmptyValidator({
     selectedAllowanceRadio,
     allowanceAmount,
@@ -361,6 +365,7 @@ export function applyOpenVaultConditions(state: OpenMultiplyVaultState): OpenMul
     insufficientAllowance,
 
     isLoadingStage,
+    isSuccessStage,
     canProgress,
     canRegress,
     isExchangeLoading,

--- a/features/sidebar/getSidebarProgress.ts
+++ b/features/sidebar/getSidebarProgress.ts
@@ -1,6 +1,7 @@
 import { TxStatusCardProgressProps } from 'components/vault/TxStatusCard'
-import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
 import { useTranslation } from 'next-i18next'
+
+import { HasSidebarTxData } from '../../helpers/extractSidebarHelpers'
 
 export function getSidebarProgress({
   stage,
@@ -11,7 +12,7 @@ export function getSidebarProgress({
   proxyConfirmations,
   safeConfirmations,
   token,
-}: OpenVaultState): TxStatusCardProgressProps | undefined {
+}: HasSidebarTxData): TxStatusCardProgressProps | undefined {
   const { t } = useTranslation()
 
   switch (stage) {

--- a/features/sidebar/getSidebarSuccess.ts
+++ b/features/sidebar/getSidebarSuccess.ts
@@ -1,6 +1,7 @@
 import { TxStatusCardProgressProps } from 'components/vault/TxStatusCard'
-import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
 import { useTranslation } from 'next-i18next'
+
+import { HasSidebarTxData } from '../../helpers/extractSidebarHelpers'
 
 export function getSidebarSuccess({
   stage,
@@ -11,7 +12,7 @@ export function getSidebarSuccess({
   safeConfirmations,
   token,
   id,
-}: OpenVaultState): TxStatusCardProgressProps | undefined {
+}: HasSidebarTxData): TxStatusCardProgressProps | undefined {
   const { t } = useTranslation()
 
   switch (stage) {

--- a/features/sidebar/getSidebarTitle.ts
+++ b/features/sidebar/getSidebarTitle.ts
@@ -11,6 +11,7 @@ interface GetSidebarTitleParams {
 function getSidebarTitleEditingTranslationKey({ flow }: { flow: SidebarFlow }) {
   switch (flow) {
     case 'openBorrow':
+    case 'openMultiply':
       return 'vault-form.header.edit'
     default:
       throw new UnreachableCaseError(flow)

--- a/features/sidebar/trackingEventOpenVault.ts
+++ b/features/sidebar/trackingEventOpenVault.ts
@@ -1,8 +1,17 @@
 import { trackingEvents } from 'analytics/analytics'
+import { BigNumber } from 'bignumber.js'
 import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
 
+import { OpenMultiplyVaultStage } from '../multiply/open/pipes/openMultiplyVault'
+
 interface TrackingEventOpenVaultProps {
-  props: OpenVaultState
+  props: {
+    stage: OpenMultiplyVaultStage | OpenVaultState
+    insufficientAllowance: boolean
+    proxyAddress?: string
+    depositAmount?: BigNumber
+    generateAmount?: BigNumber
+  }
   firstCDP?: boolean
 }
 

--- a/helpers/extractSidebarHelpers.ts
+++ b/helpers/extractSidebarHelpers.ts
@@ -2,6 +2,8 @@ import BigNumber from 'bignumber.js'
 import { SidebarFlow, SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
 import { pick } from 'ramda'
 
+import { AllowanceOption } from '../features/allowance/allowance'
+
 export interface GetPrimaryButtonLabelParams {
   flow: SidebarFlow
   stage: SidebarVaultStages
@@ -13,4 +15,61 @@ export interface GetPrimaryButtonLabelParams {
 
 export function extractSidebarButtonLabelParams(state: GetPrimaryButtonLabelParams) {
   return pick(['flow', 'stage', 'token', 'id', 'proxyAddress', 'insufficientAllowance'], state)
+}
+
+export interface HasAllowanceData {
+  stage: SidebarVaultStages
+  token: string
+  selectedAllowanceRadio: AllowanceOption
+  depositAmount?: BigNumber
+  allowanceAmount?: BigNumber
+  updateAllowanceAmount?: (amount?: BigNumber) => void
+  setAllowanceAmountUnlimited?: () => void
+  setAllowanceAmountToDepositAmount?: () => void
+  setAllowanceAmountCustom?: () => void
+}
+
+export function extractAllowanceDataFromOpenVaultState(state: HasAllowanceData) {
+  return pick(
+    [
+      'stage',
+      'token',
+      'depositAmount',
+      'allowanceAmount',
+      'updateAllowanceAmount',
+      'setAllowanceAmountUnlimited',
+      'setAllowanceAmountToDepositAmount',
+      'setAllowanceAmountCustom',
+      'selectedAllowanceRadio',
+    ],
+    state,
+  )
+}
+
+export interface HasSidebarTxData {
+  stage: SidebarVaultStages
+  token: string
+  safeConfirmations: number
+  proxyTxHash?: string
+  allowanceTxHash?: string
+  openTxHash?: string
+  etherscan?: string
+  proxyConfirmations?: number
+  id?: BigNumber
+}
+
+export function extractSidebarTxData(state: HasSidebarTxData) {
+  return pick(
+    [
+      'stage',
+      'proxyTxHash',
+      'allowanceTxHash',
+      'openTxHash',
+      'etherscan',
+      'proxyConfirmations',
+      'safeConfirmations',
+      'token',
+    ],
+    state,
+  )
 }

--- a/helpers/isFirstCdp.ts
+++ b/helpers/isFirstCdp.ts
@@ -1,0 +1,5 @@
+import { AccountDetails } from '../features/account/AccountData'
+
+export function isFirstCdp(accountData?: AccountDetails) {
+  return accountData?.numberOfVaults ? accountData.numberOfVaults === 0 : undefined
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -665,6 +665,9 @@
         "edit-dai": "Edit DAI",
         "edit-collateral": "Edit Collateral",
         "switch-to-multiply": "Switch to Multiply"
+      },
+      "multiply": {
+        "switch-to-borrow": "Switch to Borrow"
       }
     },
     "cards": {


### PR DESCRIPTION
# [Open multiply new design sidebar](https://app.shortcut.com/oazo-apps/story/4229/implement-opening-multiply-vault-according-to-new-design)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- implemented new sidebar design in open multiply vault flow (behind feature toggle)
  
## How to test 🧪
  <Please explain how to test your changes>
- enable NewComponents feature toggle and test it using goerli / hardhat
