### PR TITLE
Added stop loss step to open borrow flow

### DIFF
--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -230,7 +230,7 @@ export function AdjustSlFormControl({
     ? 'txInProgress'
     : isFailureStage
     ? 'txFailure'
-    : 'editing'
+    : 'stopLossEditing'
 
   const isProgressDisabled = !!(
     !isOwner ||

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -14,11 +14,7 @@ import {
   VaultChangesInformationItem,
 } from 'components/vault/VaultChangesInformation'
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
-import {
-  formatAmount,
-  formatFiatBalance,
-  formatPercent,
-} from 'helpers/formatters/format'
+import { formatAmount, formatFiatBalance, formatPercent } from 'helpers/formatters/format'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { TxError } from 'helpers/types'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -1,33 +1,33 @@
 import { TxStatus } from '@oasisdex/transactions'
 import { Box, Grid } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
+import { IlkData } from 'blockchain/ilks'
+import { Vault } from 'blockchain/vaults'
 import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseState'
+import { RetryableLoadingButtonProps } from 'components/dumb/RetryableLoadingButton'
 import { SliderValuePicker, SliderValuePickerProps } from 'components/dumb/SliderValuePicker'
+import { TxStatusSection } from 'components/dumb/TxStatusSection'
+import { AppLink } from 'components/Links'
 import { MessageCard } from 'components/MessageCard'
-import { useFeatureToggle } from 'helpers/useFeatureToggle'
-import { useTranslation } from 'next-i18next'
-import React, { ReactNode } from 'react'
-import { Divider, Flex, Image, Text } from 'theme-ui'
-
-import { IlkData } from '../../../../blockchain/ilks'
-import { Vault } from '../../../../blockchain/vaults'
-import { RetryableLoadingButtonProps } from '../../../../components/dumb/RetryableLoadingButton'
-import { TxStatusSection } from '../../../../components/dumb/TxStatusSection'
-import { AppLink } from '../../../../components/Links'
 import {
   VaultChangesInformationContainer,
   VaultChangesInformationItem,
-} from '../../../../components/vault/VaultChangesInformation'
-import { VaultChangesWithADelayCard } from '../../../../components/vault/VaultChangesWithADelayCard'
+} from 'components/vault/VaultChangesInformation'
+import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import {
   formatAmount,
   formatFiatBalance,
   formatPercent,
-} from '../../../../helpers/formatters/format'
-import { staticFilesRuntimeUrl } from '../../../../helpers/staticPaths'
-import { TxError } from '../../../../helpers/types'
-import { one } from '../../../../helpers/zero'
-import { OpenVaultAnimation } from '../../../../theme/animations'
+} from 'helpers/formatters/format'
+import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
+import { TxError } from 'helpers/types'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
+import { one } from 'helpers/zero'
+import { useTranslation } from 'next-i18next'
+import React, { ReactNode } from 'react'
+import { Divider, Flex, Image, Text } from 'theme-ui'
+import { OpenVaultAnimation } from 'theme/animations'
+
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from '../../../form/commonValidators'
 import { isTxStatusFailed } from '../common/AutomationTransactionPlunger'
 import { AutomationFormButtons } from '../common/components/AutomationFormButtons'
@@ -280,7 +280,7 @@ export interface AdjustSlFormLayoutProps {
   collateralizationRatioAtNextPrice: BigNumber
   gasEstimationUsd?: BigNumber
   ethBalance: BigNumber
-  stage: 'editing' | 'txInProgress' | 'txSuccess' | 'txFailure'
+  stage: 'stopLossEditing' | 'txInProgress' | 'txSuccess' | 'txFailure'
   isProgressDisabled: boolean
   redirectToCloseVault: () => void
 }

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
@@ -68,7 +68,7 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
       <Grid gap={3}>
         {stopLossWriteEnabled ? (
           <>
-            {(stage === 'editing' || stage === 'txFailure') && (
+            {(stage === 'stopLossEditing' || stage === 'txFailure') && (
               <SidebarAdjustStopLossEditingStage {...props} />
             )}
           </>
@@ -82,7 +82,7 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
         {(stage === 'txSuccess' || stage === 'txInProgress') && (
           <SidebarAdjustStopLossAddStage {...props} />
         )}
-        {stage === 'editing' && !selectedSLValue.isZero() && stopLossWriteEnabled && (
+        {stage === 'stopLossEditing' && !selectedSLValue.isZero() && stopLossWriteEnabled && (
           <>
             <VaultErrors errorMessages={errors} ilkData={ilkData} />
             <VaultWarnings warningMessages={warnings} ilkData={ilkData} />

--- a/features/borrow/open/containers/OpenVaultChangesInformation.tsx
+++ b/features/borrow/open/containers/OpenVaultChangesInformation.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@theme-ui/components'
+import { Box, Flex, Text } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
 import {
   VaultChangesInformationArrow,
@@ -7,7 +7,8 @@ import {
   VaultChangesInformationItem,
 } from 'components/vault/VaultChangesInformation'
 import { getCollRatioColor } from 'components/vault/VaultDetails'
-import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
+import { formatAmount, formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -25,11 +26,18 @@ export function OpenVaultChangesInformation(props: OpenVaultState) {
     maxGenerateAmountCurrentPrice,
     inputAmountsEmpty,
     depositAmount,
+    withStopLossStage,
+    stopLossSkipped,
   } = props
   const collRatioColor = getCollRatioColor(props, afterCollateralizationRatio)
+  const stopLossOpenFlowEnabled = useFeatureToggle('StopLossOpenFlow')
 
   // starting zero balance for UI to show arrows
   const zeroBalance = formatCryptoBalance(zero)
+
+  // TODO mock for now
+  const afterStopLossRatio = new BigNumber(180)
+  const dynamicStopLossPrice = new BigNumber(2000)
 
   return !inputAmountsEmpty ? (
     <VaultChangesInformationContainer title="Vault changes">
@@ -102,6 +110,30 @@ export function OpenVaultChangesInformation(props: OpenVaultState) {
         }
       />
       <VaultChangesInformationEstimatedGasFee {...props} />
+      {stopLossOpenFlowEnabled && withStopLossStage && !stopLossSkipped && (
+        <>
+          <Box as="li" sx={{ listStyle: 'none' }}>
+            <Text as="h3" variant="paragraph3" sx={{ fontWeight: 'semiBold' }}>
+              {t('protection.stop-loss-information')}
+            </Text>
+          </Box>
+          <VaultChangesInformationItem
+            label={`${t('protection.stop-loss-coll-ratio')}`}
+            value={
+              <Flex>
+                {formatPercent(afterStopLossRatio, {
+                  precision: 2,
+                  roundMode: BigNumber.ROUND_DOWN,
+                })}
+              </Flex>
+            }
+          />
+          <VaultChangesInformationItem
+            label={`${t('protection.dynamic-stop-loss')}`}
+            value={<Flex>${formatAmount(dynamicStopLossPrice, 'USD')}</Flex>}
+          />
+        </>
+      )}
     </VaultChangesInformationContainer>
   ) : null
 }

--- a/features/multiply/open/pipes/openMultiplyVault.ts
+++ b/features/multiply/open/pipes/openMultiplyVault.ts
@@ -10,12 +10,12 @@ import { BalanceInfo, balanceInfoChange$ } from 'features/shared/balanceInfo'
 import { PriceInfo, priceInfoChange$ } from 'features/shared/priceInfo'
 import { slippageChange$, UserSettingsState } from 'features/userSettings/userSettings'
 import { GasEstimationStatus, HasGasEstimation } from 'helpers/form'
+import { combineApplyChanges } from 'helpers/pipelines/combineApply'
+import { TxError } from 'helpers/types'
 import { curry } from 'lodash'
 import { combineLatest, iif, merge, Observable, of, Subject, throwError } from 'rxjs'
 import { first, map, scan, shareReplay, switchMap, tap } from 'rxjs/operators'
 
-import { combineApplyChanges } from '../../../../helpers/pipelines/combineApply'
-import { TxError } from '../../../../helpers/types'
 import {
   AllowanceChanges,
   AllowanceOption,
@@ -176,6 +176,7 @@ export type OpenMultiplyVaultState = MutableOpenMultiplyVaultState &
     summary: OpenVaultSummary
     totalSteps: number
     currentStep: number
+    withStopLossStage: boolean
   } & HasGasEstimation
 
 function addTransitions(
@@ -335,11 +336,13 @@ export function createOpenMultiplyVault$(
                     }
 
                     const totalSteps = calculateInitialTotalSteps(proxyAddress, token, allowance)
+                    const withStopLossStage = false // TODO TO BE UPDATED SOON
 
                     const initialState: OpenMultiplyVaultState = {
                       ...defaultMutableOpenMultiplyVaultState,
                       ...defaultOpenMultiplyVaultStateCalculations,
                       ...defaultOpenMultiplyVaultConditions,
+                      withStopLossStage,
                       priceInfo,
                       balanceInfo,
                       ilkData,

--- a/features/sidebar/getPrimaryButtonLabel.ts
+++ b/features/sidebar/getPrimaryButtonLabel.ts
@@ -90,6 +90,7 @@ export function getPrimaryButtonLabel({
 
   switch (stage) {
     case 'editing':
+    case 'stopLossEditing':
     case 'collateralEditing':
     case 'daiEditing':
     case 'adjustPosition':

--- a/features/sidebar/getSidebarTitle.ts
+++ b/features/sidebar/getSidebarTitle.ts
@@ -82,6 +82,8 @@ export function getSidebarTitle({ flow, stage, token }: GetSidebarTitleParams) {
       const editingKey = getSidebarTitleEditingTranslationKey({ flow })
 
       return t(editingKey, { token })
+    case 'stopLossEditing':
+      return t('protection.enable-stop-loss')
     case 'proxyInProgress':
       return t('vault-form.header.proxy-in-progress')
     case 'proxyWaitingForConfirmation':

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -12,6 +12,7 @@ export type Feature =
   | 'NewComponents'
   | 'StopLossRead'
   | 'StopLossWrite'
+  | 'StopLossOpenFlow'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -22,6 +23,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   NewComponents: false,
   StopLossRead: true,
   StopLossWrite: false,
+  StopLossOpenFlow: false,
   // your feature here....
 }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1019,7 +1019,9 @@
     "set-stop-loss-again": "Set up Stop-Loss again",
     "sl-triggered-gas-estimation": "These estimated fees are based on the approximate price you will get from selling your collateral to cover your debt when automation is executed and covers the Oasis fee.",
     "stop-loss-on": "Stop-Loss On",
-    "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change."
+    "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change.",
+    "enable-stop-loss": "Enable Stop-Loss",
+    "continue-without-stop-loss": "Continue without Stop-Loss"
   },
   "newsletter": {
     "title": "Stay up to date with Oasis.app",
@@ -1242,13 +1244,13 @@
   "claim-rewards": {
     "title": "{{ bonusTokenName }} position rewards",
 
-    "for-this-position":"For this position you are currently earning {{ name }} rewards.",
+    "for-this-position": "For this position you are currently earning {{ name }} rewards.",
     "instructions": {
       "tokens-to-claim": "Press the button to claim {{ readableAmount }}.",
       "claim-succeeded": "You have claimed {{ readableAmount }}. It may take a few minutes for your position to update.",
       "nothing-to-claim": "You currently have no {{ name }} rewards to claim."
     },
-    "more-info" : {
+    "more-info": {
       "text1": "More information about these rewards",
       "link-text": "here",
       "text2": "."

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1021,7 +1021,8 @@
     "stop-loss-on": "Stop-Loss On",
     "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change.",
     "enable-stop-loss": "Enable Stop-Loss",
-    "continue-without-stop-loss": "Continue without Stop-Loss"
+    "continue-without-stop-loss": "Continue without Stop-Loss",
+    "stop-loss-information": "Stop Loss Information"
   },
   "newsletter": {
     "title": "Stay up to date with Oasis.app",


### PR DESCRIPTION
# [Added stop loss step to open borrow flow](https://app.shortcut.com/oazo-apps/story/4039/add-sl-step-transitions-and-handling-to-borrow-form-opening-flow)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

> Added stop loss step to open borrow flow including following new state variables:                       `withStopLossStage`, `isStopLossEditingStage`, `stopLossSkipped`

  
## How to test 🧪
  <Please explain how to test your changes>

>  use borrow open flow and feature toggle flag `StopLossOpenFlow` and `NewComponents`
> `withStopLossStage` variable is based on list of ilks which are allowed for automation