### PR TITLE
reset sl state on coll ratio change

### DIFF
--- a/features/automation/protection/useStopLossStateInitializator.ts
+++ b/features/automation/protection/useStopLossStateInitializator.ts
@@ -1,11 +1,11 @@
+import { IlkData } from 'blockchain/ilks'
+import { InstiVault } from 'blockchain/instiVault'
+import { Vault } from 'blockchain/vaults'
+import { useAppContext } from 'components/AppContextProvider'
+import { useUIChanges } from 'helpers/uiChangesHook'
+import { zero } from 'helpers/zero'
 import { useEffect } from 'react'
 
-import { IlkData } from '../../../blockchain/ilks'
-import { InstiVault } from '../../../blockchain/instiVault'
-import { Vault } from '../../../blockchain/vaults'
-import { useAppContext } from '../../../components/AppContextProvider'
-import { useUIChanges } from '../../../helpers/uiChangesHook'
-import { zero } from '../../../helpers/zero'
 import { getStartingSlRatio } from './common/helpers'
 import { extractStopLossData } from './common/StopLossTriggerDataExtractor'
 import { ADD_FORM_CHANGE } from './common/UITypes/AddFormChange'
@@ -24,6 +24,7 @@ export function useStopLossStateInitializator(
   const { uiChanges } = useAppContext()
   const { stopLossLevel, isStopLossEnabled, isToCollateral } = extractStopLossData(autoTriggersData)
   const [currentForm] = useUIChanges<ProtectionModeChange>(PROTECTION_MODE_CHANGE_SUBJECT)
+  const collateralizationRatio = vault.collateralizationRatio.toNumber()
 
   const initialVaultCollRatio = zero
 
@@ -50,7 +51,7 @@ export function useStopLossStateInitializator(
       type: 'tx-details',
       txDetails: {},
     })
-  }, [currentForm])
+  }, [currentForm, collateralizationRatio])
 
   useEffect(() => {
     uiChanges.publish(ADD_FORM_CHANGE, {


### PR DESCRIPTION
# [reset sl state on coll ratio change](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- from now on, protection tab state will reset on coll ratio change event
  
## How to test 🧪
  <Please explain how to test your changes>
- start editing something in protection tab then move to overview and change coll ratio of the vault, when coll ratio will be refreshed, protection tab should be reset to default state
