### PR TITLE
Fix stop-loss slider filling

### DIFF
--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -176,7 +176,9 @@ export function AdjustSlFormControl({
 
   const sliderPercentageFill = uiState.selectedSLValue
     .minus(liqRatio.times(100))
-    .div(nextPriceCollRatio.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN).div(100).minus(liqRatio))
+    .div(
+      nextPriceCollRatio.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN).div(100).minus(liqRatio),
+    )
 
   const sliderProps: SliderValuePickerProps = {
     disabled: false,

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -176,7 +176,7 @@ export function AdjustSlFormControl({
 
   const sliderPercentageFill = uiState.selectedSLValue
     .minus(liqRatio.times(100))
-    .div(nextPriceCollRatio.minus(liqRatio))
+    .div(nextPriceCollRatio.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN).div(100).minus(liqRatio))
 
   const sliderProps: SliderValuePickerProps = {
     disabled: false,


### PR DESCRIPTION
# Fix stop-loss slider filling

Selected slider background was calculated using unrounded values, while in the slider user can only pick rounded value at max.
![image](https://user-images.githubusercontent.com/16230404/172347239-75a8cd5a-fb8d-4278-a910-4b0264deb90f.png)
![image](https://user-images.githubusercontent.com/16230404/172347288-fccc528f-18b1-4f51-bcbe-a97fc85bf35a.png)
