### PR TITLE
Fix tab selector on vault page

### DIFF
--- a/components/VaultTabSwitch.tsx
+++ b/components/VaultTabSwitch.tsx
@@ -157,7 +157,6 @@ export function VaultTabSwitch({
   const buttonSx = { flex: 1, px: 4 }
 
   const vaultViewModeTuples = Object.entries(VaultViewMode).filter(([entry]) => {
-    console.log(entry)
     switch (entry) {
       case 'Protection':
         return showProtectionTab

--- a/components/VaultTabSwitch.tsx
+++ b/components/VaultTabSwitch.tsx
@@ -156,10 +156,18 @@ export function VaultTabSwitch({
 
   const buttonSx = { flex: 1, px: 4 }
 
-  const vaultViewModeEntries = Object.entries(VaultViewMode)
-  const vaultViewModeTuples = vaultViewModeEntries.splice(
-    -Math.ceil(vaultViewModeEntries.length / 2),
-  )
+  const vaultViewModeTuples = Object.entries(VaultViewMode).filter(([entry]) => {
+    console.log(entry)
+    switch (entry) {
+      case 'Protection':
+        return showProtectionTab
+      case 'Optimization':
+        return basicBSEnabled
+      default:
+        return true
+    }
+  })
+
   const options = useMemo(() => {
     const tagMap = {
       [VaultViewMode.Protection]: protectionEnabled,


### PR DESCRIPTION
Fix tab selector on vault page

Context: https://discord.com/channels/837076147694207067/839088233353576468/986016818189709362
  
## Changes 👷‍♀️

Turns out that wasn't working as it should long before that. Because of that weird splice overview tab wasn't visible and protection tab was shown regardless if `showProtectionTab` was true or not. Changed to a filter with hand picking options. Used switch instead of `if, else if, else`, because we are going to have more tabs anyway.

![image](https://user-images.githubusercontent.com/16230404/173525913-82ddba4c-7a7d-485a-908b-818e99e35d60.png)
  
## How to test 🧪

Go to any vault page in mobile mode, check what options you can see in select.