### PR TITLE
Remove sidebar from vault history

### DIFF
--- a/components/vault/DefaultVaultLayout.tsx
+++ b/components/vault/DefaultVaultLayout.tsx
@@ -7,7 +7,7 @@ export function DefaultVaultLayout({
   listControl,
 }: {
   detailsViewControl: JSX.Element
-  editForm: JSX.Element
+  editForm?: JSX.Element
   listControl?: JSX.Element
 }) {
   return (
@@ -17,7 +17,7 @@ export function DefaultVaultLayout({
           {detailsViewControl}
           {listControl}
         </Grid>
-        <Box>{editForm}</Box>
+        {editForm && <Box>{editForm}</Box>}
       </Grid>
     </Container>
   )

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -36,6 +36,7 @@ export function GeneralManageLayout({
     priceInfo,
     collateralizationRatioAtNextPrice,
     balanceInfo,
+    vaultHistory,
   } = generalManageVault.state
 
   const showProtectionTab = isSupportedAutomationIlk(getNetworkName(), vault.ilk)
@@ -69,7 +70,7 @@ export function GeneralManageLayout({
         overViewControl={
           <GeneralManageVaultViewAutomation generalManageVault={generalManageVault} />
         }
-        historyControl={<HistoryControl generalManageVault={generalManageVault} />}
+        historyControl={<HistoryControl vaultHistory={vaultHistory} />}
         protectionControl={
           <ProtectionControl
             vault={vault}

--- a/components/vault/HistoryControl.tsx
+++ b/components/vault/HistoryControl.tsx
@@ -1,19 +1,14 @@
+import { DefaultVaultLayout } from 'components/vault/DefaultVaultLayout'
+import { VaultHistoryEvent } from 'features/vaultHistory/vaultHistory'
+import { VaultHistoryView } from 'features/vaultHistory/VaultHistoryView'
 import React from 'react'
 
-import { GeneralManageVaultState } from '../../features/generalManageVault/generalManageVault'
-import { VaultHistoryView } from '../../features/vaultHistory/VaultHistoryView'
-import { DefaultVaultLayout } from './DefaultVaultLayout'
-import { GeneralVaultFormControl } from './GeneralVaultFormControl'
-
 interface HistoryControlProps {
-  generalManageVault: GeneralManageVaultState
+  vaultHistory: VaultHistoryEvent[]
 }
 
-export function HistoryControl({ generalManageVault }: HistoryControlProps) {
+export function HistoryControl({ vaultHistory }: HistoryControlProps) {
   return (
-    <DefaultVaultLayout
-      detailsViewControl={<VaultHistoryView vaultHistory={generalManageVault.state.vaultHistory} />}
-      editForm={<GeneralVaultFormControl generalManageVault={generalManageVault} />}
-    />
+    <DefaultVaultLayout detailsViewControl={<VaultHistoryView vaultHistory={vaultHistory} />} />
   )
 }

--- a/components/vault/VaultInformation.tsx
+++ b/components/vault/VaultInformation.tsx
@@ -37,7 +37,6 @@ export function VaultInformation({ items }: VaultInformationProps) {
       sx={{
         p: 4,
         border: 'lightMuted',
-        maxWidth: '688px',
       }}
     >
       <Heading variant="headerSettings" sx={{ mb: 3 }}>

--- a/components/vault/VaultInformationControl.tsx
+++ b/components/vault/VaultInformationControl.tsx
@@ -1,6 +1,6 @@
+import { DefaultVaultLayout } from 'components/vault/DefaultVaultLayout'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Container } from 'theme-ui'
 
 import { GeneralManageVaultState } from '../../features/generalManageVault/generalManageVault'
 import { VaultType } from '../../features/generalManageVault/vaultType'
@@ -67,9 +67,5 @@ export function VaultInformationControl({ generalManageVault }: VaultInformation
 
   const vaultInfoItems = isGuniVault ? guniItems : isInstiVault ? instiItems : defaultItems
 
-  return (
-    <Container variant="vaultPageContainer">
-      <VaultInformation items={vaultInfoItems} />
-    </Container>
-  )
+  return <DefaultVaultLayout detailsViewControl={<VaultInformation items={vaultInfoItems} />} />
 }


### PR DESCRIPTION
# [Remove sidebar from vault history](https://app.shortcut.com/oazo-apps/story/4710/remove-sidebar-from-vault-history)
  
## Changes 👷‍♀️
- Removed sidebar from vault history according to newest version of layoyts.
- Removed fixed width from vault info tab and used `DefaultVaultLayout` there.
  
## How to test 🧪

- Check if vault history and vault info tabs are displayed correctly and without siebars.
