### PR TITLE
Basic buy details section

### DIFF
--- a/components/vault/detailsSection/ContentCardTargetColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardTargetColRatio.tsx
@@ -1,0 +1,61 @@
+import BigNumber from 'bignumber.js'
+import {
+  ChangeVariantType,
+  ContentCardProps,
+  DetailsSectionContentCard,
+} from 'components/DetailsSectionContentCard'
+import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+interface ContentCardTargetColRatioProps {
+  token: string
+  targetColRatio?: BigNumber
+  afterTargetColRatio?: BigNumber
+  threshold?: BigNumber
+  changeVariant?: ChangeVariantType
+}
+
+export function ContentCardTargetColRatio({
+  token,
+  targetColRatio,
+  afterTargetColRatio,
+  threshold,
+  changeVariant,
+}: ContentCardTargetColRatioProps) {
+  const { t } = useTranslation()
+
+  const formatted = {
+    targetColRatio:
+      targetColRatio &&
+      formatPercent(targetColRatio, {
+        precision: 2,
+        roundMode: BigNumber.ROUND_DOWN,
+      }),
+    afterTargetColRatio:
+      afterTargetColRatio &&
+      formatPercent(afterTargetColRatio, {
+        precision: 2,
+        roundMode: BigNumber.ROUND_DOWN,
+      }),
+    threshold: threshold && `$${formatAmount(threshold, 'USD')}`,
+  }
+
+  const contentCardSettings: ContentCardProps = {
+    title: t('auto-buy.target-col-ratio-after-buying'),
+    value: formatted.targetColRatio,
+  }
+
+  if (afterTargetColRatio && changeVariant)
+    contentCardSettings.change = {
+      value: `${formatted.afterTargetColRatio} ${t('system.cards.common.after')}`,
+      variant: changeVariant,
+    }
+  if (threshold)
+    contentCardSettings.footnote = t('auto-buy.continual-buy-threshold', {
+      amount: formatted.threshold,
+      token,
+    })
+
+  return <DetailsSectionContentCard {...contentCardSettings} />
+}

--- a/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
@@ -5,7 +5,6 @@ import {
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
-import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -39,7 +38,7 @@ export function ContentCardTriggerColRatio({
         precision: 2,
         roundMode: BigNumber.ROUND_DOWN,
       }),
-    nextBuyPrice: nextBuyPrice && `$${formatAmount(nextBuyPrice || zero, 'USD')}`,
+    nextBuyPrice: nextBuyPrice && `$${formatAmount(nextBuyPrice, 'USD')}`,
   }
 
   const contentCardSettings: ContentCardProps = {
@@ -52,7 +51,8 @@ export function ContentCardTriggerColRatio({
       value: `${formatted.afterTriggerColRatio} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     }
-  if (nextBuyPrice) contentCardSettings.footnote = `${t('auto-buy.next-buy-price')}: ${formatted.nextBuyPrice}`
+  if (nextBuyPrice)
+    contentCardSettings.footnote = t('auto-buy.next-buy-price', { amount: formatted.nextBuyPrice })
 
   return <DetailsSectionContentCard {...contentCardSettings} />
 }

--- a/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
@@ -1,0 +1,58 @@
+import BigNumber from 'bignumber.js'
+import {
+  ChangeVariantType,
+  ContentCardProps,
+  DetailsSectionContentCard,
+} from 'components/DetailsSectionContentCard'
+import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { zero } from 'helpers/zero'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+interface ContentCardTriggerColRatioProps {
+  token: string
+  triggerColRatio?: BigNumber
+  afterTriggerColRatio?: BigNumber
+  nextBuyPrice?: BigNumber
+  changeVariant?: ChangeVariantType
+}
+
+export function ContentCardTriggerColRatio({
+  token,
+  triggerColRatio,
+  afterTriggerColRatio,
+  nextBuyPrice,
+  changeVariant,
+}: ContentCardTriggerColRatioProps) {
+  const { t } = useTranslation()
+
+  const formatted = {
+    triggerColRatio:
+      triggerColRatio &&
+      formatPercent(triggerColRatio, {
+        precision: 2,
+        roundMode: BigNumber.ROUND_DOWN,
+      }),
+    afterTriggerColRatio:
+      afterTriggerColRatio &&
+      formatPercent(afterTriggerColRatio, {
+        precision: 2,
+        roundMode: BigNumber.ROUND_DOWN,
+      }),
+    nextBuyPrice: nextBuyPrice && `$${formatAmount(nextBuyPrice || zero, 'USD')}`,
+  }
+
+  const contentCardSettings: ContentCardProps = {
+    title: t('auto-buy.trigger-col-ratio-to-buy-token', { token }),
+    value: formatted.triggerColRatio,
+  }
+
+  if (afterTriggerColRatio && changeVariant)
+    contentCardSettings.change = {
+      value: `${formatted.afterTriggerColRatio} ${t('system.cards.common.after')}`,
+      variant: changeVariant,
+    }
+  if (nextBuyPrice) contentCardSettings.footnote = `${t('auto-buy.next-buy-price')}: ${formatted.nextBuyPrice}`
+
+  return <DetailsSectionContentCard {...contentCardSettings} />
+}

--- a/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
@@ -1,6 +1,8 @@
+import BigNumber from 'bignumber.js'
 import { Vault } from 'blockchain/vaults'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
+import { ContentCardTriggerColRatio } from 'components/vault/detailsSection/ContentCardTriggerColRatio'
 import React from 'react'
 
 export interface OptimizationDetailsLayoutProps {
@@ -8,12 +10,18 @@ export interface OptimizationDetailsLayoutProps {
 }
 
 export function OptimizationDetailsLayout({ vault }: OptimizationDetailsLayoutProps) {
+  const { token } = vault
+
   return (
     <DetailsSection
-      title="Title"
+      title="Auto buy"
       content={
         <DetailsSectionContentCardWrapper>
-          An optimization tab for vault#{vault.id.toNumber()}.
+          <ContentCardTriggerColRatio
+            token={token}
+            triggerColRatio={new BigNumber(Math.random() * 100)}
+            nextBuyPrice={new BigNumber(Math.random() * 1000)}
+          />
         </DetailsSectionContentCardWrapper>
       }
     />

--- a/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import { Vault } from 'blockchain/vaults'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
+import { ContentCardTargetColRatio } from 'components/vault/detailsSection/ContentCardTargetColRatio'
 import { ContentCardTriggerColRatio } from 'components/vault/detailsSection/ContentCardTriggerColRatio'
 import React from 'react'
 
@@ -21,6 +22,11 @@ export function OptimizationDetailsLayout({ vault }: OptimizationDetailsLayoutPr
             token={token}
             triggerColRatio={new BigNumber(Math.random() * 100)}
             nextBuyPrice={new BigNumber(Math.random() * 1000)}
+          />
+          <ContentCardTargetColRatio
+            token={token}
+            targetColRatio={new BigNumber(Math.random() * 100)}
+            threshold={new BigNumber(Math.random() * 1000)}
           />
         </DetailsSectionContentCardWrapper>
       }

--- a/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
@@ -16,6 +16,7 @@ export function OptimizationDetailsLayout({ vault }: OptimizationDetailsLayoutPr
   return (
     <DetailsSection
       title="Auto buy"
+      badge={false}
       content={
         <DetailsSectionContentCardWrapper>
           <ContentCardTriggerColRatio

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1277,5 +1277,11 @@
     "claim-button": {
       "claim-rewards": "Claim Rewards"
     }
+  },
+  "auto-buy": {
+    "next-buy-price": "Next buy price",
+    "continual-buy-threshold": "Continual buy, threshold {{amount} {{token}}",
+    "trigger-col-ratio-to-buy-token": "Trigger Col. Ratio to buy {{token}}",
+    "target-col-ratio-after-buying": "Target Col. Ratio after buying"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1279,8 +1279,8 @@
     }
   },
   "auto-buy": {
-    "next-buy-price": "Next buy price",
-    "continual-buy-threshold": "Continual buy, threshold {{amount} {{token}}",
+    "next-buy-price": "Next buy price: {{amount}}",
+    "continual-buy-threshold": "Continual buy, threshold {{amount}} {{token}}",
     "trigger-col-ratio-to-buy-token": "Trigger Col. Ratio to buy {{token}}",
     "target-col-ratio-after-buying": "Target Col. Ratio after buying"
   }


### PR DESCRIPTION
# [Basic buy details section](https://app.shortcut.com/oazo-apps/story/3879/basic-buy-detail-section)
  
## Changes 👷‍♀️

Created a static details section for basic buy, don't mind the values, they are generated randomly 🤷‍♀️
I didn't add buttons next to the title, because their visibility is conditional and `DetailsSection` already allows to use them, so no point in that currently.

![image](https://user-images.githubusercontent.com/16230404/173577548-af907490-9ac7-4b56-a973-ba7529b73369.png)
  
## How to test 🧪

Turn on BasicBS feature flag and go to any vault to Optimization tab.
