### PR TITLE
Feature selection in Optimization tab

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -285,7 +285,7 @@ export type LegalUiChanges = {
   ProtectionModeChange: ProtectionModeChangeAction
   MultiplyPillChange: MultiplyPillChangeAction
   SwapWidgetChange: SwapWidgetChangeAction
-  OptimizationChangeFeature: AutomationChangeFeatureAction
+  AutomationChangeFeature: AutomationChangeFeatureAction
 }
 
 export type UIChanges = {

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -66,6 +66,12 @@ import {
   formChangeReducer,
 } from 'features/automation/protection/common/UITypes/AddFormChange'
 import {
+  AUTOMATION_CHANGE_FEATURE,
+  AutomationChangeFeature,
+  AutomationChangeFeatureAction,
+  automationChangeFeatureReducer,
+} from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import {
   MULTIPLY_VAULT_PILL_CHANGE_SUBJECT,
   MultiplyPillChange,
   MultiplyPillChangeAction,
@@ -270,6 +276,7 @@ export type SupportedUIChangeType =
   | ProtectionModeChange
   | MultiplyPillChange
   | SwapWidgetState
+  | AutomationChangeFeature
 
 export type LegalUiChanges = {
   AddFormChange: AddFormChangeAction
@@ -278,6 +285,7 @@ export type LegalUiChanges = {
   ProtectionModeChange: ProtectionModeChangeAction
   MultiplyPillChange: MultiplyPillChangeAction
   SwapWidgetChange: SwapWidgetChangeAction
+  OptimizationChangeFeature: AutomationChangeFeatureAction
 }
 
 export type UIChanges = {
@@ -365,6 +373,7 @@ function initializeUIChanges() {
 
   uiChangesSubject.configureSubject(PROTECTION_MODE_CHANGE_SUBJECT, protectionModeChangeReducer)
   uiChangesSubject.configureSubject(SWAP_WIDGET_CHANGE_SUBJECT, swapWidgetChangeReducer)
+  uiChangesSubject.configureSubject(AUTOMATION_CHANGE_FEATURE, automationChangeFeatureReducer)
 
   return uiChangesSubject
 }

--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -1,7 +1,12 @@
 import { Vault } from 'blockchain/vaults'
+import { useAppContext } from 'components/AppContextProvider'
 import { OptimizationDetailsControl } from 'features/automation/optimization/controls/OptimizationDetailsControl'
 import { OptimizationFormControl } from 'features/automation/optimization/controls/OptimizationFormControl'
-import React from 'react'
+import {
+  AUTOMATION_CHANGE_FEATURE,
+  AutomationChangeFeature,
+} from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import React, { useEffect, useState } from 'react'
 
 import { DefaultVaultLayout } from './DefaultVaultLayout'
 
@@ -10,10 +15,36 @@ interface OptimizationControlProps {
 }
 
 export function OptimizationControl({ vault }: OptimizationControlProps) {
+  const { uiChanges } = useAppContext()
+  const [isAutoBuyOn] = useState<boolean>(false) // should be taken from pipeline or triggers
+  const [isEditingAutoBuy, setEditingIsAutoBuy] = useState<boolean>(false)
+
+  useEffect(() => {
+    const uiChanges$ = uiChanges.subscribe<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
+    const subscription = uiChanges$.subscribe((value) => {
+      console.log(value)
+    })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
   return (
     <DefaultVaultLayout
-      detailsViewControl={<OptimizationDetailsControl vault={vault} />}
-      editForm={<OptimizationFormControl vault={vault} />}
+      detailsViewControl={
+        <OptimizationDetailsControl
+          vault={vault}
+          isAutoBuyOn={isAutoBuyOn}
+          isEditingAutoBuy={isEditingAutoBuy}
+        />
+      }
+      editForm={
+        <OptimizationFormControl
+          vault={vault}
+          isAutoBuyOn={isAutoBuyOn}
+          isEditingAutoBuy={isEditingAutoBuy}
+        />
+      }
     />
   )
 }

--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -1,12 +1,7 @@
 import { Vault } from 'blockchain/vaults'
-import { useAppContext } from 'components/AppContextProvider'
 import { OptimizationDetailsControl } from 'features/automation/optimization/controls/OptimizationDetailsControl'
 import { OptimizationFormControl } from 'features/automation/optimization/controls/OptimizationFormControl'
-import {
-  AUTOMATION_CHANGE_FEATURE,
-  AutomationChangeFeature,
-} from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import { DefaultVaultLayout } from './DefaultVaultLayout'
 
@@ -15,36 +10,12 @@ interface OptimizationControlProps {
 }
 
 export function OptimizationControl({ vault }: OptimizationControlProps) {
-  const { uiChanges } = useAppContext()
-  const [isAutoBuyOn] = useState<boolean>(false) // should be taken from pipeline or triggers
-  const [isEditingAutoBuy, setEditingIsAutoBuy] = useState<boolean>(false)
-
-  useEffect(() => {
-    const uiChanges$ = uiChanges.subscribe<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
-    const subscription = uiChanges$.subscribe((value) => {
-      console.log(value)
-    })
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [])
+  const [isAutoBuyOn] = useState<boolean>(false) // should be taken from pipeline or triggers, probably on component leve, not here
 
   return (
     <DefaultVaultLayout
-      detailsViewControl={
-        <OptimizationDetailsControl
-          vault={vault}
-          isAutoBuyOn={isAutoBuyOn}
-          isEditingAutoBuy={isEditingAutoBuy}
-        />
-      }
-      editForm={
-        <OptimizationFormControl
-          vault={vault}
-          isAutoBuyOn={isAutoBuyOn}
-          isEditingAutoBuy={isEditingAutoBuy}
-        />
-      }
+      detailsViewControl={<OptimizationDetailsControl isAutoBuyOn={isAutoBuyOn} vault={vault} />}
+      editForm={<OptimizationFormControl isAutoBuyOn={isAutoBuyOn} vault={vault} />}
     />
   )
 }

--- a/features/automation/optimization/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsControl.tsx
@@ -3,9 +3,21 @@ import React from 'react'
 
 import { OptimizationDetailsLayout } from './OptimizationDetailsLayout'
 interface OptimizationDetailsControlProps {
+  isAutoBuyOn: boolean
+  isEditingAutoBuy: boolean
   vault: Vault
 }
 
-export function OptimizationDetailsControl({ vault }: OptimizationDetailsControlProps) {
-  return <OptimizationDetailsLayout vault={vault} />
+export function OptimizationDetailsControl({
+  isAutoBuyOn,
+  isEditingAutoBuy,
+  vault,
+}: OptimizationDetailsControlProps) {
+  return (
+    <OptimizationDetailsLayout
+      vault={vault}
+      isAutoBuyOn={isAutoBuyOn}
+      isEditingAutoBuy={isEditingAutoBuy}
+    />
+  )
 }

--- a/features/automation/optimization/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsControl.tsx
@@ -2,22 +2,15 @@ import { Vault } from 'blockchain/vaults'
 import React from 'react'
 
 import { OptimizationDetailsLayout } from './OptimizationDetailsLayout'
+
 interface OptimizationDetailsControlProps {
   isAutoBuyOn: boolean
-  isEditingAutoBuy: boolean
   vault: Vault
 }
 
 export function OptimizationDetailsControl({
   isAutoBuyOn,
-  isEditingAutoBuy,
   vault,
 }: OptimizationDetailsControlProps) {
-  return (
-    <OptimizationDetailsLayout
-      vault={vault}
-      isAutoBuyOn={isAutoBuyOn}
-      isEditingAutoBuy={isEditingAutoBuy}
-    />
-  )
+  return <OptimizationDetailsLayout isAutoBuyOn={isAutoBuyOn} vault={vault} />
 }

--- a/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
@@ -6,30 +6,32 @@ import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionConte
 import { ContentCardTargetColRatio } from 'components/vault/detailsSection/ContentCardTargetColRatio'
 import { ContentCardTriggerColRatio } from 'components/vault/detailsSection/ContentCardTriggerColRatio'
 import { SetupBanner, setupBannerGradientPresets } from 'components/vault/SetupBanner'
-import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import {
+  AUTOMATION_CHANGE_FEATURE,
+  AutomationChangeFeature,
+} from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
 
 export interface OptimizationDetailsLayoutProps {
   isAutoBuyOn: boolean
-  isEditingAutoBuy: boolean
   vault: Vault
 }
 
-export function OptimizationDetailsLayout({
-  isAutoBuyOn,
-  isEditingAutoBuy,
-  vault,
-}: OptimizationDetailsLayoutProps) {
+export function OptimizationDetailsLayout({ isAutoBuyOn, vault }: OptimizationDetailsLayoutProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
+  const [activeAutomationFeature] = useObservable(
+    uiChanges.subscribe<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE),
+  )
 
   const { token } = vault
 
   return (
     <Grid>
-      {(isAutoBuyOn || isEditingAutoBuy) && (
+      {isAutoBuyOn || activeAutomationFeature?.currentFeature === 'autoBuy' ? (
         <DetailsSection
           title="Auto buy"
           badge={false}
@@ -48,20 +50,21 @@ export function OptimizationDetailsLayout({
             </DetailsSectionContentCardWrapper>
           }
         />
+      ) : (
+        <SetupBanner
+          header={t('auto-buy.banner.header')}
+          content={t('auto-buy.banner.content')}
+          button={t('auto-buy.banner.button')}
+          backgroundImage="/static/img/setup-banner/auto-buy.svg"
+          backgroundColor={setupBannerGradientPresets.autoBuy[0]}
+          backgroundColorEnd={setupBannerGradientPresets.autoBuy[1]}
+          handleClick={() => {
+            uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+              currentFeature: 'autoBuy',
+            })
+          }}
+        />
       )}
-      <SetupBanner
-        header={t('auto-buy.banner.header')}
-        content={t('auto-buy.banner.content')}
-        button={t('auto-buy.banner.button')}
-        backgroundImage="/static/img/setup-banner/auto-buy.svg"
-        backgroundColor={setupBannerGradientPresets.autoBuy[0]}
-        backgroundColorEnd={setupBannerGradientPresets.autoBuy[1]}
-        handleClick={() => {
-          uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
-            currentFeature: 'autoBuy',
-          })
-        }}
-      />
     </Grid>
   )
 }

--- a/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
@@ -1,36 +1,67 @@
 import BigNumber from 'bignumber.js'
 import { Vault } from 'blockchain/vaults'
+import { useAppContext } from 'components/AppContextProvider'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { ContentCardTargetColRatio } from 'components/vault/detailsSection/ContentCardTargetColRatio'
 import { ContentCardTriggerColRatio } from 'components/vault/detailsSection/ContentCardTriggerColRatio'
+import { SetupBanner, setupBannerGradientPresets } from 'components/vault/SetupBanner'
+import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { Grid } from 'theme-ui'
 
 export interface OptimizationDetailsLayoutProps {
+  isAutoBuyOn: boolean
+  isEditingAutoBuy: boolean
   vault: Vault
 }
 
-export function OptimizationDetailsLayout({ vault }: OptimizationDetailsLayoutProps) {
+export function OptimizationDetailsLayout({
+  isAutoBuyOn,
+  isEditingAutoBuy,
+  vault,
+}: OptimizationDetailsLayoutProps) {
+  const { t } = useTranslation()
+  const { uiChanges } = useAppContext()
+
   const { token } = vault
 
   return (
-    <DetailsSection
-      title="Auto buy"
-      badge={false}
-      content={
-        <DetailsSectionContentCardWrapper>
-          <ContentCardTriggerColRatio
-            token={token}
-            triggerColRatio={new BigNumber(Math.random() * 100)}
-            nextBuyPrice={new BigNumber(Math.random() * 1000)}
-          />
-          <ContentCardTargetColRatio
-            token={token}
-            targetColRatio={new BigNumber(Math.random() * 100)}
-            threshold={new BigNumber(Math.random() * 1000)}
-          />
-        </DetailsSectionContentCardWrapper>
-      }
-    />
+    <Grid>
+      {(isAutoBuyOn || isEditingAutoBuy) && (
+        <DetailsSection
+          title="Auto buy"
+          badge={false}
+          content={
+            <DetailsSectionContentCardWrapper>
+              <ContentCardTriggerColRatio
+                token={token}
+                triggerColRatio={new BigNumber(Math.random() * 100)}
+                nextBuyPrice={new BigNumber(Math.random() * 1000)}
+              />
+              <ContentCardTargetColRatio
+                token={token}
+                targetColRatio={new BigNumber(Math.random() * 100)}
+                threshold={new BigNumber(Math.random() * 1000)}
+              />
+            </DetailsSectionContentCardWrapper>
+          }
+        />
+      )}
+      <SetupBanner
+        header={t('auto-buy.banner.header')}
+        content={t('auto-buy.banner.content')}
+        button={t('auto-buy.banner.button')}
+        backgroundImage="/static/img/setup-banner/auto-buy.svg"
+        backgroundColor={setupBannerGradientPresets.autoBuy[0]}
+        backgroundColorEnd={setupBannerGradientPresets.autoBuy[1]}
+        handleClick={() => {
+          uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+            currentFeature: 'autoBuy',
+          })
+        }}
+      />
+    </Grid>
   )
 }

--- a/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsLayout.tsx
@@ -31,7 +31,7 @@ export function OptimizationDetailsLayout({ isAutoBuyOn, vault }: OptimizationDe
 
   return (
     <Grid>
-      {isAutoBuyOn || activeAutomationFeature?.currentFeature === 'autoBuy' ? (
+      {isAutoBuyOn || activeAutomationFeature?.currentOptimizationFeature === 'autoBuy' ? (
         <DetailsSection
           title="Auto buy"
           badge={false}
@@ -60,7 +60,8 @@ export function OptimizationDetailsLayout({ isAutoBuyOn, vault }: OptimizationDe
           backgroundColorEnd={setupBannerGradientPresets.autoBuy[1]}
           handleClick={() => {
             uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
-              currentFeature: 'autoBuy',
+              type: 'Optimization',
+              currentOptimizationFeature: 'autoBuy',
             })
           }}
         />

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -1,5 +1,6 @@
 import { Vault } from 'blockchain/vaults'
 import { SidebarSetupAutoBuy } from 'features/automation/optimization/sidebars/SidebarSetupAutoBuy'
+import React from 'react'
 
 interface OptimizationFormControlProps {
   isAutoBuyOn: boolean

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -1,23 +1,11 @@
 import { Vault } from 'blockchain/vaults'
 import { SidebarSetupAutoBuy } from 'features/automation/optimization/sidebars/SidebarSetupAutoBuy'
-import React from 'react'
 
 interface OptimizationFormControlProps {
   isAutoBuyOn: boolean
-  isEditingAutoBuy: boolean
   vault: Vault
 }
 
-export function OptimizationFormControl({
-  isAutoBuyOn,
-  isEditingAutoBuy,
-  vault,
-}: OptimizationFormControlProps) {
-  return (
-    <SidebarSetupAutoBuy
-      vault={vault}
-      isAutoBuyOn={isAutoBuyOn}
-      isEditingAutoBuy={isEditingAutoBuy}
-    />
-  )
+export function OptimizationFormControl({ isAutoBuyOn, vault }: OptimizationFormControlProps) {
+  return <SidebarSetupAutoBuy isAutoBuyOn={isAutoBuyOn} vault={vault} />
 }

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -3,9 +3,21 @@ import { SidebarSetupAutoBuy } from 'features/automation/optimization/sidebars/S
 import React from 'react'
 
 interface OptimizationFormControlProps {
+  isAutoBuyOn: boolean
+  isEditingAutoBuy: boolean
   vault: Vault
 }
 
-export function OptimizationFormControl({ vault }: OptimizationFormControlProps) {
-  return <SidebarSetupAutoBuy vault={vault} />
+export function OptimizationFormControl({
+  isAutoBuyOn,
+  isEditingAutoBuy,
+  vault,
+}: OptimizationFormControlProps) {
+  return (
+    <SidebarSetupAutoBuy
+      vault={vault}
+      isAutoBuyOn={isAutoBuyOn}
+      isEditingAutoBuy={isEditingAutoBuy}
+    />
+  )
 }

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -1,66 +1,78 @@
 import { Vault } from 'blockchain/vaults'
+import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
 import { MultipleRangeSlider } from 'components/vault/MultipleRangeSlider'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
+import {
+  AUTOMATION_CHANGE_FEATURE,
+  AutomationChangeFeature,
+} from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
 
 interface SidebarSetupAutoBuyProps {
   isAutoBuyOn: boolean
-  isEditingAutoBuy: boolean
   vault: Vault
 }
 
-export function SidebarSetupAutoBuy({ vault }: SidebarSetupAutoBuyProps) {
+export function SidebarSetupAutoBuy({ isAutoBuyOn, vault }: SidebarSetupAutoBuyProps) {
   const { t } = useTranslation()
+  const { uiChanges } = useAppContext()
+  const [activeAutomationFeature] = useObservable(
+    uiChanges.subscribe<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE),
+  )
 
-  const sidebarSectionProps: SidebarSectionProps = {
-    title: `Auto Buy Setup #${vault.id.toNumber()}`,
-    content: (
-      <Grid gap={3}>
-        <MultipleRangeSlider
-          min={170}
-          max={500}
-          onChange={(value) => {
-            console.log(value)
-          }}
-          defaultValue={{
-            value0: 200,
-            value1: 220,
-          }}
-          valueColors={{
-            value1: 'onSuccess',
-          }}
-          leftDescription={t('auto-buy.target-coll-ratio')}
-          rightDescription={t('auto-buy.trigger-coll-ratio')}
-          minDescription={`(${t('auto-buy.min-ratio')})`}
-        />
-        <VaultActionInput
-          action={t('auto-buy.set-max-buy-price')}
-          hasAuxiliary={true}
-          hasError={false}
-          token="ETH"
-          onChange={(e) => console.log(e.target.value)}
-          onAuxiliaryChange={() => {}}
-          showToggle={true}
-          toggleOnLabel={t('auto-buy.set-no-threshold')}
-          toggleOffLabel={t('auto-buy.set-threshold')}
-          toggleOffPlaceholder={t('auto-buy.no-threshold')}
-        />
-        <SidebarResetButton
-          clear={() => {
-            alert('Reset!')
-          }}
-        />
-      </Grid>
-    ),
-    primaryButton: {
-      label: 'Confirm',
-      disabled: true,
-    },
+  if (isAutoBuyOn || activeAutomationFeature?.currentFeature === 'autoBuy') {
+    const sidebarSectionProps: SidebarSectionProps = {
+      title: `Auto Buy Setup #${vault.id.toNumber()}`,
+      content: (
+        <Grid gap={3}>
+          <MultipleRangeSlider
+            min={170}
+            max={500}
+            onChange={(value) => {
+              console.log(value)
+            }}
+            defaultValue={{
+              value0: 200,
+              value1: 220,
+            }}
+            valueColors={{
+              value1: 'onSuccess',
+            }}
+            leftDescription={t('auto-buy.target-coll-ratio')}
+            rightDescription={t('auto-buy.trigger-coll-ratio')}
+            minDescription={`(${t('auto-buy.min-ratio')})`}
+          />
+          <VaultActionInput
+            action={t('auto-buy.set-max-buy-price')}
+            hasAuxiliary={true}
+            hasError={false}
+            token="ETH"
+            onChange={(e) => console.log(e.target.value)}
+            onAuxiliaryChange={() => {}}
+            showToggle={true}
+            toggleOnLabel={t('auto-buy.set-no-threshold')}
+            toggleOffLabel={t('auto-buy.set-threshold')}
+            toggleOffPlaceholder={t('auto-buy.no-threshold')}
+          />
+          <SidebarResetButton
+            clear={() => {
+              alert('Reset!')
+            }}
+          />
+        </Grid>
+      ),
+      primaryButton: {
+        label: 'Confirm',
+        disabled: true,
+      },
+    }
+
+    return <SidebarSection {...sidebarSectionProps} />
   }
-
-  return <SidebarSection {...sidebarSectionProps} />
+  return null
 }

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -8,6 +8,8 @@ import React from 'react'
 import { Grid } from 'theme-ui'
 
 interface SidebarSetupAutoBuyProps {
+  isAutoBuyOn: boolean
+  isEditingAutoBuy: boolean
   vault: Vault
 }
 

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -18,16 +18,16 @@ interface SidebarSetupAutoBuyProps {
   vault: Vault
 }
 
-export function SidebarSetupAutoBuy({ isAutoBuyOn, vault }: SidebarSetupAutoBuyProps) {
+export function SidebarSetupAutoBuy({ isAutoBuyOn }: SidebarSetupAutoBuyProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
   const [activeAutomationFeature] = useObservable(
     uiChanges.subscribe<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE),
   )
 
-  if (isAutoBuyOn || activeAutomationFeature?.currentFeature === 'autoBuy') {
+  if (isAutoBuyOn || activeAutomationFeature?.currentOptimizationFeature === 'autoBuy') {
     const sidebarSectionProps: SidebarSectionProps = {
-      title: `Auto Buy Setup #${vault.id.toNumber()}`,
+      title: 'Auto Buy Setup',
       content: (
         <Grid gap={3}>
           <MultipleRangeSlider

--- a/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
+++ b/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
@@ -1,0 +1,13 @@
+type AutomationFeatures = 'stopLoss' | 'autoBuy' | 'autoSell' | 'constantMultiply' | null
+
+export const AUTOMATION_CHANGE_FEATURE = 'optimizationChangeFeature'
+
+export type AutomationChangeFeatureAction = { currentFeature: AutomationFeatures }
+
+export interface AutomationChangeFeature {
+  currentFeature: AutomationFeatures
+}
+
+export function automationChangeFeatureReducer(state: AutomationChangeFeature, action: AutomationChangeFeatureAction): AutomationChangeFeature {
+  return { ...state, currentFeature: action.currentFeature }
+}

--- a/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
+++ b/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
@@ -1,6 +1,6 @@
 type AutomationFeatures = 'stopLoss' | 'autoBuy' | 'autoSell' | 'constantMultiply' | null
 
-export const AUTOMATION_CHANGE_FEATURE = 'optimizationChangeFeature'
+export const AUTOMATION_CHANGE_FEATURE = 'automationChangeFeature'
 
 export type AutomationChangeFeatureAction = { currentFeature: AutomationFeatures }
 

--- a/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
+++ b/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
@@ -1,16 +1,27 @@
-type AutomationFeatures = 'stopLoss' | 'autoBuy' | 'autoSell' | 'constantMultiply' | null
+type AutomationKinds = 'Protection' | 'Optimization'
+type AutomationProtectionFeatures = 'stopLoss' | 'autoSell'
+type AutomationOptimizationFeatures = 'autoBuy' | 'constantMultiply'
 
 export const AUTOMATION_CHANGE_FEATURE = 'automationChangeFeature'
 
-export type AutomationChangeFeatureAction = { currentFeature: AutomationFeatures }
-
-export interface AutomationChangeFeature {
-  currentFeature: AutomationFeatures
+export type AutomationChangeFeatureAction = {
+  type: AutomationKinds
+  currentProtectionFeature?: AutomationProtectionFeatures
+  currentOptimizationFeature?: AutomationOptimizationFeatures
 }
+
+export type AutomationChangeFeature = Omit<AutomationChangeFeatureAction, 'type'>
 
 export function automationChangeFeatureReducer(
   state: AutomationChangeFeature,
   action: AutomationChangeFeatureAction,
 ): AutomationChangeFeature {
-  return { ...state, currentFeature: action.currentFeature }
+  switch (action.type) {
+    case 'Protection':
+      return { ...state, currentProtectionFeature: action.currentProtectionFeature }
+    case 'Optimization':
+      return { ...state, currentOptimizationFeature: action.currentOptimizationFeature }
+    default:
+      return state
+  }
 }

--- a/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
+++ b/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
@@ -8,6 +8,9 @@ export interface AutomationChangeFeature {
   currentFeature: AutomationFeatures
 }
 
-export function automationChangeFeatureReducer(state: AutomationChangeFeature, action: AutomationChangeFeatureAction): AutomationChangeFeature {
+export function automationChangeFeatureReducer(
+  state: AutomationChangeFeature,
+  action: AutomationChangeFeatureAction,
+): AutomationChangeFeature {
   return { ...state, currentFeature: action.currentFeature }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1296,6 +1296,11 @@
     "target-col-ratio-after-buying": "Target Col. Ratio after buying",
     "target-coll-ratio": "Target Col Ratio",
     "trigger-col-ratio-to-buy-token": "Trigger Col. Ratio to buy {{token}}",
-    "trigger-coll-ratio": "Trigger Col Ratio"
+    "trigger-coll-ratio": "Trigger Col Ratio",
+    "banner": {
+      "header": "Set up Auto Buy",
+      "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vitae erat at tellus blandit fermentum. Sed hendrerit hendrerit mi quis porttitor.",
+      "button": "Setup Auto Buy"
+    }
   }
 }


### PR DESCRIPTION
# [Feature selection in Optimization tab](https://app.shortcut.com/oazo-apps/story/4733/feature-selection-in-optimization-tab)
  
## Changes 👷‍♀️

- Added Auto Buy banner when feature is on.
- Added ability to switch between context of active features.

![image](https://user-images.githubusercontent.com/16230404/173806176-bd4a17dd-83ff-4045-a6af-5bfaa02e9a52.png)
![image](https://user-images.githubusercontent.com/16230404/173806197-4fbaf2ea-4177-434f-9717-096d21ce5448.png)
  
## How to test 🧪

Turn on `BasicBS` feature flag and go to any vault to Optimization tab. By default, there should be only a banner for Auto Buy. Clicking CTA should display details section and sidebar related to it.
