### PR TITLE
set NewComponents true by default

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -21,7 +21,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   EarnProduct: true,
   Automation: true,
   AutomationBasicBuyAndSell: false,
-  NewComponents: false,
+  NewComponents: true,
   StopLossRead: true,
   StopLossWrite: true,
   StopLossOpenFlow: false,


### PR DESCRIPTION
# Set `NewComponents` to `true` by default
  
Preparation for release.
  
## How to test 🧪

See if new components are visible without `NewComponents` set up as `true` in `localStorage`.