### PR TITLE
Set NewComponents to false by default

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -21,7 +21,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   EarnProduct: true,
   Automation: true,
   AutomationBasicBuyAndSell: false,
-  NewComponents: true,
+  NewComponents: false,
   StopLossRead: true,
   StopLossWrite: true,
   StopLossOpenFlow: false,


### PR DESCRIPTION
# Set `NewComponents` to `false` by default
  
Reverted because GUNI Vault sidebar layout needs to be updated ¯\\_(ツ)_/¯
  
## How to test 🧪

See if new components aren't visible unless feature `NewComponents` set up as `true`.