### PR TITLE
Sidebars UI fixes

### DIFF
--- a/components/vault/VaultActionInput.tsx
+++ b/components/vault/VaultActionInput.tsx
@@ -223,7 +223,6 @@ export function VaultActionInput({
             border-color 200ms
           `,
           opacity: !toggleStatus && !disabled ? '0.5' : '1',
-          cursor: !toggleStatus && !disabled ? 'not-allowed' : 'default',
           ...(!disabled &&
             toggleStatus && {
               '&:hover, &:focus-within': {

--- a/components/vault/sidebar/SidebarFields.tsx
+++ b/components/vault/sidebar/SidebarFields.tsx
@@ -166,7 +166,6 @@ export function extractFieldDepositDaiData(state: VaultState) {
 }
 
 export function extractFieldGenerateDaiData(state: VaultState) {
-  console.log(state)
   return {
     ...pick(
       [

--- a/components/vault/sidebar/SidebarFields.tsx
+++ b/components/vault/sidebar/SidebarFields.tsx
@@ -17,6 +17,7 @@ import {
   extractPaybackErrors,
   extractWithdrawErrors,
 } from 'helpers/messageMappers'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import { pick } from 'ramda'
 import React from 'react'
@@ -76,6 +77,7 @@ interface FieldDepositDaiProps extends FieldProps {
 }
 
 interface FieldGenerateDaiProps extends FieldProps {
+  debt?: BigNumber
   debtFloor?: BigNumber
   generateAmount?: BigNumber
   maxGenerateAmount?: BigNumber
@@ -164,6 +166,7 @@ export function extractFieldDepositDaiData(state: VaultState) {
 }
 
 export function extractFieldGenerateDaiData(state: VaultState) {
+  console.log(state)
   return {
     ...pick(
       [
@@ -335,6 +338,7 @@ export function FieldDepositDai({
 
 export function FieldGenerateDai({
   action = 'Generate',
+  debt = zero,
   debtFloor,
   generateAmount,
   maxGenerateAmount,
@@ -356,8 +360,9 @@ export function FieldGenerateDai({
         disabled={disabled}
         hasError={false}
         maxAmount={maxGenerateAmount}
-        minAmount={debtFloor}
-        minAmountLabel={t('from')}
+        maxAmountLabel={!debt ? '' : t('max')}
+        minAmount={debt.isZero() ? debtFloor : zero}
+        minAmountLabel={t('field-from')}
         onChange={handleNumericInput(updateGenerate! || updateGenerateAmount!)}
         onSetMin={() => {
           if (updateGenerate) updateGenerate(debtFloor)
@@ -365,7 +370,7 @@ export function FieldGenerateDai({
         }}
         onSetMax={updateGenerateMax! || updateGenerateAmountMax!}
         showMax={true}
-        showMin={true}
+        showMin={debt.isZero()}
         token={'DAI'}
       />
       <VaultErrors

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
@@ -1,12 +1,6 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { backToVaultOverview } from 'features/automation/protection/common/helpers'
-import {
-  errorsValidation,
-  warningsValidation,
-} from 'features/automation/protection/common/validation'
 import { AdjustSlFormLayoutProps } from 'features/automation/protection/controls/AdjustSlFormLayout'
 import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
 import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
@@ -27,29 +21,16 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
 
   const {
     addTriggerConfig,
-    ethBalance,
-    ethPrice,
     firstStopLossSetup,
-    gasEstimationUsd,
-    ilkData,
     isProgressDisabled,
     isStopLossEnabled,
-    selectedSLValue,
     stage,
     toggleForms,
     token,
-    txError,
     vault: { debt },
   } = props
 
   const flow = firstStopLossSetup ? 'addSl' : 'adjustSl'
-  const errors = errorsValidation({ txError, debt })
-  const warnings = warningsValidation({
-    token,
-    gasEstimationUsd,
-    ethBalance,
-    ethPrice,
-  })
   const sidebarTxData = extractSidebarTxData(props)
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -71,12 +52,6 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
         )}
         {(stage === 'txSuccess' || stage === 'txInProgress') && (
           <SidebarAdjustStopLossAddStage {...props} />
-        )}
-        {stage === 'stopLossEditing' && !selectedSLValue.isZero() && stopLossWriteEnabled && (
-          <>
-            <VaultErrors errorMessages={errors} ilkData={ilkData} />
-            <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
-          </>
         )}
       </Grid>
     ),

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage.tsx
@@ -1,110 +1,120 @@
-import { Box } from '@theme-ui/components'
 import { PickCloseState } from 'components/dumb/PickCloseState'
 import { SliderValuePicker } from 'components/dumb/SliderValuePicker'
 import { AppLink } from 'components/Links'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
+import {
+  errorsValidation,
+  warningsValidation,
+} from 'features/automation/protection/common/validation'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Text } from 'theme-ui'
+import { Grid, Text } from 'theme-ui'
 
 import { AdjustSlFormLayoutProps, SetDownsideProtectionInformation } from '../AdjustSlFormLayout'
 
 export type SidebarAdjustStopLossEditingStageProps = Pick<
   AdjustSlFormLayoutProps,
-  | 'token'
-  | 'txError'
-  | 'slValuePickerConfig'
   | 'closePickerConfig'
-  | 'tokenPrice'
-  | 'ethPrice'
-  | 'vault'
-  | 'ilkData'
-  | 'gasEstimation'
-  | 'selectedSLValue'
-  | 'isEditing'
   | 'collateralizationRatioAtNextPrice'
   | 'currentCollateralRatio'
   | 'ethBalance'
+  | 'ethPrice'
+  | 'gasEstimation'
   | 'gasEstimationUsd'
+  | 'ilkData'
+  | 'isEditing'
+  | 'selectedSLValue'
+  | 'slValuePickerConfig'
+  | 'token'
+  | 'tokenPrice'
+  | 'txError'
+  | 'vault'
 >
 
 export function SidebarAdjustStopLossEditingStage({
-  token,
-  txError,
-  slValuePickerConfig,
   closePickerConfig,
-  tokenPrice,
-  ethPrice,
-  vault,
-  ilkData,
-  gasEstimation,
-  selectedSLValue,
-  isEditing,
   collateralizationRatioAtNextPrice,
-  ethBalance,
-  gasEstimationUsd,
   currentCollateralRatio,
+  ethBalance,
+  ethPrice,
+  gasEstimation,
+  gasEstimationUsd,
+  ilkData,
+  isEditing,
+  selectedSLValue,
+  slValuePickerConfig,
+  token,
+  tokenPrice,
+  txError,
+  vault,
+  vault: { debt },
 }: SidebarAdjustStopLossEditingStageProps) {
   const { t } = useTranslation()
+
+  const errors = errorsValidation({ txError, debt })
+  const warnings = warningsValidation({
+    token,
+    gasEstimationUsd,
+    ethBalance,
+    ethPrice,
+  })
 
   return (
     <>
       {!vault.debt.isZero() ? (
-        <>
-          <Box mb={3}>
-            <PickCloseState {...closePickerConfig} />
-          </Box>
-          <Text as="p" variant="paragraph3" sx={{ color: 'lavender' }}>
+        <Grid>
+          <PickCloseState {...closePickerConfig} />
+          <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
             {t('protection.set-downside-protection-desc')}{' '}
             <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 2 }}>
               {t('here')}.
             </AppLink>
           </Text>
-          <Box mt={3}>
-            <SliderValuePicker {...slValuePickerConfig} />
-          </Box>
-        </>
+          <SliderValuePicker {...slValuePickerConfig} />
+        </Grid>
       ) : (
-        <>
-          <Text as="p" variant="paragraph3" sx={{ color: 'lavender' }}>
-            {t('protection.closed-vault-existing-sl-description')}
-          </Text>
-        </>
+        <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
+          {t('protection.closed-vault-existing-sl-description')}
+        </Text>
       )}
       {isEditing && (
-        <>
-          <Box>
-            <SetDownsideProtectionInformation
-              token={token}
-              vault={vault}
-              ilkData={ilkData}
-              gasEstimation={gasEstimation}
-              gasEstimationUsd={gasEstimationUsd}
-              afterStopLossRatio={selectedSLValue}
-              tokenPrice={tokenPrice}
-              ethPrice={ethPrice}
-              isCollateralActive={closePickerConfig.isCollateralActive}
-              collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
-              selectedSLValue={selectedSLValue}
-              ethBalance={ethBalance}
-              txError={txError}
-              currentCollateralRatio={currentCollateralRatio}
-            />
-          </Box>
-          <Box sx={{ fontSize: 2 }}>
-            <Text as="p" sx={{ mt: 3, fontWeight: 'semiBold' }}>
-              {t('protection.not-guaranteed')}
-            </Text>
-            <Text as="p" sx={{ mb: 3 }}>
-              {t('protection.guarantee-factors')}{' '}
-              <AppLink
-                href="https://kb.oasis.app/help/stop-loss-protection"
-                sx={{ fontWeight: 'body' }}
-              >
-                {t('protection.learn-more-about-automation')}
-              </AppLink>
-            </Text>
-          </Box>
-        </>
+        <Grid>
+          {!selectedSLValue.isZero() && (
+            <>
+              <VaultErrors errorMessages={errors} ilkData={ilkData} />
+              <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
+            </>
+          )}
+          <SetDownsideProtectionInformation
+            token={token}
+            vault={vault}
+            ilkData={ilkData}
+            gasEstimation={gasEstimation}
+            gasEstimationUsd={gasEstimationUsd}
+            afterStopLossRatio={selectedSLValue}
+            tokenPrice={tokenPrice}
+            ethPrice={ethPrice}
+            isCollateralActive={closePickerConfig.isCollateralActive}
+            collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
+            selectedSLValue={selectedSLValue}
+            ethBalance={ethBalance}
+            txError={txError}
+            currentCollateralRatio={currentCollateralRatio}
+          />
+          <Text as="p" variant="paragraph3" sx={{ fontWeight: 'semiBold' }}>
+            {t('protection.not-guaranteed')}
+          </Text>
+          <Text as="p" variant="paragraph3">
+            {t('protection.guarantee-factors')}{' '}
+            <AppLink
+              href="https://kb.oasis.app/help/stop-loss-protection"
+              sx={{ fontWeight: 'body' }}
+            >
+              {t('protection.learn-more-about-automation')}
+            </AppLink>
+          </Text>
+        </Grid>
       )}
     </>
   )

--- a/features/automation/protection/controls/sidebar/SidebarCancelStopLoss.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarCancelStopLoss.tsx
@@ -1,12 +1,6 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { backToVaultOverview } from 'features/automation/protection/common/helpers'
-import {
-  errorsValidation,
-  warningsValidation,
-} from 'features/automation/protection/common/validation'
 import { CancelSlFormLayoutProps } from 'features/automation/protection/controls/CancelSlFormLayout'
 import { SidebarCancelStopLossCancelStage } from 'features/automation/protection/controls/sidebar/SidebarCancelStopLossCancelStage'
 import { SidebarCancelStopLossEditingStage } from 'features/automation/protection/controls/sidebar/SidebarCancelStopLossEditingStage'
@@ -15,7 +9,6 @@ import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
 import { getSidebarTitle } from 'features/sidebar/getSidebarTitle'
 import { SidebarFlow } from 'features/types/vaults/sidebarLabels'
 import { extractSidebarTxData } from 'helpers/extractSidebarHelpers'
-import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -23,30 +16,17 @@ import { Grid } from 'theme-ui'
 export function SidebarCancelStopLoss(props: CancelSlFormLayoutProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
-  const stopLossWriteEnabled = useFeatureToggle('StopLossWrite')
 
   const {
-    ethBalance,
-    ethPrice,
-    gasEstimationUsd,
-    ilkData,
     isProgressDisabled,
     removeTriggerConfig,
     stage,
     toggleForms,
     token,
-    txError,
     vault: { debt },
   } = props
 
   const flow: SidebarFlow = 'cancelSl'
-  const errors = errorsValidation({ txError, debt: debt })
-  const warnings = warningsValidation({
-    token,
-    gasEstimationUsd,
-    ethBalance,
-    ethPrice,
-  })
   const sidebarTxData = extractSidebarTxData(props)
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -58,12 +38,6 @@ export function SidebarCancelStopLoss(props: CancelSlFormLayoutProps) {
         )}
         {(stage === 'txSuccess' || stage === 'txInProgress') && (
           <SidebarCancelStopLossCancelStage {...props} />
-        )}
-        {stage === 'editing' && stopLossWriteEnabled && (
-          <>
-            <VaultErrors errorMessages={errors} ilkData={ilkData} />
-            <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
-          </>
         )}
       </Grid>
     ),

--- a/features/automation/protection/controls/sidebar/SidebarCancelStopLossEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarCancelStopLossEditingStage.tsx
@@ -1,42 +1,58 @@
-import { Box } from '@theme-ui/components'
 import { MessageCard } from 'components/MessageCard'
 import { getEstimatedGasFeeText } from 'components/vault/VaultChangesInformation'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
+import {
+  errorsValidation,
+  warningsValidation,
+} from 'features/automation/protection/common/validation'
 import {
   CancelDownsideProtectionInformation,
   CancelSlFormLayoutProps,
 } from 'features/automation/protection/controls/CancelSlFormLayout'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Text } from 'theme-ui'
+import { Grid, Text } from 'theme-ui'
 
 export function SidebarCancelStopLossEditingStage({
-  txError,
+  ethBalance,
   ethPrice,
   gasEstimation,
-  ethBalance,
   gasEstimationUsd,
+  ilkData,
   liquidationPrice,
   selectedSLValue,
+  token,
+  txError,
+  vault: { debt },
 }: CancelSlFormLayoutProps) {
   const { t } = useTranslation()
+
   const gasEstimationText = getEstimatedGasFeeText(gasEstimation)
+  const errors = errorsValidation({ txError, debt: debt })
+  const warnings = warningsValidation({
+    token,
+    gasEstimationUsd,
+    ethBalance,
+    ethPrice,
+  })
 
   return (
-    <>
-      <Text as="p" variant="paragraph3" sx={{ color: 'lavender' }}>
+    <Grid>
+      <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
         {t('protection.cancel-downside-protection-desc')}
       </Text>
-      <Box my={3}>
-        <CancelDownsideProtectionInformation
-          gasEstimationText={gasEstimationText}
-          liquidationPrice={liquidationPrice}
-          ethPrice={ethPrice}
-          gasEstimationUsd={gasEstimationUsd}
-          ethBalance={ethBalance}
-          txError={txError}
-          selectedSLValue={selectedSLValue}
-        />
-      </Box>
+      <VaultErrors errorMessages={errors} ilkData={ilkData} />
+      <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
+      <CancelDownsideProtectionInformation
+        gasEstimationText={gasEstimationText}
+        liquidationPrice={liquidationPrice}
+        ethPrice={ethPrice}
+        gasEstimationUsd={gasEstimationUsd}
+        ethBalance={ethBalance}
+        txError={txError}
+        selectedSLValue={selectedSLValue}
+      />
       <MessageCard
         messages={[
           <>
@@ -46,6 +62,6 @@ export function SidebarCancelStopLossEditingStage({
         type="warning"
         withBullet={false}
       />
-    </>
+    </Grid>
   )
 }

--- a/features/borrow/manage/sidebars/SidebarManageBorrowVault.tsx
+++ b/features/borrow/manage/sidebars/SidebarManageBorrowVault.tsx
@@ -19,7 +19,7 @@ import {
 } from 'helpers/extractSidebarHelpers'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 import { SidebarManageBorrowVaultEditingStage } from './SidebarManageBorrowVaultEditingStage'

--- a/features/borrow/manage/sidebars/SidebarManageBorrowVault.tsx
+++ b/features/borrow/manage/sidebars/SidebarManageBorrowVault.tsx
@@ -4,8 +4,6 @@ import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarS
 import { SidebarVaultAllowanceStage } from 'components/vault/sidebar/SidebarVaultAllowanceStage'
 import { SidebarVaultProxyStage } from 'components/vault/sidebar/SidebarVaultProxyStage'
 import { SidebarVaultSLTriggered } from 'components/vault/sidebar/SidebarVaultSLTriggered'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ManageStandardBorrowVaultState } from 'features/borrow/manage/pipes/manageVault'
 import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
 import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
@@ -19,10 +17,9 @@ import {
   extractPrimaryButtonLabelParams,
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
-import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 import { SidebarManageBorrowVaultEditingStage } from './SidebarManageBorrowVaultEditingStage'
@@ -138,11 +135,6 @@ export function SidebarManageBorrowVault(props: ManageStandardBorrowVaultState) 
               <SidebarManageBorrowVaultTransitionStage stage={stage} token={token} />
             )}
             {isManageStage && <SidebarManageBorrowVaultManageStage {...props} />}
-            <VaultErrors {...props} errorMessages={extractCommonErrors(props.errorMessages)} />
-            <VaultWarnings
-              {...props}
-              warningMessages={extractCommonWarnings(props.warningMessages)}
-            />
           </>
         ) : (
           <SidebarVaultSLTriggered closeEvent={vaultHistory[0]} />

--- a/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
+++ b/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
@@ -41,7 +41,7 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
     updateGenerate,
     updatePayback,
     updateWithdraw,
-    vault: { token },
+    vault: { debt, token },
     warningMessages,
     withdrawAmount,
   } = props
@@ -90,6 +90,7 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
             <>
               <FieldDepositCollateral token={token} {...extractFieldDepositCollateralData(props)} />
               <FieldGenerateDai
+                debt={debt}
                 disabled={isSecondaryFieldDisabled}
                 {...extractFieldGenerateDaiData(props)}
               />
@@ -114,7 +115,7 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
         <>
           {isDepositOrGenerate && (
             <>
-              <FieldGenerateDai disabled={!isOwner} {...extractFieldGenerateDaiData(props)} />
+              <FieldGenerateDai debt={debt} disabled={!isOwner} {...extractFieldGenerateDaiData(props)} />
               <FieldDepositCollateral
                 token={token}
                 disabled={isSecondaryFieldDisabled}

--- a/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
+++ b/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
@@ -10,8 +10,11 @@ import {
   FieldWithdrawCollateral,
 } from 'components/vault/sidebar/SidebarFields'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ManageVaultChangesInformation } from 'features/borrow/manage/containers/ManageVaultChangesInformation'
 import { ManageStandardBorrowVaultState } from 'features/borrow/manage/pipes/manageVault'
+import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
@@ -23,6 +26,7 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
     accountIsConnected,
     accountIsController,
     depositAmount,
+    errorMessages,
     generateAmount,
     inputAmountsEmpty,
     mainAction,
@@ -38,6 +42,7 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
     updatePayback,
     updateWithdraw,
     vault: { token },
+    warningMessages,
     withdrawAmount,
   } = props
 
@@ -139,6 +144,8 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
           }}
         />
       )}
+      <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
+      <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
       <ManageVaultChangesInformation {...props} />
     </Grid>
   )

--- a/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
+++ b/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
@@ -115,7 +115,11 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
         <>
           {isDepositOrGenerate && (
             <>
-              <FieldGenerateDai debt={debt} disabled={!isOwner} {...extractFieldGenerateDaiData(props)} />
+              <FieldGenerateDai
+                debt={debt}
+                disabled={!isOwner}
+                {...extractFieldGenerateDaiData(props)}
+              />
               <FieldDepositCollateral
                 token={token}
                 disabled={isSecondaryFieldDisabled}

--- a/features/borrow/open/sidebars/SidebarOpenBorrowVault.tsx
+++ b/features/borrow/open/sidebars/SidebarOpenBorrowVault.tsx
@@ -21,6 +21,7 @@ import {
 import { isFirstCdp } from 'helpers/isFirstCdp'
 import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
+import React from 'react'
 import { Grid } from 'theme-ui'
 
 import { SidebarOpenBorrowVaultEditingStage } from './SidebarOpenBorrowVaultEditingStage'

--- a/features/borrow/open/sidebars/SidebarOpenBorrowVault.tsx
+++ b/features/borrow/open/sidebars/SidebarOpenBorrowVault.tsx
@@ -4,8 +4,6 @@ import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarS
 import { SidebarVaultAllowanceStage } from 'components/vault/sidebar/SidebarVaultAllowanceStage'
 import { SidebarVaultProxyStage } from 'components/vault/sidebar/SidebarVaultProxyStage'
 import { SidebarVaultStopLossStage } from 'components/vault/sidebar/SidebarVaultStopLossStage'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { SidebarAdjustStopLossEditingStage } from 'features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage'
 import { getDataForStopLoss } from 'features/automation/protection/openFlow/openVaultStopLoss'
 import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
@@ -21,10 +19,8 @@ import {
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
 import { isFirstCdp } from 'helpers/isFirstCdp'
-import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
-import React from 'react'
 import { Grid } from 'theme-ui'
 
 import { SidebarOpenBorrowVaultEditingStage } from './SidebarOpenBorrowVaultEditingStage'
@@ -77,8 +73,6 @@ export function SidebarOpenBorrowVault(props: OpenVaultState) {
         {isAllowanceStage && <SidebarVaultAllowanceStage {...props} />}
         {isOpenStage && <SidebarOpenBorrowVaultOpenStage {...props} />}
         {isAddStopLossStage && <SidebarVaultStopLossStage {...props} />}
-        <VaultErrors {...props} errorMessages={extractCommonErrors(props.errorMessages)} />
-        <VaultWarnings {...props} warningMessages={extractCommonWarnings(props.warningMessages)} />
       </Grid>
     ),
     ...(isStopLossEditingStage && {

--- a/features/borrow/open/sidebars/SidebarOpenBorrowVaultEditingStage.tsx
+++ b/features/borrow/open/sidebars/SidebarOpenBorrowVaultEditingStage.tsx
@@ -5,8 +5,11 @@ import {
   FieldGenerateDai,
 } from 'components/vault/sidebar/SidebarFields'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { OpenVaultChangesInformation } from 'features/borrow/open/containers/OpenVaultChangesInformation'
 import { OpenVaultState } from 'features/borrow/open/pipes/openVault'
+import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import React, { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
@@ -14,10 +17,12 @@ export function SidebarOpenBorrowVaultEditingStage(props: OpenVaultState) {
   const {
     clear,
     depositAmount,
+    errorMessages,
     inputAmountsEmpty,
     showGenerateOption,
     toggleGenerateOption,
     token,
+    warningMessages,
   } = props
 
   const [isSecondaryFieldDisabled, setIsSecondaryFieldDisabled] = useState<boolean>(true)
@@ -39,6 +44,8 @@ export function SidebarOpenBorrowVaultEditingStage(props: OpenVaultState) {
         {...extractFieldGenerateDaiData(props)}
       />
       {!inputAmountsEmpty && <SidebarResetButton clear={clear} />}
+      <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
+      <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
       <OpenVaultChangesInformation {...props} />
     </Grid>
   )

--- a/features/earn/guni/manage/sidebars/SidebarManageGuniVault.tsx
+++ b/features/earn/guni/manage/sidebars/SidebarManageGuniVault.tsx
@@ -18,6 +18,7 @@ import {
 } from 'helpers/extractSidebarHelpers'
 import { useTranslation } from 'next-i18next'
 import { useEffect, useState } from 'react'
+import React from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarManageGuniVault(props: ManageMultiplyVaultState) {

--- a/features/earn/guni/manage/sidebars/SidebarManageGuniVault.tsx
+++ b/features/earn/guni/manage/sidebars/SidebarManageGuniVault.tsx
@@ -2,8 +2,6 @@ import { getToken } from 'blockchain/tokensMetadata'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
 import { SidebarVaultAllowanceStage } from 'components/vault/sidebar/SidebarVaultAllowanceStage'
 import { SidebarVaultProxyStage } from 'components/vault/sidebar/SidebarVaultProxyStage'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { SidebarManageGuniVaultEditingState } from 'features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState'
 import { SidebarManageGuniVaultManageStage } from 'features/earn/guni/manage/sidebars/SidebarManageGuniVaultManageStage'
 import { ManageMultiplyVaultState } from 'features/multiply/manage/pipes/manageMultiplyVault'
@@ -18,9 +16,8 @@ import {
   extractPrimaryButtonLabelParams,
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
-import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarManageGuniVault(props: ManageMultiplyVaultState) {
@@ -96,8 +93,6 @@ export function SidebarManageGuniVault(props: ManageMultiplyVaultState) {
           <SidebarVaultAllowanceStage {...props} />
         )}
         {isManageStage && <SidebarManageGuniVaultManageStage {...props} />}
-        <VaultErrors {...props} errorMessages={extractCommonErrors(props.errorMessages)} />
-        <VaultWarnings {...props} warningMessages={extractCommonWarnings(props.warningMessages)} />
       </Grid>
     ),
     primaryButton: {

--- a/features/earn/guni/manage/sidebars/SidebarManageGuniVault.tsx
+++ b/features/earn/guni/manage/sidebars/SidebarManageGuniVault.tsx
@@ -17,8 +17,7 @@ import {
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
 import { useTranslation } from 'next-i18next'
-import { useEffect, useState } from 'react'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarManageGuniVault(props: ManageMultiplyVaultState) {

--- a/features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState.tsx
+++ b/features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState.tsx
@@ -1,8 +1,11 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { getToken } from 'blockchain/tokensMetadata'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { GuniManageMultiplyVaultChangesInformation } from 'features/earn/guni/manage/containers/GuniManageMultiplyVaultChangesInformation'
 import { ManageMultiplyVaultState } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { formatCryptoBalance } from 'helpers/formatters/format'
+import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid, Text } from 'theme-ui'
@@ -12,9 +15,11 @@ export function SidebarManageGuniVaultEditingState(props: ManageMultiplyVaultSta
 
   const {
     afterCloseToDai,
+    errorMessages,
     stage,
     toggle,
     vault: { debt, token },
+    warningMessages,
   } = props
 
   return (
@@ -64,11 +69,13 @@ export function SidebarManageGuniVaultEditingState(props: ManageMultiplyVaultSta
                 </Text>
                 <Text as="span">{formatCryptoBalance(afterCloseToDai)} DAI</Text>
               </Text>
-              <GuniManageMultiplyVaultChangesInformation {...props} />
             </>
           )}
         </>
       )}
+      <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
+      <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
+      <GuniManageMultiplyVaultChangesInformation {...props} />
     </Grid>
   )
 }

--- a/features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState.tsx
+++ b/features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState.tsx
@@ -25,7 +25,7 @@ export function SidebarManageGuniVaultEditingState(props: ManageMultiplyVaultSta
   return (
     <Grid gap={3}>
       {stage === 'adjustPosition' && (
-        <Text variant="paragraph3" sx={{ color: 'text.subtitle' }}>
+        <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
           <Trans
             i18nKey={'vault-info-messages.earn-overview'}
             values={{ token }}
@@ -45,7 +45,7 @@ export function SidebarManageGuniVaultEditingState(props: ManageMultiplyVaultSta
       )}
       {stage === 'otherActions' && (
         <>
-          <Text variant="paragraph3" sx={{ color: 'text.subtitle' }}>
+          <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
             {t('vault-info-messages.closing')}
           </Text>
           {!debt.isZero() && (

--- a/features/earn/guni/open/sidebars/SidebarOpenGuniVault.tsx
+++ b/features/earn/guni/open/sidebars/SidebarOpenGuniVault.tsx
@@ -2,8 +2,6 @@ import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
 import { SidebarVaultAllowanceStage } from 'components/vault/sidebar/SidebarVaultAllowanceStage'
 import { SidebarVaultProxyStage } from 'components/vault/sidebar/SidebarVaultProxyStage'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { OpenGuniVaultState } from 'features/earn/guni/open/pipes/openGuniVault'
 import { SidebarOpenGuniVaultEditingState } from 'features/earn/guni/open/sidebars/SidebarOpenGuniVaultEditingState'
 import { SidebarOpenGuniVaultOpenStage } from 'features/earn/guni/open/sidebars/SidebarOpenGuniVaultOpenStage'
@@ -19,9 +17,7 @@ import {
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
 import { isFirstCdp } from 'helpers/isFirstCdp'
-import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useObservable } from 'helpers/observableHook'
-import React from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarOpenGuniVault(props: OpenGuniVaultState) {
@@ -60,8 +56,6 @@ export function SidebarOpenGuniVault(props: OpenGuniVaultState) {
         {isProxyStage && <SidebarVaultProxyStage stage={stage} gasData={gasData} />}
         {isAllowanceStage && <SidebarVaultAllowanceStage {...props} token="DAI" />}
         {isOpenStage && <SidebarOpenGuniVaultOpenStage {...props} />}
-        <VaultErrors {...props} errorMessages={extractCommonErrors(props.errorMessages)} />
-        <VaultWarnings {...props} warningMessages={extractCommonWarnings(props.warningMessages)} />
       </Grid>
     ),
     primaryButton: {

--- a/features/earn/guni/open/sidebars/SidebarOpenGuniVault.tsx
+++ b/features/earn/guni/open/sidebars/SidebarOpenGuniVault.tsx
@@ -18,6 +18,7 @@ import {
 } from 'helpers/extractSidebarHelpers'
 import { isFirstCdp } from 'helpers/isFirstCdp'
 import { useObservable } from 'helpers/observableHook'
+import React from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarOpenGuniVault(props: OpenGuniVaultState) {

--- a/features/earn/guni/open/sidebars/SidebarOpenGuniVaultEditingState.tsx
+++ b/features/earn/guni/open/sidebars/SidebarOpenGuniVaultEditingState.tsx
@@ -1,6 +1,9 @@
 import { FieldDepositDai } from 'components/vault/sidebar/SidebarFields'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { GuniOpenMultiplyVaultChangesInformation } from 'features/earn/guni/open/containers/GuniOpenMultiplyVaultChangesInformation'
 import { OpenGuniVaultState } from 'features/earn/guni/open/pipes/openGuniVault'
+import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { Trans } from 'next-i18next'
 import React from 'react'
 import { Grid, Text } from 'theme-ui'
@@ -9,13 +12,13 @@ export function SidebarOpenGuniVaultEditingState(props: OpenGuniVaultState) {
   const {
     balanceInfo: { daiBalance },
     depositAmount,
+    errorMessages,
+    ilkData,
     maxMultiple,
     token,
     updateDeposit,
     updateDepositMax,
-    errorMessages,
     warningMessages,
-    ilkData,
   } = props
 
   return (
@@ -42,6 +45,8 @@ export function SidebarOpenGuniVaultEditingState(props: OpenGuniVaultState) {
       <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
         {maxMultiple.toNumber().toFixed(2)}x {token}
       </Text>
+      <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
+      <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
       <GuniOpenMultiplyVaultChangesInformation {...props} />
     </Grid>
   )

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
@@ -20,7 +20,7 @@ import {
 } from 'helpers/extractSidebarHelpers'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 import { SidebarManageMultiplyVaultEditingStage } from './SidebarManageMultiplyVaultEditingStage'

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
@@ -3,8 +3,6 @@ import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarS
 import { SidebarVaultAllowanceStage } from 'components/vault/sidebar/SidebarVaultAllowanceStage'
 import { SidebarVaultProxyStage } from 'components/vault/sidebar/SidebarVaultProxyStage'
 import { SidebarVaultSLTriggered } from 'components/vault/sidebar/SidebarVaultSLTriggered'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ManageMultiplyVaultState } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { SidebarManageMultiplyVaultManageStage } from 'features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage'
 import { SidebarManageMultiplyVaultTransitionStage } from 'features/multiply/manage/sidebars/SidebarManageMultiplyVaultTransitionStage'
@@ -20,10 +18,9 @@ import {
   extractPrimaryButtonLabelParams,
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
-import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 import { SidebarManageMultiplyVaultEditingStage } from './SidebarManageMultiplyVaultEditingStage'
@@ -156,11 +153,6 @@ export function SidebarManageMultiplyVault(props: ManageMultiplyVaultState) {
             )}
             {isBorrowTransitionStage && <SidebarManageMultiplyVaultTransitionStage stage={stage} />}
             {isManageStage && <SidebarManageMultiplyVaultManageStage {...props} />}
-            <VaultErrors {...props} errorMessages={extractCommonErrors(props.errorMessages)} />
-            <VaultWarnings
-              {...props}
-              warningMessages={extractCommonWarnings(props.warningMessages)}
-            />
           </>
         ) : (
           <SidebarVaultSLTriggered closeEvent={vaultHistory[0]} />

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
@@ -130,6 +130,7 @@ export function SidebarManageMultiplyVault(props: ManageMultiplyVaultState) {
           panel: 'transition',
           action: () => {
             toggle!('borrowTransitionEditing')
+            setOtherAction!('depositCollateral')
           },
         },
         {

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
@@ -17,6 +17,8 @@ import {
 import { OptionalAdjust } from 'components/vault/sidebar/SidebarOptionalAdjust'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { SidebarSliderAdjustMultiply } from 'components/vault/sidebar/SidebarSliders'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ManageMultiplyVaultChangesInformation } from 'features/multiply/manage/containers/ManageMultiplyVaultChangesInformation'
 import { ManageMultiplyVaultState } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import {
@@ -25,6 +27,7 @@ import {
 } from 'features/multiply/manage/sidebars/SidebarManageMultiplyVault'
 import { MAX_COLL_RATIO } from 'features/multiply/open/pipes/openMultiplyVaultCalculations'
 import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
+import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -37,13 +40,13 @@ interface SliderAdjustMultiplyParams extends ManageMultiplyVaultState {
 
 function SliderAdjustMultiply({ collapsed, disabled, ...props }: SliderAdjustMultiplyParams) {
   const {
-    vault: { collateralizationRatio },
+    hasToDepositCollateralOnEmptyVault,
     ilkData: { liquidationRatio },
-    requiredCollRatio,
-    updateRequiredCollRatio,
     maxCollRatio,
     minCollRatio,
-    hasToDepositCollateralOnEmptyVault,
+    requiredCollRatio,
+    updateRequiredCollRatio,
+    vault: { collateralizationRatio },
   } = props
 
   const sliderMax = maxCollRatio || MAX_COLL_RATIO
@@ -232,6 +235,7 @@ export function SidebarManageMultiplyVaultEditingStage(props: ManageMultiplyVaul
   const { t } = useTranslation()
 
   const {
+    errorMessages,
     inputAmountsEmpty,
     otherAction,
     setOtherAction,
@@ -242,6 +246,7 @@ export function SidebarManageMultiplyVaultEditingStage(props: ManageMultiplyVaul
     updatePaybackAmount,
     updateWithdrawAmount,
     vault: { debt },
+    warningMessages,
   } = props
 
   return (
@@ -333,6 +338,9 @@ export function SidebarManageMultiplyVaultEditingStage(props: ManageMultiplyVaul
           }}
         />
       )}
+
+      <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
+      <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
       <ManageMultiplyVaultChangesInformation {...props} />
     </Grid>
   )

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
@@ -218,7 +218,7 @@ function SidebarManageMultiplyVaultEditingStageWithdrawDai(props: ManageMultiply
 
   return (
     <>
-      <FieldGenerateDai action="Withdraw" {...extractFieldGenerateDaiData(props)} />
+      <FieldGenerateDai debt={debt} action="Withdraw" {...extractFieldGenerateDaiData(props)} />
       <OptionalAdjust
         label={t('adjust-your-position-additional')}
         isVisible={generateAmount?.gt(zero) && debt.gt(zero)}

--- a/features/multiply/open/sidebars/SidebarOpenMultiplyVault.tsx
+++ b/features/multiply/open/sidebars/SidebarOpenMultiplyVault.tsx
@@ -3,8 +3,6 @@ import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarS
 import { SidebarVaultAllowanceStage } from 'components/vault/sidebar/SidebarVaultAllowanceStage'
 import { SidebarVaultProxyStage } from 'components/vault/sidebar/SidebarVaultProxyStage'
 import { SidebarVaultStopLossStage } from 'components/vault/sidebar/SidebarVaultStopLossStage'
-import { VaultErrors } from 'components/vault/VaultErrors'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { SidebarAdjustStopLossEditingStage } from 'features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage'
 import { getDataForStopLoss } from 'features/automation/protection/openFlow/openVaultStopLoss'
 import { OpenMultiplyVaultState } from 'features/multiply/open/pipes/openMultiplyVault'
@@ -22,10 +20,8 @@ import {
   extractSidebarTxData,
 } from 'helpers/extractSidebarHelpers'
 import { isFirstCdp } from 'helpers/isFirstCdp'
-import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
-import React from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarOpenMultiplyVault(props: OpenMultiplyVaultState) {
@@ -74,8 +70,6 @@ export function SidebarOpenMultiplyVault(props: OpenMultiplyVaultState) {
         {isAllowanceStage && <SidebarVaultAllowanceStage {...props} />}
         {isOpenStage && <SidebarOpenMultiplyVaultOpenStage {...props} />}
         {isAddStopLossStage && <SidebarVaultStopLossStage {...props} />}
-        <VaultErrors {...props} errorMessages={extractCommonErrors(props.errorMessages)} />
-        <VaultWarnings {...props} warningMessages={extractCommonWarnings(props.warningMessages)} />
       </Grid>
     ),
     ...(isStopLossEditingStage && {

--- a/features/multiply/open/sidebars/SidebarOpenMultiplyVault.tsx
+++ b/features/multiply/open/sidebars/SidebarOpenMultiplyVault.tsx
@@ -22,6 +22,7 @@ import {
 import { isFirstCdp } from 'helpers/isFirstCdp'
 import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
+import React from 'react'
 import { Grid } from 'theme-ui'
 
 export function SidebarOpenMultiplyVault(props: OpenMultiplyVaultState) {

--- a/features/multiply/open/sidebars/SidebarOpenMultiplyVaultEditingState.tsx
+++ b/features/multiply/open/sidebars/SidebarOpenMultiplyVaultEditingState.tsx
@@ -5,8 +5,11 @@ import {
 } from 'components/vault/sidebar/SidebarFields'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { SidebarSliderAdjustMultiply } from 'components/vault/sidebar/SidebarSliders'
+import { VaultErrors } from 'components/vault/VaultErrors'
+import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { OpenMultiplyVaultChangesInformation } from 'features/multiply/open/containers/OpenMultiplyVaultChangesInformation'
 import { OpenMultiplyVaultState } from 'features/multiply/open/pipes/openMultiplyVault'
+import { extractCommonErrors, extractCommonWarnings } from 'helpers/messageMappers'
 import React from 'react'
 import { Grid } from 'theme-ui'
 
@@ -14,12 +17,14 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
   const {
     canAdjustRisk,
     clear,
+    errorMessages,
     ilkData: { liquidationRatio },
     inputAmountsEmpty,
     maxCollRatio,
     requiredCollRatio,
     token,
     updateRequiredCollRatio,
+    warningMessages,
   } = props
 
   return (
@@ -35,6 +40,8 @@ export function SidebarOpenMultiplyVaultEditingState(props: OpenMultiplyVaultSta
         }}
       />
       {!inputAmountsEmpty && <SidebarResetButton clear={clear} />}
+      <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
+      <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
       <OpenMultiplyVaultChangesInformation {...props} />
     </Grid>
   )

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -488,6 +488,7 @@
     "button-failure": "Something went wrong, try again",
     "button-success": "Transition completed, refreshing..."
   },
+  "field-from": "From",
   "max": "Max",
   "min-amount": "Minimum amount is {{minAmount}} {{token}}",
   "minimum": "Minimum",


### PR DESCRIPTION
# Sidebars UI fixes
  
## Changes 👷‍♀️

- Hide afterpills on manage multiply when you switch from close vault to transfrom to borrow,
- bring back `not-allowed` cursor on disabled fields,
- move general validations above vault changes list,
- final UI fixes to SL sidebar according to new sidebar layouts.