### PR TITLE
Fix move events

### DIFF
--- a/helpers/multiply/calculations.ts
+++ b/helpers/multiply/calculations.ts
@@ -30,6 +30,8 @@ function getCumulativeDepositUSD(total: BigNumber, event: VaultEvent) {
       return total.plus(event.depositDai)
     case 'MOVE_DEST':
       return total.plus(event.collateralAmount.times(event.oraclePrice))
+    case 'MOVE_SRC':
+      return total.plus(event.daiAmount.abs())
     default:
       return total
   }
@@ -54,6 +56,8 @@ function getCumulativeWithdrawnUSD(total: BigNumber, event: VaultEvent) {
       return total.plus(event.exitDai)
     case 'MOVE_SRC':
       return total.plus(event.collateralAmount.times(event.oraclePrice))
+    case 'MOVE_DEST':
+      return total.plus(event.daiAmount.abs())
     default:
       return total
   }


### PR DESCRIPTION
# Fix PnL for move events

Vaults https://oasis.app/27394#History and https://oasis.app/27351#Overview seem to have PnL way off due to Move events not aggregated correctly. 
  
## Changes 👷‍♀️
- Account MOVE_SRC as payback the debt
- Account MOVE_DEST as generating debt 
  
## How to test 🧪
- Checkout 27394 and 27351
