### PR TITLE
set NewComponents and StopLossOpenFlow to true

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -21,10 +21,10 @@ const configuredFeatures: Record<Feature, boolean> = {
   EarnProduct: true,
   Automation: true,
   AutomationBasicBuyAndSell: false,
-  NewComponents: false,
+  NewComponents: true,
   StopLossRead: true,
   StopLossWrite: true,
-  StopLossOpenFlow: false,
+  StopLossOpenFlow: true,
   BasicBS: false,
   // your feature here....
 }


### PR DESCRIPTION
# set `NewComponents` and `StopLossOpenFlow` to true

Displays new product pages layouts and includes opening stop-loss in vault opening process.