### PR TITLE
New components headers with spacing

### DIFF
--- a/components/DetailsSection.tsx
+++ b/components/DetailsSection.tsx
@@ -25,7 +25,7 @@ export function DetailsSection({ title, badge, buttons, content, footer }: Detai
           sx={{
             flexDirection: ['column', null, 'row'],
             justifyContent: 'space-between',
-            px: [3, null, '24px'],
+            mx: [3, null, '24px'],
             pt: 3,
             pb: ['24px', null, 3],
             borderBottom: 'lightMuted',

--- a/components/sidebar/SidebarSectionHeader.tsx
+++ b/components/sidebar/SidebarSectionHeader.tsx
@@ -36,7 +36,7 @@ export function SidebarSectionHeader({
         position: 'relative',
         justifyContent: 'space-between',
         py: 3,
-        px: '24px',
+        mx: '24px',
         borderBottom: 'lightMuted',
         zIndex: 1,
       }}


### PR DESCRIPTION
# New components headers with spacing
  
## Changes 👷‍♀️

According to comment from Anna: all new components in details section and in sidebar should have header border with margins and footer border from side to side.

![image](https://user-images.githubusercontent.com/16230404/175894767-d1149e5d-1fcd-476a-b59d-b896060fa754.png)
![image](https://user-images.githubusercontent.com/16230404/175894791-bdf7f6be-8ce4-4635-8bf6-5277ca59554d.png)

