### PR TITLE
Basic BS remove trigger handlers

### DIFF
--- a/components/VaultTabSwitch.tsx
+++ b/components/VaultTabSwitch.tsx
@@ -3,13 +3,13 @@ import {
   TAB_CHANGE_SUBJECT,
   TabChange,
 } from 'features/automation/protection/common/UITypes/TabChange'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
+import { useHash } from 'helpers/useHash'
 import { useTranslation } from 'next-i18next'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import ReactSelect, { OptionProps, SingleValueProps, ValueType } from 'react-select'
 import { Flex } from 'theme-ui'
 
-import { useFeatureToggle } from '../helpers/useFeatureToggle'
-import { useHash } from '../helpers/useHash'
 import { useAppContext } from './AppContextProvider'
 import { reactSelectCustomComponents } from './reactSelectCustomComponents'
 import { VaultTabTag } from './vault/VaultTabTag'

--- a/features/automation/common/basicBSTriggerData.ts
+++ b/features/automation/common/basicBSTriggerData.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import {
   AutomationBaseTriggerData,
   AutomationBotAddTriggerData,
+  AutomationBotRemoveTriggerData,
 } from 'blockchain/calls/automationBot'
 import { TxMetaKind } from 'blockchain/calls/txMeta'
 import { Vault } from 'blockchain/vaults'
@@ -139,5 +140,32 @@ export function prepareAddBasicBSTriggerData({
     ...baseTriggerData,
     replacedTriggerId: replacedTriggerId.toNumber(),
     kind: TxMetaKind.addTrigger,
+  }
+}
+
+export function prepareRemoveBasicBSTriggerData({
+  vaultData,
+  triggerType,
+  triggerId,
+}: {
+  vaultData: Vault
+  triggerType: BasicBSTriggerTypes
+  triggerId: BigNumber
+}): AutomationBotRemoveTriggerData {
+  const baseTriggerData = prepareBasicBSTriggerData({
+    vaultData,
+    triggerType,
+    execCollRatio: zero,
+    targetCollRatio: zero,
+    maxBuyOrMinSellPrice: zero,
+    continuous: false,
+    deviation: zero,
+  })
+
+  return {
+    ...baseTriggerData,
+    kind: TxMetaKind.removeTrigger,
+    triggerId: triggerId.toNumber(),
+    removeAllowance: false,
   }
 }

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -1,6 +1,6 @@
 import { TriggerType } from '@oasisdex/automation'
 import { BigNumber } from 'bignumber.js'
-import { addAutomationBotTrigger } from 'blockchain/calls/automationBot'
+import { addAutomationBotTrigger, removeAutomationBotTrigger } from 'blockchain/calls/automationBot'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
@@ -8,14 +8,16 @@ import { MultipleRangeSlider } from 'components/vault/MultipleRangeSlider'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
-import { prepareAddBasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
+import {
+  prepareAddBasicBSTriggerData,
+  prepareRemoveBasicBSTriggerData,
+} from 'features/automation/common/basicBSTriggerData'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
 } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import {
   BASIC_BUY_FORM_CHANGE,
-  BASIC_SELL_FORM_CHANGE,
   BasicBSFormChange,
 } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { handleNumericInput } from 'helpers/input'
@@ -29,9 +31,10 @@ import { Grid } from 'theme-ui'
 interface SidebarSetupAutoBuyProps {
   isAutoBuyOn: boolean
   vault: Vault
+  stage?: any // TODO
 }
 
-export function SidebarSetupAutoBuy({ isAutoBuyOn, vault }: SidebarSetupAutoBuyProps) {
+export function SidebarSetupAutoBuy({ isAutoBuyOn, vault, stage }: SidebarSetupAutoBuyProps) {
   const { t } = useTranslation()
 
   const { uiChanges, txHelpers$ } = useAppContext()
@@ -40,7 +43,7 @@ export function SidebarSetupAutoBuy({ isAutoBuyOn, vault }: SidebarSetupAutoBuyP
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const [uiState] = useUIChanges<BasicBSFormChange>(BASIC_BUY_FORM_CHANGE)
 
-  const txData = prepareAddBasicBSTriggerData({
+  const addTxData = prepareAddBasicBSTriggerData({
     vaultData: vault,
     triggerType: TriggerType.BasicBuy,
     execCollRatio: uiState.execCollRatio,
@@ -51,73 +54,86 @@ export function SidebarSetupAutoBuy({ isAutoBuyOn, vault }: SidebarSetupAutoBuyP
     replacedTriggerId: uiState.triggerId,
   })
 
+  const removeTxData = prepareRemoveBasicBSTriggerData({
+    vaultData: vault,
+    triggerType: TriggerType.BasicSell,
+    triggerId: uiState.triggerId,
+  })
+
+  const isAddForm = uiState.currentForm === 'add'
+
   if (isAutoBuyOn || activeAutomationFeature?.currentOptimizationFeature === 'autoBuy') {
     const sidebarSectionProps: SidebarSectionProps = {
       title: t('auto-buy.form-title'),
       content: (
         <Grid gap={3}>
-          <MultipleRangeSlider
-            min={170}
-            max={500}
-            onChange={(value) => {
-              uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-                type: 'target-coll-ratio',
-                targetCollRatio: new BigNumber(value.value0),
-              })
-              uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-                type: 'execution-coll-ratio',
-                execCollRatio: new BigNumber(value.value1),
-              })
-            }}
-            defaultValue={{
-              value0: uiState.targetCollRatio.toNumber(),
-              value1: uiState.execCollRatio.toNumber(),
-            }}
-            valueColors={{
-              value1: 'onSuccess',
-            }}
-            leftDescription={t('auto-buy.target-coll-ratio')}
-            rightDescription={t('auto-buy.trigger-coll-ratio')}
-            minDescription={`(${t('auto-buy.min-ratio')})`}
-          />
-          <VaultActionInput
-            action={t('auto-buy.set-max-buy-price')}
-            amount={uiState.maxBuyOrMinSellPrice}
-            hasAuxiliary={true}
-            hasError={false}
-            token="ETH"
-            onChange={handleNumericInput((maxBuyOrMinSellPrice) => {
-              uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-                type: 'max-buy-or-sell-price',
-                maxBuyOrMinSellPrice,
-              })
-            })}
-            onToggle={(toggleStatus) => {
-              uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-                type: 'with-threshold',
-                withThreshold: toggleStatus,
-              })
-            }}
-            onAuxiliaryChange={() => {}}
-            showToggle={true}
-            toggleOnLabel={t('protection.set-no-threshold')}
-            toggleOffLabel={t('protection.set-threshold')}
-            toggleOffPlaceholder={t('protection.no-threshold')}
-          />
-          <SidebarResetButton
-            clear={() => {
-              alert('Reset!')
-            }}
-          />
-          <MaxGasPriceSection
-            onChange={(maxGasPercentagePrice) => {
-              uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
-                type: 'max-gas-percentage-price',
-                maxGasPercentagePrice,
-              })
-            }}
-            defaultValue={uiState.maxGasPercentagePrice}
-          />
+          {isAddForm && (
+            <>
+              <MultipleRangeSlider
+                min={170}
+                max={500}
+                onChange={(value) => {
+                  uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
+                    type: 'target-coll-ratio',
+                    targetCollRatio: new BigNumber(value.value0),
+                  })
+                  uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
+                    type: 'execution-coll-ratio',
+                    execCollRatio: new BigNumber(value.value1),
+                  })
+                }}
+                defaultValue={{
+                  value0: uiState.targetCollRatio.toNumber(),
+                  value1: uiState.execCollRatio.toNumber(),
+                }}
+                valueColors={{
+                  value1: 'onSuccess',
+                }}
+                leftDescription={t('auto-buy.target-coll-ratio')}
+                rightDescription={t('auto-buy.trigger-coll-ratio')}
+                minDescription={`(${t('auto-buy.min-ratio')})`}
+              />
+              <VaultActionInput
+                action={t('auto-buy.set-max-buy-price')}
+                amount={uiState.maxBuyOrMinSellPrice}
+                hasAuxiliary={true}
+                hasError={false}
+                token="ETH"
+                onChange={handleNumericInput((maxBuyOrMinSellPrice) => {
+                  uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
+                    type: 'max-buy-or-sell-price',
+                    maxBuyOrMinSellPrice,
+                  })
+                })}
+                onToggle={(toggleStatus) => {
+                  uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
+                    type: 'with-threshold',
+                    withThreshold: toggleStatus,
+                  })
+                }}
+                onAuxiliaryChange={() => {}}
+                showToggle={true}
+                toggleOnLabel={t('protection.set-no-threshold')}
+                toggleOffLabel={t('protection.set-threshold')}
+                toggleOffPlaceholder={t('protection.no-threshold')}
+              />
+              <SidebarResetButton
+                clear={() => {
+                  alert('Reset!')
+                }}
+              />
+              <MaxGasPriceSection
+                onChange={(maxGasPercentagePrice) => {
+                  uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
+                    type: 'max-gas-percentage-price',
+                    maxGasPercentagePrice,
+                  })
+                }}
+                defaultValue={uiState.maxGasPercentagePrice}
+              />
+            </>
+          )}
+          {uiState.currentForm === 'remove' && <>Remove form TBD</>}
         </Grid>
       ),
       primaryButton: {
@@ -125,12 +141,31 @@ export function SidebarSetupAutoBuy({ isAutoBuyOn, vault }: SidebarSetupAutoBuyP
         disabled: false,
         action: () => {
           if (txHelpers) {
-            txHelpers
-              .sendWithGasEstimation(addAutomationBotTrigger, txData)
-              .subscribe((next) => console.log(next))
+            if (isAddForm) {
+              txHelpers
+                .sendWithGasEstimation(addAutomationBotTrigger, addTxData)
+                .subscribe((next) => console.log(next))
+            }
+            if (uiState.currentForm === 'remove') {
+              txHelpers
+                .sendWithGasEstimation(removeAutomationBotTrigger, removeTxData)
+                .subscribe((next) => console.log(next))
+            }
           }
         },
       },
+      ...(stage !== 'txInProgress' && {
+        textButton: {
+          label: isAddForm ? t('system.remove-trigger') : t('system.add-trigger'),
+          hidden: uiState.triggerId.isZero(),
+          action: () => {
+            uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
+              type: 'current-form',
+              currentForm: isAddForm ? 'remove' : 'add',
+            })
+          },
+        },
+      }),
     }
 
     return <SidebarSection {...sidebarSectionProps} />

--- a/features/automation/protection/common/UITypes/basicBSFormChange.ts
+++ b/features/automation/protection/common/UITypes/basicBSFormChange.ts
@@ -6,7 +6,8 @@ import { TxError } from 'helpers/types'
 export const BASIC_SELL_FORM_CHANGE = 'BASIC_SELL_FORM_CHANGE'
 export const BASIC_BUY_FORM_CHANGE = 'BASIC_BUY_FORM_CHANGE'
 
-/* End of section */
+export type CurrentBSForm = 'add' | 'remove'
+
 export type BasicBSChangeAction =
   | { type: 'trigger-id'; triggerId: BigNumber }
   | { type: 'execution-coll-ratio'; execCollRatio: BigNumber }
@@ -15,6 +16,7 @@ export type BasicBSChangeAction =
   | { type: 'continuous'; continuous: boolean }
   | { type: 'deviation'; deviation: BigNumber }
   | { type: 'max-gas-percentage-price'; maxGasPercentagePrice: MaxGasPriceValues }
+  | { type: 'current-form'; currentForm: CurrentBSForm }
   | { type: 'with-threshold'; withThreshold: boolean }
   | {
       type: 'tx-details'
@@ -45,6 +47,8 @@ export function basicBSFormChangeReducer(
       return { ...state, deviation: action.deviation }
     case 'max-gas-percentage-price':
       return { ...state, maxGasPercentagePrice: action.maxGasPercentagePrice }
+    case 'current-form':
+      return { ...state, currentForm: action.currentForm }
     case 'with-threshold':
       return { ...state, withThreshold: action.withThreshold }
     case 'tx-details':
@@ -63,6 +67,7 @@ export interface BasicBSFormChange {
   deviation: BigNumber
   withThreshold: boolean
   maxGasPercentagePrice?: MaxGasPriceValues
+  currentForm: CurrentBSForm
   txDetails?: {
     txStatus?: TxStatus
     txError?: TxError

--- a/features/automation/useBasicSellStateInitializator.ts
+++ b/features/automation/useBasicSellStateInitializator.ts
@@ -61,6 +61,10 @@ export function useBasicBSstateInitialization(
       maxGasPercentagePrice: 'FIVE',
     })
     uiChanges.publish(publishKey, {
+      type: 'current-form',
+      currentForm: 'add',
+    })
+    uiChanges.publish(publishKey, {
       type: 'with-threshold',
       withThreshold: true,
     })

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -732,7 +732,9 @@
       "dynamic-stop-price": {
         "footnote": "{{amount}} S/L Coll. Ratio"
       }
-    }
+    },
+    "remove-trigger": "Remove trigger",
+    "add-trigger": "Add trigger"
   },
   "token-balance": "{{token}} balance",
   "token-depositing": "{{token}} depositing {{amount}}",
@@ -1328,7 +1330,7 @@
     "learn-more-heading": "Want to know more?",
     "learn-more-body": "You can visit our <0>knowledge base</0> page to have a deep dive into this strategy. Or ask more questions to our community on <1>Discord →</1>"
   },
-  
+
 
   "basic-buy-sell-generic": {
     "max-gas-fee-trans-value": "Max Gas Fee (% of Transaction Value)",


### PR DESCRIPTION
# [Basic Sell remove trigger handler](https://app.shortcut.com/oazo-apps/story/4917/trigger-removal-basic-sell-logic)

# [Basic Buy remove trigger handler](https://app.shortcut.com/oazo-apps/story/4913/trigger-removal-basic-buy-logic)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added add / remove form switch
- added possibility to remove basic buy / sell trigger
  
## How to test 🧪
  <Please explain how to test your changes>
- using BasicBS feature toggle try to add and remove basic buy / sell triggers
