### PR TITLE
Update vulnerable packages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "zod": "^1.5.0"
   },
   "resolutions": {
+    "ejs": "^3.1.7",
     "minimist": "^1.2.6",
     "mixin-deep": "^1.3.2",
     "mkdirp": "^0.5.5",
@@ -206,6 +207,7 @@
     "codecov": "^3.7.2",
     "crypto-browserify": "^3.12.0",
     "earljs": "^0.0.11",
+    "ejs": "^3.1.7",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13321,6 +13321,13 @@ ejs@^3.1.6:
   dependencies:
     jake "^10.6.1"
 
+ejs@^3.1.7:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
+
 electron-to-chromium@^1.3.30:
   version "1.3.56"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.56.tgz#aad1420d23e9dd8cd2fc2bc53f4928adcf85f02f"
@@ -18130,6 +18137,16 @@ jake@^10.6.1:
   integrity sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==
   dependencies:
     async "0.9.x"
+    chalk "^4.0.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
+
+jake@^10.8.5:
+  version "10.8.5"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
+  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  dependencies:
+    async "^3.2.3"
     chalk "^4.0.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"


### PR DESCRIPTION
# Update vulnerable packages

There are two packages left with critical errors.

### xmlhttprequest-ssl
Used in: `@myetherwallet/mewconnect-connector`.
Chain of dependency: `@myetherwallet/mewconnect-connector` > `@myetherwallet/mewconnect-web-client` > `socket.io-client` > `engine.io-client` > `xmlhttprequest-ssl`

This package is deprecated, so it may takes some time to fix it.

### json-schema
Used in: `snowflake-sdk`, `node-sass`, `@oasisdex/web3-context`, `@oasisdex/connectors`, `web3`, `@oasisdex/connectors`, `@myetherwallet/mewconnect-connector`.
This package is used seven dependencies, but the problem is that it is a deep dependency of dependency of dependency (...), that always ends in the same place. This package in problematic version is used in `request` which is deprecated and even newest version causes this error. Some of the dependencies are our internal commons from `@oasisdex` and maybe they don't need `request` at all, but that doesn't solve others. Needs deep investigation if they can be updated.
  
## Changes 👷‍♀️

- linked `ejs` to resolution in version `^3.1.7`