### PR TITLE
Basic sell trigger always higher than SL trigger

### DIFF
--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -170,7 +170,6 @@ export function ProtectionControl({
                   txHelpers={txHelpersData}
                   context={context}
                   ethMarketPrice={ethAndTokenPrices['ETH']}
-                  tokenMarketPrice={ethAndTokenPrices[vault.token]}
                 />
               }
             />

--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -136,6 +136,15 @@ export function VaultErrors({
         return translate('stop-loss-max-debt')
       case 'targetCollRatioExceededDustLimitCollRatio':
         return translate('target-coll-ratio-exceeded-dust-limit-coll-ratio')
+      case 'minimumSellPriceNotProvided':
+        return (
+          <Trans
+            i18nKey="vault-errors.minimum-sell-price-not-provided"
+            components={{
+              1: <strong />,
+            }}
+          />
+        )
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/automation/common/validators.ts
+++ b/features/automation/common/validators.ts
@@ -41,17 +41,17 @@ export function errorsBasicSellValidation({
   vault,
   ilkData,
   debtDelta,
+  targetCollRatio,
 }: {
   txError?: TxError
   vault: Vault
   ilkData: IlkData
   debtDelta: BigNumber
+  targetCollRatio: BigNumber
 }) {
   const insufficientEthFundsForTx = ethFundsForTxValidator({ txError })
-
-  const targetCollRatioExceededDustLimitCollRatio = ilkData.debtFloor.gt(
-    vault.debt.minus(debtDelta.abs()),
-  )
+  const targetCollRatioExceededDustLimitCollRatio =
+    !targetCollRatio.isZero() && ilkData.debtFloor.gt(vault.debt.plus(debtDelta))
 
   return errorMessagesHandler({
     insufficientEthFundsForTx,

--- a/features/automation/common/validators.ts
+++ b/features/automation/common/validators.ts
@@ -42,19 +42,26 @@ export function errorsBasicSellValidation({
   ilkData,
   debtDelta,
   targetCollRatio,
+  withThreshold,
+  minSellPrice,
 }: {
   txError?: TxError
   vault: Vault
   ilkData: IlkData
   debtDelta: BigNumber
   targetCollRatio: BigNumber
+  withThreshold: boolean
+  minSellPrice?: BigNumber
 }) {
   const insufficientEthFundsForTx = ethFundsForTxValidator({ txError })
   const targetCollRatioExceededDustLimitCollRatio =
     !targetCollRatio.isZero() && ilkData.debtFloor.gt(vault.debt.plus(debtDelta))
 
+  const minimumSellPriceNotProvided = withThreshold && (!minSellPrice || minSellPrice.isZero())
+
   return errorMessagesHandler({
     insufficientEthFundsForTx,
     targetCollRatioExceededDustLimitCollRatio,
+    minimumSellPriceNotProvided,
   })
 }

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -46,7 +46,6 @@ interface AutoSellFormControlProps {
   isAutoSellActive: boolean
   context: Context
   ethMarketPrice: BigNumber
-  tokenMarketPrice: BigNumber
   txHelpers?: TxHelpers
 }
 
@@ -62,7 +61,6 @@ export function AutoSellFormControl({
   txHelpers,
   context,
   ethMarketPrice,
-  tokenMarketPrice,
 }: AutoSellFormControlProps) {
   const [basicSellState] = useUIChanges<BasicBSFormChange>(BASIC_SELL_FORM_CHANGE)
   const { uiChanges, addGasEstimation$ } = useAppContext()
@@ -209,7 +207,7 @@ export function AutoSellFormControl({
 
   const { debtDelta, collateralDelta } = getVaultChange({
     currentCollateralPrice: priceInfo.currentCollateralPrice,
-    marketPrice: tokenMarketPrice,
+    marketPrice: priceInfo.nextCollateralPrice,
     slippage: basicSellState.deviation.div(100),
     debt: vault.debt,
     lockedCollateral: vault.lockedCollateral,

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -72,6 +72,7 @@ export function ProtectionFormControl({
       <StopLossFormControl
         ilkData={ilkData}
         stopLossTriggerData={stopLossTriggerData}
+        autoSellTriggerData={autoSellTriggerData}
         priceInfo={priceInfo}
         vault={vault}
         account={account}

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -29,7 +29,6 @@ interface ProtectionFormControlProps {
   txHelpers?: TxHelpers
   context: Context
   ethMarketPrice: BigNumber
-  tokenMarketPrice: BigNumber
   account?: string
 }
 
@@ -43,7 +42,6 @@ export function ProtectionFormControl({
   context,
   txHelpers,
   ethMarketPrice,
-  tokenMarketPrice,
 }: ProtectionFormControlProps) {
   const stopLossTriggerData = extractStopLossData(automationTriggersData)
   const autoSellTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicSell)
@@ -94,7 +92,6 @@ export function ProtectionFormControl({
         context={context}
         txHelpers={txHelpers}
         ethMarketPrice={ethMarketPrice}
-        tokenMarketPrice={tokenMarketPrice}
       />
     </>
   )

--- a/features/automation/protection/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/controls/StopLossFormControl.tsx
@@ -5,6 +5,7 @@ import { Vault } from 'blockchain/vaults'
 import { TxHelpers, UIChanges } from 'components/AppContext'
 import { useAppContext } from 'components/AppContextProvider'
 import { useSharedUI } from 'components/SharedUIProvider'
+import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { accountIsConnectedValidator } from 'features/form/commonValidators'
 import { BalanceInfo } from 'features/shared/balanceInfo'
@@ -31,6 +32,7 @@ interface StopLossFormsProps {
   balanceInfo: BalanceInfo
   accountIsController: boolean
   stopLossTriggerData: StopLossTriggerData
+  autoSellTriggerData: BasicBSTriggerData
   ethMarketPrice: BigNumber
   txHelpers?: TxHelpers
 }
@@ -46,6 +48,7 @@ function StopLossForms({
   txHelpers,
   accountIsController,
   stopLossTriggerData,
+  autoSellTriggerData,
   ethMarketPrice,
 }: StopLossFormsProps) {
   return currentForm?.currentMode === AutomationFromKind.CANCEL ? (
@@ -72,6 +75,7 @@ function StopLossForms({
       priceInfo={priceInfo}
       ilkData={ilkData}
       triggerData={stopLossTriggerData}
+      autoSellTriggerData={autoSellTriggerData}
       tx={txHelpers}
       ctx={context}
       accountIsController={accountIsController}
@@ -90,6 +94,7 @@ function StopLossForms({
 interface StopLossFormControlProps {
   ilkData: IlkData
   stopLossTriggerData: StopLossTriggerData
+  autoSellTriggerData: BasicBSTriggerData
   priceInfo: PriceInfo
   vault: Vault
   balanceInfo: BalanceInfo
@@ -103,6 +108,7 @@ interface StopLossFormControlProps {
 export function StopLossFormControl({
   ilkData,
   stopLossTriggerData,
+  autoSellTriggerData,
   priceInfo,
   vault,
   account,
@@ -142,6 +148,7 @@ export function StopLossFormControl({
         balanceInfo={balanceInfo}
         accountIsController={accountIsController}
         stopLossTriggerData={stopLossTriggerData}
+        autoSellTriggerData={autoSellTriggerData}
         ethMarketPrice={ethMarketPrice}
       />
     ) : (
@@ -159,6 +166,7 @@ export function StopLossFormControl({
       balanceInfo={balanceInfo}
       accountIsController={accountIsController}
       stopLossTriggerData={stopLossTriggerData}
+      autoSellTriggerData={autoSellTriggerData}
       ethMarketPrice={ethMarketPrice}
     />
   )

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -125,10 +125,12 @@ export function SidebarAutoSellAddEditingStage({
           value1: uiStateBasicSell.targetCollRatio.toNumber(),
         }}
         valueColors={{
-          value1: 'onSuccess',
+          value0: 'onWarning',
+          value1: 'primary',
         }}
         leftDescription={t('auto-sell.sell-trigger-ratio')}
         rightDescription={t('auto-sell.target-coll-ratio')}
+        leftThumbColor="onWarning"
         rightThumbColor="primary"
       />
       <VaultActionInput

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -51,11 +51,11 @@ function AutoSellInfoSectionControl({
       slippageLimit={basicSellState.deviation}
       collateralAfterNextSell={{
         value: vault.lockedCollateral,
-        secondaryValue: vault.lockedCollateral.minus(collateralDelta.abs()),
+        secondaryValue: vault.lockedCollateral.plus(collateralDelta),
       }}
       outstandingDebtAfterSell={{
         value: vault.debt,
-        secondaryValue: vault.debt.minus(debtDelta.abs()),
+        secondaryValue: vault.debt.plus(debtDelta),
       }}
       ethToBeSoldAtNextSell={collateralDelta.abs()}
       estimatedTransactionCost={addTriggerGasEstimation}

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -109,6 +109,7 @@ export function SidebarSetupAutoSell({
     ilkData,
     vault,
     debtDelta,
+    targetCollRatio: basicSellState.targetCollRatio,
   })
 
   const warnings = warningsBasicSellValidation({

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -110,6 +110,8 @@ export function SidebarSetupAutoSell({
     vault,
     debtDelta,
     targetCollRatio: basicSellState.targetCollRatio,
+    withThreshold: basicSellState.withThreshold,
+    minSellPrice: basicSellState.maxBuyOrMinSellPrice,
   })
 
   const warnings = warningsBasicSellValidation({

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -22,7 +22,7 @@ import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
 import { getSidebarTitle } from 'features/sidebar/getSidebarTitle'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import { SidebarFlow, SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
-import { extractCancelAutoSellWarnings } from 'helpers/messageMappers'
+import { extractCancelAutoSellErrors, extractCancelAutoSellWarnings } from 'helpers/messageMappers'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
 import { Grid } from 'theme-ui'
@@ -124,6 +124,7 @@ export function SidebarSetupAutoSell({
   })
 
   const cancelAutoSellWarnings = extractCancelAutoSellWarnings(warnings)
+  const cancelAutoSellErrors = extractCancelAutoSellErrors(errors)
 
   if (isAutoSellActive) {
     const sidebarSectionProps: SidebarSectionProps = {
@@ -158,7 +159,7 @@ export function SidebarSetupAutoSell({
                 <SidebarAutoSellCancelEditingStage
                   vault={vault}
                   ilkData={ilkData}
-                  errors={errors}
+                  errors={cancelAutoSellErrors}
                   warnings={cancelAutoSellWarnings}
                   cancelTriggerGasEstimation={cancelTriggerGasEstimation}
                 />

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -34,6 +34,7 @@ export type VaultErrorMessage =
   | 'stopLossHigherThanCurrentOrNext'
   | 'maxDebtForSettingStopLoss'
   | 'targetCollRatioExceededDustLimitCollRatio'
+  | 'minimumSellPriceNotProvided'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -70,6 +71,7 @@ interface ErrorMessagesHandler {
   stopLossHigherThanCurrentOrNext?: boolean
   maxDebtForSettingStopLoss?: boolean
   targetCollRatioExceededDustLimitCollRatio?: boolean
+  minimumSellPriceNotProvided?: boolean
 }
 
 export function errorMessagesHandler({
@@ -107,6 +109,7 @@ export function errorMessagesHandler({
   stopLossHigherThanCurrentOrNext,
   maxDebtForSettingStopLoss,
   targetCollRatioExceededDustLimitCollRatio,
+  minimumSellPriceNotProvided,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -244,6 +247,9 @@ export function errorMessagesHandler({
 
   if (targetCollRatioExceededDustLimitCollRatio) {
     errorMessages.push('targetCollRatioExceededDustLimitCollRatio')
+  }
+  if (minimumSellPriceNotProvided) {
+    errorMessages.push('minimumSellPriceNotProvided')
   }
 
   return errorMessages

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -95,3 +95,9 @@ const cancelAutoSellWarnings = ['potentialInsufficientEthFundsForTx']
 export function extractCancelAutoSellWarnings(warningMessages: VaultWarningMessage[]) {
   return warningMessages.filter((message) => cancelAutoSellWarnings.includes(message))
 }
+
+const cancelAutoSellErrors = ['insufficientEthFundsForTx']
+
+export function extractCancelAutoSellErrors(errorMessages: VaultErrorMessage[]) {
+  return errorMessages.filter((message) => cancelAutoSellErrors.includes(message))
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -818,7 +818,8 @@
     "vault-will-be-taken-under-min-active-col-ratio": "You cannot make adjustments to your vault which take it below your minimum active coll. ratio at current or next collateral price",
     "stop-loss-near-liquidation-ratio": "Your Stop-Loss Trigger Col. Ratio would cause closing vault immediately. If this is intended, close your vault",
     "stop-loss-max-debt": "The Stop-Loss cannot be created due to the high price impact of the order. Your total vault debt has to be less than 20m DAI",
-    "target-coll-ratio-exceeded-dust-limit-coll-ratio": "You cannot select a higher Target Collateralization Ratio, as it would result in the vault hitting the dust limit"
+    "target-coll-ratio-exceeded-dust-limit-coll-ratio": "You cannot select a higher Target Collateralization Ratio, as it would result in the vault hitting the dust limit",
+    "minimum-sell-price-not-provided": "Please enter a minimum sell price or select <1>Set No Threshold<1>"
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",


### PR DESCRIPTION
# [Basic sell trigger always higher than SL trigger](https://app.shortcut.com/oazo-apps/story/4940/validation-basic-sell-higher-than-stop-loss)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added validation to basic sell and stop loss form to verify whether triggers are in correct state
  
## How to test 🧪
  <Please explain how to test your changes>

- when SL is enabled a basic sell trigger has to be higher
- when basic sell is enabled, SL has to be lower
