### PR TITLE
added validation to specify max buy price or no threshold

### DIFF
--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -136,6 +136,8 @@ export function VaultErrors({
         return translate('stop-loss-max-debt')
       case 'targetCollRatioExceededDustLimitCollRatio':
         return translate('target-coll-ratio-exceeded-dust-limit-coll-ratio')
+      case 'autoBuyMaxBuyPriceNotSpecified':
+        return translate('auto-buy-max-price-requred')  
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/automation/common/validators.ts
+++ b/features/automation/common/validators.ts
@@ -5,6 +5,7 @@ import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/co
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
 import { warningMessagesHandler } from 'features/form/warningMessagesHandler'
 import { TxError } from 'helpers/types'
+import { zero } from 'helpers/zero'
 
 export function warningsBasicSellValidation({
   token,
@@ -57,4 +58,15 @@ export function errorsBasicSellValidation({
     insufficientEthFundsForTx,
     targetCollRatioExceededDustLimitCollRatio,
   })
+}
+
+export function errorsAddBasicBuyValidation({
+  maxBuyPrice,
+  withThreshold,
+}: {
+  maxBuyPrice?: BigNumber
+  withThreshold: boolean
+}) {
+  const autoBuyMaxBuyPriceNotSpecified = withThreshold && (!maxBuyPrice || maxBuyPrice.isZero())
+  return errorMessagesHandler({autoBuyMaxBuyPriceNotSpecified})
 }

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -10,6 +10,7 @@ import { MultipleRangeSlider } from 'components/vault/MultipleRangeSlider'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { getEstimatedGasFeeText } from 'components/vault/VaultChangesInformation'
+import { VaultErrors } from 'components/vault/VaultErrors'
 import { BuyInfoSection } from 'features/automation/basicBuySell/InfoSections/BuyInfoSection'
 import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
@@ -17,6 +18,7 @@ import {
   BASIC_BUY_FORM_CHANGE,
   BasicBSFormChange,
 } from 'features/automation/protection/common/UITypes/basicBSFormChange'
+import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { GasEstimationStatus } from 'helpers/form'
@@ -35,6 +37,8 @@ interface SidebarAutoBuyEditingStageProps {
   isEditing: boolean
   autoBuyTriggerData: BasicBSTriggerData
   priceInfo: PriceInfo
+  errors: VaultErrorMessage[]
+
 }
 
 export function SidebarAutoBuyEditingStage({
@@ -45,6 +49,7 @@ export function SidebarAutoBuyEditingStage({
   basicBuyState,
   autoBuyTriggerData,
   priceInfo,
+  errors,
 }: SidebarAutoBuyEditingStageProps) {
   const { uiChanges } = useAppContext()
   const { t } = useTranslation()
@@ -108,6 +113,12 @@ export function SidebarAutoBuyEditingStage({
         toggleOffPlaceholder={t('protection.no-threshold')}
         defaultToggle={basicBuyState.withThreshold}
       />
+            {isEditing && (
+        <>
+          <VaultErrors errorMessages={errors} ilkData={ilkData} />
+          {/* <VaultWarnings warningMessages={warnings} ilkData={ilkData} /> */}
+        </>
+      )}
 
       <SidebarResetButton
         clear={() => {

--- a/features/automation/optimization/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
@@ -2,11 +2,14 @@ import {
   AutomationBotRemoveTriggerData,
   removeAutomationBotTrigger,
 } from 'blockchain/calls/automationBot'
+import { IlkData } from 'blockchain/ilks'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { getEstimatedGasFeeText } from 'components/vault/VaultChangesInformation'
+import { VaultErrors } from 'components/vault/VaultErrors'
 import { BuyInfoSection } from 'features/automation/basicBuySell/InfoSections/BuyInfoSection'
 import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
+import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { GasEstimationStatus } from 'helpers/form'
@@ -21,6 +24,8 @@ interface SidebarAutoBuyRemovalEditingStageProps {
   priceInfo: PriceInfo
   cancelTxData: AutomationBotRemoveTriggerData
   basicBuyState: BasicBSFormChange
+  ilkData: IlkData
+  errors: VaultErrorMessage[]
 }
 
 export function SidebarAutoBuyRemovalEditingStage({
@@ -28,6 +33,8 @@ export function SidebarAutoBuyRemovalEditingStage({
   cancelTxData,
   priceInfo,
   basicBuyState,
+  ilkData,
+  errors,
 }: SidebarAutoBuyRemovalEditingStageProps) {
   // TODO dummy changes information for now
   return (
@@ -35,6 +42,8 @@ export function SidebarAutoBuyRemovalEditingStage({
       <Text as="p" variant="paragraph3" sx={{ color: 'lavender' }}>
         To cancel the Auto-Buy you’ll need to click the button below and confirm the transaction.
       </Text>
+      {/* <VaultErrors errorMessages={errors} ilkData={ilkData} /> */}
+      {/* <VaultWarnings warningMessages={warnings} ilkData={ilkData} /> */}
       <AutoBuyInfoSectionControl
         cancelTxData={cancelTxData}
         priceInfo={priceInfo}

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -17,6 +17,7 @@ import {
 } from 'features/automation/common/basicBStxHandlers'
 import { resolveMaxBuyOrMinSellPrice } from 'features/automation/common/helpers'
 import { failedStatuses, progressStatuses } from 'features/automation/common/txStatues'
+import { errorsAddBasicBuyValidation as createBasicBuyErrorsValidation } from 'features/automation/common/validators'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
@@ -130,6 +131,12 @@ export function SidebarSetupAutoBuy({
     ? 'addBasicBuy'
     : 'editBasicBuy'
   const primaryButtonLabel = getPrimaryButtonLabel({ flow, stage })
+  const creationErrors = createBasicBuyErrorsValidation({
+    maxBuyPrice: uiState.maxBuyOrMinSellPrice,
+    withThreshold: uiState.withThreshold
+  })
+  console.log('errors')
+  console.log(creationErrors)
 
   const sidebarStatus = getSidebarStatus({
     stage,
@@ -154,6 +161,7 @@ export function SidebarSetupAutoBuy({
                   isEditing={isEditing}
                   autoBuyTriggerData={autoBuyTriggerData}
                   priceInfo={priceInfo}
+                  errors={creationErrors}
                 />
               )}
               {isRemoveForm && (
@@ -162,6 +170,8 @@ export function SidebarSetupAutoBuy({
                   cancelTxData={cancelTxData}
                   priceInfo={priceInfo}
                   basicBuyState={uiState}
+                  ilkData={ilkData}
+                  errors={creationErrors}
                 />
               )}
             </>
@@ -173,7 +183,7 @@ export function SidebarSetupAutoBuy({
       ),
       primaryButton: {
         label: primaryButtonLabel,
-        disabled: isDisabled,
+        disabled: isDisabled || !!creationErrors.length,
         isLoading: stage === 'txInProgress',
         action: () => {
           if (txHelpers) {

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -34,6 +34,7 @@ export type VaultErrorMessage =
   | 'stopLossHigherThanCurrentOrNext'
   | 'maxDebtForSettingStopLoss'
   | 'targetCollRatioExceededDustLimitCollRatio'
+  | 'autoBuyMaxBuyPriceNotSpecified'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -70,6 +71,7 @@ interface ErrorMessagesHandler {
   stopLossHigherThanCurrentOrNext?: boolean
   maxDebtForSettingStopLoss?: boolean
   targetCollRatioExceededDustLimitCollRatio?: boolean
+  autoBuyMaxBuyPriceNotSpecified?: boolean
 }
 
 export function errorMessagesHandler({
@@ -107,6 +109,7 @@ export function errorMessagesHandler({
   stopLossHigherThanCurrentOrNext,
   maxDebtForSettingStopLoss,
   targetCollRatioExceededDustLimitCollRatio,
+  autoBuyMaxBuyPriceNotSpecified,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -244,6 +247,10 @@ export function errorMessagesHandler({
 
   if (targetCollRatioExceededDustLimitCollRatio) {
     errorMessages.push('targetCollRatioExceededDustLimitCollRatio')
+  }
+
+  if(autoBuyMaxBuyPriceNotSpecified) {
+    errorMessages.push('autoBuyMaxBuyPriceNotSpecified')
   }
 
   return errorMessages

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -818,7 +818,8 @@
     "vault-will-be-taken-under-min-active-col-ratio": "You cannot make adjustments to your vault which take it below your minimum active coll. ratio at current or next collateral price",
     "stop-loss-near-liquidation-ratio": "Your Stop-Loss Trigger Col. Ratio would cause closing vault immediately. If this is intended, close your vault",
     "stop-loss-max-debt": "The Stop-Loss cannot be created due to the high price impact of the order. Your total vault debt has to be less than 20m DAI",
-    "target-coll-ratio-exceeded-dust-limit-coll-ratio": "You cannot select a higher Target Collateralization Ratio, as it would result in the vault hitting the dust limit"
+    "target-coll-ratio-exceeded-dust-limit-coll-ratio": "You cannot select a higher Target Collateralization Ratio, as it would result in the vault hitting the dust limit",
+    "auto-buy-max-price-requred": "Please enter a maximum buy price or select <1>Set No Threshold<1>"
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",


### PR DESCRIPTION
# [added validation to specify max buy price or no threshold](https://app.shortcut.com/oazo-apps/story/4990/validation-basic-buy-set-max-buy-price)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- item 1
  
## How to test 🧪
  <Please explain how to test your changes>
- step 1 ...
