### PR TITLE
Added basic sell and buy overview validation

### DIFF
--- a/components/vault/MultipleRangeSlider.tsx
+++ b/components/vault/MultipleRangeSlider.tsx
@@ -132,20 +132,22 @@ export function MultipleRangeSlider({
     }
   }, [middleMark?.value])
 
+  const dotsSpace = 5
+
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>, slider: number) => {
       const newValue = Number(e.target.value)
 
       if (
         slider === 0 &&
-        (newValue > value1 - step || (middleMark && newValue > middleMark.value - step))
+        (newValue > value1 - dotsSpace || (middleMark && newValue > middleMark.value - dotsSpace))
       ) {
         return
       }
 
       if (
         slider === 1 &&
-        (newValue < value0 + step || (middleMark && newValue < middleMark.value + step))
+        (newValue < value0 + dotsSpace || (middleMark && newValue < middleMark.value + dotsSpace))
       ) {
         return
       }

--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -126,6 +126,8 @@ export function VaultErrors({
         return translate('invalid-slippage')
       case 'afterCollRatioBelowStopLossRatio':
         return translate('after-coll-ratio-below-stop-loss-ratio')
+      case 'afterCollRatioBelowBasicSellRatio':
+        return translate('after-coll-ratio-below-basic-sell-ratio')
       case 'vaultWillBeTakenUnderMinActiveColRatio':
         return translate('vault-will-be-taken-under-min-active-col-ratio')
       case 'stopLossOnNearLiquidationRatio':

--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -128,6 +128,8 @@ export function VaultErrors({
         return translate('after-coll-ratio-below-stop-loss-ratio')
       case 'afterCollRatioBelowBasicSellRatio':
         return translate('after-coll-ratio-below-basic-sell-ratio')
+      case 'afterCollRatioAboveBasicBuyRatio':
+        return translate('after-coll-ratio-above-basic-buy-ratio')
       case 'vaultWillBeTakenUnderMinActiveColRatio':
         return translate('vault-will-be-taken-under-min-active-col-ratio')
       case 'stopLossOnNearLiquidationRatio':

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -74,6 +74,7 @@ export function SidebarAutoBuyEditingStage({
         valueColors={{
           value1: 'onSuccess',
         }}
+        step={1}
         leftDescription={t('auto-buy.target-coll-ratio')}
         rightDescription={t('auto-buy.trigger-coll-ratio')}
         minDescription={`(${t('auto-buy.min-ratio')})`}

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -1,7 +1,7 @@
 import { TriggerType } from '@oasisdex/automation'
 import { TxStatus } from '@oasisdex/transactions'
 import BigNumber from 'bignumber.js'
-import { addAutomationBotTrigger } from 'blockchain/calls/automationBot'
+import { addAutomationBotTrigger, removeAutomationBotTrigger } from 'blockchain/calls/automationBot'
 import { IlkData } from 'blockchain/ilks'
 import { Context } from 'blockchain/network'
 import { Vault } from 'blockchain/vaults'
@@ -103,18 +103,22 @@ export function AutoSellFormControl({
     addTriggerGasEstimationData &&
     (addTriggerGasEstimationData as HasGasEstimation).gasEstimationUsd
 
-  const cancelTxData = prepareRemoveBasicBSTriggerData({
-    vaultData: vault,
-    triggerType: TriggerType.BasicSell,
-    triggerId: basicSellState.triggerId,
-  })
+  const cancelTxData = useMemo(
+    () =>
+      prepareRemoveBasicBSTriggerData({
+        vaultData: vault,
+        triggerType: TriggerType.BasicSell,
+        triggerId: basicSellState.triggerId,
+      }),
+    [basicSellState.triggerId.toNumber()],
+  )
 
   const cancelTriggerGasEstimationData$ = useMemo(() => {
     return addGasEstimation$(
       { gasEstimationStatus: GasEstimationStatus.unset },
-      ({ estimateGas }) => estimateGas(addAutomationBotTrigger, addTxData),
+      ({ estimateGas }) => estimateGas(removeAutomationBotTrigger, cancelTxData),
     )
-  }, [addTxData])
+  }, [cancelTxData])
 
   const [cancelTriggerGasEstimationData] = useObservable(cancelTriggerGasEstimationData$)
   const cancelTriggerGasEstimation = getEstimatedGasFeeText(cancelTriggerGasEstimationData)

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -128,6 +128,7 @@ export function SidebarAutoSellAddEditingStage({
           value0: 'onWarning',
           value1: 'primary',
         }}
+        step={1}
         leftDescription={t('auto-sell.sell-trigger-ratio')}
         rightDescription={t('auto-sell.target-coll-ratio')}
         leftThumbColor="onWarning"

--- a/features/automation/protection/triggers/AutomationTriggersData.ts
+++ b/features/automation/protection/triggers/AutomationTriggersData.ts
@@ -80,7 +80,7 @@ export function createAutomationTriggersChange$(
     : []
 }
 
-export interface StopLossChange {
+export interface AutomationTriggersChange {
   kind: 'automationTriggersData'
   stopLossData: StopLossTriggerData
   basicSellData: BasicBSTriggerData

--- a/features/automation/protection/triggers/AutomationTriggersData.ts
+++ b/features/automation/protection/triggers/AutomationTriggersData.ts
@@ -1,7 +1,12 @@
+import { TriggerType } from '@oasisdex/automation'
 import BigNumber from 'bignumber.js'
 import { networksById } from 'blockchain/config'
 import { Context, every5Seconds$ } from 'blockchain/network'
 import { Vault } from 'blockchain/vaults'
+import {
+  BasicBSTriggerData,
+  extractBasicBSData,
+} from 'features/automation/common/basicBSTriggerData'
 import {
   extractStopLossData,
   StopLossTriggerData,
@@ -57,7 +62,7 @@ export function createAutomationTriggersData(
   )
 }
 
-export function createStopLossDataChange$(
+export function createAutomationTriggersChange$(
   automationTriggersData$: (id: BigNumber) => Observable<TriggersData>,
   id: BigNumber,
 ) {
@@ -66,14 +71,18 @@ export function createStopLossDataChange$(
   return stopLossReadEnabled
     ? automationTriggersData$(id).pipe(
         map((triggers) => ({
-          kind: 'stopLossData',
+          kind: 'automationTriggersData',
           stopLossData: extractStopLossData(triggers),
+          basicSellData: extractBasicBSData(triggers, TriggerType.BasicSell),
+          basicBuyData: extractBasicBSData(triggers, TriggerType.BasicBuy),
         })),
       )
     : []
 }
 
 export interface StopLossChange {
-  kind: 'stopLossData'
+  kind: 'automationTriggersData'
   stopLossData: StopLossTriggerData
+  basicSellData: BasicBSTriggerData
+  basicBuyData: BasicBSTriggerData
 }

--- a/features/borrow/manage/pipes/adapters/standardBorrowManageAdapter.ts
+++ b/features/borrow/manage/pipes/adapters/standardBorrowManageAdapter.ts
@@ -101,6 +101,8 @@ export const StandardBorrowManageAdapter: BorrowManageAdapterInterface<
       gasEstimationStatus: GasEstimationStatus.unset,
       vaultHistory: [],
       stopLossData: undefined,
+      basicBuyData: undefined,
+      basicSellData: undefined,
       injectStateOverride,
     }
     return initialState

--- a/features/borrow/manage/pipes/manageVault.ts
+++ b/features/borrow/manage/pipes/manageVault.ts
@@ -4,6 +4,7 @@ import { createIlkDataChange$, IlkData } from 'blockchain/ilks'
 import { Context } from 'blockchain/network'
 import { createVaultChange$, Vault } from 'blockchain/vaults'
 import { AddGasEstimationFunction, TxHelpers } from 'components/AppContext'
+import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { calculateInitialTotalSteps } from 'features/borrow/open/pipes/openVaultConditions'
 import {
@@ -26,7 +27,7 @@ import { MakerVaultType } from '../../../../blockchain/calls/vaultResolver'
 import { SelectedDaiAllowanceRadio } from '../../../../components/vault/commonMultiply/ManageVaultDaiAllowance'
 import { TxError } from '../../../../helpers/types'
 import {
-  createStopLossDataChange$,
+  createAutomationTriggersChange$,
   TriggersData,
 } from '../../../automation/protection/triggers/AutomationTriggersData'
 import { VaultErrorMessage } from '../../../form/errorMessagesHandler'
@@ -169,6 +170,8 @@ export type GenericManageBorrowVaultState<V extends Vault> = MutableManageVaultS
     totalSteps: number
     currentStep: number
     stopLossData?: StopLossTriggerData
+    basicBuyData?: BasicBSTriggerData
+    basicSellData?: BasicBSTriggerData
   } & HasGasEstimation
 
 export type ManageStandardBorrowVaultState = GenericManageBorrowVaultState<Vault>
@@ -442,7 +445,7 @@ export function createManageVault$<V extends Vault, VS extends ManageStandardBor
                     createIlkDataChange$(ilkData$, vault.ilk),
                     createVaultChange$(vault$, id, context.chainId),
                     createHistoryChange$(vaultHistory$, id),
-                    createStopLossDataChange$(automationTriggersData$, id),
+                    createAutomationTriggersChange$(automationTriggersData$, id),
                   )
 
                   const connectedProxyAddress$ = account ? proxyAddress$(account) : of(undefined)

--- a/features/borrow/manage/pipes/manageVaultValidations.ts
+++ b/features/borrow/manage/pipes/manageVaultValidations.ts
@@ -28,6 +28,7 @@ export function validateErrors(
     depositCollateralOnVaultUnderDebtFloor,
     ledgerWalletContractDataDisabled,
     afterCollRatioBelowStopLossRatio,
+    afterCollRatioBelowBasicSellRatio,
     insufficientEthFundsForTx,
   } = state
 
@@ -50,6 +51,7 @@ export function validateErrors(
         withdrawCollateralOnVaultUnderDebtFloor,
         depositCollateralOnVaultUnderDebtFloor,
         afterCollRatioBelowStopLossRatio,
+        afterCollRatioBelowBasicSellRatio,
       }),
     )
   }

--- a/features/borrow/manage/pipes/manageVaultValidations.ts
+++ b/features/borrow/manage/pipes/manageVaultValidations.ts
@@ -29,6 +29,7 @@ export function validateErrors(
     ledgerWalletContractDataDisabled,
     afterCollRatioBelowStopLossRatio,
     afterCollRatioBelowBasicSellRatio,
+    afterCollRatioAboveBasicBuyRatio,
     insufficientEthFundsForTx,
   } = state
 
@@ -52,6 +53,7 @@ export function validateErrors(
         depositCollateralOnVaultUnderDebtFloor,
         afterCollRatioBelowStopLossRatio,
         afterCollRatioBelowBasicSellRatio,
+        afterCollRatioAboveBasicBuyRatio,
       }),
     )
   }

--- a/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
+++ b/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
@@ -1,10 +1,10 @@
 import { IlkDataChange } from 'blockchain/ilks'
 import { VaultChange } from 'blockchain/vaults'
+import { AutomationTriggersChange } from 'features/automation/protection/triggers/AutomationTriggersData'
+import { BalanceInfoChange } from 'features/shared/balanceInfo'
 import { PriceInfoChange } from 'features/shared/priceInfo'
+import { VaultHistoryChange } from 'features/vaultHistory/vaultHistory'
 
-import { StopLossChange } from '../../../../automation/protection/triggers/AutomationTriggersData'
-import { BalanceInfoChange } from '../../../../shared/balanceInfo'
-import { VaultHistoryChange } from '../../../../vaultHistory/vaultHistory'
 import { ManageStandardBorrowVaultState, ManageVaultChange } from '../manageVault'
 
 export type ManageVaultEnvironmentChange =
@@ -13,7 +13,7 @@ export type ManageVaultEnvironmentChange =
   | IlkDataChange
   | VaultChange
   | VaultHistoryChange
-  | StopLossChange
+  | AutomationTriggersChange
 
 export function applyManageVaultEnvironment<VaultState extends ManageStandardBorrowVaultState>(
   change: ManageVaultChange,

--- a/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
+++ b/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
@@ -54,10 +54,12 @@ export function applyManageVaultEnvironment<VaultState extends ManageStandardBor
     }
   }
 
-  if (change.kind === 'stopLossData') {
+  if (change.kind === 'automationTriggersData') {
     return {
       ...state,
       stopLossData: change.stopLossData,
+      basicSellData: change.basicSellData,
+      basicBuyData: change.basicBuyData,
     }
   }
 

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js'
 
 import { maxUint256 } from '../../blockchain/calls/erc20'
 import { isNullish } from '../../helpers/functions'
-import { STOP_LOSS_MARGIN } from '../../helpers/multiply/calculations'
 import { TxError } from '../../helpers/types'
 import { zero } from '../../helpers/zero'
 
@@ -431,23 +430,37 @@ export function daiAllowanceProgressionDisabledValidator({
   )
 }
 
-export function afterCollRatioBelowThresholdRatioValidator({
+export function afterCollRatioThresholdRatioValidator({
   afterCollateralizationRatio,
   afterCollateralizationRatioAtNextPrice,
   threshold,
+  margin = new BigNumber(0.02),
+  type,
 }: {
   afterCollateralizationRatio: BigNumber
   afterCollateralizationRatioAtNextPrice: BigNumber
   threshold: BigNumber
+  margin?: BigNumber
+  type: 'below' | 'above'
 }) {
   if (afterCollateralizationRatio.isZero() || afterCollateralizationRatioAtNextPrice.isZero()) {
     return false
   }
 
-  return (
-    afterCollateralizationRatio.lt(threshold) ||
-    afterCollateralizationRatioAtNextPrice.minus(STOP_LOSS_MARGIN).lte(threshold)
-  )
+  switch (type) {
+    case 'below':
+      return (
+        afterCollateralizationRatio.lt(threshold) ||
+        afterCollateralizationRatioAtNextPrice.minus(margin).lte(threshold)
+      )
+    case 'above':
+      return (
+        afterCollateralizationRatio.gt(threshold) ||
+        afterCollateralizationRatioAtNextPrice.plus(margin).gte(threshold)
+      )
+    default:
+      return false
+  }
 }
 
 export function stopLossCloseToCollRatioValidator({

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -431,22 +431,22 @@ export function daiAllowanceProgressionDisabledValidator({
   )
 }
 
-export function afterCollRatioBelowStopLossRatioValidator({
+export function afterCollRatioBelowThresholdRatioValidator({
   afterCollateralizationRatio,
   afterCollateralizationRatioAtNextPrice,
-  stopLossRatio,
+  threshold,
 }: {
   afterCollateralizationRatio: BigNumber
   afterCollateralizationRatioAtNextPrice: BigNumber
-  stopLossRatio: BigNumber
+  threshold: BigNumber
 }) {
   if (afterCollateralizationRatio.isZero() || afterCollateralizationRatioAtNextPrice.isZero()) {
     return false
   }
 
   return (
-    afterCollateralizationRatio.lt(stopLossRatio) ||
-    afterCollateralizationRatioAtNextPrice.minus(STOP_LOSS_MARGIN).lte(stopLossRatio)
+    afterCollateralizationRatio.lt(threshold) ||
+    afterCollateralizationRatioAtNextPrice.minus(STOP_LOSS_MARGIN).lte(threshold)
   )
 }
 

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -30,6 +30,7 @@ export type VaultErrorMessage =
   | 'invalidSlippage'
   | 'afterCollRatioBelowStopLossRatio'
   | 'afterCollRatioBelowBasicSellRatio'
+  | 'afterCollRatioAboveBasicBuyRatio'
   | 'vaultWillBeTakenUnderMinActiveColRatio'
   | 'stopLossOnNearLiquidationRatio'
   | 'stopLossHigherThanCurrentOrNext'
@@ -69,6 +70,7 @@ interface ErrorMessagesHandler {
   invalidSlippage?: boolean
   afterCollRatioBelowStopLossRatio?: boolean
   afterCollRatioBelowBasicSellRatio?: boolean
+  afterCollRatioAboveBasicBuyRatio?: boolean
   stopLossOnNearLiquidationRatio?: boolean
   stopLossHigherThanCurrentOrNext?: boolean
   maxDebtForSettingStopLoss?: boolean
@@ -108,6 +110,7 @@ export function errorMessagesHandler({
   invalidSlippage,
   afterCollRatioBelowStopLossRatio,
   afterCollRatioBelowBasicSellRatio,
+  afterCollRatioAboveBasicBuyRatio,
   stopLossOnNearLiquidationRatio,
   stopLossHigherThanCurrentOrNext,
   maxDebtForSettingStopLoss,
@@ -234,6 +237,10 @@ export function errorMessagesHandler({
 
   if (afterCollRatioBelowBasicSellRatio) {
     errorMessages.push('afterCollRatioBelowBasicSellRatio')
+  }
+
+  if (afterCollRatioAboveBasicBuyRatio) {
+    errorMessages.push('afterCollRatioAboveBasicBuyRatio')
   }
 
   if (insufficientEthFundsForTx) {

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -29,6 +29,7 @@ export type VaultErrorMessage =
   | 'depositCollateralOnVaultUnderDebtFloor'
   | 'invalidSlippage'
   | 'afterCollRatioBelowStopLossRatio'
+  | 'afterCollRatioBelowBasicSellRatio'
   | 'vaultWillBeTakenUnderMinActiveColRatio'
   | 'stopLossOnNearLiquidationRatio'
   | 'stopLossHigherThanCurrentOrNext'
@@ -67,6 +68,7 @@ interface ErrorMessagesHandler {
   shouldShowExchangeError?: boolean
   invalidSlippage?: boolean
   afterCollRatioBelowStopLossRatio?: boolean
+  afterCollRatioBelowBasicSellRatio?: boolean
   stopLossOnNearLiquidationRatio?: boolean
   stopLossHigherThanCurrentOrNext?: boolean
   maxDebtForSettingStopLoss?: boolean
@@ -105,6 +107,7 @@ export function errorMessagesHandler({
   shouldShowExchangeError,
   invalidSlippage,
   afterCollRatioBelowStopLossRatio,
+  afterCollRatioBelowBasicSellRatio,
   stopLossOnNearLiquidationRatio,
   stopLossHigherThanCurrentOrNext,
   maxDebtForSettingStopLoss,
@@ -227,6 +230,10 @@ export function errorMessagesHandler({
 
   if (afterCollRatioBelowStopLossRatio) {
     errorMessages.push('afterCollRatioBelowStopLossRatio')
+  }
+
+  if (afterCollRatioBelowBasicSellRatio) {
+    errorMessages.push('afterCollRatioBelowBasicSellRatio')
   }
 
   if (insufficientEthFundsForTx) {

--- a/features/multiply/manage/pipes/manageMultiplyVault.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVault.ts
@@ -5,6 +5,7 @@ import { Context } from 'blockchain/network'
 import { createVaultChange$, Vault } from 'blockchain/vaults'
 import { AddGasEstimationFunction, TxHelpers } from 'components/AppContext'
 import { SelectedDaiAllowanceRadio } from 'components/vault/commonMultiply/ManageVaultDaiAllowance'
+import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { calculateInitialTotalSteps } from 'features/borrow/open/pipes/openVaultConditions'
 import { ExchangeAction, ExchangeType, Quote } from 'features/exchange/exchange'
@@ -23,7 +24,7 @@ import { combineLatest, merge, Observable, of, Subject } from 'rxjs'
 import { first, map, scan, shareReplay, switchMap, tap } from 'rxjs/operators'
 
 import {
-  createStopLossDataChange$,
+  createAutomationTriggersChange$,
   TriggersData,
 } from '../../../automation/protection/triggers/AutomationTriggersData'
 import { VaultErrorMessage } from '../../../form/errorMessagesHandler'
@@ -260,6 +261,8 @@ export type ManageMultiplyVaultState = MutableManageMultiplyVaultState &
     totalSteps: number
     currentStep: number
     stopLossData?: StopLossTriggerData
+    basicBuyData?: BasicBSTriggerData
+    basicSellData?: BasicBSTriggerData
   } & HasGasEstimation
 
 function addTransitions(
@@ -543,6 +546,8 @@ export function createManageMultiplyVault$(
                     priceInfo,
                     vaultHistory: [],
                     stopLossData: undefined,
+                    basicBuyData: undefined,
+                    basicSellData: undefined,
                     balanceInfo,
                     ilkData,
                     account,
@@ -578,7 +583,7 @@ export function createManageMultiplyVault$(
                     createExchangeChange$(exchangeQuote$, stateSubject$),
                     slippageChange$(slippageLimit$),
                     createHistoryChange$(vaultHistory$, id),
-                    createStopLossDataChange$(automationTriggersData$, id),
+                    createAutomationTriggersChange$(automationTriggersData$, id),
                   )
 
                   const connectedProxyAddress$ = account ? proxyAddress$(account) : of(undefined)

--- a/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
@@ -3,7 +3,7 @@ import { VaultChange } from 'blockchain/vaults'
 import { PriceInfoChange } from 'features/shared/priceInfo'
 import { SlippageChange } from 'features/userSettings/userSettings'
 
-import { StopLossChange } from '../../../automation/protection/triggers/AutomationTriggersData'
+import { AutomationTriggersChange } from '../../../automation/protection/triggers/AutomationTriggersData'
 import { BalanceInfoChange } from '../../../shared/balanceInfo'
 import { VaultHistoryChange } from '../../../vaultHistory/vaultHistory'
 import { ManageMultiplyVaultChange, ManageMultiplyVaultState } from './manageMultiplyVault'
@@ -15,7 +15,7 @@ export type ManageVaultEnvironmentChange =
   | VaultChange
   | VaultHistoryChange
   | SlippageChange
-  | StopLossChange
+  | AutomationTriggersChange
 
 export function applyManageVaultEnvironment<VS extends ManageMultiplyVaultState>(
   change: ManageMultiplyVaultChange,

--- a/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
@@ -63,10 +63,12 @@ export function applyManageVaultEnvironment<VS extends ManageMultiplyVaultState>
     }
   }
 
-  if (change.kind === 'stopLossData') {
+  if (change.kind === 'automationTriggersData') {
     return {
       ...state,
       stopLossData: change.stopLossData,
+      basicSellData: change.basicSellData,
+      basicBuyData: change.basicBuyData,
     }
   }
 

--- a/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
@@ -31,6 +31,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
     invalidSlippage,
     afterCollRatioBelowStopLossRatio,
     afterCollRatioBelowBasicSellRatio,
+    afterCollRatioAboveBasicBuyRatio,
     insufficientEthFundsForTx,
   } = state
 
@@ -58,6 +59,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
         invalidSlippage,
         afterCollRatioBelowStopLossRatio,
         afterCollRatioBelowBasicSellRatio,
+        afterCollRatioAboveBasicBuyRatio,
       }),
     )
   }

--- a/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
@@ -30,6 +30,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
     ledgerWalletContractDataDisabled,
     invalidSlippage,
     afterCollRatioBelowStopLossRatio,
+    afterCollRatioBelowBasicSellRatio,
     insufficientEthFundsForTx,
   } = state
 
@@ -56,6 +57,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
         shouldShowExchangeError,
         invalidSlippage,
         afterCollRatioBelowStopLossRatio,
+        afterCollRatioBelowBasicSellRatio,
       }),
     )
   }

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -51,6 +51,7 @@ const commonErrors = [
   'hasToDepositCollateralOnEmptyVault',
   'invalidSlippage',
   'afterCollRatioBelowStopLossRatio',
+  'afterCollRatioBelowBasicSellRatio',
   'vaultWillBeTakenUnderMinActiveColRatio',
   'stopLossOnNearLiquidationRatio',
 

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -52,6 +52,7 @@ const commonErrors = [
   'invalidSlippage',
   'afterCollRatioBelowStopLossRatio',
   'afterCollRatioBelowBasicSellRatio',
+  'afterCollRatioAboveBasicBuyRatio',
   'vaultWillBeTakenUnderMinActiveColRatio',
   'stopLossOnNearLiquidationRatio',
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -816,6 +816,7 @@
     "invalid-slippage": "Custom slippage set too high for this transaction, please reduce your slippage setting",
     "after-coll-ratio-below-stop-loss-ratio": "You cannot make adjustments to your Vault which take it below your Stop-Loss Col. Ratio at current or next collateral price",
     "after-coll-ratio-below-basic-sell-ratio": "You cannot make adjustments to your Vault which take it below your Basic-Sell Col. Ratio at current or next collateral price",
+    "after-coll-ratio-above-basic-buy-ratio": "You cannot make adjustments to your Vault which take it above your Basic-Buy Col. Ratio at current or next collateral price",
     "vault-will-be-taken-under-min-active-col-ratio": "You cannot make adjustments to your vault which take it below your minimum active coll. ratio at current or next collateral price",
     "stop-loss-near-liquidation-ratio": "Your Stop-Loss Trigger Col. Ratio would cause closing vault immediately. If this is intended, close your vault",
     "stop-loss-max-debt": "The Stop-Loss cannot be created due to the high price impact of the order. Your total vault debt has to be less than 20m DAI",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -815,6 +815,7 @@
     "deposit-collateral-on-vault-under-debt-floor": "You cannot deposit to your vault while it is below the minimum debt required of {{debtFloor}}. To add more collateral, generate Dai to get above the minimum required. Learn more about the Minimum Vault Debt here <0>here</0>)",
     "invalid-slippage": "Custom slippage set too high for this transaction, please reduce your slippage setting",
     "after-coll-ratio-below-stop-loss-ratio": "You cannot make adjustments to your Vault which take it below your Stop-Loss Col. Ratio at current or next collateral price",
+    "after-coll-ratio-below-basic-sell-ratio": "You cannot make adjustments to your Vault which take it below your Basic-Sell Col. Ratio at current or next collateral price",
     "vault-will-be-taken-under-min-active-col-ratio": "You cannot make adjustments to your vault which take it below your minimum active coll. ratio at current or next collateral price",
     "stop-loss-near-liquidation-ratio": "Your Stop-Loss Trigger Col. Ratio would cause closing vault immediately. If this is intended, close your vault",
     "stop-loss-max-debt": "The Stop-Loss cannot be created due to the high price impact of the order. Your total vault debt has to be less than 20m DAI",


### PR DESCRIPTION
# [Added basic sell overview validation](https://app.shortcut.com/oazo-apps/story/4993/overview-validation-for-stop-loss-also-works-on-basic-sell)

#[Added basic buy overview validation](https://app.shortcut.com/oazo-apps/story/4994/overview-validation-for-basic-buy)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added basic sell validation to overview view (both borrow and multiply)
- added basic buy validation to overview view (both borrow and multiply)
  
## How to test 🧪
  <Please explain how to test your changes>

- when basic sell trigger is enabled try to push vault to the state where next coll ratio will be below basic sell trigger coll ratio (you should get error and button should be blocked)
- when basic buy trigger is enabled try to push vault to the state where next coll ratio will be above basic buy trigger coll ratio (you should get error and button should be blocked)
