### PR TITLE
Move GUNI products to Earn tab.

### DIFF
--- a/content/assets.ts
+++ b/content/assets.ts
@@ -29,7 +29,7 @@ export const ASSETS_PAGES = [
     icon: 'uni_circle_color',
     descriptionKey: 'assets.lp-token.description',
     link: 'assets.lp-token.link',
-    multiplyIlks: ['GUNIV3DAIUSDC1-A', 'GUNIV3DAIUSDC2-A'],
+    earnIlks: ['GUNIV3DAIUSDC1-A', 'GUNIV3DAIUSDC2-A'],
     borrowIlks: ['UNIV2DAIUSDC-A', 'UNIV2USDCETH-A'],
   },
   {


### PR DESCRIPTION
# [bug - GUNI cards in lp token asset page still under multiply.](https://app.shortcut.com/oazo-apps/story/5041/bug-guni-cards-in-lp-token-asset-page-still-under-multiply)

(In lp-token asset page)