### PR TITLE
Basic sell warnings on min / max slider value

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -49,6 +49,12 @@ export function VaultWarnings({ warningMessages, ilkData: { debtFloor } }: Vault
         return translate('coll-ratio-close-to-current')
       case 'noMinSellPriceWhenStopLossEnabled':
         return translate('no-min-sell-price-when-stop-loss-enabled')
+      case 'basicSellTriggerCloseToStopLossTrigger':
+        return translate('basic-sell-trigger-close-to-stop-loss-trigger')
+      case 'basicSellTargetCloseToAutoBuyTrigger':
+        return translate('basic-sell-target-close-to-auto-buy-trigger')
+      case 'stopLossTriggerCloseToAutoSellTrigger':
+        return translate('stop-loss-trigger-close-to-auto-sell-trigger')
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/automation/common/validators.ts
+++ b/features/automation/common/validators.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { IlkData } from 'blockchain/ilks'
 import { Vault } from 'blockchain/vaults'
+import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
 import { warningMessagesHandler } from 'features/form/warningMessagesHandler'
@@ -11,14 +12,22 @@ export function warningsBasicSellValidation({
   gasEstimationUsd,
   ethBalance,
   ethPrice,
+  sliderMin,
+  sliderMax,
   minSellPrice,
   isStopLossEnabled,
+  isAutoBuyEnabled,
+  basicSellState,
 }: {
   token: string
   ethBalance: BigNumber
   ethPrice: BigNumber
+  sliderMin: BigNumber
+  sliderMax: BigNumber
   gasEstimationUsd?: BigNumber
   isStopLossEnabled: boolean
+  isAutoBuyEnabled: boolean
+  basicSellState: BasicBSFormChange
   minSellPrice?: BigNumber
 }) {
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
@@ -30,9 +39,16 @@ export function warningsBasicSellValidation({
   const noMinSellPriceWhenStopLossEnabled =
     (minSellPrice?.isZero() || !minSellPrice) && isStopLossEnabled
 
+  const basicSellTriggerCloseToStopLossTrigger =
+    isStopLossEnabled && basicSellState.execCollRatio.isEqualTo(sliderMin)
+  const basicSellTargetCloseToAutoBuyTrigger =
+    isAutoBuyEnabled && basicSellState.targetCollRatio.isEqualTo(sliderMax)
+
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
     noMinSellPriceWhenStopLossEnabled,
+    basicSellTriggerCloseToStopLossTrigger,
+    basicSellTargetCloseToAutoBuyTrigger,
   })
 }
 

--- a/features/automation/protection/common/validation.ts
+++ b/features/automation/protection/common/validation.ts
@@ -10,10 +10,16 @@ export function warningsStopLossValidation({
   gasEstimationUsd,
   ethBalance,
   ethPrice,
+  sliderMax,
+  isAutoSellEnabled,
+  triggerRatio,
 }: {
   token: string
   ethBalance: BigNumber
   ethPrice: BigNumber
+  sliderMax?: BigNumber
+  triggerRatio?: BigNumber
+  isAutoSellEnabled?: boolean
   gasEstimationUsd?: BigNumber
 }) {
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
@@ -22,9 +28,12 @@ export function warningsStopLossValidation({
     ethBalance,
     ethPrice,
   })
+  const stopLossTriggerCloseToAutoSellTrigger =
+    isAutoSellEnabled && sliderMax && triggerRatio?.isEqualTo(sliderMax)
 
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
+    stopLossTriggerCloseToAutoSellTrigger,
   })
 }
 

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -320,6 +320,7 @@ export function AdjustSlFormControl({
     redirectToCloseVault,
     currentCollateralRatio: vault.collateralizationRatio,
     isStopLossEnabled,
+    isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
   }
 
   return <SidebarAdjustStopLoss {...props} />

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -216,6 +216,7 @@ export interface AdjustSlFormLayoutProps {
   isProgressDisabled: boolean
   redirectToCloseVault: () => void
   isStopLossEnabled: boolean
+  isAutoSellEnabled: boolean
 }
 
 export function slCollRatioNearLiquidationRatio(selectedSLValue: BigNumber, ilkData: IlkData) {

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage.tsx
@@ -30,6 +30,7 @@ export type SidebarAdjustStopLossEditingStageProps = Pick<
   | 'tokenPrice'
   | 'txError'
   | 'vault'
+  | 'isAutoSellEnabled'
 >
 
 export function SidebarAdjustStopLossEditingStage({
@@ -49,6 +50,7 @@ export function SidebarAdjustStopLossEditingStage({
   txError,
   vault,
   vault: { debt },
+  isAutoSellEnabled,
 }: SidebarAdjustStopLossEditingStageProps) {
   const { t } = useTranslation()
 
@@ -58,6 +60,9 @@ export function SidebarAdjustStopLossEditingStage({
     gasEstimationUsd,
     ethBalance,
     ethPrice,
+    sliderMax: slValuePickerConfig.maxBoundry,
+    triggerRatio: selectedSLValue,
+    isAutoSellEnabled,
   })
 
   return (

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -10,8 +10,6 @@ import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { AddAutoSellInfoSection } from 'features/automation/basicBuySell/InfoSections/AddAutoSellInfoSection'
 import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
-import { getBasicSellMinMaxValues } from 'features/automation/protection/common/helpers'
-import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import {
   BASIC_SELL_FORM_CHANGE,
   BasicBSFormChange,
@@ -71,13 +69,13 @@ interface SidebarAutoSellAddEditingStageProps {
   isEditing: boolean
   basicSellState: BasicBSFormChange
   autoSellTriggerData: BasicBSTriggerData
-  autoBuyTriggerData: BasicBSTriggerData
-  stopLossTriggerData: StopLossTriggerData
   errors: VaultErrorMessage[]
   warnings: VaultWarningMessage[]
   addTriggerGasEstimation: ReactNode
   debtDelta: BigNumber
   collateralDelta: BigNumber
+  sliderMin: BigNumber
+  sliderMax: BigNumber
 }
 
 export function SidebarAutoSellAddEditingStage({
@@ -87,29 +85,23 @@ export function SidebarAutoSellAddEditingStage({
   priceInfo,
   basicSellState,
   autoSellTriggerData,
-  autoBuyTriggerData,
-  stopLossTriggerData,
   errors,
   warnings,
   addTriggerGasEstimation,
   debtDelta,
   collateralDelta,
+  sliderMin,
+  sliderMax,
 }: SidebarAutoSellAddEditingStageProps) {
   const { uiChanges } = useAppContext()
   const [uiStateBasicSell] = useUIChanges<BasicBSFormChange>(BASIC_SELL_FORM_CHANGE)
   const { t } = useTranslation()
 
-  const { min, max } = getBasicSellMinMaxValues({
-    autoBuyTriggerData,
-    stopLossTriggerData,
-    ilkData,
-  })
-
   return (
     <>
       <MultipleRangeSlider
-        min={min.toNumber()}
-        max={max.toNumber()}
+        min={sliderMin.toNumber()}
+        max={sliderMax.toNumber()}
         onChange={(value) => {
           uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
             type: 'execution-coll-ratio',

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -10,6 +10,7 @@ import {
   warningsBasicSellValidation,
 } from 'features/automation/common/validators'
 import { commonProtectionDropdownItems } from 'features/automation/protection/common/dropdown'
+import { getBasicSellMinMaxValues } from 'features/automation/protection/common/helpers'
 import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { SidebarAutoSellCancelEditingStage } from 'features/automation/protection/controls/sidebar/SidebarAuteSellCancelEditingStage'
@@ -114,6 +115,12 @@ export function SidebarSetupAutoSell({
     minSellPrice: basicSellState.maxBuyOrMinSellPrice,
   })
 
+  const { min, max } = getBasicSellMinMaxValues({
+    autoBuyTriggerData,
+    stopLossTriggerData,
+    ilkData,
+  })
+
   const warnings = warningsBasicSellValidation({
     token: vault.token,
     gasEstimationUsd,
@@ -121,6 +128,10 @@ export function SidebarSetupAutoSell({
     ethPrice: ethMarketPrice,
     minSellPrice: basicSellState.maxBuyOrMinSellPrice,
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
+    isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
+    basicSellState,
+    sliderMin: min,
+    sliderMax: max,
   })
 
   const cancelAutoSellWarnings = extractCancelAutoSellWarnings(warnings)
@@ -146,13 +157,13 @@ export function SidebarSetupAutoSell({
                   priceInfo={priceInfo}
                   basicSellState={basicSellState}
                   autoSellTriggerData={autoSellTriggerData}
-                  autoBuyTriggerData={autoBuyTriggerData}
-                  stopLossTriggerData={stopLossTriggerData}
                   errors={errors}
                   warnings={warnings}
                   addTriggerGasEstimation={addTriggerGasEstimation}
                   debtDelta={debtDelta}
                   collateralDelta={collateralDelta}
+                  sliderMin={min}
+                  sliderMax={max}
                 />
               )}
               {isRemoveForm && (

--- a/features/automation/protection/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/openFlow/openVaultStopLoss.ts
@@ -137,6 +137,7 @@ export function getDataForStopLoss(
     ethBalance,
     gasEstimation: null,
     currentCollateralRatio: afterCollateralizationRatio,
+    isAutoSellEnabled: false,
   }
 
   return sidebarProps

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -12,6 +12,9 @@ export type VaultWarningMessage =
   | 'vaultWillRemainUnderMinActiveColRatio'
   | 'currentCollRatioCloseToStopLoss'
   | 'noMinSellPriceWhenStopLossEnabled'
+  | 'basicSellTriggerCloseToStopLossTrigger'
+  | 'basicSellTargetCloseToAutoBuyTrigger'
+  | 'stopLossTriggerCloseToAutoSellTrigger'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -25,6 +28,9 @@ interface WarningMessagesHandler {
   customSlippageOverridden?: boolean
   currentCollRatioCloseToStopLoss?: boolean
   noMinSellPriceWhenStopLossEnabled?: boolean
+  basicSellTriggerCloseToStopLossTrigger?: boolean
+  basicSellTargetCloseToAutoBuyTrigger?: boolean
+  stopLossTriggerCloseToAutoSellTrigger?: boolean
 }
 
 export function warningMessagesHandler({
@@ -37,6 +43,9 @@ export function warningMessagesHandler({
   potentialInsufficientEthFundsForTx,
   currentCollRatioCloseToStopLoss,
   noMinSellPriceWhenStopLossEnabled,
+  basicSellTriggerCloseToStopLossTrigger,
+  basicSellTargetCloseToAutoBuyTrigger,
+  stopLossTriggerCloseToAutoSellTrigger,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -74,6 +83,18 @@ export function warningMessagesHandler({
 
   if (noMinSellPriceWhenStopLossEnabled) {
     warningMessages.push('noMinSellPriceWhenStopLossEnabled')
+  }
+
+  if (basicSellTriggerCloseToStopLossTrigger) {
+    warningMessages.push('basicSellTriggerCloseToStopLossTrigger')
+  }
+
+  if (basicSellTargetCloseToAutoBuyTrigger) {
+    warningMessages.push('basicSellTargetCloseToAutoBuyTrigger')
+  }
+
+  if (stopLossTriggerCloseToAutoSellTrigger) {
+    warningMessages.push('stopLossTriggerCloseToAutoSellTrigger')
   }
 
   // if (highSlippage) {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -834,7 +834,10 @@
     "vault-will-remain-under-min-active-col-ratio": "You are decreasing risk of this position, but it will remain under the minimum active col ratio.",
     "insufficient-eth-balance": "Your ETH balance is potentially too low to pay for this transaction",
     "coll-ratio-close-to-current": "Your Stop-Loss Trigger Col. Ratio is very close to your current Col. Ratio. Only continue if this is intended and understand your Vault could be closed with a small price change.",
-    "no-min-sell-price-when-stop-loss-enabled": "Not setting a Min. Sell Price with Stop-Loss enabled would cause your Stop-Loss to never be triggered"
+    "no-min-sell-price-when-stop-loss-enabled": "Not setting a Min. Sell Price with Stop-Loss enabled would cause your Stop-Loss to never be triggered",
+    "basic-sell-trigger-close-to-stop-loss-trigger": "Setting a lower Trigger Ratio would trigger your existing Stop-Loss. If you want to use a lower trigger ratio, please adjust your Stop-Loss trigger first.",
+    "basic-sell-target-close-to-auto-buy-trigger": "Setting a higher Target Ratio would trigger your existing Auto-Buy. If you want to use a higher trigger ratio, please adjust your Auto-Buy trigger first.",
+    "stop-loss-trigger-close-to-auto-sell-trigger": "Setting a higher Trigger Ratio would trigger your existing Auto-Sell. If you want to use a higher trigger ratio, please adjust your Auto-Sell trigger first."
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Basic sell warnings on min / max slider value](https://app.shortcut.com/oazo-apps/story/4987/validation-basic-sell-target-ratio-does-not-trigger-basic-buy-triggered-at-next-price)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added min / max slider value warnings to basic sell form when stop loss or basic buy is enabled
- added max slider value warning to stop loss form when basic sell is enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- enable stop loss and basic buy, verify if warnings are present when you try to set target coll ratio to max and trigger coll ratio to min (do the same with stop loss trigger and basic buy trigger disabled, warnings should be there in that case)
- in stop loss form verify whether warning is shown when use move slider to max value (basic sell has to be enabled but test also when is disabled (no warning in that case))
