### PR TITLE
Auto sell deviation adjustment

### DIFF
--- a/features/automation/basicBuySell/InfoSections/AddAutoSellInfoSection.tsx
+++ b/features/automation/basicBuySell/InfoSections/AddAutoSellInfoSection.tsx
@@ -10,7 +10,9 @@ interface SellInfoSectionProps {
   multipleAfterSell: BigNumber
   execCollRatio: BigNumber
   nextSellPrice: BigNumber
-  slippageLimit: BigNumber
+  slippageLimit?: BigNumber
+  targetRatioWithDeviationFloor: BigNumber
+  targetRatioWithDeviationCeiling: BigNumber
   collateralAfterNextSell: {
     value: BigNumber
     secondaryValue: BigNumber
@@ -29,11 +31,12 @@ export function AddAutoSellInfoSection({
   multipleAfterSell,
   execCollRatio,
   nextSellPrice,
-  slippageLimit,
   collateralAfterNextSell,
   outstandingDebtAfterSell,
   ethToBeSoldAtNextSell,
   estimatedTransactionCost,
+  targetRatioWithDeviationFloor,
+  targetRatioWithDeviationCeiling,
 }: SellInfoSectionProps) {
   const { t } = useTranslation()
   const collateralToBeSoldAtNextSellFormatted = formatCryptoBalance(ethToBeSoldAtNextSell)
@@ -47,9 +50,11 @@ export function AddAutoSellInfoSection({
     collateralAfterNextSell.secondaryValue,
   )
   const nextSellPriceFormatted = formatAmount(nextSellPrice, 'USD')
-  const slippageLimitFormatted = formatPercent(slippageLimit, { precision: 1 })
   const colRatioAfterSellFormatted = formatPercent(targetCollRatio, { precision: 2 })
   const ratioToPerformSellFormatted = formatPercent(execCollRatio, { precision: 2 })
+
+  const targetRatioWithDeviationFloorFormatted = formatPercent(targetRatioWithDeviationFloor)
+  const targetRatioWithDeviationCeilingFormatted = formatPercent(targetRatioWithDeviationCeiling)
 
   return (
     <InfoSection
@@ -72,8 +77,8 @@ export function AddAutoSellInfoSection({
           value: `$${nextSellPriceFormatted}`,
         },
         {
-          label: t('auto-sell.slippage-limit'),
-          value: slippageLimitFormatted,
+          label: t('auto-sell.target-ratio-with-deviation'),
+          value: `${targetRatioWithDeviationFloorFormatted} - ${targetRatioWithDeviationCeilingFormatted}`,
         },
         {
           label: t('auto-sell.collateral-after-next-sell'),

--- a/features/automation/common/basicBSTriggerData.ts
+++ b/features/automation/common/basicBSTriggerData.ts
@@ -43,8 +43,8 @@ function mapBasicBSTriggerData(basicSellTriggers: { triggerId: number; result: R
       maxBuyOrMinSellPrice: new BigNumber(maxBuyOrMinSellPrice.toString()).div(
         new BigNumber(10).pow(18),
       ),
-      continuous: continuous,
-      deviation: new BigNumber(deviation.toString()).div(1000),
+      continuous,
+      deviation: new BigNumber(deviation.toString()).div(10000),
       isTriggerEnabled: true,
     } as BasicBSTriggerData
   })
@@ -96,7 +96,7 @@ export function prepareBasicBSTriggerData({
     targetCollRatio.times(100).toString(),
     maxBuyOrMinSellPrice.times(new BigNumber(10).pow(18)).toString(),
     continuous.toString(),
-    deviation.times(1000).toString(),
+    deviation.times(10000).toString(),
   ]
 
   return {

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -40,13 +40,21 @@ function AutoSellInfoSectionControl({
   debtDelta,
   collateralDelta,
 }: AutoSellInfoSectionControlProps) {
+  const deviationPercent = basicSellState.deviation.div(100)
+
+  const targetRatioWithDeviationFloor = one
+    .minus(deviationPercent)
+    .times(basicSellState.targetCollRatio)
+  const targetRatioWithDeviationCeiling = one
+    .plus(deviationPercent)
+    .times(basicSellState.targetCollRatio)
+
   return (
     <AddAutoSellInfoSection
       targetCollRatio={basicSellState.targetCollRatio}
       multipleAfterSell={one.div(basicSellState.targetCollRatio.div(100).minus(one)).plus(one)}
       execCollRatio={basicSellState.execCollRatio}
       nextSellPrice={priceInfo.nextCollateralPrice}
-      slippageLimit={basicSellState.deviation}
       collateralAfterNextSell={{
         value: vault.lockedCollateral,
         secondaryValue: vault.lockedCollateral.plus(collateralDelta),
@@ -58,6 +66,8 @@ function AutoSellInfoSectionControl({
       ethToBeSoldAtNextSell={collateralDelta.abs()}
       estimatedTransactionCost={addTriggerGasEstimation}
       token={vault.token}
+      targetRatioWithDeviationCeiling={targetRatioWithDeviationCeiling}
+      targetRatioWithDeviationFloor={targetRatioWithDeviationFloor}
     />
   )
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1371,6 +1371,7 @@
     "outstanding-debt-after-next-sell": "Outstanding Debt after next sell",
     "col-to-be-sold": "{{token}} to be sold at next sell",
     "estimated-transaction-cost": "Estimated transaction cost",
+    "target-ratio-with-deviation": "Target Ratio With Deviation",
     "title": "Auto sell",
     "add-form-title": "Auto Sell-Setup",
     "edit-form-title": "Edit Auto-Sell",


### PR DESCRIPTION
# [Auto sell deviation adjustment](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- changed calculations regarding deviation parameter (10000 sent from frontend equals 1% on SC level)
  
## How to test 🧪
  <Please explain how to test your changes>
- remove existing basic sell trigger and add new one, check if summary present correct numbers i.e target coll ratio 200% should produce 198% - 200% range (1% deviation)
