### PR TITLE
Added current coll ratio to sl details and multiply slider

### DIFF
--- a/components/vault/detailsSection/ContentCardStopLossCollateralRatio.tsx
+++ b/components/vault/detailsSection/ContentCardStopLossCollateralRatio.tsx
@@ -14,7 +14,7 @@ interface ContentCardStopLossCollateralRatioProps {
   isStopLossEnabled: boolean
   isEditing: boolean
   slRatio: BigNumber
-  collateralizationRatioAtNextPrice: BigNumber
+  collateralizationRatio: BigNumber
   afterSlRatio: BigNumber
 }
 
@@ -44,8 +44,8 @@ export function ContentCardStopLossCollateralRatio({
   isStopLossEnabled,
   isEditing,
   slRatio,
-  collateralizationRatioAtNextPrice,
   afterSlRatio,
+  collateralizationRatio,
 }: ContentCardStopLossCollateralRatioProps) {
   const { t } = useTranslation()
 
@@ -53,7 +53,7 @@ export function ContentCardStopLossCollateralRatio({
     slRatio: formatPercent(slRatio.times(100), {
       precision: 2,
     }),
-    collateralizationRatioAtNextPrice: formatPercent(collateralizationRatioAtNextPrice.times(100), {
+    belowCurrentCollRatio: formatPercent(collateralizationRatio.minus(slRatio).times(100), {
       precision: 2,
     }),
     afterSlRatio: formatPercent(afterSlRatio.times(100), {
@@ -69,7 +69,7 @@ export function ContentCardStopLossCollateralRatio({
   const contentCardSettings: ContentCardProps = {
     title: t('manage-multiply-vault.card.stop-loss-coll-ratio'),
     footnote: t('system.cards.stop-loss-collateral-ratio.footnote', {
-      amount: formatted.collateralizationRatioAtNextPrice,
+      amount: formatted.belowCurrentCollRatio,
     }),
     modal: <ContentCardStopLossCollateralRatioModal {...contentCardModalSettings} />,
   }

--- a/components/vault/sidebar/SidebarSliders.tsx
+++ b/components/vault/sidebar/SidebarSliders.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '@makerdao/dai-ui-icons'
 import { BigNumber } from 'bignumber.js'
 import { getCollRatioColor } from 'components/vault/VaultDetails'
 import { VaultErrors } from 'components/vault/VaultErrors'
@@ -41,6 +42,8 @@ export function SidebarSliderAdjustMultiply({
 
   const slider = value ? max?.minus(value).div(max.minus(min)).times(100) : zero
 
+  const currentCollaterizationRatio = 'vault' in state ? state.vault.collateralizationRatio : zero
+
   const collRatioColor = getCollRatioColor(state, afterCollateralizationRatio)
   const sliderBackground =
     multiply && !multiply.isNaN() && slider
@@ -82,12 +85,26 @@ export function SidebarSliderAdjustMultiply({
           </Text>
         </Grid>
         <Grid as="p" gap={2}>
-          <Text as="span">{t('system.collateral-ratio')}</Text>
+          <Text as="span" sx={{ textAlign: 'right' }}>
+            {t('system.collateral-ratio')}
+          </Text>
           <Text
             as="span"
             variant="paragraph1"
             sx={{ fontWeight: 'semiBold', textAlign: 'right', color: collRatioColor }}
           >
+            {!currentCollaterizationRatio.isEqualTo(afterCollateralizationRatio) && (
+              <>
+                <Text
+                  as="span"
+                  variant="paragraph1"
+                  sx={{ fontWeight: 'semiBold', color: 'primary' }}
+                >
+                  {formatPercent(currentCollaterizationRatio.times(100))}
+                  <Icon name="arrow_right" size="16px" sx={{ ml: 2, mr: 2 }} />
+                </Text>
+              </>
+            )}
             {formatPercent(afterCollateralizationRatio.times(100))}
           </Text>
         </Grid>

--- a/features/automation/protection/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/controls/StopLossDetailsControl.tsx
@@ -57,6 +57,7 @@ export function StopLossDetailsControl({
       collateralActive: lastUIState.collateralActive,
       isToCollateral: stopLossTriggerData.isToCollateral,
     }),
+    collateralizationRatio: vault.collateralizationRatio,
   }
 
   return (

--- a/features/automation/protection/controls/StopLossDetailsLayout.tsx
+++ b/features/automation/protection/controls/StopLossDetailsLayout.tsx
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
+import { ContentCardCollateralizationRatio } from 'components/vault/detailsSection/ContentCardCollateralizationRatio'
 import { ContentCardDynamicStopPrice } from 'components/vault/detailsSection/ContentCardDynamicStopPrice'
 import { ContentCardEstTokenOnTrigger } from 'components/vault/detailsSection/ContentCardEstTokenOnTrigger'
 import { ContentCardStopLossCollateralRatio } from 'components/vault/detailsSection/ContentCardStopLossCollateralRatio'
@@ -23,6 +24,7 @@ export interface ProtectionDetailsLayoutProps {
   isCollateralActive: boolean
   isEditing: boolean
   collateralizationRatioAtNextPrice: BigNumber
+  collateralizationRatio: BigNumber
 }
 
 export function StopLossDetailsLayout({
@@ -38,6 +40,7 @@ export function StopLossDetailsLayout({
   isCollateralActive,
   isEditing,
   collateralizationRatioAtNextPrice,
+  collateralizationRatio,
 }: ProtectionDetailsLayoutProps) {
   const { t } = useTranslation()
 
@@ -56,8 +59,12 @@ export function StopLossDetailsLayout({
                   isStopLossEnabled={isStopLossEnabled}
                   isEditing={isEditing}
                   slRatio={slRatio}
-                  collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
+                  collateralizationRatio={collateralizationRatio}
                   afterSlRatio={afterSlRatio}
+                />
+                <ContentCardCollateralizationRatio
+                  collateralizationRatio={collateralizationRatio}
+                  collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
                 />
                 <ContentCardDynamicStopPrice
                   isStopLossEnabled={isStopLossEnabled}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -758,7 +758,7 @@
         "footnote": "{{amount}} on next price"
       },
       "stop-loss-collateral-ratio": {
-        "footnote": "{{amount}} Next Collateral Ratio"
+        "footnote": "{{amount}} below Current Collateral Ratio"
       },
       "dynamic-stop-price": {
         "footnote": "{{amount}} S/L Coll. Ratio"


### PR DESCRIPTION
# [Added current coll ratio to sl details and multiply slider](https://app.shortcut.com/oazo-apps/story/5086/add-current-collateralisation-ratio)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added current coll ratio to sl details and multiply slider
  
## How to test 🧪
  <Please explain how to test your changes>

- when changing coll ratio in multiply vault using slider a current coll ratio should be showed (with arrow) next to next coll ratio
- in stop loss details section card with current coll ratio should be present
