### PR TITLE
Adjusted basic buy and sell slider dot and text colors

### DIFF
--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -98,12 +98,14 @@ export function SidebarAutoBuyEditingStage({
           value1: basicBuyState.execCollRatio.toNumber(),
         }}
         valueColors={{
+          value0: 'onWarning',
           value1: 'onSuccess',
         }}
         step={1}
         leftDescription={t('auto-buy.target-coll-ratio')}
         rightDescription={t('auto-buy.trigger-coll-ratio')}
-        leftThumbColor="primary"
+        leftThumbColor="onWarning"
+        rightThumbColor="onSuccess"
       />
       <VaultActionInput
         action={t('auto-buy.set-max-buy-price')}

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -182,13 +182,13 @@ export function SidebarAutoSellAddEditingStage({
         }}
         valueColors={{
           value0: 'onWarning',
-          value1: 'primary',
+          value1: 'onSuccess',
         }}
         step={1}
         leftDescription={t('auto-sell.sell-trigger-ratio')}
         rightDescription={t('auto-sell.target-coll-ratio')}
         leftThumbColor="onWarning"
-        rightThumbColor="primary"
+        rightThumbColor="onSuccess"
       />
       <VaultActionInput
         action={t('auto-sell.set-min-sell-price')}


### PR DESCRIPTION
# [Adjusted basic buy and sell slider dot and text colors](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- adjusted basic buy and sell slider dot and text colors
  
## How to test 🧪
  <Please explain how to test your changes>
- in manage vault go to protection and optimization tab and check slider value and dot colors in form
