### PR TITLE
added explanation for basic buy

### DIFF
--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -232,7 +232,6 @@ export function AutoBuyFormControl({
     <SidebarSetupAutoBuy
       vault={vault}
       ilkData={ilkData}
-      priceInfo={priceInfo}
       balanceInfo={balanceInfo}
       autoSellTriggerData={autoSellTriggerData}
       autoBuyTriggerData={autoBuyTriggerData}

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -19,7 +19,6 @@ import {
 } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
-import { PriceInfo } from 'features/shared/priceInfo'
 import { handleNumericInput } from 'helpers/input'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { one, zero } from 'helpers/zero'

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -1,7 +1,9 @@
 import BigNumber from 'bignumber.js'
 import { IlkData } from 'blockchain/ilks'
+import { collateralPriceAtRatio } from 'blockchain/vault.maths'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
+import { AppLink } from 'components/Links'
 import { MultipleRangeSlider } from 'components/vault/MultipleRangeSlider'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
@@ -23,11 +25,11 @@ import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
+import { Text } from 'theme-ui'
 
 interface SidebarAutoBuyEditingStageProps {
   vault: Vault
   ilkData: IlkData
-  priceInfo: PriceInfo
   isEditing: boolean
   basicBuyState: BasicBSFormChange
   autoBuyTriggerData: BasicBSTriggerData
@@ -44,7 +46,6 @@ export function SidebarAutoBuyEditingStage({
   vault,
   ilkData,
   isEditing,
-  priceInfo,
   basicBuyState,
   autoBuyTriggerData,
   errors,
@@ -59,6 +60,11 @@ export function SidebarAutoBuyEditingStage({
   const { t } = useTranslation()
   const readOnlyBasicBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const isVaultEmpty = vault.debt.isZero()
+  const executionPrice = collateralPriceAtRatio({
+    colRatio: basicBuyState.execCollRatio.div(100),
+    collateral: vault.lockedCollateral,
+    vaultDebt: vault.debt,
+  })
 
   if (readOnlyBasicBSEnabled && !isVaultEmpty) {
     return (
@@ -80,6 +86,26 @@ export function SidebarAutoBuyEditingStage({
 
   return (
     <>
+      <Text as="p" variant="paragraph3" sx={{ color: 'text.subtitle' }}>
+        {basicBuyState.maxBuyOrMinSellPrice !== undefined
+          ? t('auto-buy.set-trigger-description', {
+              targetCollRatio: basicBuyState.targetCollRatio.toNumber(),
+              token: vault.token,
+              execCollRatio: basicBuyState.execCollRatio,
+              executionPrice: executionPrice.toFixed(2),
+              minSellPrice: basicBuyState.maxBuyOrMinSellPrice,
+            })
+          : t('auto-buy.set-trigger-description-no-threshold', {
+              targetCollRatio: basicBuyState.targetCollRatio.toNumber(),
+              token: vault.token,
+              execCollRatio: basicBuyState.execCollRatio,
+              executionPrice: executionPrice.toFixed(2),
+            })}{' '}
+        {/* TODO ŁW link to article in kb */}
+        <AppLink href="https://kb.oasis.app/help/" sx={{ fontSize: 2 }}>
+          {t('here')}.
+        </AppLink>
+      </Text>{' '}
       <MultipleRangeSlider
         min={sliderMin.toNumber()}
         max={sliderMax.toNumber()}
@@ -143,7 +169,6 @@ export function SidebarAutoBuyEditingStage({
           <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
         </>
       )}
-
       <SidebarResetButton
         clear={() => {
           uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
@@ -171,7 +196,7 @@ export function SidebarAutoBuyEditingStage({
       />
       {isEditing && (
         <AutoBuyInfoSectionControl
-          priceInfo={priceInfo}
+          executionPrice={executionPrice}
           basicBuyState={basicBuyState}
           vault={vault}
           addTriggerGasEstimation={addTriggerGasEstimation}
@@ -184,7 +209,7 @@ export function SidebarAutoBuyEditingStage({
 }
 
 interface AutoBuyInfoSectionControlProps {
-  priceInfo: PriceInfo
+  executionPrice: BigNumber
   vault: Vault
   basicBuyState: BasicBSFormChange
   addTriggerGasEstimation: ReactNode
@@ -193,7 +218,7 @@ interface AutoBuyInfoSectionControlProps {
 }
 
 function AutoBuyInfoSectionControl({
-  priceInfo,
+  executionPrice,
   vault,
   basicBuyState,
   addTriggerGasEstimation,
@@ -215,7 +240,7 @@ function AutoBuyInfoSectionControl({
       colRatioAfterBuy={basicBuyState.targetCollRatio}
       multipleAfterBuy={one.div(basicBuyState.targetCollRatio.div(100).minus(one)).plus(one)}
       execCollRatio={basicBuyState.execCollRatio}
-      nextBuyPrice={priceInfo.nextCollateralPrice}
+      nextBuyPrice={executionPrice}
       collateralAfterNextBuy={{
         value: vault.lockedCollateral,
         secondaryValue: vault.lockedCollateral.plus(collateralDelta),

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -16,7 +16,6 @@ import {
 } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { BalanceInfo } from 'features/shared/balanceInfo'
-import { PriceInfo } from 'features/shared/priceInfo'
 import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
 import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
 import { SidebarFlow, SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
@@ -33,7 +32,6 @@ import { SidebarAutoBuyRemovalEditingStage } from './SidebarAutoBuyRemovalEditin
 export interface SidebarSetupAutoBuyProps {
   vault: Vault
   ilkData: IlkData
-  priceInfo: PriceInfo
   balanceInfo: BalanceInfo
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
@@ -60,7 +58,6 @@ export interface SidebarSetupAutoBuyProps {
 export function SidebarSetupAutoBuy({
   vault,
   ilkData,
-  priceInfo,
   balanceInfo,
   context,
   ethMarketPrice,
@@ -148,7 +145,6 @@ export function SidebarSetupAutoBuy({
                   ilkData={ilkData}
                   basicBuyState={basicBuyState}
                   isEditing={isEditing}
-                  priceInfo={priceInfo}
                   autoBuyTriggerData={autoBuyTriggerData}
                   errors={errors}
                   warnings={warnings}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1419,8 +1419,8 @@
     "sell-trigger-ratio": "Sell Trigger Ratio",
     "target-coll-ratio": "Target Col Ratio (After Sell)",
     "set-min-sell-price": "Set Min Sell Price",
-    "set-trigger-description": "You are setting a recurring automated sell action at a Target Collateral Ratio of {{targetCollRatio}}% and a trigger to sell more {{token}} at your Collateral Ratio Trigger of {{execCollRatio}}%. Your first sell being ${{executionPrice}}/{{token}}, limited to a price of ${{minSellPrice}}/{{token}} Learn More ",
-    "set-trigger-description-no-threshold": "You are setting a recurring automated sell action at a Target Collateral Ratio of {{targetCollRatio}}% and a trigger to sell more {{token}} at your Collateral Ratio Trigger of {{execCollRatio}}%. With no min sell price Learn More ",
+    "set-trigger-description": "You are setting a recurring automated sell action at a Target Collateral Ratio of {{targetCollRatio}}% and a trigger to sell more {{token}} at your Collateral Ratio Trigger of {{execCollRatio}}%. Your first sell being ${{executionPrice}}/{{token}}, limited to a price of ${{minSellPrice}}/{{token}}. Learn More ",
+    "set-trigger-description-no-threshold": "You are setting a recurring automated sell action at a Target Collateral Ratio of {{targetCollRatio}}% and a trigger to sell more {{token}} at your Collateral Ratio Trigger of {{execCollRatio}}%. With no min sell price. Learn More ",
     "closed-vault-existing-trigger-header": "Your vault is closed but Auto-Sell is still active",
     "closed-vault-existing-trigger-description": "You can cancel your existing Auto-Sell here or deposit into your vault in overview tab",
     "closed-vault-not-existing-trigger-header": "You need to generate Dai before you can set up Auto-Sell",
@@ -1467,7 +1467,9 @@
       "button": "Setup Auto Buy"
     },
     "setting-auto-buy": "Setting up your Auto-Buy",
-    "cancelling-auto-buy": "Cancelling your Auto-Buy"
+    "cancelling-auto-buy": "Cancelling your Auto-Buy",
+    "set-trigger-description": "You are setting a recurring automated buy action at a Target Collateral Ratio of {{targetCollRatio}}% and a trigger to buy more {{token}} at your Collateral Ratio Trigger of {{execCollRatio}}%. Your first buy being ${{executionPrice}}/{{token}}, limited to a price of ${{minSellPrice}}/{{token}}. Learn More ",
+    "set-trigger-description-no-threshold": "You are setting a recurring automated buy action at a Target Collateral Ratio of {{targetCollRatio}}% and a trigger to buy more {{token}} at your Collateral Ratio Trigger of {{execCollRatio}}%. With no min buy price. Learn More "
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",


### PR DESCRIPTION
# [Add explanation wording next to slider -  Auto Buy](https://app.shortcut.com/oazo-apps/story/5111/add-explanation-wording-next-to-slider-auto-buy)

<please insert a shortcut link above>  
## Changes 👷‍♀️
![image](https://user-images.githubusercontent.com/6871923/178258508-e84cce28-dbb5-47a5-91db-fb86087f786c.png)

## How to test 🧪
- notice explanation next to slider in autobiy
- check if values are correct and if values change properly when one interacts with ui
