### PR TITLE
Show optimization tab for specific ilks

### DIFF
--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -28,7 +28,7 @@ export function GeneralManageLayout({
   const { t } = useTranslation()
   const { ilkData, vault, priceInfo } = generalManageVault.state
 
-  const showProtectionTab = isSupportedAutomationIlk(getNetworkName(), vault.ilk)
+  const showAutomationTabs = isSupportedAutomationIlk(getNetworkName(), vault.ilk)
   const isStopLossEnabled = useStopLossStateInitializator(ilkData, vault, autoTriggersData)
   const isBasicSellEnabled = useBasicBSstateInitialization(
     ilkData,
@@ -66,7 +66,7 @@ export function GeneralManageLayout({
       <GeneralManageTabBar
         positionInfo={positionInfo}
         generalManageVault={generalManageVault}
-        showProtectionTab={showProtectionTab}
+        showAutomationTabs={showAutomationTabs}
         protectionEnabled={protectionEnabled}
         optimizationEnabled={optimizationEnabled}
       />

--- a/components/vault/GeneralManageTabBar.tsx
+++ b/components/vault/GeneralManageTabBar.tsx
@@ -28,7 +28,7 @@ export enum VaultViewMode {
 interface GeneralManageTabBarProps {
   generalManageVault: GeneralManageVaultState
   positionInfo?: JSX.Element
-  showProtectionTab: boolean
+  showAutomationTabs: boolean
   protectionEnabled: boolean
   optimizationEnabled: boolean
 }
@@ -36,7 +36,7 @@ interface GeneralManageTabBarProps {
 export function GeneralManageTabBar({
   generalManageVault,
   positionInfo,
-  showProtectionTab,
+  showAutomationTabs,
   protectionEnabled,
   optimizationEnabled,
 }: GeneralManageTabBarProps): JSX.Element {
@@ -70,7 +70,7 @@ export function GeneralManageTabBar({
           value: VaultViewMode.Overview,
           content: <GeneralManageVaultViewAutomation generalManageVault={generalManageVault} />,
         },
-        ...(showProtectionTab
+        ...(showAutomationTabs
           ? [
               {
                 label: t('system.protection'),
@@ -87,7 +87,7 @@ export function GeneralManageTabBar({
               },
             ]
           : []),
-        ...(basicBSEnabled
+        ...(basicBSEnabled && showAutomationTabs
           ? [
               {
                 label: t('system.optimization'),


### PR DESCRIPTION
# [Show optimization tab for specific ilks](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- optimization tab will be visible only for specific ilks
  
## How to test 🧪
  <Please explain how to test your changes>

- use ilk which is not on following list (goerli) ['ETH-A', 'ETH-B', 'ETH-C', 'WSTETH-A', 'WBTC-A', 'WBTC-B', 'WBTC-C'] or just remove ilk for this list in code and check whether optimization & protection tab will be visible (shouldn't be visible)
