### PR TITLE
Protection tab details section titles update

### DIFF
--- a/features/automation/protection/controls/StopLossDetailsLayout.tsx
+++ b/features/automation/protection/controls/StopLossDetailsLayout.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Grid } from 'theme-ui'
 
-export interface ProtectionDetailsLayoutProps {
+export interface StopLossDetailsLayoutProps {
   slRatio: BigNumber
   vaultDebt: BigNumber
   currentOraclePrice: BigNumber
@@ -41,7 +41,7 @@ export function StopLossDetailsLayout({
   isEditing,
   collateralizationRatioAtNextPrice,
   collateralizationRatio,
-}: ProtectionDetailsLayoutProps) {
+}: StopLossDetailsLayoutProps) {
   const { t } = useTranslation()
 
   const liquidationPrice = vaultDebt.times(liquidationRatio).div(lockedCollateral)
@@ -51,7 +51,7 @@ export function StopLossDetailsLayout({
       <Grid>
         <Box>
           <DetailsSection
-            title={t('system.protection')}
+            title={t('system.stop-loss')}
             badge={isStopLossEnabled}
             content={
               <DetailsSectionContentCardWrapper>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1403,7 +1403,7 @@
     "col-to-be-sold": "{{token}} to be sold at next sell",
     "estimated-transaction-cost": "Estimated transaction cost",
     "target-ratio-with-deviation": "Target ratio with deviation",
-    "title": "Auto sell",
+    "title": "Auto-Sell",
     "add-form-title": "Auto Sell-Setup",
     "edit-form-title": "Edit Auto-Sell",
     "setting-form-title": "Setting Auto-Sell",


### PR DESCRIPTION
# [Protection tab details section titles update](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- Protection tab details section titles update
  
## How to test 🧪
  <Please explain how to test your changes>
- go to protection tab with enabled BasicBS feature toggle, details section tiles should be Stop-Loss and Auto-Sell
