### PR TITLE
Added missing Basic Buy and Sell validations

### DIFF
--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -140,6 +140,12 @@ export function VaultErrors({
         return translate('stop-loss-max-debt')
       case 'targetCollRatioExceededDustLimitCollRatio':
         return translate('target-coll-ratio-exceeded-dust-limit-coll-ratio')
+      case 'autoSellTriggerHigherThanAutoBuyTarget':
+        return translate('auto-sell-trigger-higher-than-auto-buy-target')
+      case 'autoBuyTriggerLowerThanAutoSellTarget':
+        return translate('auto-buy-trigger-lower-than-auto-sell-target')
+      case 'stopLossTriggerHigherThanAutoBuyTarget':
+        return translate('stop-loss-trigger-higher-than-auto-buy-target')
       case 'autoBuyMaxBuyPriceNotSpecified':
         return (
           <Trans

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -176,8 +176,17 @@ export function AutoBuyFormControl({
       currentForm: isAddForm ? 'remove' : 'add',
     })
     uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-      type: 'tx-details',
-      txDetails: {},
+      type: 'reset',
+      resetData: {
+        targetCollRatio: autoBuyTriggerData.targetCollRatio,
+        execCollRatio: autoBuyTriggerData.execCollRatio,
+        maxBuyOrMinSellPrice: autoBuyTriggerData.maxBuyOrMinSellPrice,
+        maxBaseFeeInGwei: autoBuyTriggerData.maxBaseFeeInGwei,
+        withThreshold:
+          !autoBuyTriggerData.maxBuyOrMinSellPrice.isZero() ||
+          autoBuyTriggerData.triggerId.isZero(),
+        txDetails: {},
+      },
     })
   }
 

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -180,7 +180,9 @@ export function AutoBuyFormControl({
       resetData: {
         targetCollRatio: autoBuyTriggerData.targetCollRatio,
         execCollRatio: autoBuyTriggerData.execCollRatio,
-        maxBuyOrMinSellPrice: autoBuyTriggerData.maxBuyOrMinSellPrice,
+        maxBuyOrMinSellPrice: autoBuyTriggerData.maxBuyOrMinSellPrice.isEqualTo(maxUint256)
+          ? undefined
+          : autoBuyTriggerData.maxBuyOrMinSellPrice,
         maxBaseFeeInGwei: autoBuyTriggerData.maxBaseFeeInGwei,
         withThreshold:
           !autoBuyTriggerData.maxBuyOrMinSellPrice.isZero() ||

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -177,7 +177,9 @@ export function SidebarAutoBuyEditingStage({
             resetData: {
               targetCollRatio: autoBuyTriggerData.targetCollRatio,
               execCollRatio: autoBuyTriggerData.execCollRatio,
-              maxBuyOrMinSellPrice: autoBuyTriggerData.maxBuyOrMinSellPrice,
+              maxBuyOrMinSellPrice: autoBuyTriggerData.maxBuyOrMinSellPrice.isEqualTo(maxUint256)
+                ? undefined
+                : autoBuyTriggerData.maxBuyOrMinSellPrice,
               maxBaseFeeInGwei: autoBuyTriggerData.maxBaseFeeInGwei,
               withThreshold:
                 !autoBuyTriggerData.maxBuyOrMinSellPrice.isZero() ||

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -104,9 +104,8 @@ export function SidebarSetupAutoBuy({
   const primaryButtonLabel = getPrimaryButtonLabel({ flow, stage })
 
   const errors = errorsBasicBuyValidation({
-    txError: basicBuyState.txDetails?.txError,
-    withThreshold: basicBuyState.withThreshold,
-    maxBuyPrice: basicBuyState.maxBuyOrMinSellPrice,
+    basicBuyState,
+    autoSellTriggerData,
     isRemoveForm,
   })
 

--- a/features/automation/protection/common/UITypes/basicBSFormChange.ts
+++ b/features/automation/protection/common/UITypes/basicBSFormChange.ts
@@ -1,6 +1,5 @@
 import { TxStatus } from '@oasisdex/transactions'
 import BigNumber from 'bignumber.js'
-import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { TxError } from 'helpers/types'
 
 export const BASIC_SELL_FORM_CHANGE = 'BASIC_SELL_FORM_CHANGE'
@@ -9,7 +8,7 @@ export const BASIC_BUY_FORM_CHANGE = 'BASIC_BUY_FORM_CHANGE'
 export type CurrentBSForm = 'add' | 'remove'
 
 export type BasicBSTriggerResetData = Pick<
-  BasicBSTriggerData,
+  BasicBSFormChange,
   'execCollRatio' | 'targetCollRatio' | 'maxBuyOrMinSellPrice' | 'maxBaseFeeInGwei'
 > & {
   withThreshold: boolean

--- a/features/automation/protection/common/validation.ts
+++ b/features/automation/protection/common/validation.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { MAX_DEBT_FOR_SETTING_STOP_LOSS } from 'features/automation/protection/common/consts/automationDefaults'
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
@@ -40,12 +41,24 @@ export function warningsStopLossValidation({
 export function errorsStopLossValidation({
   txError,
   debt,
+  stopLossLevel,
+  autoBuyTriggerData,
 }: {
   txError?: TxError
   debt: BigNumber
+  stopLossLevel?: BigNumber
+  autoBuyTriggerData?: BasicBSTriggerData
 }) {
   const insufficientEthFundsForTx = ethFundsForTxValidator({ txError })
   const maxDebtForSettingStopLoss = debt.gt(MAX_DEBT_FOR_SETTING_STOP_LOSS)
+  const stopLossTriggerHigherThanAutoBuyTarget =
+    stopLossLevel && autoBuyTriggerData
+      ? stopLossLevel.plus(5).gt(autoBuyTriggerData.targetCollRatio)
+      : false
 
-  return errorMessagesHandler({ insufficientEthFundsForTx, maxDebtForSettingStopLoss })
+  return errorMessagesHandler({
+    insufficientEthFundsForTx,
+    maxDebtForSettingStopLoss,
+    stopLossTriggerHigherThanAutoBuyTarget,
+  })
 }

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -51,6 +51,7 @@ interface AdjustSlFormControlProps {
   ilkData: IlkData
   triggerData: StopLossTriggerData
   autoSellTriggerData: BasicBSTriggerData
+  autoBuyTriggerData: BasicBSTriggerData
   ctx: Context
   accountIsController: boolean
   toggleForms: () => void
@@ -65,6 +66,7 @@ export function AdjustSlFormControl({
   ilkData,
   triggerData,
   autoSellTriggerData,
+  autoBuyTriggerData,
   ctx,
   accountIsController,
   toggleForms,
@@ -321,6 +323,7 @@ export function AdjustSlFormControl({
     currentCollateralRatio: vault.collateralizationRatio,
     isStopLossEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
+    autoBuyTriggerData,
   }
 
   return <SidebarAdjustStopLoss {...props} />

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -10,6 +10,7 @@ import {
   VaultChangesInformationContainer,
   VaultChangesInformationItem,
 } from 'components/vault/VaultChangesInformation'
+import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { formatAmount, formatFiatBalance, formatPercent } from 'helpers/formatters/format'
 import { TxError } from 'helpers/types'
 import { one } from 'helpers/zero'
@@ -207,4 +208,5 @@ export interface AdjustSlFormLayoutProps {
   redirectToCloseVault: () => void
   isStopLossEnabled: boolean
   isAutoSellEnabled: boolean
+  autoBuyTriggerData: BasicBSTriggerData
 }

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -178,8 +178,17 @@ export function AutoSellFormControl({
       currentForm: isAddForm ? 'remove' : 'add',
     })
     uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
-      type: 'tx-details',
-      txDetails: {},
+      type: 'reset',
+      resetData: {
+        targetCollRatio: autoSellTriggerData.targetCollRatio,
+        execCollRatio: autoSellTriggerData.execCollRatio,
+        maxBuyOrMinSellPrice: autoSellTriggerData.maxBuyOrMinSellPrice,
+        maxBaseFeeInGwei: autoSellTriggerData.maxBaseFeeInGwei,
+        withThreshold:
+          !autoSellTriggerData.maxBuyOrMinSellPrice.isZero() ||
+          autoSellTriggerData.triggerId.isZero(),
+        txDetails: {},
+      },
     })
   }
 

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -182,7 +182,9 @@ export function AutoSellFormControl({
       resetData: {
         targetCollRatio: autoSellTriggerData.targetCollRatio,
         execCollRatio: autoSellTriggerData.execCollRatio,
-        maxBuyOrMinSellPrice: autoSellTriggerData.maxBuyOrMinSellPrice,
+        maxBuyOrMinSellPrice: autoSellTriggerData.maxBuyOrMinSellPrice.isZero()
+          ? undefined
+          : autoSellTriggerData.maxBuyOrMinSellPrice,
         maxBaseFeeInGwei: autoSellTriggerData.maxBaseFeeInGwei,
         withThreshold:
           !autoSellTriggerData.maxBuyOrMinSellPrice.isZero() ||

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -71,6 +71,7 @@ export function ProtectionFormControl({
         ilkData={ilkData}
         stopLossTriggerData={stopLossTriggerData}
         autoSellTriggerData={autoSellTriggerData}
+        autoBuyTriggerData={autoBuyTriggerData}
         priceInfo={priceInfo}
         vault={vault}
         account={account}

--- a/features/automation/protection/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/controls/StopLossFormControl.tsx
@@ -33,6 +33,7 @@ interface StopLossFormsProps {
   accountIsController: boolean
   stopLossTriggerData: StopLossTriggerData
   autoSellTriggerData: BasicBSTriggerData
+  autoBuyTriggerData: BasicBSTriggerData
   ethMarketPrice: BigNumber
   txHelpers?: TxHelpers
 }
@@ -49,6 +50,7 @@ function StopLossForms({
   accountIsController,
   stopLossTriggerData,
   autoSellTriggerData,
+  autoBuyTriggerData,
   ethMarketPrice,
 }: StopLossFormsProps) {
   return currentForm?.currentMode === AutomationFromKind.CANCEL ? (
@@ -76,6 +78,7 @@ function StopLossForms({
       ilkData={ilkData}
       triggerData={stopLossTriggerData}
       autoSellTriggerData={autoSellTriggerData}
+      autoBuyTriggerData={autoBuyTriggerData}
       tx={txHelpers}
       ctx={context}
       accountIsController={accountIsController}
@@ -95,6 +98,7 @@ interface StopLossFormControlProps {
   ilkData: IlkData
   stopLossTriggerData: StopLossTriggerData
   autoSellTriggerData: BasicBSTriggerData
+  autoBuyTriggerData: BasicBSTriggerData
   priceInfo: PriceInfo
   vault: Vault
   balanceInfo: BalanceInfo
@@ -109,6 +113,7 @@ export function StopLossFormControl({
   ilkData,
   stopLossTriggerData,
   autoSellTriggerData,
+  autoBuyTriggerData,
   priceInfo,
   vault,
   account,
@@ -149,6 +154,7 @@ export function StopLossFormControl({
         accountIsController={accountIsController}
         stopLossTriggerData={stopLossTriggerData}
         autoSellTriggerData={autoSellTriggerData}
+        autoBuyTriggerData={autoBuyTriggerData}
         ethMarketPrice={ethMarketPrice}
       />
     ) : (
@@ -167,6 +173,7 @@ export function StopLossFormControl({
       accountIsController={accountIsController}
       stopLossTriggerData={stopLossTriggerData}
       autoSellTriggerData={autoSellTriggerData}
+      autoBuyTriggerData={autoBuyTriggerData}
       ethMarketPrice={ethMarketPrice}
     />
   )

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
@@ -2,6 +2,10 @@ import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
 import { commonProtectionDropdownItems } from 'features/automation/protection/common/dropdown'
 import { backToVaultOverview } from 'features/automation/protection/common/helpers'
+import {
+  errorsStopLossValidation,
+  warningsStopLossValidation,
+} from 'features/automation/protection/common/validation'
 import { AdjustSlFormLayoutProps } from 'features/automation/protection/controls/AdjustSlFormLayout'
 import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
 import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
@@ -29,11 +33,36 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
     stage,
     toggleForms,
     token,
+    slValuePickerConfig,
+    selectedSLValue,
+    gasEstimationUsd,
+    ethBalance,
+    ethPrice,
+    isAutoSellEnabled,
+    txError,
+    vault: { debt },
+    autoBuyTriggerData,
   } = props
 
   const flow = firstStopLossSetup ? 'addSl' : 'adjustSl'
   const sidebarTxData = extractSidebarTxData(props)
   const basicBSEnabled = useFeatureToggle('BasicBS')
+
+  const errors = errorsStopLossValidation({
+    txError,
+    debt,
+    stopLossLevel: selectedSLValue,
+    autoBuyTriggerData,
+  })
+  const warnings = warningsStopLossValidation({
+    token,
+    gasEstimationUsd,
+    ethBalance,
+    ethPrice,
+    sliderMax: slValuePickerConfig.maxBoundry,
+    triggerRatio: selectedSLValue,
+    isAutoSellEnabled,
+  })
 
   const sidebarSectionProps: SidebarSectionProps = {
     title: getSidebarTitle({ flow, stage, token, isStopLossEnabled }),
@@ -49,7 +78,7 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
         {stopLossWriteEnabled ? (
           <>
             {(stage === 'stopLossEditing' || stage === 'txFailure') && (
-              <SidebarAdjustStopLossEditingStage {...props} />
+              <SidebarAdjustStopLossEditingStage {...props} errors={errors} warnings={warnings} />
             )}
           </>
         ) : (
@@ -66,7 +95,7 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
     ),
     primaryButton: {
       label: getPrimaryButtonLabel({ flow, stage, token }),
-      disabled: isProgressDisabled,
+      disabled: isProgressDisabled || !!errors.length,
       isLoading: stage === 'txInProgress',
       action: () => {
         if (stage !== 'txSuccess') addTriggerConfig.onClick(() => null)

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLossEditingStage.tsx
@@ -4,10 +4,8 @@ import { AppLink } from 'components/Links'
 import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
-import {
-  errorsStopLossValidation,
-  warningsStopLossValidation,
-} from 'features/automation/protection/common/validation'
+import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
+import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid, Text } from 'theme-ui'
@@ -33,8 +31,7 @@ export type SidebarAdjustStopLossEditingStageProps = Pick<
   | 'vault'
   | 'isAutoSellEnabled'
   | 'isStopLossEnabled'
->
-
+> & { errors: VaultErrorMessage[]; warnings: VaultWarningMessage[] }
 export function SidebarAdjustStopLossEditingStage({
   closePickerConfig,
   collateralizationRatioAtNextPrice,
@@ -51,22 +48,12 @@ export function SidebarAdjustStopLossEditingStage({
   tokenPrice,
   txError,
   vault,
-  vault: { debt },
-  isAutoSellEnabled,
   isStopLossEnabled,
+  errors,
+  warnings,
 }: SidebarAdjustStopLossEditingStageProps) {
   const { t } = useTranslation()
 
-  const errors = errorsStopLossValidation({ txError, debt })
-  const warnings = warningsStopLossValidation({
-    token,
-    gasEstimationUsd,
-    ethBalance,
-    ethPrice,
-    sliderMax: slValuePickerConfig.maxBoundry,
-    triggerRatio: selectedSLValue,
-    isAutoSellEnabled,
-  })
   const isVaultEmpty = vault.debt.isZero()
 
   if (isVaultEmpty && !isStopLossEnabled) {

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -233,7 +233,9 @@ export function SidebarAutoSellAddEditingStage({
             resetData: {
               targetCollRatio: autoSellTriggerData.targetCollRatio,
               execCollRatio: autoSellTriggerData.execCollRatio,
-              maxBuyOrMinSellPrice: autoSellTriggerData.maxBuyOrMinSellPrice,
+              maxBuyOrMinSellPrice: autoSellTriggerData.maxBuyOrMinSellPrice.isZero()
+                ? undefined
+                : autoSellTriggerData.maxBuyOrMinSellPrice,
               maxBaseFeeInGwei: autoSellTriggerData.maxBaseFeeInGwei,
               withThreshold:
                 !autoSellTriggerData.maxBuyOrMinSellPrice.isZero() ||

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -103,13 +103,11 @@ export function SidebarSetupAutoSell({
   const sidebarTitle = getSidebarTitle({ flow, stage, token: vault.token })
 
   const errors = errorsBasicSellValidation({
-    txError: basicSellState.txDetails?.txError,
     ilkData,
     vault,
     debtDelta,
-    targetCollRatio: basicSellState.targetCollRatio,
-    withThreshold: basicSellState.withThreshold,
-    minSellPrice: basicSellState.maxBuyOrMinSellPrice,
+    basicSellState,
+    autoBuyTriggerData,
     isRemoveForm,
   })
 

--- a/features/automation/protection/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/openFlow/openVaultStopLoss.ts
@@ -139,6 +139,8 @@ export function getDataForStopLoss(
     currentCollateralRatio: afterCollateralizationRatio,
     isAutoSellEnabled: false,
     isStopLossEnabled: false,
+    warnings: [],
+    errors: [],
   }
 
   return sidebarProps

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -38,6 +38,9 @@ export type VaultErrorMessage =
   | 'targetCollRatioExceededDustLimitCollRatio'
   | 'autoBuyMaxBuyPriceNotSpecified'
   | 'minimumSellPriceNotProvided'
+  | 'autoSellTriggerHigherThanAutoBuyTarget'
+  | 'autoBuyTriggerLowerThanAutoSellTarget'
+  | 'stopLossTriggerHigherThanAutoBuyTarget'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -78,6 +81,9 @@ interface ErrorMessagesHandler {
   targetCollRatioExceededDustLimitCollRatio?: boolean
   autoBuyMaxBuyPriceNotSpecified?: boolean
   minimumSellPriceNotProvided?: boolean
+  autoSellTriggerHigherThanAutoBuyTarget?: boolean
+  autoBuyTriggerLowerThanAutoSellTarget?: boolean
+  stopLossTriggerHigherThanAutoBuyTarget?: boolean
 }
 
 export function errorMessagesHandler({
@@ -119,6 +125,9 @@ export function errorMessagesHandler({
   targetCollRatioExceededDustLimitCollRatio,
   autoBuyMaxBuyPriceNotSpecified,
   minimumSellPriceNotProvided,
+  autoSellTriggerHigherThanAutoBuyTarget,
+  autoBuyTriggerLowerThanAutoSellTarget,
+  stopLossTriggerHigherThanAutoBuyTarget,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -271,6 +280,18 @@ export function errorMessagesHandler({
 
   if (autoBuyMaxBuyPriceNotSpecified) {
     errorMessages.push('autoBuyMaxBuyPriceNotSpecified')
+  }
+
+  if (autoSellTriggerHigherThanAutoBuyTarget) {
+    errorMessages.push('autoSellTriggerHigherThanAutoBuyTarget')
+  }
+
+  if (autoBuyTriggerLowerThanAutoSellTarget) {
+    errorMessages.push('autoBuyTriggerLowerThanAutoSellTarget')
+  }
+
+  if (stopLossTriggerHigherThanAutoBuyTarget) {
+    errorMessages.push('stopLossTriggerHigherThanAutoBuyTarget')
   }
 
   return errorMessages

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -839,7 +839,10 @@
     "stop-loss-max-debt": "The Stop-Loss cannot be created due to the high price impact of the order. Your total vault debt has to be less than 20m DAI",
     "target-coll-ratio-exceeded-dust-limit-coll-ratio": "You cannot select a higher Target Collateralization Ratio, as it would result in the vault hitting the dust limit",
     "auto-buy-max-price-requred": "Please enter a maximum buy price or select <1>Set No Threshold<1>",
-    "minimum-sell-price-not-provided": "Please enter a minimum sell price or select <1>Set No Threshold<1>"
+    "minimum-sell-price-not-provided": "Please enter a minimum sell price or select <1>Set No Threshold<1>",
+    "auto-sell-trigger-higher-than-auto-buy-target": "Setting your an Auto-Sell trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",
+    "stop-loss-trigger-higher-than-auto-buy-target": "Setting your an Stop-Loss trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",
+    "auto-buy-trigger-lower-than-auto-sell-target": "Setting your an Auto-Buy trigger at this level could result in it being executed by your Auto-Sell. Please adjust your Auto-Sell Target ratio first"
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",


### PR DESCRIPTION
# [Adjusting auto sell trigger ratio cannot go above existing auto buy target (should work in the sam way for setting stop loss trigger)](https://app.shortcut.com/oazo-apps/story/5197/validation-adjusting-auto-sell-trigger-ratio-cannot-go-above-existing-auto-buy-target)


# [Adjusting auto buy trigger ratio cannot go below existing auto sell target](https://app.shortcut.com/oazo-apps/story/5196/validation-adjusting-auto-buy-trigger-ratio-cannot-go-below-existing-auto-sell-target)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added missing validation to auto buy and auto sell form
  
## How to test 🧪
  <Please explain how to test your changes>

- check story description
