### PR TITLE
Instant stop loss button disable and validation fix

### DIFF
--- a/features/automation/protection/common/validation.ts
+++ b/features/automation/protection/common/validation.ts
@@ -52,7 +52,7 @@ export function errorsStopLossValidation({
   const insufficientEthFundsForTx = ethFundsForTxValidator({ txError })
   const maxDebtForSettingStopLoss = debt.gt(MAX_DEBT_FOR_SETTING_STOP_LOSS)
   const stopLossTriggerHigherThanAutoBuyTarget =
-    stopLossLevel && autoBuyTriggerData
+    stopLossLevel && autoBuyTriggerData?.isTriggerEnabled
       ? stopLossLevel.plus(5).gt(autoBuyTriggerData.targetCollRatio)
       : false
 

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -80,6 +80,8 @@ export function AdjustSlFormControl({
   const { addGasEstimation$, uiChanges } = useAppContext()
 
   const [firstStopLossSetup, setFirstStopLossSetup] = useState(!isStopLossEnabled)
+  // below useState has been added to handle button disable just after click
+  const [isTxStarted, setIsTxStarted] = useState(false)
 
   const token = vault.token
   const tokenData = getToken(token)
@@ -202,6 +204,7 @@ export function AdjustSlFormControl({
     !isOwner ||
     (!isEditing && txStatus !== TxStatus.Success) ||
     isProgressStage ||
+    isTxStarted ||
     maxDebtForSettingStopLoss
   )
 
@@ -211,6 +214,9 @@ export function AdjustSlFormControl({
       if (tx === undefined) {
         return
       }
+
+      setIsTxStarted(true)
+
       const txSendSuccessHandler = (transactionState: TxState<AutomationBotAddTriggerData>) => {
         transactionStateHandler(
           (txState) => {
@@ -246,6 +252,10 @@ export function AdjustSlFormControl({
                 txCost: totalCost,
               },
             })
+
+            if (progressStatuses.includes(txState.status)) {
+              setIsTxStarted(false)
+            }
           },
           transactionState,
           finishLoader,


### PR DESCRIPTION
# [Instant stop loss button disable and validation fix](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- due to potential network lag it was possible to click the button several times before it was blocked. Added handling for instant stop loss button disable when tx is submitted
  
## How to test 🧪
  <Please explain how to test your changes>
- using hardhat try to add stop loss and observe whether button is disabled right after click
