### PR TITLE
constant multiple banner, no details yet

### DIFF
--- a/features/automation/optimization/controls/ConstantMultipleControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleControl.tsx
@@ -1,14 +1,17 @@
+import { Vault } from 'blockchain/vaults'
 import React from 'react'
-import { ColorMode, Grid } from 'theme-ui'
+import { Grid } from 'theme-ui'
+
 import { ConstantMultipleDetailsLayout } from './ConstantMultipleDetailsLayout'
 
-interface ConstantMultipleControlProps{}
+interface ConstantMultipleControlProps {
+  vault: Vault
+}
 
-export function ConstantMultipleControl({}: ConstantMultipleControlProps) {
-
-    return (
-        <Grid>
-            <ConstantMultipleDetailsLayout/>
-        </Grid>
-    )
+export function ConstantMultipleControl({ vault }: ConstantMultipleControlProps) {
+  return (
+    <Grid>
+      <ConstantMultipleDetailsLayout token={vault.token} />
+    </Grid>
+  )
 }

--- a/features/automation/optimization/controls/ConstantMultipleControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleControl.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { ColorMode, Grid } from 'theme-ui'
+import { ConstantMultipleDetailsLayout } from './ConstantMultipleDetailsLayout'
+
+interface ConstantMultipleControlProps{}
+
+export function ConstantMultipleControl({}: ConstantMultipleControlProps) {
+
+    return (
+        <Grid>
+            <ConstantMultipleDetailsLayout/>
+        </Grid>
+    )
+}

--- a/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
@@ -4,11 +4,11 @@ import { Grid } from 'theme-ui'
 
 import { ConstantMultipleDetailsLayout } from './ConstantMultipleDetailsLayout'
 
-interface ConstantMultipleControlProps {
+interface ConstantMultipleDetailsControlProps {
   vault: Vault
 }
 
-export function ConstantMultipleControl({ vault }: ConstantMultipleControlProps) {
+export function ConstantMultipleDetailsControl({ vault }: ConstantMultipleDetailsControlProps) {
   return (
     <Grid>
       <ConstantMultipleDetailsLayout token={vault.token} />

--- a/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
@@ -1,4 +1,3 @@
-
 import { useAppContext } from 'components/AppContextProvider'
 import { Banner, bannerGradientPresets } from 'components/Banner'
 import { DetailsSection } from 'components/DetailsSection'

--- a/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
@@ -1,18 +1,29 @@
+
 import { useAppContext } from 'components/AppContextProvider'
 import { Banner, bannerGradientPresets } from 'components/Banner'
-import { AppLink } from 'components/Links'
+import { DetailsSection } from 'components/DetailsSection'
 import {
-  AutomationChangeFeature,
+  DetailsSectionContentCard,
+  DetailsSectionContentCardWrapper,
+} from 'components/DetailsSectionContentCard'
+import { AppLink } from 'components/Links'
+import { ContentCardTargetColRatio } from 'components/vault/detailsSection/ContentCardTargetColRatio'
+import { ContentCardTriggerColRatio } from 'components/vault/detailsSection/ContentCardTriggerColRatio'
+import {
   AUTOMATION_CHANGE_FEATURE,
+  AutomationChangeFeature,
 } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import { useUIChanges } from 'helpers/uiChangesHook'
+import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
 
-export interface ConstantMultipleDetailsLayoutProps {}
+export interface ConstantMultipleDetailsLayoutProps {
+  token: string
+}
 
-export function ConstantMultipleDetailsLayout({}: ConstantMultipleDetailsLayoutProps) {
+export function ConstantMultipleDetailsLayout({ token }: ConstantMultipleDetailsLayoutProps) {
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
@@ -20,7 +31,40 @@ export function ConstantMultipleDetailsLayout({}: ConstantMultipleDetailsLayoutP
   return (
     <Grid>
       {activeAutomationFeature?.currentOptimizationFeature === 'constantMultiple' ? (
-        <>details section tbd</>
+        <DetailsSection
+          title={t('constant-multiple.title')}
+          // badge={isConstantMultipleOn}
+          content={
+            <DetailsSectionContentCardWrapper>
+              {/* TODO -ŁW details TBD */}
+              <DetailsSectionContentCard title={t('constant-multiple.target-multiple')} />
+              <DetailsSectionContentCard title={t('constant-multiple.total-cost-of-feature')} />
+              <ContentCardTargetColRatio
+                threshold={one}
+                token={''}
+                // targetColRatio={targetColRatio}
+                // afterTargetColRatio={uiState.targetCollRatio}
+                // threshold={threshold}
+                // changeVariant="positive"
+                // token={token}
+              />
+              {/* TODO - ŁW allow to pass title for ContentCardTriggerColRatio re-use for buy, sell ? */}
+              {/* not sure if it makes sense to reuse those components, there are some differences in designs */}
+              {/* buy trigger */}
+              <ContentCardTriggerColRatio
+                token={token}
+                //   triggerColRatio={triggerColRatio}
+                //   afterTriggerColRatio={uiState.execCollRatio}
+                //   nextBuyPrice={nextBuyPrice}
+                //   changeVariant="positive"
+              />
+              {/* sell trigger */}
+              <ContentCardTriggerColRatio token={token} />
+              <DetailsSectionContentCard title={t('auto-buy.next-buy-prices')} />
+              <DetailsSectionContentCard title={t('auto-buy.next-sell-prices')} />
+            </DetailsSectionContentCardWrapper>
+          }
+        />
       ) : (
         <>
           <Banner

--- a/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
@@ -1,0 +1,55 @@
+import { useAppContext } from 'components/AppContextProvider'
+import { Banner, bannerGradientPresets } from 'components/Banner'
+import { AppLink } from 'components/Links'
+import {
+  AutomationChangeFeature,
+  AUTOMATION_CHANGE_FEATURE,
+} from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import { useUIChanges } from 'helpers/uiChangesHook'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Grid } from 'theme-ui'
+
+export interface ConstantMultipleDetailsLayoutProps {}
+
+export function ConstantMultipleDetailsLayout({}: ConstantMultipleDetailsLayoutProps) {
+  const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
+  const { t } = useTranslation()
+  const { uiChanges } = useAppContext()
+
+  return (
+    <Grid>
+      {activeAutomationFeature?.currentOptimizationFeature === 'constantMultiple' ? (
+        <>details section tbd</>
+      ) : (
+        <>
+          <Banner
+            title={t('constant-multiple.banner.header')}
+            description={
+              <>
+                {t('constant-multiple.banner.content')}{' '}
+                <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 2 }}>
+                  {t('here')}.
+                </AppLink>
+              </>
+            }
+            image={{
+              src: '/static/img/setup-banner/constant-multiply.svg',
+              backgroundColor: bannerGradientPresets.autoBuy[0],
+              backgroundColorEnd: bannerGradientPresets.autoBuy[1],
+            }}
+            button={{
+              action: () => {
+                uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+                  type: 'Optimization',
+                  currentOptimizationFeature: 'constantMultiple',
+                })
+              },
+              text: t('constant-multiple.banner.button'),
+            }}
+          />
+        </>
+      )}
+    </Grid>
+  )
+}

--- a/features/automation/optimization/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsControl.tsx
@@ -5,7 +5,8 @@ import { BasicBuyDetailsControl } from 'features/automation/optimization/control
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
-import { ConstantMultipleDetailsLayout } from './ConstantMultipleDetailsLayout'
+
+import { ConstantMultipleControl } from './ConstantMultipleControl'
 
 interface OptimizationDetailsControlProps {
   automationTriggersData: TriggersData
@@ -19,12 +20,14 @@ export function OptimizationDetailsControl({
   const basicBuyTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicBuy)
   const constantMultipleEnabled = useFeatureToggle('ConstantMultiple')
 
-  return (<>
-  <BasicBuyDetailsControl vault={vault} basicBuyTriggerData={basicBuyTriggerData} />
-  { constantMultipleEnabled && <>
-  <ConstantMultipleDetailsLayout/>
-  </>}  
-  </>
-  
+  return (
+    <>
+      <BasicBuyDetailsControl vault={vault} basicBuyTriggerData={basicBuyTriggerData} />
+      {constantMultipleEnabled && (
+        <>
+          <ConstantMultipleControl vault={vault} />
+        </>
+      )}
+    </>
   )
 }

--- a/features/automation/optimization/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsControl.tsx
@@ -6,7 +6,7 @@ import { TriggersData } from 'features/automation/protection/triggers/Automation
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
 
-import { ConstantMultipleControl } from './ConstantMultipleControl'
+import { ConstantMultipleDetailsControl } from './ConstantMultipleDetailsControl'
 
 interface OptimizationDetailsControlProps {
   automationTriggersData: TriggersData
@@ -25,7 +25,7 @@ export function OptimizationDetailsControl({
       <BasicBuyDetailsControl vault={vault} basicBuyTriggerData={basicBuyTriggerData} />
       {constantMultipleEnabled && (
         <>
-          <ConstantMultipleControl vault={vault} />
+          <ConstantMultipleDetailsControl vault={vault} />
         </>
       )}
     </>

--- a/features/automation/optimization/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsControl.tsx
@@ -3,7 +3,9 @@ import { Vault } from 'blockchain/vaults'
 import { extractBasicBSData } from 'features/automation/common/basicBSTriggerData'
 import { BasicBuyDetailsControl } from 'features/automation/optimization/controls/BasicBuyDetailsControl'
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
+import { ConstantMultipleDetailsLayout } from './ConstantMultipleDetailsLayout'
 
 interface OptimizationDetailsControlProps {
   automationTriggersData: TriggersData
@@ -15,6 +17,14 @@ export function OptimizationDetailsControl({
   vault,
 }: OptimizationDetailsControlProps) {
   const basicBuyTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicBuy)
+  const constantMultipleEnabled = useFeatureToggle('ConstantMultiple')
 
-  return <BasicBuyDetailsControl vault={vault} basicBuyTriggerData={basicBuyTriggerData} />
+  return (<>
+  <BasicBuyDetailsControl vault={vault} basicBuyTriggerData={basicBuyTriggerData} />
+  { constantMultipleEnabled && <>
+  <ConstantMultipleDetailsLayout/>
+  </>}  
+  </>
+  
+  )
 }

--- a/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
+++ b/features/automation/protection/common/UITypes/AutomationFeatureChange.ts
@@ -1,6 +1,6 @@
 type AutomationKinds = 'Protection' | 'Optimization'
 export type AutomationProtectionFeatures = 'stopLoss' | 'autoSell'
-export type AutomationOptimizationFeatures = 'autoBuy' | 'constantMultiply'
+export type AutomationOptimizationFeatures = 'autoBuy' | 'constantMultiple'
 
 export const AUTOMATION_CHANGE_FEATURE = 'automationChangeFeature'
 

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -15,6 +15,7 @@ export type Feature =
   | 'ReadOnlyBasicBS'
   | 'Notifications'
   | 'Referrals'
+  | 'ConstantMultiple'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -28,6 +29,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   ReadOnlyBasicBS: false,
   Notifications: false,
   Referrals: false,
+  ConstantMultiple: false,
   // your feature here....
 }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1493,6 +1493,13 @@
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Optimization triggers",
     "unable-to-access-auto-buy": "Unable to access Optimization"
   },
+  "constant-multiple": {
+    "banner": {
+    "header": "Set up Constant Multiple",
+    "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vitae erat at tellus blandit fermentum. Sed hendrerit hendrerit mi quis porttitor.",
+    "button": "Setup Constant Multiple"
+  }
+  },
   "ref": {
     "banner": "Introducing Refer a Friend. Earn DAI today",
     "ref-a-friend": "Refer a Friend",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1496,7 +1496,7 @@
   "constant-multiple": {
     "banner": {
     "header": "Set up Constant Multiple",
-    "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vitae erat at tellus blandit fermentum. Sed hendrerit hendrerit mi quis porttitor.",
+    "content": "Set up Constant Multiple to keep your vault's collateralization ratio within a range that you select",
     "button": "Setup Constant Multiple"
   }
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1494,6 +1494,9 @@
     "unable-to-access-auto-buy": "Unable to access Optimization"
   },
   "constant-multiple": {
+    "title": "Constant Multiple",
+    "target-multiple": "Target Multiple",
+    "total-cost-of-feature": "Total cost of feature",
     "banner": {
     "header": "Set up Constant Multiple",
     "content": "Set up Constant Multiple to keep your vault's collateralization ratio within a range that you select",


### PR DESCRIPTION
# [Constant multiple banner](https://app.shortcut.com/oazo-apps/story/5211/add-constant-multiple-banner-to-opimization-tab)

![image](https://user-images.githubusercontent.com/6871923/178763217-2d1a3582-cce2-4b94-81d8-fb68c1ad17dd.png)

not sure if it makes sense to re-use details cards from auto buy and auto sell, it has more fields than in designs for cm

![image](https://user-images.githubusercontent.com/6871923/178772440-e7b0b23a-9442-44cd-8043-0adbddb1d61e.png)

  

## Changes 👷‍♀️
  <Please add short list of changes>
- item 1
  
## How to test 🧪
  <Please explain how to test your changes>
- step 1 ...
