### PR TITLE
Modal not closing on /referrals

### DIFF
--- a/features/termsOfService/TermsOfService.tsx
+++ b/features/termsOfService/TermsOfService.tsx
@@ -235,8 +235,10 @@ export function TermsOfService({ userReferral }: { userReferral?: UserReferralSt
 }
 
 export function WithTermsOfService({ children }: WithTermsOfServiceProps) {
-  const { web3ContextConnected$ } = useAppContext()
+  const { web3ContextConnected$, userReferral$ } = useAppContext()
   const [web3ContextConnected] = useObservable(web3ContextConnected$)
+  const [userReferral] = useObservable(userReferral$)
+  
   const shouldUseTermsOfService = getConfig()?.publicRuntimeConfig?.useTermsOfService
 
   if (!web3ContextConnected) {
@@ -250,7 +252,7 @@ export function WithTermsOfService({ children }: WithTermsOfServiceProps) {
   return (
     <>
       {children}
-      <TermsOfService />
+      <TermsOfService userReferral={userReferral} />
     </>
   )
 }

--- a/features/termsOfService/TermsOfService.tsx
+++ b/features/termsOfService/TermsOfService.tsx
@@ -238,7 +238,7 @@ export function WithTermsOfService({ children }: WithTermsOfServiceProps) {
   const { web3ContextConnected$, userReferral$ } = useAppContext()
   const [web3ContextConnected] = useObservable(web3ContextConnected$)
   const [userReferral] = useObservable(userReferral$)
-  
+
   const shouldUseTermsOfService = getConfig()?.publicRuntimeConfig?.useTermsOfService
 
   if (!web3ContextConnected) {


### PR DESCRIPTION
# [Modal not closing on /referrals](https://app.shortcut.com/oazo-apps/story/5259/fix-referral-flow-after-testing)

- [ ]  The pop-up doesn’t close when clicking ‘decide later’ when the user is on the /referrals page
    - [ ]  `must` pop-up doesn’t close when the user has accepted a referral, and is trying to go to the referral page.
  
## Changes 👷‍♀️
- supply `userReferral` to `TermsOfService` when not on homepage
  
## How to test 🧪
1. land with a referral link
2. manually change the url to `/referrals`
3. try `accept` or `decide later`