### PR TITLE
Use execution price in calcs

### DIFF
--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -93,15 +93,7 @@ interface OptimizationControlProps {
 }
 
 export function OptimizationControl({ vault, ilkData, balanceInfo }: OptimizationControlProps) {
-  const {
-    automationTriggersData$,
-    priceInfo$,
-    context$,
-    txHelpers$,
-    tokenPriceUSD$,
-  } = useAppContext()
-  const priceInfoObs$ = useMemo(() => priceInfo$(vault.token), [vault.token])
-  const [priceInfoData, priceInfoError] = useObservable(priceInfoObs$)
+  const { automationTriggersData$, context$, txHelpers$, tokenPriceUSD$ } = useAppContext()
   const [txHelpersData, txHelpersError] = useObservable(txHelpers$)
   const [contextData, contextError] = useObservable(context$)
   const autoTriggersData$ = automationTriggersData$(vault.id)
@@ -135,19 +127,13 @@ export function OptimizationControl({ vault, ilkData, balanceInfo }: Optimizatio
 
   return (
     <WithErrorHandler
-      error={[
-        automationTriggersError,
-        priceInfoError,
-        ethAndTokenPricesError,
-        contextError,
-        txHelpersError,
-      ]}
+      error={[automationTriggersError, ethAndTokenPricesError, contextError, txHelpersError]}
     >
       <WithLoadingIndicator
-        value={[automationTriggersData, priceInfoData, contextData, ethAndTokenPricesData]}
+        value={[automationTriggersData, contextData, ethAndTokenPricesData]}
         customLoader={<VaultContainerSpinner />}
       >
-        {([automationTriggers, priceInfo, context, ethAndTokenPrices]) => (
+        {([automationTriggers, context, ethAndTokenPrices]) => (
           <DefaultVaultLayout
             detailsViewControl={
               <OptimizationDetailsControl
@@ -160,12 +146,10 @@ export function OptimizationControl({ vault, ilkData, balanceInfo }: Optimizatio
                 vault={vault}
                 automationTriggersData={automationTriggers}
                 ilkData={ilkData}
-                priceInfo={priceInfo}
                 txHelpers={txHelpersData}
                 context={context}
                 balanceInfo={balanceInfo}
                 ethMarketPrice={ethAndTokenPrices['ETH']}
-                tokenMarketPrice={ethAndTokenPrices[vault.token]}
               />
             }
           />

--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -175,7 +175,6 @@ export function ProtectionControl({
                   txHelpers={txHelpersData}
                   context={context}
                   ethMarketPrice={ethAndTokenPrices['ETH']}
-                  tokenMarketPrice={ethAndTokenPrices[vault.token]}
                 />
               }
             />

--- a/features/automation/common/validators.ts
+++ b/features/automation/common/validators.ts
@@ -88,9 +88,9 @@ export function errorsBasicSellValidation({
   const minimumSellPriceNotProvided =
     !isRemoveForm && withThreshold && (!maxBuyOrMinSellPrice || maxBuyOrMinSellPrice.isZero())
 
-  const autoSellTriggerHigherThanAutoBuyTarget = execCollRatio
-    .plus(5)
-    .gt(autoBuyTriggerData.targetCollRatio)
+  const autoSellTriggerHigherThanAutoBuyTarget =
+    autoBuyTriggerData.isTriggerEnabled &&
+    execCollRatio.plus(5).gt(autoBuyTriggerData.targetCollRatio)
 
   return errorMessagesHandler({
     insufficientEthFundsForTx,

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -11,31 +11,26 @@ import { extractStopLossData } from 'features/automation/protection/common/stopL
 import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
 import { BalanceInfo } from 'features/shared/balanceInfo'
-import { PriceInfo } from 'features/shared/priceInfo'
 import React, { useEffect } from 'react'
 
 interface OptimizationFormControlProps {
   automationTriggersData: TriggersData
   vault: Vault
   ilkData: IlkData
-  priceInfo: PriceInfo
   txHelpers?: TxHelpers
   context: Context
   balanceInfo: BalanceInfo
   ethMarketPrice: BigNumber
-  tokenMarketPrice: BigNumber
 }
 
 export function OptimizationFormControl({
   automationTriggersData,
   vault,
   ilkData,
-  priceInfo,
   txHelpers,
   context,
   balanceInfo,
   ethMarketPrice,
-  tokenMarketPrice,
 }: OptimizationFormControlProps) {
   const autoBuyTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicBuy)
   const autoSellTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicSell)
@@ -55,7 +50,6 @@ export function OptimizationFormControl({
     <AutoBuyFormControl
       vault={vault}
       ilkData={ilkData}
-      priceInfo={priceInfo}
       balanceInfo={balanceInfo}
       autoSellTriggerData={autoSellTriggerData}
       autoBuyTriggerData={autoBuyTriggerData}
@@ -64,7 +58,6 @@ export function OptimizationFormControl({
       context={context}
       txHelpers={txHelpers}
       ethMarketPrice={ethMarketPrice}
-      tokenMarketPrice={tokenMarketPrice}
     />
   )
 }

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -71,9 +71,9 @@ export function errorsBasicBuyValidation({
   const autoBuyMaxBuyPriceNotSpecified =
     !isRemoveForm && withThreshold && (!maxBuyOrMinSellPrice || maxBuyOrMinSellPrice.isZero())
 
-  const autoBuyTriggerLowerThanAutoSellTarget = execCollRatio
-    .minus(5)
-    .lt(autoSellTriggerData.targetCollRatio)
+  const autoBuyTriggerLowerThanAutoSellTarget =
+    autoSellTriggerData.isTriggerEnabled &&
+    execCollRatio.minus(5).lt(autoSellTriggerData.targetCollRatio)
 
   return errorMessagesHandler({
     insufficientEthFundsForTx,

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -29,7 +29,6 @@ interface ProtectionFormControlProps {
   txHelpers?: TxHelpers
   context: Context
   ethMarketPrice: BigNumber
-  tokenMarketPrice: BigNumber
   account?: string
 }
 
@@ -43,7 +42,6 @@ export function ProtectionFormControl({
   context,
   txHelpers,
   ethMarketPrice,
-  tokenMarketPrice,
 }: ProtectionFormControlProps) {
   const stopLossTriggerData = extractStopLossData(automationTriggersData)
   const autoSellTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicSell)
@@ -86,7 +84,6 @@ export function ProtectionFormControl({
       <AutoSellFormControl
         vault={vault}
         ilkData={ilkData}
-        priceInfo={priceInfo}
         balanceInfo={balanceInfo}
         autoSellTriggerData={autoSellTriggerData}
         autoBuyTriggerData={autoBuyTriggerData}
@@ -95,7 +92,6 @@ export function ProtectionFormControl({
         context={context}
         txHelpers={txHelpers}
         ethMarketPrice={ethMarketPrice}
-        tokenMarketPrice={tokenMarketPrice}
       />
     </>
   )

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -132,7 +132,6 @@ export function SidebarSetupAutoSell({
 
   const cancelAutoSellWarnings = extractCancelAutoSellWarnings(warnings)
   const cancelAutoSellErrors = extractCancelAutoSellErrors(errors)
-  console.log(errors)
 
   if (isAutoSellActive) {
     const sidebarSectionProps: SidebarSectionProps = {

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -132,6 +132,7 @@ export function SidebarSetupAutoSell({
 
   const cancelAutoSellWarnings = extractCancelAutoSellWarnings(warnings)
   const cancelAutoSellErrors = extractCancelAutoSellErrors(errors)
+  console.log(errors)
 
   if (isAutoSellActive) {
     const sidebarSectionProps: SidebarSectionProps = {


### PR DESCRIPTION
# [Use execution price in calcs](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- calculation used to get debt delta now using execution price
  
## How to test 🧪
  <Please explain how to test your changes>

- in auto buy and auto sell form information section should contain calculation based on execution price
- in auto sell form error validation regarding dust limit should take into account correct debtDelta (based on executionPrice)
