### PR TITLE
Fixed issue with 0 execution price

### DIFF
--- a/blockchain/vault.maths.ts
+++ b/blockchain/vault.maths.ts
@@ -156,5 +156,7 @@ export function collateralPriceAtRatio({
   collateral,
   vaultDebt,
 }: CollateralPriceAtRatioThresholdArgs): BigNumber {
-  return collateral.eq(zero) ? zero : vaultDebt.times(colRatio).div(collateral)
+  return collateral.isZero() || vaultDebt.isZero()
+    ? zero
+    : vaultDebt.times(colRatio).div(collateral)
 }

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -22,6 +22,7 @@ import {
 import {
   checkIfDisabledBasicBS,
   checkIfEditingBasicBS,
+  getBasicBSVaultChange,
   prepareBasicBSResetData,
 } from 'features/automation/common/helpers'
 import { failedStatuses, progressStatuses } from 'features/automation/common/txStatues'
@@ -31,13 +32,10 @@ import {
   BASIC_BUY_FORM_CHANGE,
   BasicBSFormChange,
 } from 'features/automation/protection/common/UITypes/basicBSFormChange'
-import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { GasEstimationStatus, HasGasEstimation } from 'helpers/form'
-import { LOAN_FEE, OAZO_FEE } from 'helpers/multiply/calculations'
 import { useObservable } from 'helpers/observableHook'
 import { useUIChanges } from 'helpers/uiChangesHook'
-import { zero } from 'helpers/zero'
 import React, { useMemo } from 'react'
 
 interface AutoBuyFormControlProps {
@@ -211,23 +209,11 @@ export function AutoBuyFormControl({
     vaultDebt: vault.debt,
   })
 
-  const { debtDelta, collateralDelta } =
-    basicBuyState.targetCollRatio.gt(zero) && basicBuyState.execCollRatio.gt(zero)
-      ? getVaultChange({
-          currentCollateralPrice: executionPrice,
-          marketPrice: executionPrice,
-          slippage: basicBuyState.deviation.div(100),
-          debt: vault.debt,
-          lockedCollateral: vault.lockedCollateral,
-          requiredCollRatio: basicBuyState.targetCollRatio.div(100),
-          depositAmount: zero,
-          paybackAmount: zero,
-          generateAmount: zero,
-          withdrawAmount: zero,
-          OF: OAZO_FEE,
-          FF: LOAN_FEE,
-        })
-      : { debtDelta: zero, collateralDelta: zero }
+  const { debtDelta, collateralDelta } = getBasicBSVaultChange({
+    basicBSState: basicBuyState,
+    vault,
+    executionPrice,
+  })
 
   return (
     <SidebarSetupAutoBuy

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -21,6 +21,7 @@ import {
 import {
   checkIfDisabledBasicBS,
   checkIfEditingBasicBS,
+  getBasicBSVaultChange,
   prepareBasicBSResetData,
 } from 'features/automation/common/helpers'
 import { failedStatuses, progressStatuses } from 'features/automation/common/txStatues'
@@ -30,10 +31,8 @@ import {
   BasicBSFormChange,
 } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { SidebarSetupAutoSell } from 'features/automation/protection/controls/sidebar/SidebarSetupAutoSell'
-import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { GasEstimationStatus, HasGasEstimation } from 'helpers/form'
-import { LOAN_FEE, OAZO_FEE } from 'helpers/multiply/calculations'
 import { useObservable } from 'helpers/observableHook'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { zero } from 'helpers/zero'
@@ -209,24 +208,11 @@ export function AutoSellFormControl({
     collateral: vault.lockedCollateral,
     vaultDebt: vault.debt,
   })
-
-  const { debtDelta, collateralDelta } =
-    basicSellState.targetCollRatio.gt(zero) && basicSellState.execCollRatio.gt(zero)
-      ? getVaultChange({
-          currentCollateralPrice: executionPrice,
-          marketPrice: executionPrice,
-          slippage: basicSellState.deviation.div(100),
-          debt: vault.debt,
-          lockedCollateral: vault.lockedCollateral,
-          requiredCollRatio: basicSellState.targetCollRatio.div(100),
-          depositAmount: zero,
-          paybackAmount: zero,
-          generateAmount: zero,
-          withdrawAmount: zero,
-          OF: OAZO_FEE,
-          FF: LOAN_FEE,
-        })
-      : { debtDelta: zero, collateralDelta: zero }
+  const { debtDelta, collateralDelta } = getBasicBSVaultChange({
+    basicBSState: basicSellState,
+    vault,
+    executionPrice,
+  })
 
   return (
     <SidebarSetupAutoSell


### PR DESCRIPTION
# [Fixed issue with 0 execution price](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- we no longer pass zero as execution price for multiply calcs method
  
## How to test 🧪
  <Please explain how to test your changes>
- with zero debt o zero collateral and enabled auto buy or sell trigger go to optimization tab
