### PR TITLE
Adjusted isDisabled method for basic buy and sell

### DIFF
--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -77,17 +77,16 @@ export function checkIfDisabledBasicBS({
   stage: SidebarVaultStages
 }) {
   return (
-    ((isProgressStage ||
+    (isProgressStage ||
       !isOwner ||
       !isEditing ||
       (isAddForm &&
-        basicBSState.withThreshold &&
-        (basicBSState.maxBuyOrMinSellPrice === undefined ||
-          basicBSState.maxBuyOrMinSellPrice?.isZero())) ||
-      basicBSState.execCollRatio.isZero()) &&
-      stage !== 'txSuccess') ||
-    basicBSState.execCollRatio.isZero() ||
-    basicBSState.targetCollRatio.isZero()
+        (basicBSState.execCollRatio.isZero() ||
+          basicBSState.targetCollRatio.isZero() ||
+          (basicBSState.withThreshold &&
+            (basicBSState.maxBuyOrMinSellPrice === undefined ||
+              basicBSState.maxBuyOrMinSellPrice?.isZero()))))) &&
+    stage !== 'txSuccess'
   )
 }
 

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -131,6 +131,8 @@ export function SidebarSetupAutoBuy({
   const cancelAutoBuyWarnings = extractCancelAutoBuyWarnings(warnings)
   const cancelAutoBuyErrors = extractCancelAutoBuyErrors(errors)
 
+  const validationErrors = isAddForm ? errors : cancelAutoBuyErrors
+
   if (isAutoBuyOn || activeAutomationFeature?.currentOptimizationFeature === 'autoBuy') {
     const sidebarSectionProps: SidebarSectionProps = {
       title: t('auto-buy.form-title'),
@@ -177,7 +179,7 @@ export function SidebarSetupAutoBuy({
       ),
       primaryButton: {
         label: primaryButtonLabel,
-        disabled: (isDisabled || !!errors.length) && stage !== 'txSuccess',
+        disabled: isDisabled || !!validationErrors.length,
         isLoading: stage === 'txInProgress',
         action: () => txHandler(),
       },

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -133,6 +133,8 @@ export function SidebarSetupAutoSell({
   const cancelAutoSellWarnings = extractCancelAutoSellWarnings(warnings)
   const cancelAutoSellErrors = extractCancelAutoSellErrors(errors)
 
+  const validationErrors = isAddForm ? errors : cancelAutoSellErrors
+
   if (isAutoSellActive) {
     const sidebarSectionProps: SidebarSectionProps = {
       title: sidebarTitle,
@@ -184,7 +186,7 @@ export function SidebarSetupAutoSell({
       ),
       primaryButton: {
         label: primaryButtonLabel,
-        disabled: (isDisabled || !!errors.length) && stage !== 'txSuccess',
+        disabled: isDisabled || !!validationErrors.length,
         isLoading: stage === 'txInProgress',
         action: () => txHandler(),
       },


### PR DESCRIPTION
# [Adjusted isDisabled method for basic buy and sell](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- cancel form button for basic buy and sell shouldn't be disabled by errors regarding add form inputs
  
## How to test 🧪
  <Please explain how to test your changes>
- add triggers in different combinations and check whether button in cancel for is disabled (shouldn't be)
