### PR TITLE
Fixed issue with generating when user is not the owner

### DIFF
--- a/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
+++ b/features/borrow/manage/sidebars/SidebarManageBorrowVaultEditingStage.tsx
@@ -91,7 +91,7 @@ export function SidebarManageBorrowVaultEditingStage(props: ManageStandardBorrow
               <FieldDepositCollateral token={token} {...extractFieldDepositCollateralData(props)} />
               <FieldGenerateDai
                 debt={debt}
-                disabled={isSecondaryFieldDisabled}
+                disabled={isSecondaryFieldDisabled || !isOwner}
                 {...extractFieldGenerateDaiData(props)}
               />
             </>

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
@@ -133,6 +133,7 @@ function SidebarManageMultiplyVaultEditingStageDepositCollateral(props: ManageMu
     showSliderController,
     toggleSliderController,
     vault: { token },
+    accountIsController,
   } = props
 
   return (
@@ -140,7 +141,7 @@ function SidebarManageMultiplyVaultEditingStageDepositCollateral(props: ManageMu
       <FieldDepositCollateral token={token} {...extractFieldDepositCollateralData(props)} />
       <OptionalAdjust
         label={t('adjust-your-position-additional')}
-        isVisible={depositAmount?.gt(zero)}
+        isVisible={depositAmount?.gt(zero) && accountIsController}
         isExpanded={showSliderController}
         clickHandler={toggleSliderController}
       >


### PR DESCRIPTION
# [Fixed issue with generating when user is not the owner](https://app.shortcut.com/oazo-apps/story/5116/gas-estimation-fails-on-goerli-for-vault-308)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- handled case when user is not the owner and tries to generate dai (button / input has to be disabled in that case)
  
## How to test 🧪
  <Please explain how to test your changes>
- try deposit and generate in multiply / borrow vault which is not yours and additionally verify whether you can perform these actions on your vault
