### PR TITLE
Wrapped automation history events

### DIFF
--- a/features/vaultHistory/VaultHistoryEntry.tsx
+++ b/features/vaultHistory/VaultHistoryEntry.tsx
@@ -20,9 +20,25 @@ import { Box, Flex, Text } from 'theme-ui'
 
 import { VaultHistoryEvent } from './vaultHistory'
 
+function resolveTranslationForEventsWithTriggers(event: VaultHistoryEvent) {
+  switch (event.kind) {
+    case 'DECREASE_MULTIPLE':
+      return 'basic-sell'
+    case 'INCREASE_MULTIPLE':
+      return 'basic-buy'
+    case 'CLOSE_VAULT_TO_DAI':
+    case 'CLOSE_VAULT_TO_COLLATERAL':
+      return 'stop-loss'
+    default:
+      return event.kind
+  }
+}
+
 export function getHistoryEventTranslation(t: TFunction, event: VaultHistoryEvent) {
   if ('triggerId' in event) {
-    return `${t(`history.${event.kind}`)} ${t(`triggers.${event.eventType}`)}`
+    const resolveKind = resolveTranslationForEventsWithTriggers(event)
+
+    return `${t(`history.${resolveKind}`)} ${t(`triggers.${event.eventType}`)}`
   }
 
   return t(`history.${event.kind.toLowerCase()}`, {

--- a/features/vaultHistory/VaultHistoryView.tsx
+++ b/features/vaultHistory/VaultHistoryView.tsx
@@ -1,12 +1,12 @@
 import { useAppContext } from 'components/AppContextProvider'
+import { DefinitionList } from 'components/DefinitionList'
 import { useObservable } from 'helpers/observableHook'
 import { flatten } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Card, Heading } from 'theme-ui'
 
-import { DefinitionList } from '../../components/DefinitionList'
-import { splitEvents, VaultHistoryEvent } from './vaultHistory'
+import { mapAutomationEvents, splitEvents, VaultHistoryEvent } from './vaultHistory'
 import { VaultHistoryEntry } from './VaultHistoryEntry'
 
 export function VaultHistoryView({ vaultHistory }: { vaultHistory: VaultHistoryEvent[] }) {
@@ -14,7 +14,8 @@ export function VaultHistoryView({ vaultHistory }: { vaultHistory: VaultHistoryE
   const [context] = useObservable(context$)
   const { t } = useTranslation()
 
-  const spitedEvents = flatten(vaultHistory.map(splitEvents))
+  const mappedAuto = mapAutomationEvents(vaultHistory)
+  const spitedEvents = flatten(mappedAuto.map(splitEvents))
 
   return (
     <>

--- a/features/vaultHistory/vaultHistoryEvents.ts
+++ b/features/vaultHistory/vaultHistoryEvents.ts
@@ -222,8 +222,11 @@ interface StopLossBaseEvent extends AutomationBaseEvent {
   kind: 'stop-loss'
 }
 
-interface StopLossExecutedEvent extends StopLossBaseEvent {
+type StopLossCloseEvent = CloseVaultExitDaiMultipleEvent | CloseVaultExitCollateralMultipleEvent
+
+type StopLossExecutedEvent = StopLossCloseEvent & {
   eventType: 'executed'
+  triggerId: string
 }
 interface StopLossAddedEvent extends StopLossBaseEvent {
   eventType: 'added'
@@ -236,8 +239,9 @@ interface BasicBuyBaseEvent extends AutomationBaseEvent {
   kind: 'basic-buy'
 }
 
-interface BasicBuyExecutedEvent extends BasicBuyBaseEvent {
+export interface BasicBuyExecutedEvent extends IncreaseMultipleEvent {
   eventType: 'executed'
+  triggerId: string
 }
 interface BasicBuyAddedEvent extends BasicBuyBaseEvent {
   eventType: 'added'
@@ -250,14 +254,21 @@ interface BasicSellBaseEvent extends AutomationBaseEvent {
   kind: 'basic-sell'
 }
 
-interface BasicSellExecutedEvent extends BasicSellBaseEvent {
+export interface BasicSellExecutedEvent extends DecreaseMultipleEvent {
   eventType: 'executed'
+  triggerId: string
 }
+
 interface BasicSellAddedEvent extends BasicSellBaseEvent {
   eventType: 'added'
 }
 interface BasicSellRemovedEvent extends BasicSellBaseEvent {
   eventType: 'removed'
+}
+
+interface AutomationUpdateEvent extends AutomationBaseEvent {
+  kind: 'basic-sell' | 'basic-buy' | 'stop-loss'
+  eventType: 'updated'
 }
 
 export type MultiplyEvent =
@@ -269,7 +280,7 @@ export type MultiplyEvent =
   | CloseGuniVaultExitDaiMultipleEvent
   | CloseVaultExitCollateralMultipleEvent
 
-type AutomationEvent =
+export type AutomationEvent =
   | StopLossExecutedEvent
   | StopLossAddedEvent
   | StopLossRemovedEvent
@@ -279,6 +290,7 @@ type AutomationEvent =
   | BasicSellExecutedEvent
   | BasicSellAddedEvent
   | BasicSellRemovedEvent
+  | AutomationUpdateEvent
 
 export interface ReturnedEvent {
   kind: string

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -259,7 +259,8 @@
   "triggers": {
     "added": "added",
     "removed": "removed",
-    "executed": "executed"
+    "executed": "executed",
+    "updated": "updated"
   },
   "jwt-auth-failed": "Signature failed",
   "jwt-auth-in-progress": "Waiting for signature...",


### PR DESCRIPTION
# [Wrapped automation history events](https://app.shortcut.com/oazo-apps/story/5289/vault-history-wrap-events-with-same-txhash-into-single-history-event)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- automation events with same txHash has been wrapped into single history event
  
## How to test 🧪
  <Please explain how to test your changes>
- history should contain update events (when stop loss / auto sell or buy are updated), execution events with detailed informations
