### PR TITLE
[SC-5255] Fix showing stop loss info on all vaults.

### DIFF
--- a/features/vaultHistory/vaultsHistory.ts
+++ b/features/vaultHistory/vaultsHistory.ts
@@ -113,7 +113,7 @@ function mapToVaultWithHistory(
     const history = flatEvents([vaultEvents, vaultAutomationEvents])
     const stopLossData = extractStopLossData({
       isAutomationEnabled: vaultActiveTriggers.length > 0,
-      triggers: activeTriggers.map((trigger) => ({
+      triggers: vaultActiveTriggers.map((trigger) => ({
         ...trigger,
         executionParams: trigger.triggerData,
       })),


### PR DESCRIPTION
# [When the user has set 1 stop loss, all other vaults look like they have it active on the owner page.
](https://app.shortcut.com/oazo-apps/story/5255/bug-when-the-user-has-set-1-stop-loss-all-other-vaults-look-like-they-have-it-active-on-the-owner-page)
