### PR TITLE
Display proper protection values on vaults overview page

### DIFF
--- a/components/dumb/PositionList.tsx
+++ b/components/dumb/PositionList.tsx
@@ -86,6 +86,7 @@ export type MultiplyPositionVM = {
   liquidationPrice: string
   fundingCost: string
   automationEnabled: boolean
+  protectionAmount?: string
   automationLinkProps: AppLinkProps
 } & PositionCommonProps
 
@@ -113,7 +114,7 @@ function AutomationButton({ position }: { position: BorrowPositionVM | MultiplyP
     return (
       <AppLink {...automationLinkProps}>
         <Button variant="actionActiveGreen" sx={{ px: '24px', py: '11px' }}>
-          {t('earn.automation-button-on')} {position.type === 'borrow' && position.protectionAmount}
+          {t('earn.automation-button-on')} {position.protectionAmount}
         </Button>
       </AppLink>
     )

--- a/features/vaultsOverview/vaultsOverview.ts
+++ b/features/vaultsOverview/vaultsOverview.ts
@@ -100,7 +100,8 @@ function mapToPositionVM(vaults: PositionDetails[]): PositionVM[] {
       fundingCost: formatPercent(fundingCost, {
         precision: 2,
       }),
-      automationEnabled: position.stopLossData.isStopLossEnabled,
+      automationEnabled: isAutomationEnabled(position),
+      protectionAmount: getProtectionAmount(position),
       editLinkProps: {
         href: `/${position.id}`,
         hash: VaultViewMode.Overview,

--- a/features/vaultsOverview/vaultsOverview.ts
+++ b/features/vaultsOverview/vaultsOverview.ts
@@ -70,8 +70,8 @@ function mapToPositionVM(vaults: PositionDetails[]): PositionVM[] {
       daiDebt: formatCryptoBalance(position.debt),
       collateralLocked: `${formatCryptoBalance(position.lockedCollateral)} ${position.token}`,
       variable: formatPercent(position.stabilityFee.times(100), { precision: 2 }),
-      automationEnabled: position.stopLossData.isStopLossEnabled,
-      protectionAmount: formatPercent(position.stopLossData.stopLossLevel.times(100)),
+      automationEnabled: isAutomationEnabled(position),
+      protectionAmount: getProtectionAmount(position),
       editLinkProps: {
         href: `/${position.id}`,
         hash: VaultViewMode.Overview,
@@ -142,4 +142,19 @@ function getPnl(vault: PositionDetails): BigNumber {
   const { lockedCollateralUSD, debt, history } = vault
   const netValueUSD = lockedCollateralUSD.minus(debt)
   return calculatePNL(history, netValueUSD)
+}
+
+function isAutomationEnabled(position: PositionDetails): boolean {
+  return position.stopLossData.isStopLossEnabled || position.basicSellData.isTriggerEnabled
+}
+
+function getProtectionAmount(position: PositionDetails): string {
+  let protectionAmount = zero
+
+  if (position.stopLossData.stopLossLevel.gt(zero))
+    protectionAmount = position.stopLossData.stopLossLevel.times(100)
+  else if (position.basicSellData.execCollRatio.gt(zero))
+    protectionAmount = position.basicSellData.execCollRatio
+
+  return formatPercent(protectionAmount)
 }


### PR DESCRIPTION
# Display proper protection values on vaults overview page
https://app.shortcut.com/oazo-apps/story/5319/show-protection-active-when-auto-sell-has-been-added
https://app.shortcut.com/oazo-apps/story/5323/protection-column-on-my-positions-is-inconsistent-between-borrow-and-multiply
  
## Changes 👷‍♀️

- When vault has auto sell enabled, its value should be visible in its row on vaults overview page,
- Multiply vaults should display protection values, not just simple "On".
  
## How to test 🧪

Add SL and auto-sell to both borrow and multiply vault, check if their values are correctly reflected in vaults overview page.

![image](https://user-images.githubusercontent.com/16230404/179958202-132ae147-a2fc-4dca-bcce-ee7905886110.png)
![image](https://user-images.githubusercontent.com/16230404/179958245-71bfb3a7-b8ad-4918-be10-e39a9d278c2d.png)

