### PR TITLE
Do not show the JWT modal when TOS is updated

### DIFF
--- a/features/termsOfService/termsAcceptance.test.ts
+++ b/features/termsOfService/termsAcceptance.test.ts
@@ -126,7 +126,6 @@ describe('termsAcceptance', () => {
         jwtAuthSetupToken$: () => of('xxx'),
       }),
     )
-    ;(state() as any).acceptJwtAuth()
     expect(state().stage).to.be.deep.eq('acceptanceWaiting4TOSAcceptance')
     expect(state().updated).to.be.deep.eq(true)
   })


### PR DESCRIPTION
# [Do not show the JWT modal when TOS is updated](https://app.shortcut.com/oazo-apps/story/5335/do-not-show-the-jwt-modal-when-tos-is-updated)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
added the 
```
      if (updated) {
        return jwtAuthSetupToken$(web3, account).pipe(
          switchMap((token) => {
            return checkAcceptance(token, version, magicLinkEmail)
          }),
          catchError(() => {
            return withClose({ stage: 'jwtAuthFailed' })
          }),
          startWith({
            stage: 'jwtAuthInProgress',
          }),
        )
      }
```
to force the `acceptanceWaiting4TOSAcceptance` stage when user has jwt in local storage and the TOS has been updated.

Removed the `;(state() as any).acceptJwtAuth()` in `termsAcceptance.test.ts` - as the JWT accpetance is not required.
  
## How to test 🧪
remove the latest TOS signature from the DB, so only the previous one is left  (`version-1.06.2021`)
remove the latest TOS signature and jwt token from local storage from the DB, so only the previous one is left  (`version-1.06.2021`)
remove all TOS signatures and jw token from local storage from the DB

and go to TOS requiring page like vault creation