### PR TITLE
fix duplicated chainId

### DIFF
--- a/handlers/vault/createOrUpdate.ts
+++ b/handlers/vault/createOrUpdate.ts
@@ -23,6 +23,9 @@ export async function createOrUpdate(req: NextApiRequest, res: NextApiResponse) 
     chain_id: params.chainId,
   }
 
+  const insertQuery = `INSERT INTO vault (vault_id, chain_id, type, owner_address) VALUES (${vaultData.vault_id},${vaultData.chain_id},'${vaultData.type}','${vaultData.owner_address}')`
+  const updateQuery = `UPDATE vault SET type='${vaultData.type}' WHERE vault_id=${vaultData.vault_id} AND chain_id = ${vaultData.chain_id}`
+
   if (params.type !== 'borrow' && params.type !== 'multiply') {
     return res.status(403).send('Incorrect type of vault')
   }
@@ -31,13 +34,9 @@ export async function createOrUpdate(req: NextApiRequest, res: NextApiResponse) 
 
   if (vault === null || vault.owner_address === user.address) {
     if (vault === null) {
-      await prisma.$executeRawUnsafe(`
-        INSERT INTO vault (vault_id, chain_id, type, owner_address) VALUES (${vaultData.vault_id},${vaultData.chain_id},'${vaultData.type}','${vaultData.owner_address}') }
-      `)
+      await prisma.$executeRawUnsafe(insertQuery)
     } else {
-      await prisma.$executeRawUnsafe(`
-        UPDATE vault SET type='${vaultData.type}' WHERE vault_id=${vaultData.vault_id} AND chain_id = ${vaultData.chain_id}
-      `)
+      await prisma.$executeRawUnsafe(updateQuery)
     }
     return res.status(200).send('OK')
   } else {

--- a/handlers/vault/createOrUpdate.ts
+++ b/handlers/vault/createOrUpdate.ts
@@ -22,6 +22,7 @@ export async function createOrUpdate(req: NextApiRequest, res: NextApiResponse) 
     owner_address: user.address,
     chain_id: params.chainId,
   }
+  
   if (params.type !== 'borrow' && params.type !== 'multiply') {
     return res.status(403).send('Incorrect type of vault')
   }
@@ -29,16 +30,15 @@ export async function createOrUpdate(req: NextApiRequest, res: NextApiResponse) 
   const vault = await selectVaultByIdAndChainId(vaultData)
 
   if (vault === null || vault.owner_address === user.address) {
-    await prisma.vault.upsert({
-      where: {
-        vault_vault_id_chain_id_unique_constraint: {
-          vault_id: vaultData.vault_id,
-          chain_id: vaultData.chain_id,
-        },
-      },
-      update: vaultData,
-      create: vaultData,
-    })
+    if (vault === null) {
+      await prisma.$executeRawUnsafe(`
+        INSERT INTO vault (vault_id, chain_id, type, owner_address) VALUES (${vaultData.vault_id},${vaultData.chain_id},'${vaultData.type}','${vaultData.owner_address}') }
+      `)
+    } else {
+      await prisma.$executeRawUnsafe(`
+        UPDATE vault SET type='${vaultData.type}' WHERE vault_id=${vaultData.vault_id} AND chain_id = ${vaultData.chain_id}
+      `)
+    }
     return res.status(200).send('OK')
   } else {
     return res.status(401).send('Unauthorized')

--- a/handlers/vault/createOrUpdate.ts
+++ b/handlers/vault/createOrUpdate.ts
@@ -22,7 +22,7 @@ export async function createOrUpdate(req: NextApiRequest, res: NextApiResponse) 
     owner_address: user.address,
     chain_id: params.chainId,
   }
-  
+
   if (params.type !== 'borrow' && params.type !== 'multiply') {
     return res.status(403).send('Incorrect type of vault')
   }


### PR DESCRIPTION
Fix inability to switch from borrow to multiply (and vice versa) for vaultId on many networks