### PR TITLE
Fixed total cost issue in stop loss executed summary

### DIFF
--- a/components/vault/sidebar/SidebarVaultSLTriggered.tsx
+++ b/components/vault/sidebar/SidebarVaultSLTriggered.tsx
@@ -36,7 +36,7 @@ export function SidebarVaultSLTriggered({ closeEvent }: SidebarVaultSLTriggeredP
   const isToCollateral = closeEvent.kind === 'CLOSE_VAULT_TO_COLLATERAL'
   const priceImpact = calculatePriceImpact(marketPrice, offerPrice)
   const withdrawAmount = isToCollateral ? closeEvent.exitCollateral : exitDai
-  const fee = BigNumber.sum(totalFee, amountFromWei(gasFee, token).times(ethPrice))
+  const fee = BigNumber.sum(totalFee, amountFromWei(gasFee, 'ETH').times(ethPrice))
 
   return (
     <>


### PR DESCRIPTION
# [Fixed total cost issue in stop loss executed summary](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- amountFromWei method was using wrong precision based on token, ETH should be hardcoded there
  
## How to test 🧪
  <Please explain how to test your changes>
- go to https://oasis.app/28944#overview totalCost in Stop-Loss executed summary should be equal to total cost in history event
