### PR TITLE
CM sell trigger above stop-loss trigger validation

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -9,6 +9,9 @@ import React from 'react'
 import { Dictionary } from 'ts-essentials'
 
 const SupportLink = <AppLink sx={{ color: 'warning100' }} href="mailto:support@oasis.app" />
+const ConstantMultipleKBLink = (
+  <AppLink sx={{ color: 'warning100' }} href="https://kb.oasis.app/help/" />
+)
 
 interface VaultWarningsProps {
   warningMessages: VaultWarningMessage[]
@@ -71,6 +74,13 @@ export function VaultWarnings({ warningMessages, ilkData: { debtFloor } }: Vault
       // TEMPORARY override message as banner in overview details
       case 'autoSellOverride':
         return <Trans i18nKey="vault-warnings.auto-sell-override" components={[SupportLink]} />
+      case 'constantMultipleSellTriggerCloseToStopLossTrigger':
+        return (
+          <Trans
+            i18nKey="vault-warnings.constant-multiple-sell-trigger-close-to-stop-loss-trigger"
+            components={[ConstantMultipleKBLink]}
+          />
+        )
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
@@ -15,11 +15,13 @@ import {
   CONSTANT_MULTIPLE_FORM_CHANGE,
   ConstantMultipleFormChange,
 } from 'features/automation/protection/common/UITypes/constantMultipleFormChange'
+import { BalanceInfo } from 'features/shared/balanceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { zero } from 'helpers/zero'
 import React, { useMemo } from 'react'
 
 import { SidebarSetupConstantMultiple } from '../sidebars/SidebarSetupConstantMultiple'
+
 interface ConstantMultipleFormControlProps {
   context: Context
   isConstantMultipleActive: boolean
@@ -30,6 +32,7 @@ interface ConstantMultipleFormControlProps {
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
+  balanceInfo: BalanceInfo
 }
 
 export function ConstantMultipleFormControl({
@@ -43,6 +46,7 @@ export function ConstantMultipleFormControl({
   stopLossTriggerData,
   // autoSellTriggerData,
   autoBuyTriggerData,
+  balanceInfo,
 }: ConstantMultipleFormControlProps) {
   const { uiChanges /*, addGasEstimation$*/ } = useAppContext()
   const [constantMultipleState] = useUIChanges<ConstantMultipleFormChange>(
@@ -135,10 +139,6 @@ export function ConstantMultipleFormControl({
       isFirstSetup={true}
       onChange={(multiplier) => {
         const targetCollRatioForSelectedMultiplier = calculateCollRatioForMultiply(multiplier)
-        console.log('multiplier')
-        console.log(multiplier)
-        console.log('targetCollRatioForSelectedMultiplier')
-        console.log(targetCollRatioForSelectedMultiplier.toFixed(2))
         uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
           type: 'multiplier',
           multiplier: multiplier,
@@ -149,6 +149,8 @@ export function ConstantMultipleFormControl({
       ilkData={ilkData}
       autoBuyTriggerData={autoBuyTriggerData}
       stopLossTriggerData={stopLossTriggerData}
+      ethMarketPrice={ethMarketPrice}
+      balanceInfo={balanceInfo}
     />
   )
 }

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -89,6 +89,7 @@ export function OptimizationFormControl({
           autoSellTriggerData={autoSellTriggerData}
           autoBuyTriggerData={autoBuyTriggerData}
           stopLossTriggerData={stopLossTriggerData}
+          balanceInfo={balanceInfo}
         />
       )}
     </>

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -18,7 +18,7 @@ import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
 import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import { SidebarFlow, SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
-import { extractCancelAutoBuyErrors, extractCancelAutoBuyWarnings } from 'helpers/messageMappers'
+import { extractCancelBSErrors, extractCancelBSWarnings } from 'helpers/messageMappers'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
@@ -129,8 +129,8 @@ export function SidebarSetupAutoBuy({
     withThreshold: basicBuyState.withThreshold,
   })
 
-  const cancelAutoBuyWarnings = extractCancelAutoBuyWarnings(warnings)
-  const cancelAutoBuyErrors = extractCancelAutoBuyErrors(errors)
+  const cancelAutoBuyWarnings = extractCancelBSWarnings(warnings)
+  const cancelAutoBuyErrors = extractCancelBSErrors(errors)
 
   if (isAutoBuyActive) {
     const validationErrors = isAddForm ? errors : cancelAutoBuyErrors

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import { Vault } from 'blockchain/vaults'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
+import { ConstantMultipleFormChange } from 'features/automation/protection/common/UITypes/constantMultipleFormChange'
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
 import { warningMessagesHandler } from 'features/form/warningMessagesHandler'
@@ -79,5 +80,38 @@ export function errorsBasicBuyValidation({
     insufficientEthFundsForTx,
     autoBuyMaxBuyPriceNotSpecified,
     autoBuyTriggerLowerThanAutoSellTarget,
+  })
+}
+
+export function warningsConstantMultipleValidation({
+  vault,
+  gasEstimationUsd,
+  ethBalance,
+  ethPrice,
+  sliderMin,
+  isStopLossEnabled,
+  constantMultipleState,
+}: {
+  vault: Vault
+  ethBalance: BigNumber
+  ethPrice: BigNumber
+  sliderMin: BigNumber
+  gasEstimationUsd?: BigNumber
+  isStopLossEnabled: boolean
+  constantMultipleState: ConstantMultipleFormChange
+}) {
+  const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
+    token: vault.token,
+    gasEstimationUsd,
+    ethBalance,
+    ethPrice,
+  })
+
+  const constantMultipleSellTriggerCloseToStopLossTrigger =
+    isStopLossEnabled && constantMultipleState.sellExecutionCollRatio.isEqualTo(sliderMin)
+
+  return warningMessagesHandler({
+    potentialInsufficientEthFundsForTx,
+    constantMultipleSellTriggerCloseToStopLossTrigger,
   })
 }

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -22,7 +22,7 @@ import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
 import { getSidebarTitle } from 'features/sidebar/getSidebarTitle'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import { SidebarFlow, SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
-import { extractCancelAutoSellErrors, extractCancelAutoSellWarnings } from 'helpers/messageMappers'
+import { extractCancelBSErrors, extractCancelBSWarnings } from 'helpers/messageMappers'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
 import { Grid } from 'theme-ui'
@@ -130,8 +130,8 @@ export function SidebarSetupAutoSell({
     sliderMax: max,
   })
 
-  const cancelAutoSellWarnings = extractCancelAutoSellWarnings(warnings)
-  const cancelAutoSellErrors = extractCancelAutoSellErrors(errors)
+  const cancelAutoSellWarnings = extractCancelBSWarnings(warnings)
+  const cancelAutoSellErrors = extractCancelBSErrors(errors)
 
   const validationErrors = isAddForm ? errors : cancelAutoSellErrors
 

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -21,6 +21,7 @@ export type VaultWarningMessage =
   | 'autoBuyTriggeredImmediately'
   | 'autoSellTriggeredImmediately'
   | 'autoSellOverride'
+  | 'constantMultipleSellTriggerCloseToStopLossTrigger'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -42,6 +43,7 @@ interface WarningMessagesHandler {
   autoBuyTargetCloseToAutoSellTrigger?: boolean
   autoSellTriggeredImmediately?: boolean
   autoBuyTriggeredImmediately?: boolean
+  constantMultipleSellTriggerCloseToStopLossTrigger?: boolean
 }
 
 export function warningMessagesHandler({
@@ -62,6 +64,7 @@ export function warningMessagesHandler({
   autoBuyTargetCloseToAutoSellTrigger,
   autoSellTriggeredImmediately,
   autoBuyTriggeredImmediately,
+  constantMultipleSellTriggerCloseToStopLossTrigger,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -132,13 +135,9 @@ export function warningMessagesHandler({
     warningMessages.push('autoSellTriggeredImmediately')
   }
 
-  // if (highSlippage) {
-  //   warningMessages.push('highSlippage')
-  // }
-
-  // if (customSlippageOverridden) {
-  //   warningMessages.push('customSlippageOverridden')
-  // }
+  if (constantMultipleSellTriggerCloseToStopLossTrigger) {
+    warningMessages.push('constantMultipleSellTriggerCloseToStopLossTrigger')
+  }
 
   return warningMessages
 }

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -92,26 +92,26 @@ export function extractCommonWarnings(warningMessages: VaultWarningMessage[]) {
   return warningMessages.filter((message) => commonWarnings.includes(message))
 }
 
-const cancelAutoSellWarnings = ['potentialInsufficientEthFundsForTx']
-
-export function extractCancelAutoSellWarnings(warningMessages: VaultWarningMessage[]) {
-  return warningMessages.filter((message) => cancelAutoSellWarnings.includes(message))
-}
-
-const cancelAutoSellErrors = ['insufficientEthFundsForTx']
-
-export function extractCancelAutoSellErrors(errorMessages: VaultErrorMessage[]) {
-  return errorMessages.filter((message) => cancelAutoSellErrors.includes(message))
-}
-
 const cancelAutoBuyWarnings = ['potentialInsufficientEthFundsForTx']
 
-export function extractCancelAutoBuyWarnings(warningMessages: VaultWarningMessage[]) {
+export function extractCancelBSWarnings(warningMessages: VaultWarningMessage[]) {
   return warningMessages.filter((message) => cancelAutoBuyWarnings.includes(message))
 }
 
 const cancelAutoBuyErrors = ['insufficientEthFundsForTx']
 
-export function extractCancelAutoBuyErrors(errorMessages: VaultErrorMessage[]) {
+export function extractCancelBSErrors(errorMessages: VaultErrorMessage[]) {
   return errorMessages.filter((message) => cancelAutoBuyErrors.includes(message))
+}
+
+const constantMultipleSliderWarnings = ['constantMultipleSellTriggerCloseToStopLossTrigger']
+
+export function extractConstantMultipleSliderWarnings(warningMessages: VaultWarningMessage[]) {
+  return warningMessages.filter((message) => constantMultipleSliderWarnings.includes(message))
+}
+
+const constantMultipleCommonWarnings = ['potentialInsufficientEthFundsForTx']
+
+export function extractConstantMultipleCommonWarnings(warningMessages: VaultWarningMessage[]) {
+  return warningMessages.filter((message) => constantMultipleCommonWarnings.includes(message))
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -881,7 +881,8 @@
     "auto-buy-target-close-to-auto-sell-trigger": "Setting a lower Target Ratio would trigger your existing Auto-Sell. If you want to use a lower target ratio, please adjust your Auto-Sell trigger first.",
     "auto-buy-triggered-immediately": "Setting your trigger ratio at this level will cause your Auto-Buy to execute immediately. If this not your intention, please increase your trigger ratio",
     "auto-sell-triggered-immediately": "Setting your trigger ratio at this level will cause your Auto-Sell to execute immediately. If this not your intention, please decrease your trigger ratio",
-    "auto-sell-override": "Auto-Sell has been updated to override your Max gas fee if required to prevent vault liquidation. To make use of this protection, please remove your Auto-sell and create a new one. You are eligible for a gas cost refund, please contact <0>support@oasis.app</0>"
+    "auto-sell-override": "Auto-Sell has been updated to override your Max gas fee if required to prevent vault liquidation. To make use of this protection, please remove your Auto-sell and create a new one. You are eligible for a gas cost refund, please contact <0>support@oasis.app</0>",
+    "constant-multiple-sell-trigger-close-to-stop-loss-trigger": "You cannot set your Constant Multiple Sell trigger below your stop loss trigger. Find out more about how this works <0>here</0>"
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [CM sell trigger above stop-loss trigger validation](https://app.shortcut.com/oazo-apps/story/5225/validation-cm-sell-trigger-is-above-stop-loss-trigger)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added validation to CM form which checks if user moved sell trigger ratio to min value when SL is enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- enable SL on vault, move sell trigger ratio in constant multiply form to min value, warning should appear and min value should be equal to stop loss trigger ratio + 5%
