### PR TITLE
Prevent Stop Loss trigger to set above CM sell trigger

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -81,6 +81,13 @@ export function VaultWarnings({ warningMessages, ilkData: { debtFloor } }: Vault
             components={[ConstantMultipleKBLink]}
           />
         )
+      case 'stopLossTriggerCloseToConstantMultipleSellTrigger':
+        return (
+          <Trans
+            i18nKey="vault-warnings.stop-loss-trigger-close-to-constant-multiple-sell-trigger"
+            components={[ConstantMultipleKBLink]}
+          />
+        )
       default:
         throw new UnreachableCaseError(message)
     }

--- a/features/automation/protection/common/validation.ts
+++ b/features/automation/protection/common/validation.ts
@@ -13,6 +13,7 @@ export function warningsStopLossValidation({
   ethPrice,
   sliderMax,
   isAutoSellEnabled,
+  isConstantMultipleEnabled,
   triggerRatio,
 }: {
   token: string
@@ -21,6 +22,7 @@ export function warningsStopLossValidation({
   sliderMax?: BigNumber
   triggerRatio?: BigNumber
   isAutoSellEnabled?: boolean
+  isConstantMultipleEnabled?: boolean
   gasEstimationUsd?: BigNumber
 }) {
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
@@ -31,10 +33,13 @@ export function warningsStopLossValidation({
   })
   const stopLossTriggerCloseToAutoSellTrigger =
     isAutoSellEnabled && sliderMax && triggerRatio?.isEqualTo(sliderMax)
+  const stopLossTriggerCloseToConstantMultipleSellTrigger =
+    isConstantMultipleEnabled && sliderMax && triggerRatio?.isEqualTo(sliderMax)
 
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
     stopLossTriggerCloseToAutoSellTrigger,
+    stopLossTriggerCloseToConstantMultipleSellTrigger,
   })
 }
 

--- a/features/automation/protection/controls/AdjustSlFormControl.tsx
+++ b/features/automation/protection/controls/AdjustSlFormControl.tsx
@@ -52,6 +52,8 @@ interface AdjustSlFormControlProps {
   triggerData: StopLossTriggerData
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
+  // TODO best way to handle it would be to map this triggerData to the same key-value pairs as we have on ui
+  constantMultipleTriggerData: any
   ctx: Context
   accountIsController: boolean
   toggleForms: () => void
@@ -67,6 +69,7 @@ export function AdjustSlFormControl({
   triggerData,
   autoSellTriggerData,
   autoBuyTriggerData,
+  constantMultipleTriggerData,
   ctx,
   accountIsController,
   toggleForms,
@@ -147,6 +150,8 @@ export function AdjustSlFormControl({
 
   const max = autoSellTriggerData.isTriggerEnabled
     ? autoSellTriggerData.execCollRatio.div(100).minus(DEFAULT_SL_SLIDER_BOUNDARY)
+    : constantMultipleTriggerData.isTriggerEnabled
+    ? constantMultipleTriggerData.sellExecutionCollRatio.div(100).minus(DEFAULT_SL_SLIDER_BOUNDARY)
     : vault.collateralizationRatioAtNextPrice.minus(MAX_SL_SLIDER_VALUE_OFFSET)
 
   const sliderPercentageFill = getSliderPercentageFill({
@@ -333,6 +338,7 @@ export function AdjustSlFormControl({
     currentCollateralRatio: vault.collateralizationRatio,
     isStopLossEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
+    isConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     autoBuyTriggerData,
   }
 

--- a/features/automation/protection/controls/AdjustSlFormLayout.tsx
+++ b/features/automation/protection/controls/AdjustSlFormLayout.tsx
@@ -208,5 +208,6 @@ export interface AdjustSlFormLayoutProps {
   redirectToCloseVault: () => void
   isStopLossEnabled: boolean
   isAutoSellEnabled: boolean
+  isConstantMultipleEnabled: boolean
   autoBuyTriggerData: BasicBSTriggerData
 }

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -46,6 +46,7 @@ export function ProtectionFormControl({
   const stopLossTriggerData = extractStopLossData(automationTriggersData)
   const autoSellTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicSell)
   const autoBuyTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicBuy)
+  const constantMultipleTriggerData = {} as any
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const { uiChanges } = useAppContext()
 
@@ -72,6 +73,7 @@ export function ProtectionFormControl({
         stopLossTriggerData={stopLossTriggerData}
         autoSellTriggerData={autoSellTriggerData}
         autoBuyTriggerData={autoBuyTriggerData}
+        constantMultipleTriggerData={constantMultipleTriggerData}
         priceInfo={priceInfo}
         vault={vault}
         account={account}

--- a/features/automation/protection/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/controls/StopLossFormControl.tsx
@@ -34,6 +34,7 @@ interface StopLossFormsProps {
   stopLossTriggerData: StopLossTriggerData
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
+  constantMultipleTriggerData: any
   ethMarketPrice: BigNumber
   txHelpers?: TxHelpers
 }
@@ -51,6 +52,7 @@ function StopLossForms({
   stopLossTriggerData,
   autoSellTriggerData,
   autoBuyTriggerData,
+  constantMultipleTriggerData,
   ethMarketPrice,
 }: StopLossFormsProps) {
   return currentForm?.currentMode === AutomationFromKind.CANCEL ? (
@@ -79,6 +81,7 @@ function StopLossForms({
       triggerData={stopLossTriggerData}
       autoSellTriggerData={autoSellTriggerData}
       autoBuyTriggerData={autoBuyTriggerData}
+      constantMultipleTriggerData={constantMultipleTriggerData}
       tx={txHelpers}
       ctx={context}
       accountIsController={accountIsController}
@@ -99,6 +102,7 @@ interface StopLossFormControlProps {
   stopLossTriggerData: StopLossTriggerData
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
+  constantMultipleTriggerData: any
   priceInfo: PriceInfo
   vault: Vault
   balanceInfo: BalanceInfo
@@ -114,6 +118,7 @@ export function StopLossFormControl({
   stopLossTriggerData,
   autoSellTriggerData,
   autoBuyTriggerData,
+  constantMultipleTriggerData,
   priceInfo,
   vault,
   account,
@@ -155,6 +160,7 @@ export function StopLossFormControl({
         stopLossTriggerData={stopLossTriggerData}
         autoSellTriggerData={autoSellTriggerData}
         autoBuyTriggerData={autoBuyTriggerData}
+        constantMultipleTriggerData={constantMultipleTriggerData}
         ethMarketPrice={ethMarketPrice}
       />
     ) : (
@@ -174,6 +180,7 @@ export function StopLossFormControl({
       stopLossTriggerData={stopLossTriggerData}
       autoSellTriggerData={autoSellTriggerData}
       autoBuyTriggerData={autoBuyTriggerData}
+      constantMultipleTriggerData={constantMultipleTriggerData}
       ethMarketPrice={ethMarketPrice}
     />
   )

--- a/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAdjustStopLoss.tsx
@@ -39,6 +39,7 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
     ethBalance,
     ethPrice,
     isAutoSellEnabled,
+    isConstantMultipleEnabled,
     txError,
     vault: { debt },
     autoBuyTriggerData,
@@ -62,6 +63,7 @@ export function SidebarAdjustStopLoss(props: AdjustSlFormLayoutProps) {
     sliderMax: slValuePickerConfig.maxBoundry,
     triggerRatio: selectedSLValue,
     isAutoSellEnabled,
+    isConstantMultipleEnabled,
   })
 
   const sidebarSectionProps: SidebarSectionProps = {

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -22,6 +22,7 @@ export type VaultWarningMessage =
   | 'autoSellTriggeredImmediately'
   | 'autoSellOverride'
   | 'constantMultipleSellTriggerCloseToStopLossTrigger'
+  | 'stopLossTriggerCloseToConstantMultipleSellTrigger'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -44,6 +45,7 @@ interface WarningMessagesHandler {
   autoSellTriggeredImmediately?: boolean
   autoBuyTriggeredImmediately?: boolean
   constantMultipleSellTriggerCloseToStopLossTrigger?: boolean
+  stopLossTriggerCloseToConstantMultipleSellTrigger?: boolean
 }
 
 export function warningMessagesHandler({
@@ -65,6 +67,7 @@ export function warningMessagesHandler({
   autoSellTriggeredImmediately,
   autoBuyTriggeredImmediately,
   constantMultipleSellTriggerCloseToStopLossTrigger,
+  stopLossTriggerCloseToConstantMultipleSellTrigger,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -137,6 +140,10 @@ export function warningMessagesHandler({
 
   if (constantMultipleSellTriggerCloseToStopLossTrigger) {
     warningMessages.push('constantMultipleSellTriggerCloseToStopLossTrigger')
+  }
+
+  if (stopLossTriggerCloseToConstantMultipleSellTrigger) {
+    warningMessages.push('stopLossTriggerCloseToConstantMultipleSellTrigger')
   }
 
   return warningMessages

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -104,7 +104,10 @@ export function extractCancelBSErrors(errorMessages: VaultErrorMessage[]) {
   return errorMessages.filter((message) => cancelAutoBuyErrors.includes(message))
 }
 
-const constantMultipleSliderWarnings = ['constantMultipleSellTriggerCloseToStopLossTrigger']
+const constantMultipleSliderWarnings = [
+  'constantMultipleSellTriggerCloseToStopLossTrigger',
+  'stopLossTriggerCloseToConstantMultipleSellTrigger',
+]
 
 export function extractConstantMultipleSliderWarnings(warningMessages: VaultWarningMessage[]) {
   return warningMessages.filter((message) => constantMultipleSliderWarnings.includes(message))

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -882,7 +882,8 @@
     "auto-buy-triggered-immediately": "Setting your trigger ratio at this level will cause your Auto-Buy to execute immediately. If this not your intention, please increase your trigger ratio",
     "auto-sell-triggered-immediately": "Setting your trigger ratio at this level will cause your Auto-Sell to execute immediately. If this not your intention, please decrease your trigger ratio",
     "auto-sell-override": "Auto-Sell has been updated to override your Max gas fee if required to prevent vault liquidation. To make use of this protection, please remove your Auto-sell and create a new one. You are eligible for a gas cost refund, please contact <0>support@oasis.app</0>",
-    "constant-multiple-sell-trigger-close-to-stop-loss-trigger": "You cannot set your Constant Multiple Sell trigger below your stop loss trigger. Find out more about how this works <0>here</0>"
+    "constant-multiple-sell-trigger-close-to-stop-loss-trigger": "You cannot set your Constant Multiple Sell trigger below your stop loss trigger. Find out more about how this works <0>here</0>",
+    "stop-loss-trigger-close-to-constant-multiple-sell-trigger": "You cannot set your Stop Loss Trigger above the existing Constant Multiple Trigger. Find out more about how this works <0>here</0>"
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Prevent Stop Loss trigger to set above CM sell trigger](https://app.shortcut.com/oazo-apps/story/5226/validation-prevent-stop-loss-trigger-set-above-cm-sell-trigger)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added validation to stop loss when CM is enabled and user will set maximum value using slider
  
## How to test 🧪
  <Please explain how to test your changes>

- add CM trigger, in stop loss form move slider to max, warning should appear (currently not testable due to missing data from cache)
