### PR TITLE
Warning when CM is being added and auto buy/sell are enabled

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -16,9 +16,16 @@ const ConstantMultipleKBLink = (
 interface VaultWarningsProps {
   warningMessages: VaultWarningMessage[]
   ilkData: IlkData
+  isAutoSellEnabled?: boolean
+  isAutoBuyEnabled?: boolean
 }
 
-export function VaultWarnings({ warningMessages, ilkData: { debtFloor } }: VaultWarningsProps) {
+export function VaultWarnings({
+  warningMessages,
+  ilkData: { debtFloor },
+  isAutoSellEnabled,
+  isAutoBuyEnabled,
+}: VaultWarningsProps) {
   const { t } = useTranslation()
   if (!warningMessages.length) return null
 
@@ -78,6 +85,23 @@ export function VaultWarnings({ warningMessages, ilkData: { debtFloor } }: Vault
         return (
           <Trans
             i18nKey="vault-warnings.constant-multiple-sell-trigger-close-to-stop-loss-trigger"
+            components={[ConstantMultipleKBLink]}
+          />
+        )
+      case 'addingConstantMultipleWhenAutoSellOrBuyEnabled':
+        return (
+          <Trans
+            i18nKey="vault-warnings.adding-constant-multiple-when-auto-sell-or-buy-enabled"
+            values={{
+              enabledTriggers:
+                isAutoSellEnabled && isAutoBuyEnabled
+                  ? `Auto-Sell ${t('and')} Auto-Buy`
+                  : isAutoSellEnabled
+                  ? 'Auto-Sell'
+                  : isAutoBuyEnabled
+                  ? 'Auto-Buy'
+                  : t('active-triggers'),
+            }}
             components={[ConstantMultipleKBLink]}
           />
         )

--- a/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
@@ -44,7 +44,7 @@ export function ConstantMultipleFormControl({
   ethMarketPrice,
   ilkData,
   stopLossTriggerData,
-  // autoSellTriggerData,
+  autoSellTriggerData,
   autoBuyTriggerData,
   balanceInfo,
 }: ConstantMultipleFormControlProps) {
@@ -148,6 +148,7 @@ export function ConstantMultipleFormControl({
       txHandler={txHandler}
       ilkData={ilkData}
       autoBuyTriggerData={autoBuyTriggerData}
+      autoSellTriggerData={autoSellTriggerData}
       stopLossTriggerData={stopLossTriggerData}
       ethMarketPrice={ethMarketPrice}
       balanceInfo={balanceInfo}

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -55,6 +55,7 @@ interface SidebarSetupConstantMultipleProps {
   txHandler: () => void
   ilkData: IlkData
   autoBuyTriggerData: BasicBSTriggerData
+  autoSellTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
   ethMarketPrice: BigNumber
   gasEstimationUsd?: BigNumber
@@ -77,6 +78,7 @@ export function SidebarSetupConstantMultiple({
   txHandler,
   ilkData,
   autoBuyTriggerData,
+  autoSellTriggerData,
   stopLossTriggerData,
   ethMarketPrice,
   gasEstimationUsd,
@@ -139,6 +141,8 @@ export function SidebarSetupConstantMultiple({
     ethPrice: ethMarketPrice,
     sliderMin,
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
+    isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
+    isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
     constantMultipleState,
   })
 
@@ -255,6 +259,8 @@ export function SidebarSetupConstantMultiple({
           <VaultWarnings
             warningMessages={extractConstantMultipleCommonWarnings(warnings)}
             ilkData={ilkData}
+            isAutoBuyEnabled={autoBuyTriggerData.isTriggerEnabled}
+            isAutoSellEnabled={autoSellTriggerData.isTriggerEnabled}
           />
           <ConstantMultipleInfoSectionControl
             token={token}

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -90,6 +90,8 @@ export function warningsConstantMultipleValidation({
   ethPrice,
   sliderMin,
   isStopLossEnabled,
+  isAutoBuyEnabled,
+  isAutoSellEnabled,
   constantMultipleState,
 }: {
   vault: Vault
@@ -98,6 +100,8 @@ export function warningsConstantMultipleValidation({
   sliderMin: BigNumber
   gasEstimationUsd?: BigNumber
   isStopLossEnabled: boolean
+  isAutoBuyEnabled: boolean
+  isAutoSellEnabled: boolean
   constantMultipleState: ConstantMultipleFormChange
 }) {
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
@@ -110,8 +114,11 @@ export function warningsConstantMultipleValidation({
   const constantMultipleSellTriggerCloseToStopLossTrigger =
     isStopLossEnabled && constantMultipleState.sellExecutionCollRatio.isEqualTo(sliderMin)
 
+  const addingConstantMultipleWhenAutoSellOrBuyEnabled = isAutoBuyEnabled || isAutoSellEnabled
+
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
     constantMultipleSellTriggerCloseToStopLossTrigger,
+    addingConstantMultipleWhenAutoSellOrBuyEnabled,
   })
 }

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -22,6 +22,8 @@ export type VaultWarningMessage =
   | 'autoSellTriggeredImmediately'
   | 'autoSellOverride'
   | 'constantMultipleSellTriggerCloseToStopLossTrigger'
+  | 'stopLossTriggerCloseToConstantMultipleSellTrigger'
+  | 'addingConstantMultipleWhenAutoSellOrBuyEnabled'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -44,6 +46,8 @@ interface WarningMessagesHandler {
   autoSellTriggeredImmediately?: boolean
   autoBuyTriggeredImmediately?: boolean
   constantMultipleSellTriggerCloseToStopLossTrigger?: boolean
+  stopLossTriggerCloseToConstantMultipleSellTrigger?: boolean
+  addingConstantMultipleWhenAutoSellOrBuyEnabled?: boolean
 }
 
 export function warningMessagesHandler({
@@ -65,6 +69,8 @@ export function warningMessagesHandler({
   autoSellTriggeredImmediately,
   autoBuyTriggeredImmediately,
   constantMultipleSellTriggerCloseToStopLossTrigger,
+  stopLossTriggerCloseToConstantMultipleSellTrigger,
+  addingConstantMultipleWhenAutoSellOrBuyEnabled,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -137,6 +143,14 @@ export function warningMessagesHandler({
 
   if (constantMultipleSellTriggerCloseToStopLossTrigger) {
     warningMessages.push('constantMultipleSellTriggerCloseToStopLossTrigger')
+  }
+
+  if (stopLossTriggerCloseToConstantMultipleSellTrigger) {
+    warningMessages.push('stopLossTriggerCloseToConstantMultipleSellTrigger')
+  }
+
+  if (addingConstantMultipleWhenAutoSellOrBuyEnabled) {
+    warningMessages.push('addingConstantMultipleWhenAutoSellOrBuyEnabled')
   }
 
   return warningMessages

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -110,7 +110,10 @@ export function extractConstantMultipleSliderWarnings(warningMessages: VaultWarn
   return warningMessages.filter((message) => constantMultipleSliderWarnings.includes(message))
 }
 
-const constantMultipleCommonWarnings = ['potentialInsufficientEthFundsForTx']
+const constantMultipleCommonWarnings = [
+  'potentialInsufficientEthFundsForTx',
+  'addingConstantMultipleWhenAutoSellOrBuyEnabled',
+]
 
 export function extractConstantMultipleCommonWarnings(warningMessages: VaultWarningMessage[]) {
   return warningMessages.filter((message) => constantMultipleCommonWarnings.includes(message))

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -23,6 +23,7 @@
   "account-support": "Support",
   "account-terms": "Terms",
   "activity": "Activity",
+  "and": "and",
   "address": "Address",
   "address-invalid": "Address not found",
   "add-stop-loss": "Add Stop-Loss",
@@ -268,6 +269,7 @@
     "executed": "executed",
     "updated": "updated"
   },
+  "active-triggers": "active triggers",
   "jwt-auth-failed": "Signature failed",
   "jwt-auth-in-progress": "Waiting for signature...",
   "jwt-auth-rejected": "Signature rejected",
@@ -882,7 +884,9 @@
     "auto-buy-triggered-immediately": "Setting your trigger ratio at this level will cause your Auto-Buy to execute immediately. If this not your intention, please increase your trigger ratio",
     "auto-sell-triggered-immediately": "Setting your trigger ratio at this level will cause your Auto-Sell to execute immediately. If this not your intention, please decrease your trigger ratio",
     "auto-sell-override": "Auto-Sell has been updated to override your Max gas fee if required to prevent vault liquidation. To make use of this protection, please remove your Auto-sell and create a new one. You are eligible for a gas cost refund, please contact <0>support@oasis.app</0>",
-    "constant-multiple-sell-trigger-close-to-stop-loss-trigger": "You cannot set your Constant Multiple Sell trigger below your stop loss trigger. Find out more about how this works <0>here</0>"
+    "constant-multiple-sell-trigger-close-to-stop-loss-trigger": "You cannot set your Constant Multiple Sell trigger below your stop loss trigger. Find out more about how this works <0>here</0>",
+    "stop-loss-trigger-close-to-constant-multiple-sell-trigger": "You cannot set your Stop Loss Trigger above the existing Constant Multiple Trigger. Find out more about how this works <0>here</0>",
+    "adding-constant-multiple-when-auto-sell-or-buy-enabled": "Creating a Constant multiple will remove your existing {{enabledTriggers}}. Are you sure you want to continue?"
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Warning when CM is being added and auto buy/sell are enabled](https://app.shortcut.com/oazo-apps/story/5227/validation-adding-constant-multiple-removes-any-existing-auto-buy-and-auto-sell)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added warning message when user tries to add CM trigger when auto buy or sell are enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- three cases, just auto-sell, just auto-buy, both enabled - try to add CM trigger in each case and check whether warning message pops up