### PR TITLE
Auto BS error when CM enabled

### DIFF
--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -20,6 +20,7 @@ interface VaultErrorsProps {
   maxGenerateAmount?: BigNumber
   ilkData: IlkData
   maxWithdrawAmount?: BigNumber
+  autoType?: 'Auto-Buy' | 'Auto-Sell'
 }
 
 export function VaultErrors({
@@ -27,6 +28,7 @@ export function VaultErrors({
   maxGenerateAmount = zero,
   maxWithdrawAmount = zero,
   ilkData: { debtFloor, token },
+  autoType,
 }: VaultErrorsProps) {
   const { t } = useTranslation()
   if (!errorMessages.length) return null
@@ -146,6 +148,8 @@ export function VaultErrors({
         return translate('auto-buy-trigger-lower-than-auto-sell-target')
       case 'stopLossTriggerHigherThanAutoBuyTarget':
         return translate('stop-loss-trigger-higher-than-auto-buy-target')
+      case 'cantSetupAutoBuyOrSellWhenConstantMultipleEnabled':
+        return translate('cant-setup-auto-buy-or-sell-when-constant-multiple-enabled', { autoType })
       case 'autoBuyMaxBuyPriceNotSpecified':
         return (
           <Trans

--- a/features/automation/common/validators.ts
+++ b/features/automation/common/validators.ts
@@ -64,6 +64,7 @@ export function errorsBasicSellValidation({
   isRemoveForm,
   basicSellState,
   autoBuyTriggerData,
+  constantMultipleTriggerData,
 }: {
   vault: Vault
   ilkData: IlkData
@@ -71,6 +72,7 @@ export function errorsBasicSellValidation({
   isRemoveForm: boolean
   basicSellState: BasicBSFormChange
   autoBuyTriggerData: BasicBSTriggerData
+  constantMultipleTriggerData: any
 }) {
   const {
     execCollRatio,
@@ -92,10 +94,14 @@ export function errorsBasicSellValidation({
     autoBuyTriggerData.isTriggerEnabled &&
     execCollRatio.plus(5).gt(autoBuyTriggerData.targetCollRatio)
 
+  const cantSetupAutoBuyOrSellWhenConstantMultipleEnabled =
+    constantMultipleTriggerData.isTriggerEnabled
+
   return errorMessagesHandler({
     insufficientEthFundsForTx,
     targetCollRatioExceededDustLimitCollRatio,
     minimumSellPriceNotProvided,
     autoSellTriggerHigherThanAutoBuyTarget,
+    cantSetupAutoBuyOrSellWhenConstantMultipleEnabled,
   })
 }

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -45,6 +45,7 @@ interface AutoBuyFormControlProps {
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
+  constantMultipleTriggerData: any
   isAutoBuyOn: boolean
   context: Context
   ethMarketPrice: BigNumber
@@ -59,6 +60,7 @@ export function AutoBuyFormControl({
   autoSellTriggerData,
   autoBuyTriggerData,
   stopLossTriggerData,
+  constantMultipleTriggerData,
   isAutoBuyOn,
   txHelpers,
   context,
@@ -225,6 +227,7 @@ export function AutoBuyFormControl({
       autoSellTriggerData={autoSellTriggerData}
       autoBuyTriggerData={autoBuyTriggerData}
       stopLossTriggerData={stopLossTriggerData}
+      constantMultipleTriggerData={constantMultipleTriggerData}
       isAutoBuyOn={isAutoBuyOn}
       context={context}
       ethMarketPrice={ethMarketPrice}

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -43,6 +43,7 @@ export function OptimizationFormControl({
   const autoBuyTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicBuy)
   const autoSellTriggerData = extractBasicBSData(automationTriggersData, TriggerType.BasicSell)
   const stopLossTriggerData = extractStopLossData(automationTriggersData)
+  const constantMultipleTriggerData = {} as any
   const { uiChanges } = useAppContext()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
 
@@ -72,6 +73,7 @@ export function OptimizationFormControl({
         autoSellTriggerData={autoSellTriggerData}
         autoBuyTriggerData={autoBuyTriggerData}
         stopLossTriggerData={stopLossTriggerData}
+        constantMultipleTriggerData={constantMultipleTriggerData}
         isAutoBuyOn={autoBuyTriggerData.isTriggerEnabled}
         context={context}
         txHelpers={txHelpers}

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -167,7 +167,7 @@ export function SidebarAutoBuyEditingStage({
       />
       {isEditing && (
         <>
-          <VaultErrors errorMessages={errors} ilkData={ilkData} />
+          <VaultErrors errorMessages={errors} ilkData={ilkData} autoType="Auto-Buy" />
           <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
         </>
       )}

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -35,6 +35,7 @@ interface SidebarSetupAutoBuyProps {
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
+  constantMultipleTriggerData: any
   isAutoBuyOn: boolean
   context: Context
   ethMarketPrice: BigNumber
@@ -65,6 +66,7 @@ export function SidebarSetupAutoBuy({
   autoSellTriggerData,
   autoBuyTriggerData,
   stopLossTriggerData,
+  constantMultipleTriggerData,
 
   basicBuyState,
   txHandler,
@@ -107,6 +109,7 @@ export function SidebarSetupAutoBuy({
   const errors = errorsBasicBuyValidation({
     basicBuyState,
     autoSellTriggerData,
+    constantMultipleTriggerData,
     isRemoveForm,
   })
 

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -60,10 +60,12 @@ export function warningsBasicBuyValidation({
 export function errorsBasicBuyValidation({
   basicBuyState,
   autoSellTriggerData,
+  constantMultipleTriggerData,
   isRemoveForm,
 }: {
   basicBuyState: BasicBSFormChange
   autoSellTriggerData: BasicBSTriggerData
+  constantMultipleTriggerData: any
   isRemoveForm: boolean
 }) {
   const { maxBuyOrMinSellPrice, txDetails, withThreshold, execCollRatio } = basicBuyState
@@ -76,10 +78,14 @@ export function errorsBasicBuyValidation({
     autoSellTriggerData.isTriggerEnabled &&
     execCollRatio.minus(5).lt(autoSellTriggerData.targetCollRatio)
 
+  const cantSetupAutoBuyOrSellWhenConstantMultipleEnabled =
+    constantMultipleTriggerData.isTriggerEnabled
+
   return errorMessagesHandler({
     insufficientEthFundsForTx,
     autoBuyMaxBuyPriceNotSpecified,
     autoBuyTriggerLowerThanAutoSellTarget,
+    cantSetupAutoBuyOrSellWhenConstantMultipleEnabled,
   })
 }
 

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -45,6 +45,7 @@ interface AutoSellFormControlProps {
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
+  constantMultipleTriggerData: any
   isAutoSellActive: boolean
   context: Context
   ethMarketPrice: BigNumber
@@ -58,6 +59,7 @@ export function AutoSellFormControl({
   autoSellTriggerData,
   autoBuyTriggerData,
   stopLossTriggerData,
+  constantMultipleTriggerData,
   isAutoSellActive,
   txHelpers,
   context,
@@ -222,6 +224,7 @@ export function AutoSellFormControl({
       autoSellTriggerData={autoSellTriggerData}
       autoBuyTriggerData={autoBuyTriggerData}
       stopLossTriggerData={stopLossTriggerData}
+      constantMultipleTriggerData={constantMultipleTriggerData}
       isAutoSellActive={isAutoSellActive}
       context={context}
       ethMarketPrice={ethMarketPrice}

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -90,6 +90,7 @@ export function ProtectionFormControl({
         autoSellTriggerData={autoSellTriggerData}
         autoBuyTriggerData={autoBuyTriggerData}
         stopLossTriggerData={stopLossTriggerData}
+        constantMultipleTriggerData={constantMultipleTriggerData}
         isAutoSellActive={isAutoSellActive}
         context={context}
         txHelpers={txHelpers}

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -223,7 +223,7 @@ export function SidebarAutoSellAddEditingStage({
       />
       {isEditing && (
         <>
-          <VaultErrors errorMessages={errors} ilkData={ilkData} />
+          <VaultErrors errorMessages={errors} ilkData={ilkData} autoType="Auto-Sell" />
           <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
         </>
       )}

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -34,6 +34,7 @@ interface SidebarSetupAutoSellProps {
   autoSellTriggerData: BasicBSTriggerData
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
+  constantMultipleTriggerData: any
   isAutoSellActive: boolean
   context: Context
   ethMarketPrice: BigNumber
@@ -63,6 +64,7 @@ export function SidebarSetupAutoSell({
   autoSellTriggerData,
   autoBuyTriggerData,
   stopLossTriggerData,
+  constantMultipleTriggerData,
 
   isAutoSellActive,
   basicSellState,
@@ -108,6 +110,7 @@ export function SidebarSetupAutoSell({
     debtDelta,
     basicSellState,
     autoBuyTriggerData,
+    constantMultipleTriggerData,
     isRemoveForm,
   })
 

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -41,6 +41,7 @@ export type VaultErrorMessage =
   | 'autoSellTriggerHigherThanAutoBuyTarget'
   | 'autoBuyTriggerLowerThanAutoSellTarget'
   | 'stopLossTriggerHigherThanAutoBuyTarget'
+  | 'cantSetupAutoBuyOrSellWhenConstantMultipleEnabled'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -84,6 +85,7 @@ interface ErrorMessagesHandler {
   autoSellTriggerHigherThanAutoBuyTarget?: boolean
   autoBuyTriggerLowerThanAutoSellTarget?: boolean
   stopLossTriggerHigherThanAutoBuyTarget?: boolean
+  cantSetupAutoBuyOrSellWhenConstantMultipleEnabled?: boolean
 }
 
 export function errorMessagesHandler({
@@ -128,6 +130,7 @@ export function errorMessagesHandler({
   autoSellTriggerHigherThanAutoBuyTarget,
   autoBuyTriggerLowerThanAutoSellTarget,
   stopLossTriggerHigherThanAutoBuyTarget,
+  cantSetupAutoBuyOrSellWhenConstantMultipleEnabled,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -292,6 +295,10 @@ export function errorMessagesHandler({
 
   if (stopLossTriggerHigherThanAutoBuyTarget) {
     errorMessages.push('stopLossTriggerHigherThanAutoBuyTarget')
+  }
+
+  if (cantSetupAutoBuyOrSellWhenConstantMultipleEnabled) {
+    errorMessages.push('cantSetupAutoBuyOrSellWhenConstantMultipleEnabled')
   }
 
   return errorMessages

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -859,7 +859,8 @@
     "minimum-sell-price-not-provided": "Please enter a minimum sell price or select <1>Set No Threshold<1>",
     "auto-sell-trigger-higher-than-auto-buy-target": "Setting your an Auto-Sell trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",
     "stop-loss-trigger-higher-than-auto-buy-target": "Setting your an Stop-Loss trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",
-    "auto-buy-trigger-lower-than-auto-sell-target": "Setting your an Auto-Buy trigger at this level could result in it being executed by your Auto-Sell. Please adjust your Auto-Sell Target ratio first"
+    "auto-buy-trigger-lower-than-auto-sell-target": "Setting your an Auto-Buy trigger at this level could result in it being executed by your Auto-Sell. Please adjust your Auto-Sell Target ratio first",
+    "cant-setup-auto-buy-or-sell-when-constant-multiple-enabled": "You cannot set up an {{autoType}} if you have an existing Constant Multiple set up. Please remove your Constant Multiple before continuing."
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",


### PR DESCRIPTION
# [Auto BS error when CM enabled](https://app.shortcut.com/oazo-apps/story/5240/ab-as-form-validation-cannot-add-auto-buy-or-auto-sell-if-the-user-has-constant-multiple)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added error to auto buy and sell forms when user tries to add trigger when CM is enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- enable CM and then try to add auto sell or buy trigger, you should get error (not testable due to lack data from cache)
