### PR TITLE
Constant multiple changes information data

### DIFF
--- a/components/infoSection/Item.tsx
+++ b/components/infoSection/Item.tsx
@@ -51,10 +51,10 @@ export function Item({
     >
       <Flex
         sx={{
-          cursor: dropdownValues?.length ? 'pointer' : 'auto',
+          cursor: !isLoading && dropdownValues?.length ? 'pointer' : 'auto',
         }}
         onClick={() => {
-          dropdownValues?.length && setOpen(!open)
+          !isLoading && dropdownValues?.length && setOpen(!open)
         }}
       >
         {label && (
@@ -111,7 +111,7 @@ export function Item({
           )}
         </Text>
       </Flex>
-      {open && (
+      {!isLoading && open && (
         <>
           {subLabel && (
             <Text

--- a/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
+++ b/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
@@ -18,6 +18,8 @@ interface ConstantMultipleInfoSectionProps {
   collateralToBeSold: BigNumber
   minPriceToSell?: BigNumber
   addTriggerGasEstimationUsd?: BigNumber
+  estimatedOasisFee: BigNumber[]
+  estimatedGasPriceOnTrigger?: BigNumber
 }
 
 export function ConstantMultipleInfoSection({
@@ -34,6 +36,8 @@ export function ConstantMultipleInfoSection({
   collateralToBeSold,
   minPriceToSell,
   addTriggerGasEstimationUsd,
+  estimatedOasisFee,
+  estimatedGasPriceOnTrigger,
 }: ConstantMultipleInfoSectionProps) {
   const { t } = useTranslation()
 
@@ -55,8 +59,29 @@ export function ConstantMultipleInfoSection({
         },
         {
           label: t('constant-multiple.vault-changes.cost-per-adjustment'),
-          // TODO: PK calculate this value
-          value: '$0',
+          value:
+            estimatedGasPriceOnTrigger &&
+            estimatedOasisFee
+              .map((feeItem) => {
+                return `$${formatAmount(feeItem.plus(estimatedGasPriceOnTrigger), 'USD')}`
+              })
+              .join(' - '),
+          isLoading: estimatedGasPriceOnTrigger === undefined,
+          dropdownValues: [
+            {
+              label: t('constant-multiple.vault-changes.estimated-oasis-fee'),
+              value: estimatedOasisFee
+                .map((feeItem) => {
+                  return `$${formatAmount(feeItem, 'USD')}`
+                })
+                .join(' - '),
+            },
+            {
+              label: t('constant-multiple.vault-changes.estimated-max-gas-fee'),
+              value:
+                estimatedGasPriceOnTrigger && `$${formatAmount(estimatedGasPriceOnTrigger, 'USD')}`,
+            },
+          ],
         },
         {
           label: t('auto-sell.setup-transaction-cost'),

--- a/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
+++ b/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
@@ -60,7 +60,8 @@ export function ConstantMultipleInfoSection({
         },
         {
           label: t('auto-sell.setup-transaction-cost'),
-          value: addTriggerGasEstimationUsd && `$${formatAmount(addTriggerGasEstimationUsd, 'USD')}`,
+          value:
+            addTriggerGasEstimationUsd && `$${formatAmount(addTriggerGasEstimationUsd, 'USD')}`,
           isLoading: addTriggerGasEstimationUsd === undefined,
         },
         {

--- a/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
+++ b/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
@@ -75,7 +75,7 @@ export function ConstantMultipleInfoSection({
             },
             {
               label: t('auto-buy.col-to-be-purchased', { token }),
-              value: `${formatCryptoBalance(collateralToBePurchased)} ${token}`,
+              value: `${formatCryptoBalance(collateralToBePurchased.abs())} ${token}`,
             },
             {
               label: t('constant-multiple.vault-changes.max-price-buy'),
@@ -93,7 +93,7 @@ export function ConstantMultipleInfoSection({
             },
             {
               label: t('auto-sell.col-to-be-sold', { token }),
-              value: `${formatCryptoBalance(collateralToBeSold)} ${token}`,
+              value: `${formatCryptoBalance(collateralToBeSold.abs())} ${token}`,
             },
             {
               label: t('constant-multiple.vault-changes.max-price-sell'),

--- a/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
+++ b/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
@@ -9,17 +9,17 @@ interface ConstantMultipleInfoSectionProps {
   targetColRatio: BigNumber
   multiplier: number
   slippage: BigNumber
-  triggerColRatioToBuy: BigNumber
+  buyExecutionCollRatio: BigNumber
   nextBuyPrice: BigNumber
   collateralToBePurchased: BigNumber
   maxPriceToBuy?: BigNumber
-  triggerColRatioToSell: BigNumber
+  sellExecutionCollRatio: BigNumber
   nextSellPrice: BigNumber
   collateralToBeSold: BigNumber
   minPriceToSell?: BigNumber
   addTriggerGasEstimationUsd?: BigNumber
   estimatedOasisFee: BigNumber[]
-  estimatedGasPriceOnTrigger?: BigNumber
+  estimatedGasCostOnTrigger?: BigNumber
 }
 
 export function ConstantMultipleInfoSection({
@@ -27,17 +27,17 @@ export function ConstantMultipleInfoSection({
   targetColRatio,
   multiplier,
   slippage,
-  triggerColRatioToBuy,
+  buyExecutionCollRatio,
   nextBuyPrice,
   collateralToBePurchased,
   maxPriceToBuy,
-  triggerColRatioToSell,
+  sellExecutionCollRatio,
   nextSellPrice,
   collateralToBeSold,
   minPriceToSell,
   addTriggerGasEstimationUsd,
   estimatedOasisFee,
-  estimatedGasPriceOnTrigger,
+  estimatedGasCostOnTrigger,
 }: ConstantMultipleInfoSectionProps) {
   const { t } = useTranslation()
 
@@ -60,13 +60,13 @@ export function ConstantMultipleInfoSection({
         {
           label: t('constant-multiple.vault-changes.cost-per-adjustment'),
           value:
-            estimatedGasPriceOnTrigger &&
+            estimatedGasCostOnTrigger &&
             estimatedOasisFee
               .map((feeItem) => {
-                return `$${formatAmount(feeItem.plus(estimatedGasPriceOnTrigger), 'USD')}`
+                return `$${formatAmount(feeItem.plus(estimatedGasCostOnTrigger), 'USD')}`
               })
               .join(' - '),
-          isLoading: estimatedGasPriceOnTrigger === undefined,
+          isLoading: estimatedGasCostOnTrigger === undefined,
           dropdownValues: [
             {
               label: t('constant-multiple.vault-changes.estimated-oasis-fee'),
@@ -79,7 +79,7 @@ export function ConstantMultipleInfoSection({
             {
               label: t('constant-multiple.vault-changes.estimated-max-gas-fee'),
               value:
-                estimatedGasPriceOnTrigger && `$${formatAmount(estimatedGasPriceOnTrigger, 'USD')}`,
+                estimatedGasCostOnTrigger && `$${formatAmount(estimatedGasCostOnTrigger, 'USD')}`,
             },
           ],
         },
@@ -95,7 +95,7 @@ export function ConstantMultipleInfoSection({
           dropdownValues: [
             {
               label: t('auto-buy.trigger-col-ratio-to-perfrom-buy'),
-              value: `${triggerColRatioToBuy}%`,
+              value: `${buyExecutionCollRatio}%`,
             },
             {
               label: t('auto-buy.next-buy-prices'),
@@ -113,7 +113,7 @@ export function ConstantMultipleInfoSection({
             },
             {
               label: t('auto-sell.trigger-col-ratio-to-perfrom-sell'),
-              value: `${triggerColRatioToSell}%`,
+              value: `${sellExecutionCollRatio}%`,
             },
             {
               label: t('auto-sell.next-sell-prices'),

--- a/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
+++ b/features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection.tsx
@@ -17,6 +17,7 @@ interface ConstantMultipleInfoSectionProps {
   nextSellPrice: BigNumber
   collateralToBeSold: BigNumber
   minPriceToSell?: BigNumber
+  addTriggerGasEstimationUsd?: BigNumber
 }
 
 export function ConstantMultipleInfoSection({
@@ -32,6 +33,7 @@ export function ConstantMultipleInfoSection({
   nextSellPrice,
   collateralToBeSold,
   minPriceToSell,
+  addTriggerGasEstimationUsd,
 }: ConstantMultipleInfoSectionProps) {
   const { t } = useTranslation()
 
@@ -58,8 +60,8 @@ export function ConstantMultipleInfoSection({
         },
         {
           label: t('auto-sell.setup-transaction-cost'),
-          // TODO: PK calculate this value
-          value: '$0',
+          value: addTriggerGasEstimationUsd && `$${formatAmount(addTriggerGasEstimationUsd, 'USD')}`,
+          isLoading: addTriggerGasEstimationUsd === undefined,
         },
         {
           label: t('constant-multiple.vault-changes.buy-sell-trigger-summary'),

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -1,5 +1,4 @@
 import BigNumber from 'bignumber.js'
-import { Vault } from 'blockchain/vaults'
 import { BasicBSTriggerData, maxUint256 } from 'features/automation/common/basicBSTriggerData'
 import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
@@ -95,21 +94,23 @@ export function getBasicBSVaultChange({
   execCollRatio,
   deviation,
   executionPrice,
-  vault,
+  debt,
+  lockedCollateral,
 }: {
   targetCollRatio: BigNumber
   execCollRatio: BigNumber
   executionPrice: BigNumber
   deviation: BigNumber
-  vault: Vault
+  debt: BigNumber
+  lockedCollateral: BigNumber
 }) {
   return targetCollRatio.gt(zero) && execCollRatio.gt(zero) && executionPrice.gt(zero)
     ? getVaultChange({
         currentCollateralPrice: executionPrice,
         marketPrice: executionPrice,
         slippage: deviation.div(100),
-        debt: vault.debt,
-        lockedCollateral: vault.lockedCollateral,
+        debt: debt,
+        lockedCollateral: lockedCollateral,
         requiredCollRatio: targetCollRatio.div(100),
         depositAmount: zero,
         paybackAmount: zero,

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -6,6 +6,8 @@ import { SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
 import { LOAN_FEE, OAZO_FEE } from 'helpers/multiply/calculations'
 import { zero } from 'helpers/zero'
 
+export const ACCEPTABLE_FEE_DIFF = new BigNumber(3)
+
 export function resolveMaxBuyOrMinSellPrice(maxBuyOrMinSellPrice: BigNumber) {
   return maxBuyOrMinSellPrice.isZero() || maxBuyOrMinSellPrice.isEqualTo(maxUint256)
     ? undefined

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -103,9 +103,7 @@ export function getBasicBSVaultChange({
   deviation: BigNumber
   vault: Vault
 }) {
-  return targetCollRatio.gt(zero) &&
-    execCollRatio.gt(zero) &&
-    executionPrice.gt(zero)
+  return targetCollRatio.gt(zero) && execCollRatio.gt(zero) && executionPrice.gt(zero)
     ? getVaultChange({
         currentCollateralPrice: executionPrice,
         marketPrice: executionPrice,

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -91,24 +91,28 @@ export function checkIfDisabledBasicBS({
 }
 
 export function getBasicBSVaultChange({
-  basicBSState,
+  targetCollRatio,
+  execCollRatio,
+  deviation,
   executionPrice,
   vault,
 }: {
-  basicBSState: BasicBSFormChange
+  targetCollRatio: BigNumber
+  execCollRatio: BigNumber
   executionPrice: BigNumber
+  deviation: BigNumber
   vault: Vault
 }) {
-  return basicBSState.targetCollRatio.gt(zero) &&
-    basicBSState.execCollRatio.gt(zero) &&
+  return targetCollRatio.gt(zero) &&
+    execCollRatio.gt(zero) &&
     executionPrice.gt(zero)
     ? getVaultChange({
         currentCollateralPrice: executionPrice,
         marketPrice: executionPrice,
-        slippage: basicBSState.deviation.div(100),
+        slippage: deviation.div(100),
         debt: vault.debt,
         lockedCollateral: vault.lockedCollateral,
-        requiredCollRatio: basicBSState.targetCollRatio.div(100),
+        requiredCollRatio: targetCollRatio.div(100),
         depositAmount: zero,
         paybackAmount: zero,
         generateAmount: zero,

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -216,7 +216,8 @@ export function AutoBuyFormControl({
     execCollRatio: basicBuyState.execCollRatio,
     deviation: basicBuyState.deviation,
     executionPrice,
-    vault,
+    lockedCollateral: vault.lockedCollateral,
+    debt: vault.debt,
   })
 
   return (

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -212,9 +212,11 @@ export function AutoBuyFormControl({
   })
 
   const { debtDelta, collateralDelta } = getBasicBSVaultChange({
-    basicBSState: basicBuyState,
-    vault,
+    targetCollRatio: basicBuyState.targetCollRatio,
+    execCollRatio: basicBuyState.execCollRatio,
+    deviation: basicBuyState.deviation,
     executionPrice,
+    vault,
   })
 
   return (

--- a/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
@@ -136,7 +136,8 @@ export function ConstantMultipleFormControl({
     execCollRatio: constantMultipleState.buyExecutionCollRatio,
     deviation: constantMultipleState.deviation,
     executionPrice: nextBuyPrice,
-    vault,
+    lockedCollateral,
+    debt,
   })
   const {
     collateralDelta: collateralToBeSold,
@@ -146,7 +147,8 @@ export function ConstantMultipleFormControl({
     execCollRatio: constantMultipleState.sellExecutionCollRatio,
     deviation: constantMultipleState.deviation,
     executionPrice: nextSellPrice,
-    vault,
+    lockedCollateral,
+    debt,
   })
 
   const addTriggerGasEstimationData$ = useMemo(() => {
@@ -164,7 +166,7 @@ export function ConstantMultipleFormControl({
   const gasEstimationUsd = isAddForm ? addTriggerGasEstimationUsd : undefined
 
   const adjustMultiplyGasEstimation = new BigNumber(1100000) // average based on historical data from blockchain
-  const estimatedGasPriceOnTrigger = gasPrice
+  const estimatedGasCostOnTrigger = gasPrice
     ? amountFromWei(
         adjustMultiplyGasEstimation
           .multipliedBy(gasPrice?.maxFeePerGas)
@@ -228,7 +230,7 @@ export function ConstantMultipleFormControl({
       collateralToBePurchased={collateralToBePurchased}
       collateralToBeSold={collateralToBeSold}
       gasEstimationUsd={gasEstimationUsd}
-      estimatedGasPriceOnTrigger={estimatedGasPriceOnTrigger}
+      estimatedGasCostOnTrigger={estimatedGasCostOnTrigger}
       estimatedBuyFee={estimatedBuyFee}
       estimatedSellFee={estimatedSellFee}
       addTriggerGasEstimationUsd={addTriggerGasEstimationUsd}

--- a/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
@@ -128,6 +128,9 @@ export function ConstantMultipleFormControl({
     }
   }
 
+  // TODO: get this value based on something similar to checkIfEditingBasicBS
+  const isEditing = true
+
   return (
     <SidebarSetupConstantMultiple
       vault={vault}
@@ -151,6 +154,7 @@ export function ConstantMultipleFormControl({
       stopLossTriggerData={stopLossTriggerData}
       ethMarketPrice={ethMarketPrice}
       balanceInfo={balanceInfo}
+      isEditing={isEditing}
     />
   )
 }

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -59,8 +59,9 @@ interface SidebarSetupConstantMultipleProps {
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
   ethMarketPrice: BigNumber
-  gasEstimationUsd?: BigNumber
   isEditing: boolean
+  gasEstimationUsd?: BigNumber
+  addTriggerGasEstimationUsd?: BigNumber
 }
 
 const largestSliderValueAllowed = DEFAULT_BASIC_BS_MAX_SLIDER_VALUE.times(100)
@@ -81,8 +82,9 @@ export function SidebarSetupConstantMultiple({
   autoBuyTriggerData,
   stopLossTriggerData,
   ethMarketPrice,
-  gasEstimationUsd,
   isEditing,
+  gasEstimationUsd,
+  addTriggerGasEstimationUsd,
 }: SidebarSetupConstantMultipleProps) {
   const { t } = useTranslation()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
@@ -271,6 +273,7 @@ export function SidebarSetupConstantMultiple({
               nextSellPrice={nextSellPrice}
               collateralToBePurchased={collateralToBePurchased}
               collateralToBeSold={collateralToBeSold}
+              addTriggerGasEstimationUsd={addTriggerGasEstimationUsd}
               constantMultipleState={constantMultipleState}
             />
           )}
@@ -306,6 +309,7 @@ interface ConstantMultipleInfoSectionControlProps {
   nextSellPrice: BigNumber
   collateralToBePurchased: BigNumber
   collateralToBeSold: BigNumber
+  addTriggerGasEstimationUsd?: BigNumber
   constantMultipleState: ConstantMultipleFormChange
 }
 
@@ -315,6 +319,7 @@ function ConstantMultipleInfoSectionControl({
   nextSellPrice,
   collateralToBePurchased,
   collateralToBeSold,
+  addTriggerGasEstimationUsd,
   constantMultipleState,
 }: ConstantMultipleInfoSectionControlProps) {
   // TODO: PK where do I get slippage?
@@ -342,6 +347,7 @@ function ConstantMultipleInfoSectionControl({
           ? constantMultipleState.minSellPrice || zero
           : undefined
       }
+      addTriggerGasEstimationUsd={addTriggerGasEstimationUsd}
     />
   )
 }

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -63,7 +63,7 @@ interface SidebarSetupConstantMultipleProps {
   collateralToBePurchased: BigNumber
   collateralToBeSold: BigNumber
   gasEstimationUsd?: BigNumber
-  estimatedGasPriceOnTrigger?: BigNumber
+  estimatedGasCostOnTrigger?: BigNumber
   estimatedBuyFee: BigNumber
   estimatedSellFee: BigNumber
   addTriggerGasEstimationUsd?: BigNumber
@@ -93,7 +93,7 @@ export function SidebarSetupConstantMultiple({
   collateralToBePurchased,
   collateralToBeSold,
   gasEstimationUsd,
-  estimatedGasPriceOnTrigger,
+  estimatedGasCostOnTrigger,
   estimatedBuyFee,
   estimatedSellFee,
   addTriggerGasEstimationUsd,
@@ -261,7 +261,7 @@ export function SidebarSetupConstantMultiple({
               collateralToBePurchased={collateralToBePurchased}
               collateralToBeSold={collateralToBeSold}
               addTriggerGasEstimationUsd={addTriggerGasEstimationUsd}
-              estimatedGasPriceOnTrigger={estimatedGasPriceOnTrigger}
+              estimatedGasCostOnTrigger={estimatedGasCostOnTrigger}
               estimatedBuyFee={estimatedBuyFee}
               estimatedSellFee={estimatedSellFee}
               constantMultipleState={constantMultipleState}
@@ -300,7 +300,7 @@ interface ConstantMultipleInfoSectionControlProps {
   collateralToBePurchased: BigNumber
   collateralToBeSold: BigNumber
   addTriggerGasEstimationUsd?: BigNumber
-  estimatedGasPriceOnTrigger?: BigNumber
+  estimatedGasCostOnTrigger?: BigNumber
   estimatedBuyFee: BigNumber
   estimatedSellFee: BigNumber
   constantMultipleState: ConstantMultipleFormChange
@@ -313,7 +313,7 @@ function ConstantMultipleInfoSectionControl({
   collateralToBePurchased,
   collateralToBeSold,
   addTriggerGasEstimationUsd,
-  estimatedGasPriceOnTrigger,
+  estimatedGasCostOnTrigger,
   estimatedBuyFee,
   estimatedSellFee,
   constantMultipleState,
@@ -331,7 +331,7 @@ function ConstantMultipleInfoSectionControl({
       targetColRatio={constantMultipleState.targetCollRatio}
       multiplier={constantMultipleState.multiplier}
       slippage={slippage}
-      triggerColRatioToBuy={constantMultipleState.buyExecutionCollRatio}
+      buyExecutionCollRatio={constantMultipleState.buyExecutionCollRatio}
       nextBuyPrice={nextBuyPrice}
       collateralToBePurchased={collateralToBePurchased}
       maxPriceToBuy={
@@ -339,7 +339,7 @@ function ConstantMultipleInfoSectionControl({
           ? constantMultipleState.maxBuyPrice || zero
           : undefined
       }
-      triggerColRatioToSell={constantMultipleState.sellExecutionCollRatio}
+      sellExecutionCollRatio={constantMultipleState.sellExecutionCollRatio}
       nextSellPrice={nextSellPrice}
       collateralToBeSold={collateralToBeSold}
       minPriceToSell={
@@ -349,7 +349,7 @@ function ConstantMultipleInfoSectionControl({
       }
       addTriggerGasEstimationUsd={addTriggerGasEstimationUsd}
       estimatedOasisFee={estimatedOasisFee}
-      estimatedGasPriceOnTrigger={estimatedGasPriceOnTrigger}
+      estimatedGasCostOnTrigger={estimatedGasCostOnTrigger}
     />
   )
 }

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -9,6 +9,7 @@ import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ConstantMultipleInfoSection } from 'features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
+import { ACCEPTABLE_FEE_DIFF } from 'features/automation/common/helpers'
 import { commonOptimizationDropdownItems } from 'features/automation/optimization/common/dropdown'
 import { warningsConstantMultipleValidation } from 'features/automation/optimization/validators'
 import { DEFAULT_BASIC_BS_MAX_SLIDER_VALUE } from 'features/automation/protection/common/consts/automationDefaults'
@@ -321,7 +322,7 @@ function ConstantMultipleInfoSectionControl({
   // TODO: PK where do I get slippage?
   const slippage = new BigNumber(0.5)
   const feeDiff = estimatedBuyFee.minus(estimatedSellFee).abs()
-  const estimatedOasisFee = feeDiff.gt(new BigNumber(3))
+  const estimatedOasisFee = feeDiff.gt(ACCEPTABLE_FEE_DIFF)
     ? [estimatedBuyFee, estimatedSellFee].sort((a, b) => (a.gt(b) ? 0 : -1))
     : [BigNumber.maximum(estimatedBuyFee, estimatedSellFee)]
 

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -10,6 +10,7 @@ import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ConstantMultipleInfoSection } from 'features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
+import { getBasicBSVaultChange } from 'features/automation/common/helpers'
 import { commonOptimizationDropdownItems } from 'features/automation/optimization/common/dropdown'
 import { warningsConstantMultipleValidation } from 'features/automation/optimization/validators'
 import { DEFAULT_BASIC_BS_MAX_SLIDER_VALUE } from 'features/automation/protection/common/consts/automationDefaults'
@@ -70,7 +71,6 @@ export function SidebarSetupConstantMultiple({
   balanceInfo,
   isAddForm,
   isRemoveForm,
-  // isEditing,
   isDisabled,
   isFirstSetup,
   stage,
@@ -102,25 +102,30 @@ export function SidebarSetupConstantMultiple({
   }
 
   const nextBuyPrice = collateralPriceAtRatio({
-    // TODO: PK get value from constantMultipleState
     colRatio: constantMultipleState.buyExecutionCollRatio.div(100),
     collateral: lockedCollateral,
     vaultDebt: debt,
   })
   const nextSellPrice = collateralPriceAtRatio({
-    // TODO: PK get value from constantMultipleState
     colRatio: constantMultipleState.sellExecutionCollRatio.div(100),
     collateral: lockedCollateral,
     vaultDebt: debt,
   })
-  // TODO: PK get both values based on function:
-  // const { debtDelta } = getBasicBSVaultChange({
-  //   basicBSState: basicBuyState,
-  //   vault,
-  //   executionPrice,
-  // })
-  const collateralToBePurchased = new BigNumber(1.125)
-  const collateralToBeSold = new BigNumber(1.125)
+  const { collateralDelta: collateralToBePurchased } = getBasicBSVaultChange({
+    targetCollRatio: constantMultipleState.targetCollRatio,
+    execCollRatio: constantMultipleState.buyExecutionCollRatio,
+    deviation: constantMultipleState.deviation,
+    executionPrice: nextBuyPrice,
+    vault,
+  })
+  const { collateralDelta: collateralToBeSold } = getBasicBSVaultChange({
+    targetCollRatio: constantMultipleState.targetCollRatio,
+    execCollRatio: constantMultipleState.sellExecutionCollRatio,
+    deviation: constantMultipleState.deviation,
+    executionPrice: nextSellPrice,
+    vault,
+  })
+
   const { min: sliderMin } = getBasicSellMinMaxValues({
     autoBuyTriggerData,
     stopLossTriggerData,

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -209,9 +209,11 @@ export function AutoSellFormControl({
     vaultDebt: vault.debt,
   })
   const { debtDelta, collateralDelta } = getBasicBSVaultChange({
-    basicBSState: basicSellState,
-    vault,
+    targetCollRatio: basicSellState.targetCollRatio,
+    execCollRatio: basicSellState.execCollRatio,
+    deviation: basicSellState.deviation,
     executionPrice,
+    vault,
   })
 
   return (

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -213,7 +213,8 @@ export function AutoSellFormControl({
     execCollRatio: basicSellState.execCollRatio,
     deviation: basicSellState.deviation,
     executionPrice,
-    vault,
+    lockedCollateral: vault.lockedCollateral,
+    debt: vault.debt,
   })
 
   return (

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1530,7 +1530,9 @@
       "target-multiple-ratio-after-buy-sell": "Target Multiple after each buy/sell",
       "cost-per-adjustment": "Estimated  transaction cost per adjustment",
       "max-price-buy": "Max price to perform auto buy",
-      "max-price-sell": "Min price to perform auto sell"
+      "max-price-sell": "Min price to perform auto sell",
+      "estimated-oasis-fee": "Estimated Oasis fee",
+      "estimated-max-gas-fee": "Estimated max gas fee"
     }
   },
   "ref": {


### PR DESCRIPTION
# [Constant multiple changes information data](https://app.shortcut.com/oazo-apps/story/3876/constant-multiple-changes-information)
  
## Changes 👷‍♀️

- Connected changes information to `constantMultipleState`,
- updated `getBasicBSVaultChange` method to accept constant multiple values.

![image](https://user-images.githubusercontent.com/16230404/182101334-80771255-dade-435a-a140-94e89af286e1.png)

To do in the future, in next PR:
- Decide if `slippage` needs to be removed.
  
## How to test 🧪

- Check if changes information are updating in constant multiple form.
