### PR TITLE
Added warning message if CM would be executed immediately

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -81,6 +81,10 @@ export function VaultWarnings({
       // TEMPORARY override message as banner in overview details
       case 'autoSellOverride':
         return <Trans i18nKey="vault-warnings.auto-sell-override" components={[SupportLink]} />
+      case 'constantMultipleAutoSellTriggeredImmediately':
+        return translate('constant-multiple-auto-sell-triggered-immediately')
+      case 'constantMultipleAutoBuyTriggeredImmediately':
+        return translate('constant-multiple-auto-buy-triggered-immediately')
       case 'constantMultipleSellTriggerCloseToStopLossTrigger':
         return (
           <Trans

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -122,9 +122,19 @@ export function warningsConstantMultipleValidation({
 
   const addingConstantMultipleWhenAutoSellOrBuyEnabled = isAutoBuyEnabled || isAutoSellEnabled
 
+  const constantMultipleAutoSellTriggeredImmediately = constantMultipleState.sellExecutionCollRatio
+    .div(100)
+    .gte(vault.collateralizationRatioAtNextPrice)
+
+  const constantMultipleAutoBuyTriggeredImmediately = constantMultipleState.buyExecutionCollRatio
+    .div(100)
+    .lte(vault.collateralizationRatioAtNextPrice)
+
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
     constantMultipleSellTriggerCloseToStopLossTrigger,
     addingConstantMultipleWhenAutoSellOrBuyEnabled,
+    constantMultipleAutoSellTriggeredImmediately,
+    constantMultipleAutoBuyTriggeredImmediately,
   })
 }

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -24,6 +24,8 @@ export type VaultWarningMessage =
   | 'constantMultipleSellTriggerCloseToStopLossTrigger'
   | 'stopLossTriggerCloseToConstantMultipleSellTrigger'
   | 'addingConstantMultipleWhenAutoSellOrBuyEnabled'
+  | 'constantMultipleAutoSellTriggeredImmediately'
+  | 'constantMultipleAutoBuyTriggeredImmediately'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -48,6 +50,8 @@ interface WarningMessagesHandler {
   constantMultipleSellTriggerCloseToStopLossTrigger?: boolean
   stopLossTriggerCloseToConstantMultipleSellTrigger?: boolean
   addingConstantMultipleWhenAutoSellOrBuyEnabled?: boolean
+  constantMultipleAutoSellTriggeredImmediately?: boolean
+  constantMultipleAutoBuyTriggeredImmediately?: boolean
 }
 
 export function warningMessagesHandler({
@@ -71,6 +75,8 @@ export function warningMessagesHandler({
   constantMultipleSellTriggerCloseToStopLossTrigger,
   stopLossTriggerCloseToConstantMultipleSellTrigger,
   addingConstantMultipleWhenAutoSellOrBuyEnabled,
+  constantMultipleAutoSellTriggeredImmediately,
+  constantMultipleAutoBuyTriggeredImmediately,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -155,6 +161,14 @@ export function warningMessagesHandler({
 
   if (stopLossTriggerCloseToConstantMultipleSellTrigger) {
     warningMessages.push('stopLossTriggerCloseToConstantMultipleSellTrigger')
+  }
+
+  if (constantMultipleAutoSellTriggeredImmediately) {
+    warningMessages.push('constantMultipleAutoSellTriggeredImmediately')
+  }
+
+  if (constantMultipleAutoBuyTriggeredImmediately) {
+    warningMessages.push('constantMultipleAutoBuyTriggeredImmediately')
   }
 
   return warningMessages

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -107,6 +107,8 @@ export function extractCancelBSErrors(errorMessages: VaultErrorMessage[]) {
 const constantMultipleSliderWarnings = [
   'constantMultipleSellTriggerCloseToStopLossTrigger',
   'stopLossTriggerCloseToConstantMultipleSellTrigger',
+  'constantMultipleAutoSellTriggeredImmediately',
+  'constantMultipleAutoBuyTriggeredImmediately',
 ]
 
 export function extractConstantMultipleSliderWarnings(warningMessages: VaultWarningMessage[]) {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -887,7 +887,9 @@
     "auto-sell-override": "Auto-Sell has been updated to override your Max gas fee if required to prevent vault liquidation. To make use of this protection, please remove your Auto-sell and create a new one. You are eligible for a gas cost refund, please contact <0>support@oasis.app</0>",
     "constant-multiple-sell-trigger-close-to-stop-loss-trigger": "You cannot set your Constant Multiple Sell trigger below your stop loss trigger. Find out more about how this works <0>here</0>",
     "stop-loss-trigger-close-to-constant-multiple-sell-trigger": "You cannot set your Stop Loss Trigger above the existing Constant Multiple Trigger. Find out more about how this works <0>here</0>",
-    "adding-constant-multiple-when-auto-sell-or-buy-enabled": "Creating a Constant multiple will remove your existing {{enabledTriggers}}. Are you sure you want to continue?"
+    "adding-constant-multiple-when-auto-sell-or-buy-enabled": "Creating a Constant multiple will remove your existing {{enabledTriggers}}. Are you sure you want to continue?",
+    "constant-multiple-auto-sell-triggered-immediately": "Setting your Sell Trigger at this ratio would result in it being executed immediately",
+    "constant-multiple-auto-buy-triggered-immediately": "Setting your Buy Trigger at this ratio would result in it being executed immediately"
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Added warning message if CM would be executed immediately](https://app.shortcut.com/oazo-apps/story/5457/validation-warning-if-cm-from-being-triggered-immediately)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- added validation to check whether trigger that is being added will result in immediate execution
  
## How to test 🧪
  <Please explain how to test your changes>
- try to setup CM sell trigger ratio in buy trigger ratio in the range that will result in immediate execution
