### PR TITLE
only load product card data once for landing pages, not on every block

### DIFF
--- a/blockchain/calls/observe.ts
+++ b/blockchain/calls/observe.ts
@@ -6,14 +6,14 @@ import { Context } from '../network'
 import { call, CallDef } from './callsHelpers'
 
 export function observe<A, R>(
-  onEveryBlock$: Observable<number>,
+  refreshTrigger$: Observable<any>,
   connectedContext$: Observable<Context>,
   callDef: CallDef<A, R>,
   resolver?: (args: A) => string,
 ): (args: A) => Observable<R> {
   return memoize(
     (args: A) =>
-      combineLatest(connectedContext$, onEveryBlock$).pipe(
+      combineLatest(connectedContext$, refreshTrigger$).pipe(
         switchMap(([context]) => call(context, callDef)(args)),
         distinctUntilChanged(isEqual),
         shareReplay(1),

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -512,6 +512,8 @@ export function setupAppContext() {
     return doGasEstimation(gasPrice$, daiEthTokenPrice$, txHelpers$, state, call)
   }
 
+  const once$ = of(undefined)
+
   // base
   const proxyAddress$ = memoize(curry(createProxyAddress$)(onEveryBlock$, context$))
   const proxyOwner$ = memoize(curry(createProxyOwner$)(onEveryBlock$, context$))
@@ -521,11 +523,15 @@ export function setupAppContext() {
   const cdpRegistryOwns$ = observe(onEveryBlock$, context$, cdpRegistryOwns)
   const cdpRegistryCdps$ = observe(onEveryBlock$, context$, cdpRegistryCdps)
   const vatIlks$ = observe(onEveryBlock$, context$, vatIlk)
+  const vatIlksLean$ = observe(once$, context$, vatIlk)
   const vatUrns$ = observe(onEveryBlock$, context$, vatUrns, ilkUrnAddressToString)
   const vatGem$ = observe(onEveryBlock$, context$, vatGem, ilkUrnAddressToString)
   const spotIlks$ = observe(onEveryBlock$, context$, spotIlk)
+  const spotIlksLean$ = observe(once$, context$, spotIlk)
   const jugIlks$ = observe(onEveryBlock$, context$, jugIlk)
+  const jugIlksLean$ = observe(once$, context$, jugIlk)
   const dogIlks$ = observe(onEveryBlock$, context$, dogIlk)
+  const dogIlksLean$ = observe(once$, context$, dogIlk)
 
   const charterNib$ = observe(onEveryBlock$, context$, charterNib)
   const charterPeace$ = observe(onEveryBlock$, context$, charterPeace)
@@ -541,9 +547,13 @@ export function setupAppContext() {
   const cropperBonusTokenAddress$ = observe(onEveryBlock$, context$, cropperBonusTokenAddress)
 
   const pipZzz$ = observe(onEveryBlock$, context$, pipZzz)
+  const pipZzzLean$ = observe(once$, context$, pipZzz)
   const pipHop$ = observe(onEveryBlock$, context$, pipHop)
+  const pipHopLean$ = observe(once$, context$, pipHop)
   const pipPeek$ = observe(onEveryBlock$, oracleContext$, pipPeek)
+  const pipPeekLean$ = observe(once$, oracleContext$, pipPeek)
   const pipPeep$ = observe(onEveryBlock$, oracleContext$, pipPeep)
+  const pipPeepLean$ = observe(once$, oracleContext$, pipPeep)
 
   const unclaimedCrvLdoRewardsForIlk$ = observe(onEveryBlock$, context$, crvLdoRewardsEarned)
 
@@ -557,6 +567,13 @@ export function setupAppContext() {
 
   const oraclePriceData$ = memoize(
     curry(createOraclePriceData$)(context$, pipPeek$, pipPeep$, pipZzz$, pipHop$),
+    ({ token, requestedData }) => {
+      return `${token}-${requestedData.join(',')}`
+    },
+  )
+
+  const oraclePriceDataLean$ = memoize(
+    curry(createOraclePriceData$)(context$, pipPeekLean$, pipPeepLean$, pipZzzLean$, pipHopLean$),
     ({ token, requestedData }) => {
       return `${token}-${requestedData.join(',')}`
     },
@@ -581,6 +598,10 @@ export function setupAppContext() {
 
   const ilkData$ = memoize(
     curry(createIlkData$)(vatIlks$, spotIlks$, jugIlks$, dogIlks$, ilkToToken$),
+  )
+
+  const ilkDataLean$ = memoize(
+    curry(createIlkData$)(vatIlksLean$, spotIlksLean$, jugIlksLean$, dogIlksLean$, ilkToToken$),
   )
 
   const charterCdps$ = memoize(
@@ -907,7 +928,7 @@ export function setupAppContext() {
   const collateralPrices$ = createCollateralPrices$(collateralTokens$, oraclePriceData$)
 
   const productCardsData$ = memoize(
-    curry(createProductCardsData$)(ilksSupportedOnNetwork$, ilkData$, oraclePriceData$),
+    curry(createProductCardsData$)(ilksSupportedOnNetwork$, ilkDataLean$, oraclePriceDataLean$),
     (ilks: string[]) => {
       return ilks.join(',')
     },


### PR DESCRIPTION
Stops loading product card data on everyblock for landing pages

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- Creates lean versions of all the pipes for the product card data so it is not refreshed on every block.
  
## How to test 🧪
- open and close a few positions on hardhat.
