### PR TITLE
Bug: Align breakeven with 30 day returns on Simulate page

### DIFF
--- a/components/vault/detailsSection/ContentFooterItemsEarnSimulate.tsx
+++ b/components/vault/detailsSection/ContentFooterItemsEarnSimulate.tsx
@@ -31,7 +31,7 @@ export function ContentFooterItemsEarnSimulate({
     <>
       <DetailsSectionFooterItem
         title={t('system.est-break-even')}
-        value={t('system.est-break-even-value', { days: formatted.breakeven })}
+        value={`${t('system.est-break-even-value', { days: formatted.breakeven })}**`}
       />
       <DetailsSectionFooterItem title={t('system.est-entry-fees')} value={formatted.entryFees} />
       <DetailsSectionFooterItem title={t('system.apy')} value={formatted.apy} />

--- a/features/earn/guni/open/containers/GuniOpenMultiplyVaultDetails.tsx
+++ b/features/earn/guni/open/containers/GuniOpenMultiplyVaultDetails.tsx
@@ -76,11 +76,12 @@ export function GuniOpenMultiplyVaultDetails(
     props.gasEstimationDai,
   )
 
-  if (depositAmount.gt(zero) && apy7.gt(zero)) {
+  const useApy30ForBreakeven = apy30?.gt(zero)
+  if (depositAmount.gt(zero) && (apy30.gt(zero) || apy7.gt(zero))) {
     breakeven = calculateBreakeven({
       depositAmount,
       entryFees: entryFees,
-      apy: apy7,
+      apy: useApy30ForBreakeven ? apy30 : apy7,
     })
   }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -415,9 +415,9 @@
       "header3": "Net value",
       "rowlabel1": "Previous 30 days*",
       "rowlabel2": "Previous 90 days*",
-      "rowlabel3": "Previous 1 year**",
+      "rowlabel3": "Previous 1 year*",
       "footnote1": "*Past performance is not indicative of future results.",
-      "footnote2": "**Prior year estimates use the 90 day APY."
+      "footnote2": "**Breakeven is estimated using 30 day APY."
     }
   },
   "manage-insti-vault": {


### PR DESCRIPTION
# [Make Breakeven on simulate page clearer](https://app.shortcut.com/oazo-apps/story/5513/make-breakeven-on-simulate-page-clearer)
  
## Changes 👷‍♀️
- Update breakeven to use 30 day APY on simulate page.
  
## How to test 🧪
- Go to earn simulate view and plug in a various DAI amounts. Confirm that the estimated breakeven 'makes sense' in the context of 30 day earnings after fees
