### PR TITLE
Missing estimatedGasCostOnTrigger

### DIFF
--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -71,6 +71,7 @@ export function SidebarSetupConstantMultiple({
   nextSellPrice,
   collateralToBePurchased,
   collateralToBeSold,
+  estimatedGasCostOnTrigger,
   estimatedBuyFee,
   estimatedSellFee,
 }: SidebarSetupConstantMultipleProps) {
@@ -133,6 +134,7 @@ export function SidebarSetupConstantMultiple({
                 nextSellPrice={nextSellPrice}
                 collateralToBePurchased={collateralToBePurchased}
                 collateralToBeSold={collateralToBeSold}
+                estimatedGasCostOnTrigger={estimatedGasCostOnTrigger}
                 estimatedBuyFee={estimatedBuyFee}
                 estimatedSellFee={estimatedSellFee}
               />


### PR DESCRIPTION
# Missing estimatedGasCostOnTrigger

`estimatedGasCostOnTrigger` went missing during some of the refactors and prop drilling during changing files structure in CM.
  
## Changes 👷‍♀️

- Passed `estimatedGasCostOnTrigger` value down to the `ConstantMultipleEditingStage` component.
  
## How to test 🧪

- Go to CM and check if "Estimated transaction cost per adjustment" is displaying properly.
