### PR TITLE
Max gas price section in CM

### DIFF
--- a/components/infoSection/Item.tsx
+++ b/components/infoSection/Item.tsx
@@ -52,6 +52,7 @@ export function Item({
       <Flex
         sx={{
           cursor: !isLoading && dropdownValues?.length ? 'pointer' : 'auto',
+          justifyContent: 'space-between',
         }}
         onClick={() => {
           !isLoading && dropdownValues?.length && setOpen(!open)
@@ -118,6 +119,8 @@ export function Item({
               sx={{
                 fontWeight: 400,
                 color: 'neutral80',
+                fontSize: 2,
+                mt: 2,
               }}
             >
               {subLabel}

--- a/features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection.tsx
+++ b/features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection.tsx
@@ -24,6 +24,7 @@ export function MaxGasPriceSection({ onChange, value }: MaxGasPriceSectionProps)
       label={t('basic-buy-sell-generic.max-gas-fee-trans-value')}
       labelColorPrimary
       dropDownElementType="element"
+      isHeading
       subLabel={t('basic-buy-sell-generic.max-gas-fee-trans-subheading')}
       dropdownValues={[
         {

--- a/features/automation/optimization/sidebars/ConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/ConstantMultipleEditingStage.tsx
@@ -6,6 +6,7 @@ import { MultipleRangeSlider } from 'components/vault/MultipleRangeSlider'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { ConstantMultipleInfoSection } from 'features/automation/basicBuySell/InfoSections/ConstantMultipleInfoSection'
+import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { ACCEPTABLE_FEE_DIFF } from 'features/automation/common/helpers'
 import { getConstantMultipleMultipliers } from 'features/automation/optimization/common/multipliers'
@@ -185,6 +186,15 @@ export function ConstantMultipleEditingStage({
         ilkData={ilkData}
         isAutoBuyEnabled={autoBuyTriggerData.isTriggerEnabled}
         isAutoSellEnabled={autoSellTriggerData.isTriggerEnabled}
+      />
+      <MaxGasPriceSection
+        onChange={(maxBaseFeeInGwei) => {
+          uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+            type: 'max-gas-fee-in-gwei',
+            maxBaseFeeInGwei: new BigNumber(maxBaseFeeInGwei),
+          })
+        }}
+        value={constantMultipleState.maxBaseFeeInGwei.toNumber()}
       />
       {isEditing && (
         <ConstantMultipleInfoSectionControl


### PR DESCRIPTION
# [Max gas price section in CM](https://app.shortcut.com/oazo-apps/story/5563/constant-multiple-max-gas-fee-ui)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added max gas price section in constant multiply form
  
## How to test 🧪
  <Please explain how to test your changes>

- use feature toggle `ConstantMultiple` and go to CM form. Expand max gas price section and play with buttons. For now to test it it is recommended to console log either `constantMultipleState` or verify transaction payload
