### PR TITLE
Prevent uBlock from blocking sentry analytics

### DIFF
--- a/pages/api/sentry.tsx
+++ b/pages/api/sentry.tsx
@@ -1,0 +1,39 @@
+import { withSentry } from '@sentry/nextjs'
+import axios from 'axios'
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
+
+const handler: NextApiHandler = async (req, res) => {
+  switch (req.method) {
+    case 'POST':
+      return tunnel(req, res)
+    default:
+      return res.status(405).end()
+  }
+}
+
+const SENTRY_HOST = 'o1143494.ingest.sentry.io'
+const SENTRY_PROJECT_IDS = ['6204127']
+
+async function tunnel(req: NextApiRequest, res: NextApiResponse) {
+  const envelope = req.body
+  const piece = envelope.split('\n')[0]
+  const header = JSON.parse(piece)
+  const dsn = new URL(header.dsn)
+  const projectId = dsn.pathname.replace('/', '')
+  const upstreamSentryUrl = `https://${SENTRY_HOST}/api/${projectId}/envelope/`
+
+  if (dsn.hostname !== SENTRY_HOST) {
+    return res.status(404).json({ error: `tunnel/invalid-host` })
+  }
+  if (SENTRY_PROJECT_IDS.includes(projectId)) {
+    return res.status(404).json({ error: `tunnel/invalid-project-id-${projectId}` })
+  }
+  const postRes = await axios.post(upstreamSentryUrl, envelope)
+  if (postRes.status === 200) {
+    return res.status(200).json('tunnel/ok')
+  } else {
+    return res.status(500).json({ error: `tunnel/error` })
+  }
+}
+
+export default withSentry(handler)

--- a/pages/api/sentry.tsx
+++ b/pages/api/sentry.tsx
@@ -22,17 +22,13 @@ async function tunnel(req: NextApiRequest, res: NextApiResponse) {
   const projectId = dsn.pathname.replace('/', '')
   const upstreamSentryUrl = `https://${SENTRY_HOST}/api/${projectId}/envelope/`
 
-  if (dsn.hostname !== SENTRY_HOST) {
-    return res.status(404).json({ error: `tunnel/invalid-host` })
-  }
-  if (SENTRY_PROJECT_IDS.includes(projectId)) {
-    return res.status(404).json({ error: `tunnel/invalid-project-id-${projectId}` })
-  }
-  const postRes = await axios.post(upstreamSentryUrl, envelope)
-  if (postRes.status === 200) {
-    return res.status(200).json('tunnel/ok')
-  } else {
-    return res.status(500).json({ error: `tunnel/error` })
+  if (dsn.hostname === SENTRY_HOST && SENTRY_PROJECT_IDS.includes(projectId)) {
+    const postRes = await axios.post(upstreamSentryUrl, envelope)
+    if (postRes.status === 200) {
+      return res.status(200).json('tunnel/ok')
+    } else {
+      return res.status(500).json({ error: `tunnel/error` })
+    }
   }
 }
 

--- a/pages/api/sentry.tsx
+++ b/pages/api/sentry.tsx
@@ -2,6 +2,7 @@ import { withSentry } from '@sentry/nextjs'
 import axios from 'axios'
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
 
+import { sentryBaseConfig } from './../../sentry.base.config'
 const handler: NextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'POST':
@@ -11,8 +12,8 @@ const handler: NextApiHandler = async (req, res) => {
   }
 }
 
-const SENTRY_HOST = 'o1143494.ingest.sentry.io'
-const SENTRY_PROJECT_IDS = ['6204127']
+const SENTRY_HOST = sentryBaseConfig.host
+const SENTRY_PROJECT_IDS = [sentryBaseConfig.projectId]
 
 async function tunnel(req: NextApiRequest, res: NextApiResponse) {
   const envelope = req.body

--- a/sentry.base.config.ts
+++ b/sentry.base.config.ts
@@ -6,6 +6,7 @@ const SENTRY_DSN: string =
 export const sentryBaseConfig = {
   dsn: SENTRY_DSN,
   tracesSampleRate: 1.0,
+  tunnel: "/api/sentry",
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV,
   // release is also used for source map uploads at build time,
   // so ensure that SENTRY_RELEASE is the same at build time.

--- a/sentry.base.config.ts
+++ b/sentry.base.config.ts
@@ -6,7 +6,7 @@ const SENTRY_DSN: string =
 export const sentryBaseConfig = {
   dsn: SENTRY_DSN,
   tracesSampleRate: 1.0,
-  tunnel: "/api/sentry",
+  tunnel: '/api/sentry',
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV,
   // release is also used for source map uploads at build time,
   // so ensure that SENTRY_RELEASE is the same at build time.

--- a/sentry.base.config.ts
+++ b/sentry.base.config.ts
@@ -3,8 +3,14 @@ import getConfig from 'next/config'
 const SENTRY_DSN: string =
   'https://2fdf00b007464e2784ef445e16a6039f@o1143494.ingest.sentry.io/6204127'
 
+const SENTRY_URL = new URL(SENTRY_DSN)
+const SENTRY_PROJECT_ID = SENTRY_URL.pathname.replace('/', '')
+const SENTRY_HOST = SENTRY_URL.hostname
+
 export const sentryBaseConfig = {
   dsn: SENTRY_DSN,
+  projectId: SENTRY_PROJECT_ID,
+  host: SENTRY_HOST,
   tracesSampleRate: 1.0,
   tunnel: '/api/sentry',
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV,


### PR DESCRIPTION
# [Prevent uBlock from blocking sentry analytics](https://app.shortcut.com/oazo-apps/story/5648/prevent-ublock-from-blocking-sentry-analytics)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
`/api/sentry` endpoint added
  
## How to test 🧪
- change the following lines in `.env.local` :
```
NEXT_PUBLIC_SENTRY_ENV="pullrequest"
SENTRY_RELEASE="pullrequest"
```

- go to a page that would generate sentry event eg your owner page 
- check for calls to `/api/sentry` 
- 
![image](https://user-images.githubusercontent.com/6533433/184818777-4d7c6931-7a80-4eef-b36a-f550f3cf4e24.png)
- check if response === `tunnel/ok`
- check sentry dashboard