### PR TITLE
Prevent uBlock from blocking mixpanel analytics

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -6,6 +6,7 @@ import getConfig from 'next/config'
 export type MixpanelDevelopmentType = {
   track: (eventType: string, payload: any) => void
   get_distinct_id: () => string
+  has_opted_out_tracking: boolean
 }
 
 export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevelopmentType {
@@ -17,6 +18,7 @@ export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevel
         console.info('Mixpanel Event: ', eventType, payload)
       },
       get_distinct_id: () => 'test_id',
+      has_opted_out_tracking: false,
     }
   }
 
@@ -27,6 +29,8 @@ type MixpanelType = MixpanelDevelopmentType | typeof mixpanelBrowser
 let mixpanel: MixpanelType = mixpanelBrowser
 
 mixpanel = enableMixpanelDevelopmentMode<MixpanelType>(mixpanel)
+
+const optedOut = mixpanel.has_opted_out_tracking
 
 const product = 'borrow'
 export const INPUT_DEBOUNCE_TIME = 800
@@ -94,7 +98,7 @@ export const trackingEvents = {
       id: location,
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   accountChange: (account: string, network: string, walletType: string) => {
@@ -123,7 +127,7 @@ export const trackingEvents = {
       section: 'SelectCollateral',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   openVault: (page: Pages.LandingPage | Pages.OpenVaultOverview, ilk: string) => {
@@ -150,7 +154,7 @@ export const trackingEvents = {
       section: 'CreateVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultGenerate: (firstCDP: boolean | undefined, amount: string) => {
@@ -164,7 +168,7 @@ export const trackingEvents = {
       section: 'CreateVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultSetupProxy: (
@@ -183,7 +187,7 @@ export const trackingEvents = {
       section: 'Configure',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createProxy: (firstCDP: boolean | undefined) => {
@@ -196,7 +200,7 @@ export const trackingEvents = {
       section: 'ProxyDeploy',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   pickAllowance: (firstCDP: boolean | undefined, type: string, amount: string) => {
@@ -211,7 +215,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   setTokenAllowance: (firstCDP: boolean | undefined) => {
@@ -224,7 +228,7 @@ export const trackingEvents = {
       section: 'Configure',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   approveAllowance: (firstCDP: boolean | undefined) => {
@@ -237,7 +241,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultConfirm: (firstCDP: boolean | undefined) => {
@@ -250,7 +254,7 @@ export const trackingEvents = {
       section: 'CreateVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultConfirm: (
@@ -271,7 +275,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultConfirmTransaction: (
@@ -311,7 +315,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   overviewManage: (vaultId: string, ilk: string) => {
@@ -325,7 +329,7 @@ export const trackingEvents = {
       section: 'Table',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createNewVault: (firstCDP: boolean | undefined) => {
@@ -337,7 +341,7 @@ export const trackingEvents = {
       section: 'NavBar',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   yourVaults: () => {
@@ -348,7 +352,7 @@ export const trackingEvents = {
       section: 'NavBar',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   switchToDai: (ControllerIsConnected: boolean) => {
@@ -361,7 +365,7 @@ export const trackingEvents = {
       section: 'Dai',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   switchToCollateral: (ControllerIsConnected: boolean) => {
@@ -374,7 +378,7 @@ export const trackingEvents = {
       section: 'Collateral',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultDepositAmount: (
@@ -391,7 +395,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultGenerateAmount: (
@@ -408,7 +412,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultWithdrawAmount: (
@@ -425,7 +429,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultPaybackAmount: (
@@ -442,7 +446,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultConfirmVaultEdit: () => {
@@ -453,7 +457,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Can we distinguish if went through collateral/daiEditing?
@@ -474,7 +478,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultConfirmTransaction: (
@@ -514,7 +518,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageCollateralApproveAllowance: () => {
@@ -526,7 +530,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageDaiPickAllowance: (type: string, amount: string) => {
@@ -540,7 +544,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageDaiApproveAllowance: () => {
@@ -552,7 +556,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // First Confirm button when the user is on Collateral and type into Deposit
@@ -565,7 +569,7 @@ export const trackingEvents = {
       section: 'Deposit',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Confirm button when the user is on Collateral and type into Withdraw
@@ -578,7 +582,7 @@ export const trackingEvents = {
       section: 'Withdraw',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // First Confirm button when the user is on Dai and type into Generate
@@ -591,7 +595,7 @@ export const trackingEvents = {
       section: 'Generate',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Confirm button when the user is on Dai and type into Payback
@@ -604,7 +608,7 @@ export const trackingEvents = {
       section: 'Payback',
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   newsletterSubscribe: (section: 'Footer' | 'Homepage') => {
@@ -615,7 +619,7 @@ export const trackingEvents = {
       section,
     }
 
-    mixpanelInternalAPI(eventName, eventBody)
+    !optedOut && mixpanelInternalAPI(eventName, eventBody)
   },
 
   multiply: {
@@ -637,7 +641,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanelInternalAPI(eventName, eventBody)
+      !optedOut && mixpanelInternalAPI(eventName, eventBody)
     },
 
     confirmOpenMultiplyConfirmTransaction: (
@@ -678,7 +682,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanelInternalAPI(eventName, eventBody)
+      !optedOut && mixpanelInternalAPI(eventName, eventBody)
     },
 
     adjustPositionConfirmTransaction: (
@@ -716,7 +720,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanelInternalAPI(eventName, eventBody)
+      !optedOut && mixpanelInternalAPI(eventName, eventBody)
     },
 
     otherActionsConfirmTransaction: (
@@ -756,7 +760,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanelInternalAPI(eventName, eventBody)
+      !optedOut && mixpanelInternalAPI(eventName, eventBody)
     },
 
     closeVaultConfirmTransaction: (

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -44,13 +44,33 @@ export enum Pages {
   OtherActions = 'OtherActions',
   CloseVault = 'CloseVault',
 }
+
 // https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
 export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string]: any }) {
+  let win: Window
+  if (typeof window === 'undefined') {
+    var loc = {
+      hostname: '',
+    }
+    win = {
+      navigator: { userAgent: '' },
+      document: {
+        location: loc,
+        referrer: '',
+      },
+      screen: { width: 0, height: 0 },
+      location: loc,
+    } as Window
+  } else {
+    win = window
+  }
+
   const distinctId = mixpanel.get_distinct_id()
-  const currentUrl = window.location.href
-  const referrer = document.referrer
+  const currentUrl = win.location.href
+  const referrer = win.document.referrer
+
   // eslint-disable-next-line
-  fetch('/api/t', {
+  fetch(`/api/t`, {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -24,6 +24,8 @@ export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevel
         switch (propertyName) {
           case '$initial_referrer':
             return '$direct'
+          case '$user_id':
+            return 'test_user_id'
           default:
             return null
         }
@@ -84,6 +86,7 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
       ? '$direct'
       : new URL(initialReferrer).hostname
     : ''
+  const userId = mixpanel.get_property('$user_id')
   // eslint-disable-next-line
   fetch(`/api/t`, {
     method: 'POST',
@@ -98,6 +101,7 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
       currentUrl,
       initialReferrer,
       initialReferrerHost,
+      userId,
     }),
   })
 }

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -6,7 +6,7 @@ import getConfig from 'next/config'
 export type MixpanelDevelopmentType = {
   track: (eventType: string, payload: any) => void
   get_distinct_id: () => string
-  has_opted_out_tracking: boolean
+  has_opted_out_tracking: () => boolean
 }
 
 export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevelopmentType {
@@ -18,7 +18,7 @@ export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevel
         console.info('Mixpanel Event: ', eventType, payload)
       },
       get_distinct_id: () => 'test_id',
-      has_opted_out_tracking: false,
+      has_opted_out_tracking: () => false,
     }
   }
 
@@ -29,8 +29,6 @@ type MixpanelType = MixpanelDevelopmentType | typeof mixpanelBrowser
 let mixpanel: MixpanelType = mixpanelBrowser
 
 mixpanel = enableMixpanelDevelopmentMode<MixpanelType>(mixpanel)
-
-const optedOut = mixpanel.has_opted_out_tracking
 
 const product = 'borrow'
 export const INPUT_DEBOUNCE_TIME = 800
@@ -98,7 +96,7 @@ export const trackingEvents = {
       id: location,
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+     mixpanelInternalAPI(eventName, eventBody)
   },
 
   accountChange: (account: string, network: string, walletType: string) => {
@@ -127,7 +125,7 @@ export const trackingEvents = {
       section: 'SelectCollateral',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   openVault: (page: Pages.LandingPage | Pages.OpenVaultOverview, ilk: string) => {
@@ -154,7 +152,7 @@ export const trackingEvents = {
       section: 'CreateVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultGenerate: (firstCDP: boolean | undefined, amount: string) => {
@@ -168,7 +166,7 @@ export const trackingEvents = {
       section: 'CreateVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultSetupProxy: (
@@ -187,7 +185,7 @@ export const trackingEvents = {
       section: 'Configure',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createProxy: (firstCDP: boolean | undefined) => {
@@ -200,7 +198,7 @@ export const trackingEvents = {
       section: 'ProxyDeploy',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   pickAllowance: (firstCDP: boolean | undefined, type: string, amount: string) => {
@@ -215,7 +213,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   setTokenAllowance: (firstCDP: boolean | undefined) => {
@@ -228,7 +226,7 @@ export const trackingEvents = {
       section: 'Configure',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   approveAllowance: (firstCDP: boolean | undefined) => {
@@ -241,7 +239,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultConfirm: (firstCDP: boolean | undefined) => {
@@ -254,7 +252,7 @@ export const trackingEvents = {
       section: 'CreateVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultConfirm: (
@@ -275,7 +273,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultConfirmTransaction: (
@@ -315,7 +313,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   overviewManage: (vaultId: string, ilk: string) => {
@@ -329,7 +327,7 @@ export const trackingEvents = {
       section: 'Table',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   createNewVault: (firstCDP: boolean | undefined) => {
@@ -341,7 +339,7 @@ export const trackingEvents = {
       section: 'NavBar',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   yourVaults: () => {
@@ -352,7 +350,7 @@ export const trackingEvents = {
       section: 'NavBar',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   switchToDai: (ControllerIsConnected: boolean) => {
@@ -365,7 +363,7 @@ export const trackingEvents = {
       section: 'Dai',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   switchToCollateral: (ControllerIsConnected: boolean) => {
@@ -378,7 +376,7 @@ export const trackingEvents = {
       section: 'Collateral',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultDepositAmount: (
@@ -395,7 +393,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultGenerateAmount: (
@@ -412,7 +410,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultWithdrawAmount: (
@@ -429,7 +427,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultPaybackAmount: (
@@ -446,7 +444,7 @@ export const trackingEvents = {
       setMax,
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultConfirmVaultEdit: () => {
@@ -457,7 +455,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Can we distinguish if went through collateral/daiEditing?
@@ -478,7 +476,7 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultConfirmTransaction: (
@@ -518,7 +516,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageCollateralApproveAllowance: () => {
@@ -530,7 +528,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageDaiPickAllowance: (type: string, amount: string) => {
@@ -544,7 +542,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageDaiApproveAllowance: () => {
@@ -556,7 +554,7 @@ export const trackingEvents = {
       section: 'Allowance',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // First Confirm button when the user is on Collateral and type into Deposit
@@ -569,7 +567,7 @@ export const trackingEvents = {
       section: 'Deposit',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Confirm button when the user is on Collateral and type into Withdraw
@@ -582,7 +580,7 @@ export const trackingEvents = {
       section: 'Withdraw',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // First Confirm button when the user is on Dai and type into Generate
@@ -595,7 +593,7 @@ export const trackingEvents = {
       section: 'Generate',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Confirm button when the user is on Dai and type into Payback
@@ -608,7 +606,7 @@ export const trackingEvents = {
       section: 'Payback',
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   newsletterSubscribe: (section: 'Footer' | 'Homepage') => {
@@ -619,7 +617,7 @@ export const trackingEvents = {
       section,
     }
 
-    !optedOut && mixpanelInternalAPI(eventName, eventBody)
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
   },
 
   multiply: {
@@ -641,7 +639,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      !optedOut && mixpanelInternalAPI(eventName, eventBody)
+      !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
     },
 
     confirmOpenMultiplyConfirmTransaction: (
@@ -682,7 +680,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      !optedOut && mixpanelInternalAPI(eventName, eventBody)
+      !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
     },
 
     adjustPositionConfirmTransaction: (
@@ -720,7 +718,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      !optedOut && mixpanelInternalAPI(eventName, eventBody)
+      !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
     },
 
     otherActionsConfirmTransaction: (
@@ -760,7 +758,7 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      !optedOut && mixpanelInternalAPI(eventName, eventBody)
+      !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(eventName, eventBody)
     },
 
     closeVaultConfirmTransaction: (

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -65,10 +65,13 @@ function mixpanelInternalAPI(eventName: string, eventBody: { [key: string]: any 
 
 export const trackingEvents = {
   pageView: (location: string) => {
-    mixpanel.track('Pageview', {
+    const eventName = 'Pageview'
+    const eventBody = {
       product,
       id: location,
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   accountChange: (account: string, network: string, walletType: string) => {
@@ -81,7 +84,6 @@ export const trackingEvents = {
       walletType,
     }
 
-    mixpanel.track(eventName, eventBody)
     mixpanelInternalAPI(eventName, eventBody)
   },
 
@@ -89,45 +91,57 @@ export const trackingEvents = {
     page: Pages.LandingPage | Pages.OpenVaultOverview | Pages.VaultsOverview,
     query: string,
   ) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'SearchToken',
       product,
       page,
       query,
       section: 'SelectCollateral',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   openVault: (page: Pages.LandingPage | Pages.OpenVaultOverview, ilk: string) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'OpenVault',
       product,
       ilk,
       page,
       section: 'SelectCollateral',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultDeposit: (firstCDP: boolean | undefined, amount: string) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'Deposit',
       product,
       firstCDP,
       amount,
       page: Pages.VaultCreate,
       section: 'CreateVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultGenerate: (firstCDP: boolean | undefined, amount: string) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'Generate',
       product,
       firstCDP,
       amount,
       page: Pages.VaultCreate,
       section: 'CreateVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultSetupProxy: (
@@ -135,7 +149,8 @@ export const trackingEvents = {
     depositAmount: string,
     generateAmount: string,
   ) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'SetupProxy',
       product,
       firstCDP,
@@ -143,21 +158,27 @@ export const trackingEvents = {
       generateAmount,
       page: Pages.VaultCreate,
       section: 'Configure',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   createProxy: (firstCDP: boolean | undefined) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'CreateProxy',
       product,
       firstCDP,
       page: Pages.VaultCreate,
       section: 'ProxyDeploy',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   pickAllowance: (firstCDP: boolean | undefined, type: string, amount: string) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'PickAllowance',
       product,
       firstCDP,
@@ -165,37 +186,48 @@ export const trackingEvents = {
       amount,
       page: Pages.VaultCreate,
       section: 'Allowance',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   setTokenAllowance: (firstCDP: boolean | undefined) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'SetAllowance',
       product,
       firstCDP,
       page: Pages.VaultCreate,
       section: 'Configure',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   approveAllowance: (firstCDP: boolean | undefined) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'ApproveAllowance',
       product,
       firstCDP,
       page: Pages.VaultCreate,
       section: 'Allowance',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   createVaultConfirm: (firstCDP: boolean | undefined) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       firstCDP,
       page: Pages.VaultCreate,
       section: 'CreateVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultConfirm: (
@@ -204,7 +236,8 @@ export const trackingEvents = {
     daiAmount: string,
     firstCDP: boolean | undefined,
   ) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       ilk,
@@ -213,7 +246,9 @@ export const trackingEvents = {
       firstCDP,
       page: Pages.VaultCreate,
       section: 'ConfirmVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultConfirmTransaction: (
@@ -240,66 +275,83 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    mixpanel.track(eventName, eventBody)
     mixpanelInternalAPI(eventName, eventBody)
   },
 
   confirmVaultEdit: (firstCDP: boolean | undefined) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'EditVault',
       product,
       firstCDP,
       page: Pages.VaultCreate,
       section: 'ConfirmVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   overviewManage: (vaultId: string, ilk: string) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Manage',
       product,
       vaultId,
       ilk,
       page: Pages.VaultsOverview,
       section: 'Table',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   createNewVault: (firstCDP: boolean | undefined) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'createNewVault',
       product,
       firstCDP,
       section: 'NavBar',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   yourVaults: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'YourVaults',
       product,
       section: 'NavBar',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   switchToDai: (ControllerIsConnected: boolean) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'SwitchToDai',
       product,
       ControllerIsConnected,
       page: Pages.ManageCollateral,
       section: 'Dai',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   switchToCollateral: (ControllerIsConnected: boolean) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'SwitchToCollateral',
       product,
       ControllerIsConnected,
       page: Pages.ManageDai,
       section: 'Collateral',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultDepositAmount: (
@@ -307,13 +359,16 @@ export const trackingEvents = {
     amount: string,
     setMax: boolean,
   ) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'DepositAmount',
       product,
       page,
       amount,
       setMax,
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultGenerateAmount: (
@@ -321,13 +376,16 @@ export const trackingEvents = {
     amount: string,
     setMax: boolean,
   ) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'GenerateAmount',
       product,
       page,
       amount,
       setMax,
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultWithdrawAmount: (
@@ -335,13 +393,16 @@ export const trackingEvents = {
     amount: string,
     setMax: boolean,
   ) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'WithdrawAmount',
       product,
       page,
       amount,
       setMax,
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultPaybackAmount: (
@@ -349,21 +410,27 @@ export const trackingEvents = {
     amount: string,
     setMax: boolean,
   ) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'PaybackAmount',
       product,
       page,
       amount,
       setMax,
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultConfirmVaultEdit: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'EditVault',
       product,
       section: 'ConfirmVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Can we distinguish if went through collateral/daiEditing?
@@ -373,7 +440,8 @@ export const trackingEvents = {
     collateralAmount: string,
     daiAmount: string,
   ) => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       ilk,
@@ -381,7 +449,9 @@ export const trackingEvents = {
       daiAmount,
       page,
       section: 'ConfirmVault',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageVaultConfirmTransaction: (
@@ -407,96 +477,122 @@ export const trackingEvents = {
       section: 'ConfirmVault',
     }
 
-    mixpanel.track(eventName, eventBody)
     mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageCollateralPickAllowance: (type: string, amount: string) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'PickAllowance',
       product,
       type,
       amount,
       page: Pages.ManageCollateral,
       section: 'Allowance',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageCollateralApproveAllowance: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'ApproveAllowance',
       product,
       page: Pages.ManageCollateral,
       section: 'Allowance',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageDaiPickAllowance: (type: string, amount: string) => {
-    mixpanel.track('input-change', {
+    const eventName = 'input-change'
+    const eventBody = {
       id: 'PickAllowance',
       product,
       type,
       amount,
       page: Pages.ManageDai,
       section: 'Allowance',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   manageDaiApproveAllowance: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'ApproveAllowance',
       product,
       page: Pages.ManageDai,
       section: 'Allowance',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   // First Confirm button when the user is on Collateral and type into Deposit
   manageCollateralDepositConfirm: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       page: Pages.ManageCollateral,
       section: 'Deposit',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Confirm button when the user is on Collateral and type into Withdraw
   manageCollateralWithdrawConfirm: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       page: Pages.ManageCollateral,
       section: 'Withdraw',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   // First Confirm button when the user is on Dai and type into Generate
   manageDaiGenerateConfirm: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       page: Pages.ManageDai,
       section: 'Generate',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   // Confirm button when the user is on Dai and type into Payback
   manageDaiPaybackConfirm: () => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'Confirm',
       product,
       page: Pages.ManageDai,
       section: 'Payback',
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   newsletterSubscribe: (section: 'Footer' | 'Homepage') => {
-    mixpanel.track('btn-click', {
+    const eventName = 'btn-click'
+    const eventBody = {
       id: 'NewsletterSubscribe',
       product,
       section,
-    })
+    }
+
+    mixpanelInternalAPI(eventName, eventBody)
   },
 
   multiply: {
@@ -506,7 +602,8 @@ export const trackingEvents = {
       collAmount: string,
       multiply: string,
     ) => {
-      mixpanel.track('btn-click', {
+      const eventName = 'btn-click'
+      const eventBody = {
         id: 'Confirm',
         product,
         ilk,
@@ -515,7 +612,9 @@ export const trackingEvents = {
         multiply,
         page: Pages.OpenMultiply,
         section: 'ConfirmVault',
-      })
+      }
+
+      mixpanelInternalAPI(eventName, eventBody)
     },
 
     confirmOpenMultiplyConfirmTransaction: (
@@ -542,19 +641,21 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanel.track(eventName, eventBody)
       mixpanelInternalAPI(eventName, eventBody)
     },
 
     adjustPositionConfirm: (ilk: string, multiply: string) => {
-      mixpanel.track('btn-click', {
+      const eventName = 'btn-click'
+      const eventBody = {
         id: 'Confirm',
         product,
         ilk,
         multiply,
         page: Pages.AdjustPosition,
         section: 'ConfirmVault',
-      })
+      }
+
+      mixpanelInternalAPI(eventName, eventBody)
     },
 
     adjustPositionConfirmTransaction: (
@@ -577,12 +678,12 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanel.track(eventName, eventBody)
       mixpanelInternalAPI(eventName, eventBody)
     },
 
     otherActionsConfirm: (ilk: string, collateralAmount: string, daiAmount: string) => {
-      mixpanel.track('btn-click', {
+      const eventName = 'btn-click'
+      const eventBody = {
         id: 'Confirm',
         product,
         ilk,
@@ -590,7 +691,9 @@ export const trackingEvents = {
         daiAmount,
         page: Pages.OtherActions,
         section: 'ConfirmVault',
-      })
+      }
+
+      mixpanelInternalAPI(eventName, eventBody)
     },
 
     otherActionsConfirmTransaction: (
@@ -615,12 +718,12 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanel.track(eventName, eventBody)
       mixpanelInternalAPI(eventName, eventBody)
     },
 
     closeVaultConfirm: (ilk: string, debt: string, closeTo: CloseVaultTo) => {
-      mixpanel.track('btn-click', {
+      const eventName = 'btn-click'
+      const eventBody = {
         id: 'Confirm',
         product,
         ilk,
@@ -628,7 +731,9 @@ export const trackingEvents = {
         closeTo,
         page: Pages.CloseVault,
         section: 'ConfirmVault',
-      })
+      }
+
+      mixpanelInternalAPI(eventName, eventBody)
     },
 
     closeVaultConfirmTransaction: (
@@ -653,7 +758,6 @@ export const trackingEvents = {
         section: 'ConfirmVault',
       }
 
-      mixpanel.track(eventName, eventBody)
       mixpanelInternalAPI(eventName, eventBody)
     },
   },

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -44,10 +44,11 @@ export enum Pages {
   OtherActions = 'OtherActions',
   CloseVault = 'CloseVault',
 }
-
+// https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
 export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string]: any }) {
   const distinctId = mixpanel.get_distinct_id()
-
+  const currentUrl = window.location.href
+  const referrer = document.referrer
   // eslint-disable-next-line
   fetch('/api/t', {
     method: 'POST',
@@ -59,6 +60,8 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
       eventName,
       eventBody,
       distinctId,
+      currentUrl,
+      referrer,
     }),
   })
 }

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -3,11 +3,13 @@ import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault
 import * as mixpanelBrowser from 'mixpanel-browser'
 import getConfig from 'next/config'
 
+type PropertyNameType = '$initial_referrer' | '$user_id'
+
 export type MixpanelDevelopmentType = {
   track: (eventType: string, payload: any) => void
   get_distinct_id: () => string
   has_opted_out_tracking: () => boolean
-  get_property: (propertyName: string) => any
+  get_property: (propertyName: PropertyNameType) => string | null
 }
 
 export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevelopmentType {
@@ -20,7 +22,7 @@ export function enableMixpanelDevelopmentMode<T>(mixpanel: T): T | MixpanelDevel
       },
       get_distinct_id: () => 'test_id',
       has_opted_out_tracking: () => false,
-      get_property: (propertyName: any) => {
+      get_property: (propertyName: PropertyNameType) => {
         switch (propertyName) {
           case '$initial_referrer':
             return '$direct'

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -45,7 +45,7 @@ export enum Pages {
   CloseVault = 'CloseVault',
 }
 
-function mixpanelInternalAPI(eventName: string, eventBody: { [key: string]: any }) {
+export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string]: any }) {
   const distinctId = mixpanel.get_distinct_id()
 
   // eslint-disable-next-line

--- a/analytics/mixpanel.ts
+++ b/analytics/mixpanel.ts
@@ -36,7 +36,7 @@ export function mixpanelInit() {
     console.debug(`[Mixpanel] Tracking initialized for ${env} env using ${config.mixpanel.token}`)
   }
   mixpanel.init(config.mixpanel.token, config.mixpanel.config)
-  mixpanelInternalAPI('Pageview', { product: 'borrow', id: window.location.pathname })
+  mixpanelInternalAPI('Pageview', { product: 'borrow' })
 }
 
 export function mixpanelIdentify(id: string, props: any) {

--- a/analytics/mixpanel.ts
+++ b/analytics/mixpanel.ts
@@ -6,6 +6,8 @@ import * as mixpanel from 'mixpanel-browser'
 import { Config, Mixpanel } from 'mixpanel-browser'
 import getConfig from 'next/config'
 
+import { mixpanelInternalAPI } from './analytics'
+
 const env =
   getConfig()?.publicRuntimeConfig.mixpanelEnv === 'production' ||
   process.env.MIXPANEL_ENV === 'production'
@@ -34,7 +36,7 @@ export function mixpanelInit() {
     console.debug(`[Mixpanel] Tracking initialized for ${env} env using ${config.mixpanel.token}`)
   }
   mixpanel.init(config.mixpanel.token, config.mixpanel.config)
-  mixpanel.track('Pageview', { product: 'borrow' })
+  mixpanelInternalAPI('Pageview', { product: 'borrow', id: window.location.pathname })
 }
 
 export function mixpanelIdentify(id: string, props: any) {

--- a/analytics/mixpanel.ts
+++ b/analytics/mixpanel.ts
@@ -6,8 +6,6 @@ import * as mixpanel from 'mixpanel-browser'
 import { Config, Mixpanel } from 'mixpanel-browser'
 import getConfig from 'next/config'
 
-import { mixpanelInternalAPI } from './analytics'
-
 const env =
   getConfig()?.publicRuntimeConfig.mixpanelEnv === 'production' ||
   process.env.MIXPANEL_ENV === 'production'
@@ -35,7 +33,8 @@ export function mixpanelInit() {
   if (config.mixpanel.config.debug) {
     console.debug(`[Mixpanel] Tracking initialized for ${env} env using ${config.mixpanel.token}`)
   }
-  mixpanelInternalAPI('Pageview', { product: 'borrow' })
+  mixpanel.init(config.mixpanel.token, config.mixpanel.config)
+  mixpanel.track('Pageview', { product: 'borrow' })
 }
 
 export function mixpanelIdentify(id: string, props: any) {

--- a/analytics/mixpanel.ts
+++ b/analytics/mixpanel.ts
@@ -6,6 +6,8 @@ import * as mixpanel from 'mixpanel-browser'
 import { Config, Mixpanel } from 'mixpanel-browser'
 import getConfig from 'next/config'
 
+import { mixpanelInternalAPI } from './analytics'
+
 const env =
   getConfig()?.publicRuntimeConfig.mixpanelEnv === 'production' ||
   process.env.MIXPANEL_ENV === 'production'
@@ -33,8 +35,7 @@ export function mixpanelInit() {
   if (config.mixpanel.config.debug) {
     console.debug(`[Mixpanel] Tracking initialized for ${env} env using ${config.mixpanel.token}`)
   }
-  mixpanel.init(config.mixpanel.token, config.mixpanel.config)
-  mixpanel.track('Pageview', { product: 'borrow' })
+  mixpanelInternalAPI('Pageview', { product: 'borrow' })
 }
 
 export function mixpanelIdentify(id: string, props: any) {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -105,8 +105,6 @@ interface CustomAppProps {
   }
 }
 
-mixpanelInit()
-
 // script for disabling Next.js overlay for particular event errors
 // currently there is no option to configure error overlay in development mode
 const noOverlayWorkaroundScript = `
@@ -130,6 +128,7 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
   const router = useRouter()
 
   useEffect(() => {
+    mixpanelInit()
     const handleRouteChange = (url: string) => {
       // track events when not in development
       if (process.env.NODE_ENV !== 'development') {

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -18,6 +18,7 @@ const handler = async function (req: NextApiRequest, res: NextApiResponse<{ stat
       currentUrl,
       initialReferrer,
       initialReferrerHost,
+      userId,
     } = req.body
 
     mixpanel.track(`${eventName}`, {
@@ -26,6 +27,7 @@ const handler = async function (req: NextApiRequest, res: NextApiResponse<{ stat
       $current_url: currentUrl,
       $initial_referrer: initialReferrer,
       $initial_referring_domain: initialReferrerHost,
+      $user_id: userId,
     })
 
     res.json({ status: 200 })

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -11,13 +11,21 @@ mixpanel = enableMixpanelDevelopmentMode(mixpanel)
 
 const handler = async function (req: NextApiRequest, res: NextApiResponse<{ status: number }>) {
   try {
-    const { eventName, eventBody, distinctId, currentUrl, referrer } = req.body
+    const {
+      eventName,
+      eventBody,
+      distinctId,
+      currentUrl,
+      initialReferrer,
+      initialReferrerHost,
+    } = req.body
 
     mixpanel.track(`${eventName}`, {
       ...eventBody,
       distinct_id: distinctId,
-      current_url: currentUrl,
-      referrer: referrer,
+      $current_url: currentUrl,
+      $initial_referrer: initialReferrer,
+      $initial_referring_domain: initialReferrerHost,
     })
 
     res.json({ status: 200 })

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -11,11 +11,13 @@ mixpanel = enableMixpanelDevelopmentMode(mixpanel)
 
 const handler = async function (req: NextApiRequest, res: NextApiResponse<{ status: number }>) {
   try {
-    const { eventName, eventBody, distinctId } = req.body
+    const { eventName, eventBody, distinctId, currentUrl, referrer } = req.body
 
     mixpanel.track(`be-${eventName}`, {
       ...eventBody,
       distinct_id: distinctId,
+      current_url: currentUrl,
+      referrer: referrer,
       id: `be-${eventBody.id}`,
     })
 

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -18,7 +18,6 @@ const handler = async function (req: NextApiRequest, res: NextApiResponse<{ stat
       distinct_id: distinctId,
       current_url: currentUrl,
       referrer: referrer,
-      id: `be-${eventBody.id}`,
     })
 
     res.json({ status: 200 })

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -13,7 +13,7 @@ const handler = async function (req: NextApiRequest, res: NextApiResponse<{ stat
   try {
     const { eventName, eventBody, distinctId, currentUrl, referrer } = req.body
 
-    mixpanel.track(`be-${eventName}`, {
+    mixpanel.track(`${eventName}`, {
       ...eventBody,
       distinct_id: distinctId,
       current_url: currentUrl,


### PR DESCRIPTION
# [Prevent uBlock from blocking mixpanel analytics](https://app.shortcut.com/oazo-apps/story/5645/prevent-ublock-from-blocking-mixpanel-analytics)


  
## Changes 👷‍♀️
- remove double tracking (directly from FE + proxied) for FE events
- proxy all tracked events through mixpanel endpoint (`/api/t`)
- added `$current_url` , `$initial_referrer` and `$initial_referring_domain` as per `https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel` to supplement the data forwarded by proxy
- moved ` mixpanelInit()` in `_app.tsx` to the `useEffect` so `window` object  is visible ( we can get current URL)
-  removed `be-` prefix to keep the current data format
- if the user opted out (cookie settings) track only `AccountChange` address and `ConfirmTransaction`
  
## How to test 🧪

- change `MIXPANEL_ENV` to `production`
- remove `if (process.env.NODE_ENV !== 'development') {` in `_app.tsx` to track route changes
- check if the calls to `/api/t` are successful
- check events mixpanel dashboard in `Testing Environments`
- check mixpanel events in terminal when `MIXPANEL_ENV=='developement'`