### PR TITLE
Constant multiple available multipliers validation

### DIFF
--- a/components/ActionPills.tsx
+++ b/components/ActionPills.tsx
@@ -7,6 +7,7 @@ interface ActionPillsProps {
   items: {
     id: string
     label: string
+    disabled?: boolean
     action: () => void
   }[]
 }
@@ -34,6 +35,10 @@ export function ActionPills({ active, items, variant }: ActionPillsProps) {
             sx={{
               mx: 1,
               ...(variant === 'secondary' && secondaryVarientStyles),
+              ...(item.disabled && {
+                opacity: 0.5,
+                pointerEvents: 'none',
+              }),
             }}
           >
             {item.label}

--- a/features/automation/optimization/common/multipliers.ts
+++ b/features/automation/optimization/common/multipliers.ts
@@ -8,7 +8,7 @@ interface GetConstantMultipleMultipliersProps {
 }
 
 const AMOUNT_OF_MULTIPLIERS_TO_GENERATE = 5
-const MIX_MAX_COL_RATIO_TRIGGER_OFFSET = 5
+export const MIX_MAX_COL_RATIO_TRIGGER_OFFSET = 5
 
 const multipliersPresets = {
   '1.25-2': [1.25, 1.5, 1.75, 2],

--- a/features/automation/optimization/common/multipliers.ts
+++ b/features/automation/optimization/common/multipliers.ts
@@ -11,25 +11,24 @@ const AMOUNT_OF_MULTIPLIERS_TO_GENERATE = 5
 export const MIX_MAX_COL_RATIO_TRIGGER_OFFSET = 5
 
 const multipliersPresets = {
-  '1.25-2': [1.25, 1.5, 1.75, 2],
-  '1.5-2.25': [1.5, 1.75, 2, 2.25],
-  '1.5-3': [1.5, 2, 2.5, 2.75, 3],
-  '2-4': [2, 2.5, 3, 3.5, 4],
+  '1.3-2': [1.3, 1.5, 1.75, 2],
+  '1.3-2.25': [1.3, 1.5, 1.75, 2, 2.25],
+  '1.5-2.75': [1.5, 2, 2.25, 2.5, 2.75],
+  '1.5-3.5': [1.5, 2, 2.5, 3, 3.5],
 }
 
 const ilksMultipliers: { [key: string]: number[] } = {
-  'ETH-A': multipliersPresets['1.5-3'],
-  'ETH-B': multipliersPresets['2-4'],
-  'ETH-C': multipliersPresets['1.5-2.25'],
-  'LINK-A': multipliersPresets['1.5-2.25'],
-  'MATIC-A': multipliersPresets['1.25-2'],
-  'RENBTC-A': multipliersPresets['1.5-2.25'],
-  'WBTC-A': multipliersPresets['1.5-3'],
-  'WBTC-B': multipliersPresets['2-4'],
-  'WBTC-C': multipliersPresets['1.5-2.25'],
-  'WSTETH-A': multipliersPresets['1.5-2.25'],
-  'WSTETH-B': multipliersPresets['1.25-2'],
-  'YFI-A': multipliersPresets['1.5-2.25'],
+  'ETH-A': multipliersPresets['1.5-2.75'],
+  'ETH-B': multipliersPresets['1.5-3.5'],
+  'ETH-C': multipliersPresets['1.3-2.25'],
+  'LINK-A': multipliersPresets['1.3-2.25'],
+  'RENBTC-A': multipliersPresets['1.3-2.25'],
+  'WBTC-A': multipliersPresets['1.3-2.25'],
+  'WBTC-B': multipliersPresets['1.5-3.5'],
+  'WBTC-C': multipliersPresets['1.3-2.25'],
+  'WSTETH-A': multipliersPresets['1.3-2.25'],
+  'WSTETH-B': multipliersPresets['1.3-2'],
+  'YFI-A': multipliersPresets['1.3-2.25'],
 }
 
 function generateMultipliers({

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -9,11 +9,15 @@ import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { AddConstantMultipleInfoSection } from 'features/automation/basicBuySell/InfoSections/AddConstantMultipleInfoSection'
 import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
-import { ACCEPTABLE_FEE_DIFF } from 'features/automation/common/helpers'
+import {
+  ACCEPTABLE_FEE_DIFF,
+  calculateMultipleFromTargetCollRatio,
+} from 'features/automation/common/helpers'
 import {
   ConstantMultipleTriggerData,
   prepareConstantMultipleResetData,
 } from 'features/automation/optimization/common/constantMultipleTriggerData'
+import { MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/optimization/common/multipliers'
 import {
   CONSTANT_MULTIPLE_FORM_CHANGE,
   ConstantMultipleFormChange,
@@ -68,6 +72,12 @@ export function SidebarConstantMultipleEditingStage({
 }: SidebaConstantMultiplerEditingStageProps) {
   const { uiChanges } = useAppContext()
   const { t } = useTranslation()
+  const maxMultiplier = calculateMultipleFromTargetCollRatio(
+    constantMultipleState.minTargetRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
+  ).toNumber()
+  const minMultiplier = calculateMultipleFromTargetCollRatio(
+    constantMultipleState.maxTargetRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
+  ).toNumber()
 
   return (
     <>
@@ -78,6 +88,7 @@ export function SidebarConstantMultipleEditingStage({
           items={constantMultipleState.acceptableMultipliers.map((multiplier) => ({
             id: multiplier.toString(),
             label: `${multiplier}x`,
+            disabled: multiplier < minMultiplier || multiplier > maxMultiplier,
             action: () => {
               uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
                 type: 'is-editing',

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1553,7 +1553,7 @@
       "estimated-oasis-fee": "Estimated Oasis fee",
       "estimated-max-gas-fee": "Estimated max gas fee"
     },
-    "adding-constant-multiple": "adding Constant Multiple trigger",
+    "adding-constant-multiple": "Adding Constant Multiple trigger",
     "adjusting-constant-multiple": "Adjusting Constant Multiple trigger",
     "removing-constant-multiple": "Removing Constant Multiple trigger",
     "setting-constant-multiple": "Setting up your Constant Multiple",


### PR DESCRIPTION
# Constant multiple available multipliers validation
  
## Changes 👷‍♀️

- Updated list of multipliers for selected ilks,
- added option to `ActionPills` to disable single item,
- added validation to multipliers list so user can't choose value that would push his collateral ratio above or below slider min or max values.

![image](https://user-images.githubusercontent.com/16230404/184878445-f3400bc5-e36d-45bc-9c01-91bd4ba167ab.png)
  
## How to test 🧪

- Try setting constant multiple on vaults with different types of ilks.
