### PR TITLE
fixed reset button for constant multiple form

### DIFF
--- a/components/vault/MultipleRangeSlider.tsx
+++ b/components/vault/MultipleRangeSlider.tsx
@@ -83,6 +83,7 @@ interface MultipleRangeSliderProps {
   rightThumbColor?: string
   minDescription?: ReactNode
   maxDescription?: ReactNode
+  isResetAction?: boolean
 }
 
 export function MultipleRangeSlider({
@@ -100,6 +101,7 @@ export function MultipleRangeSlider({
   rightDescription,
   minDescription = '',
   maxDescription = '',
+  isResetAction = false,
 }: MultipleRangeSliderProps) {
   const [side, setSide] = useState('')
   const [sliderBoxBoundaries, setSliderBoxBoundaries] = useState(sliderDefaultBoundaries)
@@ -126,7 +128,7 @@ export function MultipleRangeSlider({
   }, [])
 
   useEffect(() => {
-    if (middleMark && middleMarkDidMount.current) {
+    if (middleMark && middleMarkDidMount.current && !isResetAction) {
       const newValue = {
         value0: Math.max(middleMark.value - middleMarkOffset, min),
         value1: Math.min(middleMark.value + middleMarkOffset, max),

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -128,6 +128,7 @@ export function SidebarConstantMultipleEditingStage({
           text: `${constantMultipleState.multiplier}x`,
           value: constantMultipleState.targetCollRatio.toNumber(),
         }}
+        isResetAction={constantMultipleState.isResetAction}
       />
       <VaultWarnings
         warningMessages={extractConstantMultipleSliderWarnings(warnings)}
@@ -236,6 +237,7 @@ export function SidebarConstantMultipleEditingStage({
                   defaultCollRatio: constantMultipleState.defaultCollRatio,
                   constantMultipleTriggerData,
                 }),
+                isResetAction: true,
               })
             }}
           />

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -231,13 +231,16 @@ export function SidebarConstantMultipleEditingStage({
           <SidebarResetButton
             clear={() => {
               uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+                type: 'is-reset-action',
+                isResetAction: true,
+              })
+              uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
                 type: 'reset',
                 resetData: prepareConstantMultipleResetData({
                   defaultMultiplier: constantMultipleState.defaultMultiplier,
                   defaultCollRatio: constantMultipleState.defaultCollRatio,
                   constantMultipleTriggerData,
                 }),
-                isResetAction: true,
               })
             }}
           />

--- a/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
+++ b/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
@@ -23,6 +23,7 @@ export type ConstantMultipleChangeAction =
       minTargetRatio: BigNumber
       maxTargetRatio: BigNumber
     }
+  | { type: 'is-reset-action'; isResetAction: boolean }
 
 export type ConstantMultipleFormChange = AutomationFormChange & {
   maxBuyPrice?: BigNumber
@@ -38,6 +39,7 @@ export type ConstantMultipleFormChange = AutomationFormChange & {
   minTargetRatio: BigNumber
   maxTargetRatio: BigNumber
   isEditing: boolean
+  isResetAction: boolean
 }
 
 export function constantMultipleFormChangeReducer(
@@ -88,6 +90,8 @@ export function constantMultipleFormChangeReducer(
       }
     case 'is-editing':
       return { ...state, isEditing: action.isEditing }
+    case 'is-reset-action':
+      return { ...state, isResetAction: action.isResetAction }
     default:
       return state
   }

--- a/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
+++ b/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
@@ -89,7 +89,7 @@ export function constantMultipleFormChangeReducer(
         maxTargetRatio: action.maxTargetRatio,
       }
     case 'is-editing':
-      return { ...state, isEditing: action.isEditing }
+      return { ...state, isEditing: action.isEditing, isResetAction: false }
     case 'is-reset-action':
       return { ...state, isResetAction: action.isResetAction }
     default:

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -59,6 +59,7 @@ export function useConstantMultipleStateInitialization(
       defaultCollRatio,
       minTargetRatio: min,
       maxTargetRatio: max,
+      isResetAction: false,
     })
     uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
       type: 'reset',

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -59,6 +59,9 @@ export function useConstantMultipleStateInitialization(
       defaultCollRatio,
       minTargetRatio: min,
       maxTargetRatio: max,
+    })
+    uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+      type: 'is-reset-action',
       isResetAction: false,
     })
     uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {

--- a/scripts/docker/launch.sh
+++ b/scripts/docker/launch.sh
@@ -12,4 +12,4 @@ docker-compose "$@" pull
 (sleep 10 && cd ../.. && DATABASE_URL="postgresql://user:pass@localhost:5432/db?schema=public" yarn migrate)&
 
 export DATABASE_URL="postgresql://user:pass@postgres-oasis-borrow:5432/db?schema=public"
-docker-compose -p oasis-borrow --env-file ../../.env "$@" up
+docker-compose -p oasis-borrow --env-file ../../.env --env-file ../../.env.local "$@" up

--- a/scripts/docker/launch.sh
+++ b/scripts/docker/launch.sh
@@ -12,4 +12,4 @@ docker-compose "$@" pull
 (sleep 10 && cd ../.. && DATABASE_URL="postgresql://user:pass@localhost:5432/db?schema=public" yarn migrate)&
 
 export DATABASE_URL="postgresql://user:pass@postgres-oasis-borrow:5432/db?schema=public"
-docker-compose -p oasis-borrow --env-file ../../.env --env-file ../../.env.local "$@" up
+docker-compose -p oasis-borrow --env-file ../../.env "$@" up


### PR DESCRIPTION
# [Range slider - reset button issue](https://app.shortcut.com/oazo-apps/story/5677/range-slider-reset-button-issue)

  
## Changes 👷‍♀️
  Added extra isResetAction to prevent recalculation slider values (dependent on multiple variables) when one hits reset button, to make it behave in more predictable way, reset the initial state
  
## How to test 🧪
- Have a vault with constant multiple trigger enabled
- view details of cm trigger, memorize initial state on slider values
- edit slider or multiplier
- hit reset button, it should bring slider to same state as when initially displayed
