### PR TITLE
Afterpills tweaks in BS and CM

### DIFF
--- a/components/vault/detailsSection/ContentCardTargetColRatioAfterBuy.tsx
+++ b/components/vault/detailsSection/ContentCardTargetColRatioAfterBuy.tsx
@@ -49,7 +49,7 @@ export function ContentCardTargetColRatioAfterBuy({
     value: formatted.targetColRatio,
   }
 
-  if (afterTargetColRatio && !targetColRatio?.isEqualTo(afterTargetColRatio) && changeVariant)
+  if (afterTargetColRatio && changeVariant)
     contentCardSettings.change = {
       value: `${formatted.afterTargetColRatio} ${t('system.cards.common.after')}`,
       variant: changeVariant,

--- a/components/vault/detailsSection/ContentCardTargetColRatioAfterSell.tsx
+++ b/components/vault/detailsSection/ContentCardTargetColRatioAfterSell.tsx
@@ -46,7 +46,7 @@ export function ContentCardTargetColRatioAfterSell({
     value: formatted.targetColRatio,
   }
 
-  if (afterTargetColRatio && !targetColRatio?.isEqualTo(afterTargetColRatio) && changeVariant)
+  if (afterTargetColRatio && changeVariant)
     contentCardSettings.change = {
       value: `${formatted.afterTargetColRatio} ${t('system.cards.common.after')}`,
       variant: changeVariant,

--- a/components/vault/detailsSection/ContentCardTargetMultiple.tsx
+++ b/components/vault/detailsSection/ContentCardTargetMultiple.tsx
@@ -39,7 +39,7 @@ export function ContentCardTargetMultiple({
   }
 
   if (targetMultiple) contentCardSettings.value = formatted.targetMultiple
-  if (afterTargetMultiple && changeVariant)
+  if (afterTargetMultiple !== undefined && changeVariant)
     contentCardSettings.change = {
       value: `${formatted.afterTargetMultiple} ${t('system.cards.common.after')}`,
       variant: changeVariant,

--- a/features/automation/optimization/controls/BasicBuyDetailsControl.tsx
+++ b/features/automation/optimization/controls/BasicBuyDetailsControl.tsx
@@ -1,7 +1,13 @@
 import { collateralPriceAtRatio } from 'blockchain/vault.maths'
 import { Vault } from 'blockchain/vaults'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
+import { checkIfEditingBasicBS } from 'features/automation/common/helpers'
 import { BasicBuyDetailsLayout } from 'features/automation/optimization/controls/BasicBuyDetailsLayout'
+import {
+  BASIC_BUY_FORM_CHANGE,
+  BasicBSFormChange,
+} from 'features/automation/protection/common/UITypes/basicBSFormChange'
+import { useUIChanges } from 'helpers/uiChangesHook'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -16,6 +22,7 @@ export function BasicBuyDetailsControl({
   basicBuyTriggerData,
 }: BasicBuyDetailsControlProps) {
   const readOnlyBasicBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
+  const [basicBuyState] = useUIChanges<BasicBSFormChange>(BASIC_BUY_FORM_CHANGE)
   const { execCollRatio, targetCollRatio, maxBuyOrMinSellPrice } = basicBuyTriggerData
   const isDebtZero = vault.debt.isZero()
 
@@ -24,6 +31,19 @@ export function BasicBuyDetailsControl({
     collateral: vault.lockedCollateral,
     vaultDebt: vault.debt,
   })
+
+  const isEditing = checkIfEditingBasicBS({
+    basicBSTriggerData: basicBuyTriggerData,
+    basicBSState: basicBuyState,
+    isRemoveForm: basicBuyState.currentForm === 'remove',
+  })
+
+  const basicBuyDetailsLayoutOptionalParams = {
+    ...(isEditing && {
+      afterTriggerColRatio: basicBuyState.execCollRatio,
+      afterTargetColRatio: basicBuyState.targetCollRatio,
+    }),
+  }
 
   if (readOnlyBasicBSEnabled) {
     return null
@@ -42,6 +62,7 @@ export function BasicBuyDetailsControl({
         targetColRatio={targetCollRatio}
         threshold={maxBuyOrMinSellPrice}
         basicBuyTriggerData={basicBuyTriggerData}
+        {...basicBuyDetailsLayoutOptionalParams}
       />
     </Grid>
   )

--- a/features/automation/optimization/controls/BasicBuyDetailsLayout.tsx
+++ b/features/automation/optimization/controls/BasicBuyDetailsLayout.tsx
@@ -11,10 +11,6 @@ import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
 } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
-import {
-  BASIC_BUY_FORM_CHANGE,
-  BasicBSFormChange,
-} from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -27,6 +23,8 @@ export interface BasicBuyDetailsLayoutProps {
   targetColRatio: BigNumber
   threshold: BigNumber
   basicBuyTriggerData: BasicBSTriggerData
+  afterTriggerColRatio?: BigNumber
+  afterTargetColRatio?: BigNumber
 }
 
 export function BasicBuyDetailsLayout({
@@ -36,12 +34,13 @@ export function BasicBuyDetailsLayout({
   nextBuyPrice,
   threshold,
   targetColRatio,
+  afterTriggerColRatio,
+  afterTargetColRatio,
 }: BasicBuyDetailsLayoutProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const isAutoBuyOn = basicBuyTriggerData.isTriggerEnabled
-  const [uiState] = useUIChanges<BasicBSFormChange>(BASIC_BUY_FORM_CHANGE)
 
   return (
     <Grid>
@@ -54,13 +53,13 @@ export function BasicBuyDetailsLayout({
               <ContentCardTriggerColRatioToBuy
                 token={token}
                 triggerColRatio={triggerColRatio}
-                afterTriggerColRatio={uiState.execCollRatio}
+                afterTriggerColRatio={afterTriggerColRatio}
                 nextBuyPrice={nextBuyPrice}
                 changeVariant="positive"
               />
               <ContentCardTargetColRatioAfterBuy
                 targetColRatio={targetColRatio}
-                afterTargetColRatio={uiState.targetCollRatio}
+                afterTargetColRatio={afterTargetColRatio}
                 threshold={threshold}
                 changeVariant="positive"
                 token={token}

--- a/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
@@ -37,7 +37,7 @@ export function ConstantMultipleDetailsControl({
   const isEditing = checkIfEditingConstantMultiple({
     triggerData: constantMultipleTriggerData,
     state: constantMultipleState,
-    isRemoveForm: constantMultipleState.currentForm === 'remove'
+    isRemoveForm: constantMultipleState.currentForm === 'remove',
   })
   const {
     isTriggerEnabled,

--- a/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
@@ -37,6 +37,7 @@ export function ConstantMultipleDetailsControl({
   const isEditing = checkIfEditingConstantMultiple({
     triggerData: constantMultipleTriggerData,
     state: constantMultipleState,
+    isRemoveForm: constantMultipleState.currentForm === 'remove'
   })
   const {
     isTriggerEnabled,

--- a/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
@@ -143,6 +143,14 @@ export function ConstantMultipleFormControl({
     if (txHelpers) {
       if (stage === 'txSuccess') {
         uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+          type: 'reset',
+          resetData: prepareConstantMultipleResetData({
+            defaultMultiplier: constantMultipleState.defaultMultiplier,
+            defaultCollRatio: constantMultipleState.defaultCollRatio,
+            constantMultipleTriggerData,
+          }),
+        })
+        uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
           type: 'tx-details',
           txDetails: {},
         })
@@ -166,14 +174,29 @@ export function ConstantMultipleFormControl({
       type: 'current-form',
       currentForm: isAddForm ? 'remove' : 'add',
     })
-    uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
-      type: 'reset',
-      resetData: prepareConstantMultipleResetData({
-        defaultMultiplier: constantMultipleState.defaultMultiplier,
-        defaultCollRatio: constantMultipleState.defaultCollRatio,
-        constantMultipleTriggerData,
-      }),
-    })
+    if (isAddForm) {
+      uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+        type: 'multiplier',
+        multiplier: 0,
+      })
+      uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+        type: 'sell-execution-coll-ratio',
+        sellExecutionCollRatio: zero,
+      })
+      uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+        type: 'buy-execution-coll-ratio',
+        buyExecutionCollRatio: zero,
+      })
+    } else {
+      uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
+        type: 'reset',
+        resetData: prepareConstantMultipleResetData({
+          defaultMultiplier: constantMultipleState.defaultMultiplier,
+          defaultCollRatio: constantMultipleState.defaultCollRatio,
+          constantMultipleTriggerData,
+        }),
+      })
+    }
   }
 
   const isAddForm = constantMultipleState.currentForm === 'add'

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -181,7 +181,7 @@ export function SidebarSetupConstantMultiple({
         isLoading: stage === 'txInProgress',
         action: () => txHandler(),
       },
-      ...(stage !== 'txInProgress' && {
+      ...(stage !== 'txInProgress' && stage !== 'txSuccess' && {
         textButton: {
           label: isAddForm ? t('system.remove-trigger') : t('system.add-trigger'),
           hidden: isFirstSetup,

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -181,13 +181,14 @@ export function SidebarSetupConstantMultiple({
         isLoading: stage === 'txInProgress',
         action: () => txHandler(),
       },
-      ...(stage !== 'txInProgress' && stage !== 'txSuccess' && {
-        textButton: {
-          label: isAddForm ? t('system.remove-trigger') : t('system.add-trigger'),
-          hidden: isFirstSetup,
-          action: () => textButtonHandler(),
-        },
-      }),
+      ...(stage !== 'txInProgress' &&
+        stage !== 'txSuccess' && {
+          textButton: {
+            label: isAddForm ? t('system.remove-trigger') : t('system.add-trigger'),
+            hidden: isFirstSetup,
+            action: () => textButtonHandler(),
+          },
+        }),
       status: sidebarStatus,
     }
 

--- a/features/automation/protection/controls/BasicSellDetailsLayout.tsx
+++ b/features/automation/protection/controls/BasicSellDetailsLayout.tsx
@@ -4,11 +4,6 @@ import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionConte
 import { ContentCardTargetColRatioAfterSell } from 'components/vault/detailsSection/ContentCardTargetColRatioAfterSell'
 import { ContentCardTriggerColRatioToSell } from 'components/vault/detailsSection/ContentCardTriggerColRatioToSell'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
-import {
-  BASIC_SELL_FORM_CHANGE,
-  BasicBSFormChange,
-} from 'features/automation/protection/common/UITypes/basicBSFormChange'
-import { useUIChanges } from 'helpers/uiChangesHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -19,6 +14,8 @@ interface BasicSellDetailsLayoutProps {
   targetColRatio: BigNumber
   threshold: BigNumber
   basicSellTriggerData: BasicBSTriggerData
+  afterTriggerColRatio?: BigNumber
+  afterTargetColRatio?: BigNumber
 }
 
 export function BasicSellDetailsLayout({
@@ -28,9 +25,10 @@ export function BasicSellDetailsLayout({
   targetColRatio,
   threshold,
   basicSellTriggerData,
+  afterTriggerColRatio,
+  afterTargetColRatio,
 }: BasicSellDetailsLayoutProps) {
   const { t } = useTranslation()
-  const [uiState] = useUIChanges<BasicBSFormChange>(BASIC_SELL_FORM_CHANGE)
 
   return (
     <DetailsSection
@@ -41,13 +39,13 @@ export function BasicSellDetailsLayout({
           <ContentCardTriggerColRatioToSell
             token={token}
             triggerColRatio={triggerColRatio}
-            afterTriggerColRatio={uiState.execCollRatio}
+            afterTriggerColRatio={afterTriggerColRatio}
             nextSellPrice={nextSellPrice}
             changeVariant="positive"
           />
           <ContentCardTargetColRatioAfterSell
             targetColRatio={targetColRatio}
-            afterTargetColRatio={uiState.targetCollRatio}
+            afterTargetColRatio={afterTargetColRatio}
             threshold={threshold}
             changeVariant="positive"
             token={token}

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -48,7 +48,7 @@ export function useConstantMultipleStateInitialization(
     minColRatio: min,
     maxColRatio: max,
   })
-  const defaultMultiplier = acceptableMultipliers[Math.floor(acceptableMultipliers.length / 2) - 1]
+  const defaultMultiplier = acceptableMultipliers[Math.ceil(acceptableMultipliers.length / 2) - 1]
   const defaultCollRatio = calculateCollRatioFromMultiple(defaultMultiplier)
 
   useEffect(() => {


### PR DESCRIPTION
# [Afterpills tweaks in BS and CM](https://app.shortcut.com/oazo-apps/story/5681/details-section-regression-is-editing-after-pills)
  
## Changes 👷‍♀️

- Changed condition when to show afterpills in BS,
- fixed afterpills calculations for removal state in Constant Multiple,
- hidden removal button from Constant Multiple on success stage.
  
## How to test 🧪

- Try editing BS features and see if after pills behavior is correct,
- Try removing CM trigger and see if afterpills are set on 0.
