### PR TITLE
Constant Multiple on non-multiply vaults

### DIFF
--- a/components/vault/GeneralManageTabBar.tsx
+++ b/components/vault/GeneralManageTabBar.tsx
@@ -96,6 +96,7 @@ export function GeneralManageTabBar({
                 content: (
                   <OptimizationControl
                     vault={vault}
+                    vaultType={generalManageVault.type}
                     ilkData={ilkData}
                     balanceInfo={balanceInfo}
                     vaultHistory={vaultHistory}

--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -7,6 +7,7 @@ import { AppLink } from 'components/Links'
 import { extractBasicBSData } from 'features/automation/common/basicBSTriggerData'
 import { OptimizationDetailsControl } from 'features/automation/optimization/controls/OptimizationDetailsControl'
 import { OptimizationFormControl } from 'features/automation/optimization/controls/OptimizationFormControl'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { VaultNotice } from 'features/notices/VaultsNoticesView'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { VaultHistoryEvent } from 'features/vaultHistory/vaultHistory'
@@ -89,6 +90,7 @@ function getZeroDebtOptimizationBannerProps({
 
 interface OptimizationControlProps {
   vault: Vault
+  vaultType: VaultType
   ilkData: IlkData
   balanceInfo: BalanceInfo
   vaultHistory: VaultHistoryEvent[]
@@ -96,6 +98,7 @@ interface OptimizationControlProps {
 
 export function OptimizationControl({
   vault,
+  vaultType,
   ilkData,
   balanceInfo,
   vaultHistory,
@@ -148,6 +151,7 @@ export function OptimizationControl({
             detailsViewControl={
               <OptimizationDetailsControl
                 vault={vault}
+                vaultType={vaultType}
                 vaultHistory={vaultHistory}
                 automationTriggersData={automationTriggers}
                 tokenMarketPrice={ethAndTokenPrices[vault.token]}

--- a/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsControl.tsx
@@ -8,6 +8,7 @@ import {
   CONSTANT_MULTIPLE_FORM_CHANGE,
   ConstantMultipleFormChange,
 } from 'features/automation/protection/common/UITypes/constantMultipleFormChange'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { VaultHistoryEvent } from 'features/vaultHistory/vaultHistory'
 import { calculatePNL } from 'helpers/multiply/calculations'
 import { useUIChanges } from 'helpers/uiChangesHook'
@@ -18,6 +19,7 @@ import { ConstantMultipleDetailsLayout } from './ConstantMultipleDetailsLayout'
 
 interface ConstantMultipleDetailsControlProps {
   vault: Vault
+  vaultType: VaultType
   vaultHistory: VaultHistoryEvent[]
   tokenMarketPrice: BigNumber
   constantMultipleTriggerData: ConstantMultipleTriggerData
@@ -25,6 +27,7 @@ interface ConstantMultipleDetailsControlProps {
 
 export function ConstantMultipleDetailsControl({
   vault,
+  vaultType,
   vaultHistory,
   tokenMarketPrice,
   constantMultipleTriggerData,
@@ -76,6 +79,7 @@ export function ConstantMultipleDetailsControl({
   return (
     <Grid>
       <ConstantMultipleDetailsLayout
+        vaultType={vaultType}
         token={token}
         isTriggerEnabled={isTriggerEnabled}
         {...constantMultipleDetailsLayoutOptionalParams}

--- a/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
@@ -8,17 +8,21 @@ import { ContentCardTargetMultiple } from 'components/vault/detailsSection/Conte
 import { ContentCardTotalCostOfFeature } from 'components/vault/detailsSection/ContentCardTotalCostOfFeature'
 import { ContentCardTriggerColRatioToBuy } from 'components/vault/detailsSection/ContentCardTriggerColRatioToBuy'
 import { ContentCardTriggerColRatioToSell } from 'components/vault/detailsSection/ContentCardTriggerColRatioToSell'
+import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
 } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { useUIChanges } from 'helpers/uiChangesHook'
+import { useHash } from 'helpers/useHash'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Grid } from 'theme-ui'
+import { Grid, Text } from 'theme-ui'
 
 export interface ConstantMultipleDetailsLayoutProps {
   token: string
+  vaultType: VaultType
   isTriggerEnabled: boolean
   targetMultiple?: BigNumber
   targetColRatio?: BigNumber
@@ -35,6 +39,7 @@ export interface ConstantMultipleDetailsLayoutProps {
 
 export function ConstantMultipleDetailsLayout({
   token,
+  vaultType,
   isTriggerEnabled,
   targetMultiple,
   targetColRatio,
@@ -51,7 +56,9 @@ export function ConstantMultipleDetailsLayout({
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
 
+  const setHash = useHash()[1]
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
+  const isMultiplyVault = vaultType === VaultType.Multiply
 
   return (
     <Grid>
@@ -98,6 +105,9 @@ export function ConstantMultipleDetailsLayout({
                 <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 2 }}>
                   {t('here')}.
                 </AppLink>
+                <Text as="span" sx={{ display: 'block', mt: 3 }}>
+                  {t('constant-multiple.banner.content-no-multiply')}
+                </Text>
               </>
             }
             image={{
@@ -107,12 +117,20 @@ export function ConstantMultipleDetailsLayout({
             }}
             button={{
               action: () => {
-                uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
-                  type: 'Optimization',
-                  currentOptimizationFeature: 'constantMultiple',
-                })
+                if (isMultiplyVault) {
+                  uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+                    type: 'Optimization',
+                    currentOptimizationFeature: 'constantMultiple',
+                  })
+                } else {
+                  setHash(VaultViewMode.Overview)
+                }
               },
-              text: t('constant-multiple.banner.button'),
+              text: t(
+                isMultiplyVault
+                  ? 'constant-multiple.banner.button'
+                  : 'constant-multiple.banner.button-no-multiply',
+              ),
             }}
           />
         </>

--- a/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
@@ -56,7 +56,7 @@ export function ConstantMultipleDetailsLayout({
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
 
-  const setHash = useHash()[1]
+  const [, setHash] = useHash()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const isMultiplyVault = vaultType === VaultType.Multiply
 

--- a/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleDetailsLayout.tsx
@@ -18,7 +18,7 @@ import { useUIChanges } from 'helpers/uiChangesHook'
 import { useHash } from 'helpers/useHash'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Grid, Text } from 'theme-ui'
+import { Grid } from 'theme-ui'
 
 export interface ConstantMultipleDetailsLayoutProps {
   token: string
@@ -98,16 +98,21 @@ export function ConstantMultipleDetailsLayout({
       ) : (
         <>
           <Banner
-            title={t('constant-multiple.banner.header')}
+            title={t(
+              isMultiplyVault
+                ? 'constant-multiple.banner.header'
+                : 'constant-multiple.banner.header-no-multiply',
+            )}
             description={
               <>
-                {t('constant-multiple.banner.content')}{' '}
+                {t(
+                  isMultiplyVault
+                    ? 'constant-multiple.banner.content'
+                    : 'constant-multiple.banner.content-no-multiply',
+                )}{' '}
                 <AppLink href="https://kb.oasis.app/help" sx={{ fontSize: 2 }}>
                   {t('here')}.
                 </AppLink>
-                <Text as="span" sx={{ display: 'block', mt: 3 }}>
-                  {t('constant-multiple.banner.content-no-multiply')}
-                </Text>
               </>
             }
             image={{

--- a/features/automation/optimization/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/controls/OptimizationDetailsControl.tsx
@@ -5,6 +5,7 @@ import { extractBasicBSData } from 'features/automation/common/basicBSTriggerDat
 import { extractConstantMultipleData } from 'features/automation/optimization/common/constantMultipleTriggerData'
 import { BasicBuyDetailsControl } from 'features/automation/optimization/controls/BasicBuyDetailsControl'
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { VaultHistoryEvent } from 'features/vaultHistory/vaultHistory'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
@@ -14,6 +15,7 @@ import { ConstantMultipleDetailsControl } from './ConstantMultipleDetailsControl
 interface OptimizationDetailsControlProps {
   automationTriggersData: TriggersData
   vault: Vault
+  vaultType: VaultType
   vaultHistory: VaultHistoryEvent[]
   tokenMarketPrice: BigNumber
 }
@@ -21,6 +23,7 @@ interface OptimizationDetailsControlProps {
 export function OptimizationDetailsControl({
   automationTriggersData,
   vault,
+  vaultType,
   vaultHistory,
   tokenMarketPrice,
 }: OptimizationDetailsControlProps) {
@@ -37,6 +40,7 @@ export function OptimizationDetailsControl({
       {constantMultipleEnabled && (
         <ConstantMultipleDetailsControl
           vault={vault}
+          vaultType={vaultType}
           vaultHistory={vaultHistory}
           tokenMarketPrice={tokenMarketPrice}
           constantMultipleTriggerData={constantMultipleTriggerData}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1541,7 +1541,7 @@
     "banner": {
       "header": "Set up Constant Multiple",
       "header-no-multiply": "Want to Set Up Constant Multiple?",
-      "content": "Set up Constant Multiple to keep your vault's collateralization ratio within a range that you select",
+      "content": "Constant Multiple maintains your vault at a multiple that you select - find out more",
       "content-no-multiply": "Constant Multiple maintains your vault at a multiple that you select. It is only available on Multiply Vaults, but you can change your vault type from your Vault Overview tab. Find out more",
       "button": "Setup Constant Multiple",
       "button-no-multiply": "Go to vault overview"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1540,8 +1540,11 @@
     "cancel-instructions": "To cancel the Constant Multiple you'll need to click the button below and confirm the transaction.",
     "banner": {
       "header": "Set up Constant Multiple",
+      "header-no-multiply": "Want to Set Up Constant Multiple?",
       "content": "Set up Constant Multiple to keep your vault's collateralization ratio within a range that you select",
-      "button": "Setup Constant Multiple"
+      "content-no-multiply": "Constant Multiple maintains your vault at a multiple that you select. It is only available on Multiply Vaults, but you can change your vault type from your Vault Overview tab. Find out more",
+      "button": "Setup Constant Multiple",
+      "button-no-multiply": "Go to vault overview"
     },
     "vault-changes": {
       "general-summary": "General summary",


### PR DESCRIPTION
# Constant Multiple on non-multiply vaults

https://app.shortcut.com/oazo-apps/story/5704/cm-banner-on-borrow-vault
https://app.shortcut.com/oazo-apps/story/5675/bug-remove-constant-multiple-from-borrow-vaults
https://app.shortcut.com/oazo-apps/story/5726/update-copy-cm-banner
  
## Changes 👷‍♀️

Changed Constant Multiple banner on non-multiply vaults:
- different text,
- CTA doesn't open Constant Multiple form, instead it moves user to overview tab.

Constant Multiple enabled in multiply vault that was switched to borrow stays intact, but after user removes it he can't set it up anymore until they go back to mutliply interface.

![image](https://user-images.githubusercontent.com/16230404/185101947-9c946e23-0216-467b-b5e1-ebe2859dc777.png)

Important note: in MVP we are only moving user to overview tab, later on we should update the button so it would also chose "Switch to multiply" option in dropdown.
  
## How to test 🧪

- Try opening Constant Multiple in both multiply and borrow vault.
