### PR TITLE
Max slider value below Auto-Buy or Constant-Multiple Buy trigger validation

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -85,6 +85,10 @@ export function VaultWarnings({
         return translate('constant-multiple-auto-sell-triggered-immediately')
       case 'constantMultipleAutoBuyTriggeredImmediately':
         return translate('constant-multiple-auto-buy-triggered-immediately')
+      case 'afterCollRatioBelowConstantMultipleBuyRatio':
+        return translate('after-coll-ratio-below-constant-multiple-buy-ratio')
+      case 'afterCollRatioBelowAutoBuyRatio':
+        return translate('after-coll-ratio-below-auto-buy-ratio')
       case 'constantMultipleSellTriggerCloseToStopLossTrigger':
         return (
           <Trans

--- a/features/automation/optimization/helpers.ts
+++ b/features/automation/optimization/helpers.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { IlkData } from 'blockchain/ilks'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { DEFAULT_BASIC_BS_MAX_SLIDER_VALUE } from 'features/automation/protection/common/consts/automationDefaults'
@@ -5,36 +6,45 @@ import { StopLossTriggerData } from 'features/automation/protection/common/stopL
 
 export function getBasicBuyMinMaxValues({
   ilkData,
+  lockedCollateralUSD,
   autoSellTriggerData,
   stopLossTriggerData,
 }: {
   ilkData: IlkData
+  lockedCollateralUSD: BigNumber
   autoSellTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
 }) {
+  const max = BigNumber.minimum(
+    lockedCollateralUSD.div(ilkData.debtFloor),
+    DEFAULT_BASIC_BS_MAX_SLIDER_VALUE,
+  )
+    .times(100)
+    .decimalPlaces(0, BigNumber.ROUND_DOWN)
+
   if (autoSellTriggerData.isTriggerEnabled && stopLossTriggerData.isStopLossEnabled) {
     return {
       min: autoSellTriggerData.execCollRatio.plus(5),
-      max: DEFAULT_BASIC_BS_MAX_SLIDER_VALUE.times(100),
+      max,
     }
   }
 
   if (autoSellTriggerData.isTriggerEnabled) {
     return {
       min: autoSellTriggerData.execCollRatio.plus(5),
-      max: DEFAULT_BASIC_BS_MAX_SLIDER_VALUE.times(100),
+      max,
     }
   }
 
   if (stopLossTriggerData.isStopLossEnabled) {
     return {
       min: stopLossTriggerData.stopLossLevel.times(100).plus(5),
-      max: DEFAULT_BASIC_BS_MAX_SLIDER_VALUE.times(100),
+      max,
     }
   }
 
   return {
     min: ilkData.liquidationRatio.times(100).plus(5),
-    max: DEFAULT_BASIC_BS_MAX_SLIDER_VALUE.times(100),
+    max,
   }
 }

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -196,6 +196,10 @@ export function SidebarConstantMultipleEditingStage({
         errorMessages={errors.filter((item) => item === 'autoBuyMaxBuyPriceNotSpecified')}
         ilkData={ilkData}
       />
+      <VaultWarnings
+        warningMessages={warnings.filter((item) => item === 'settingAutoBuyTriggerWithNoThreshold')}
+        ilkData={ilkData}
+      />
       <VaultActionInput
         action={t('auto-sell.set-min-sell-price')}
         amount={constantMultipleState?.minSellPrice}

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -112,6 +112,7 @@ export function SidebarSetupAutoBuy({
   })
 
   const { min, max } = getBasicBuyMinMaxValues({
+    lockedCollateralUSD: vault.lockedCollateralUSD,
     autoSellTriggerData,
     stopLossTriggerData,
     ilkData,

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -111,7 +111,12 @@ export function warningsConstantMultipleValidation({
   isAutoSellEnabled: boolean
   constantMultipleState: ConstantMultipleFormChange
 }) {
-  const { sellExecutionCollRatio, buyExecutionCollRatio, sellWithThreshold } = constantMultipleState
+  const {
+    sellExecutionCollRatio,
+    buyExecutionCollRatio,
+    sellWithThreshold,
+    buyWithThreshold,
+  } = constantMultipleState
 
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
     token: vault.token,
@@ -135,8 +140,11 @@ export function warningsConstantMultipleValidation({
 
   const noMinSellPriceWhenStopLossEnabled = !sellWithThreshold && isStopLossEnabled
 
+  const settingAutoBuyTriggerWithNoThreshold = !buyWithThreshold
+
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
+    settingAutoBuyTriggerWithNoThreshold,
     constantMultipleSellTriggerCloseToStopLossTrigger,
     addingConstantMultipleWhenAutoSellOrBuyEnabled,
     constantMultipleAutoSellTriggeredImmediately,

--- a/features/borrow/manage/pipes/manageVaultValidations.ts
+++ b/features/borrow/manage/pipes/manageVaultValidations.ts
@@ -109,6 +109,8 @@ export function validateWarnings(
     vaultWillBeAtRiskLevelWarningAtNextPrice,
     debtIsLessThanDebtFloor,
     potentialGenerateAmountLessThanDebtFloor,
+    afterCollRatioBelowConstantMultipleBuyRatio,
+    afterCollRatioBelowAutoBuyRatio,
   } = state
 
   const warningMessages: VaultWarningMessage[] = []
@@ -124,6 +126,8 @@ export function validateWarnings(
         vaultWillBeAtRiskLevelDangerAtNextPrice,
         vaultWillBeAtRiskLevelWarning,
         vaultWillBeAtRiskLevelWarningAtNextPrice,
+        afterCollRatioBelowConstantMultipleBuyRatio,
+        afterCollRatioBelowAutoBuyRatio,
       }),
     )
   }

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -493,3 +493,22 @@ export function stopLossTriggeredValidator({
       vaultHistory[0].kind === 'CLOSE_VAULT_TO_DAI')
   )
 }
+
+export function ratioGreaterOrLowerThanThresholdValidator({
+  ratio,
+  threshold,
+  type,
+}: {
+  ratio: BigNumber
+  threshold: BigNumber
+  type: 'greater' | 'lower'
+}) {
+  switch (type) {
+    case 'greater':
+      return ratio.gt(threshold)
+    case 'lower':
+      return ratio.lt(threshold)
+    default:
+      return false
+  }
+}

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -26,6 +26,8 @@ export type VaultWarningMessage =
   | 'addingConstantMultipleWhenAutoSellOrBuyEnabled'
   | 'constantMultipleAutoSellTriggeredImmediately'
   | 'constantMultipleAutoBuyTriggeredImmediately'
+  | 'afterCollRatioBelowConstantMultipleBuyRatio'
+  | 'afterCollRatioBelowAutoBuyRatio'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -52,6 +54,8 @@ interface WarningMessagesHandler {
   addingConstantMultipleWhenAutoSellOrBuyEnabled?: boolean
   constantMultipleAutoSellTriggeredImmediately?: boolean
   constantMultipleAutoBuyTriggeredImmediately?: boolean
+  afterCollRatioBelowConstantMultipleBuyRatio?: boolean
+  afterCollRatioBelowAutoBuyRatio?: boolean
 }
 
 export function warningMessagesHandler({
@@ -77,6 +81,8 @@ export function warningMessagesHandler({
   addingConstantMultipleWhenAutoSellOrBuyEnabled,
   constantMultipleAutoSellTriggeredImmediately,
   constantMultipleAutoBuyTriggeredImmediately,
+  afterCollRatioBelowConstantMultipleBuyRatio,
+  afterCollRatioBelowAutoBuyRatio,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -165,6 +171,14 @@ export function warningMessagesHandler({
 
   if (constantMultipleAutoBuyTriggeredImmediately) {
     warningMessages.push('constantMultipleAutoBuyTriggeredImmediately')
+  }
+
+  if (afterCollRatioBelowConstantMultipleBuyRatio) {
+    warningMessages.push('afterCollRatioBelowConstantMultipleBuyRatio')
+  }
+
+  if (afterCollRatioBelowAutoBuyRatio) {
+    warningMessages.push('afterCollRatioBelowAutoBuyRatio')
   }
 
   return warningMessages

--- a/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
@@ -114,6 +114,8 @@ export function validateWarnings(state: ManageMultiplyVaultState): ManageMultipl
     vaultWillBeAtRiskLevelWarning,
     vaultWillBeAtRiskLevelWarningAtNextPrice,
     highSlippage,
+    afterCollRatioBelowConstantMultipleBuyRatio,
+    afterCollRatioBelowAutoBuyRatio,
   } = state
 
   const warningMessages: VaultWarningMessage[] = []
@@ -130,6 +132,8 @@ export function validateWarnings(state: ManageMultiplyVaultState): ManageMultipl
         vaultWillBeAtRiskLevelWarning,
         vaultWillBeAtRiskLevelWarningAtNextPrice,
         highSlippage,
+        afterCollRatioBelowConstantMultipleBuyRatio,
+        afterCollRatioBelowAutoBuyRatio,
       }),
     )
   }

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -88,6 +88,8 @@ const commonWarnings = [
   'vaultWillRemainUnderMinActiveColRatio',
   'potentialInsufficientEthFundsForTx',
   'nextCollRatioCloseToCurrentSl',
+  'afterCollRatioBelowConstantMultipleBuyRatio',
+  'afterCollRatioBelowAutoBuyRatio',
 ]
 
 export function extractCommonWarnings(warningMessages: VaultWarningMessage[]) {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -898,7 +898,9 @@
     "stop-loss-trigger-close-to-constant-multiple-sell-trigger": "Setting a higher Trigger Ratio would trigger your existing Constant-Multiple. If you want to use a higher trigger ratio, please adjust your Constant-Multiple Sell trigger first.",
     "adding-constant-multiple-when-auto-sell-or-buy-enabled": "Creating a Constant multiple will remove your existing {{enabledTriggers}}. Are you sure you want to continue?",
     "constant-multiple-auto-sell-triggered-immediately": "Setting your Sell Trigger at this ratio would result in it being executed immediately",
-    "constant-multiple-auto-buy-triggered-immediately": "Setting your Buy Trigger at this ratio would result in it being executed immediately"
+    "constant-multiple-auto-buy-triggered-immediately": "Setting your Buy Trigger at this ratio would result in it being executed immediately",
+    "after-coll-ratio-below-constant-multiple-buy-ratio": "TBD",
+    "after-coll-ratio-below-basic-buy-ratio": "TBD"
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Max slider value below Auto-Buy or Constant-Multiple Buy trigger validation](https://app.shortcut.com/oazo-apps/story/5723/validation-withdrawing-col-impacts-max-buy-trigger)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes
>
- added warning message when user try to perform action on vault that would lower value of locked collateral (max slider value for auto buy trigger and constant multiple buy trigger will change) when Auto Buy or CM is enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- use feature toggle ConstantMultiple, add CM trigger with Buy trigger close to max and then try to withdraw collateral in overview
- do the same but using auto buy feature
