### PR TITLE
Disable selecting ineligible multiplier in CM

### DIFF
--- a/features/automation/optimization/common/multipliers.ts
+++ b/features/automation/optimization/common/multipliers.ts
@@ -99,6 +99,6 @@ export function getDefaultMultiplier({
       if (acceptableMultipliers[i] >= minMultiplier && acceptableMultipliers[i] <= maxMultiplier)
         return acceptableMultipliers[i]
     }
-    return 0
+    return acceptableMultipliers[midIndex]
   }
 }

--- a/features/automation/optimization/common/multipliers.ts
+++ b/features/automation/optimization/common/multipliers.ts
@@ -7,6 +7,12 @@ interface GetConstantMultipleMultipliersProps {
   maxColRatio: BigNumber
 }
 
+interface GetDefaultMultiplierProps {
+  acceptableMultipliers: number[]
+  minColRatio: BigNumber
+  maxColRatio: BigNumber
+}
+
 const AMOUNT_OF_MULTIPLIERS_TO_GENERATE = 5
 export const MIX_MAX_COL_RATIO_TRIGGER_OFFSET = 5
 
@@ -64,4 +70,35 @@ export function getConstantMultipleMultipliers({
   return Object.keys(ilksMultipliers).includes(ilk)
     ? ilksMultipliers[ilk]
     : generateMultipliers({ minColRatio, maxColRatio })
+}
+
+export function getDefaultMultiplier({
+  acceptableMultipliers,
+  minColRatio,
+  maxColRatio,
+}: GetDefaultMultiplierProps): number {
+  const midIndex = Math.ceil(acceptableMultipliers.length / 2) - 1
+  const minMultiplier = calculateMultipleFromTargetCollRatio(
+    maxColRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
+  ).toNumber()
+  const maxMultiplier = calculateMultipleFromTargetCollRatio(
+    minColRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
+  ).toNumber()
+
+  if (
+    acceptableMultipliers[midIndex] >= minMultiplier &&
+    acceptableMultipliers[midIndex] <= maxMultiplier
+  )
+    return acceptableMultipliers[midIndex]
+  else {
+    for (let i = midIndex; i >= 0; i--) {
+      if (acceptableMultipliers[i] >= minMultiplier && acceptableMultipliers[i] <= maxMultiplier)
+        return acceptableMultipliers[i]
+    }
+    for (let i = midIndex; i < acceptableMultipliers.length; i++) {
+      if (acceptableMultipliers[i] >= minMultiplier && acceptableMultipliers[i] <= maxMultiplier)
+        return acceptableMultipliers[i]
+    }
+    return 0
+  }
 }

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -10,7 +10,10 @@ import {
   prepareConstantMultipleResetData,
 } from 'features/automation/optimization/common/constantMultipleTriggerData'
 import { getConstantMutliplyMinMaxValues } from 'features/automation/optimization/common/helpers'
-import { getConstantMultipleMultipliers } from 'features/automation/optimization/common/multipliers'
+import {
+  getConstantMultipleMultipliers,
+  getDefaultMultiplier,
+} from 'features/automation/optimization/common/multipliers'
 import { extractStopLossData } from 'features/automation/protection/common/stopLossTriggerData'
 import { useEffect } from 'react'
 
@@ -48,7 +51,11 @@ export function useConstantMultipleStateInitialization(
     minColRatio: min,
     maxColRatio: max,
   })
-  const defaultMultiplier = acceptableMultipliers[Math.ceil(acceptableMultipliers.length / 2) - 1]
+  const defaultMultiplier = getDefaultMultiplier({
+    acceptableMultipliers,
+    minColRatio: min,
+    maxColRatio: max,
+  })
   const defaultCollRatio = calculateCollRatioFromMultiple(defaultMultiplier)
 
   useEffect(() => {
@@ -84,7 +91,7 @@ export function useConstantMultipleStateInitialization(
       type: 'current-form',
       currentForm: 'add',
     })
-  }, [collateralizationRatio])
+  }, [collateralizationRatio, stopLossTriggerData.triggerId])
 
   return constantMultipleTriggerData.isTriggerEnabled
 }


### PR DESCRIPTION
# Disable selecting ineligible multiplier in CM
  
## Changes 👷‍♀️

Fixed an issue where default multiplier was selected without considering if it's eligible in current vault state.

Does not contain fix an issue where all multipliers are disabled, that one is still waiting to be decided how are we going to handle it.

On the side note - if no multiplier is acceptable, the method will return the middle one as without any multiplier selected whole Constant Multiple state is breaking. But that is going to be addressed (or not if we are going to hide form) along with issue mentioned above.
  
## How to test 🧪

Set up Stop-Loss above the level of middle multiplier in any vault and check if it's selected as default.
