### PR TITLE
CM max price input warning when no threshold

### DIFF
--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -196,6 +196,10 @@ export function SidebarConstantMultipleEditingStage({
         errorMessages={errors.filter((item) => item === 'autoBuyMaxBuyPriceNotSpecified')}
         ilkData={ilkData}
       />
+      <VaultWarnings
+        warningMessages={warnings.filter((item) => item === 'settingAutoBuyTriggerWithNoThreshold')}
+        ilkData={ilkData}
+      />
       <VaultActionInput
         action={t('auto-sell.set-min-sell-price')}
         amount={constantMultipleState?.minSellPrice}

--- a/features/automation/optimization/validators.ts
+++ b/features/automation/optimization/validators.ts
@@ -111,7 +111,12 @@ export function warningsConstantMultipleValidation({
   isAutoSellEnabled: boolean
   constantMultipleState: ConstantMultipleFormChange
 }) {
-  const { sellExecutionCollRatio, buyExecutionCollRatio, sellWithThreshold } = constantMultipleState
+  const {
+    sellExecutionCollRatio,
+    buyExecutionCollRatio,
+    sellWithThreshold,
+    buyWithThreshold,
+  } = constantMultipleState
 
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
     token: vault.token,
@@ -135,8 +140,11 @@ export function warningsConstantMultipleValidation({
 
   const noMinSellPriceWhenStopLossEnabled = !sellWithThreshold && isStopLossEnabled
 
+  const settingAutoBuyTriggerWithNoThreshold = !buyWithThreshold
+
   return warningMessagesHandler({
     potentialInsufficientEthFundsForTx,
+    settingAutoBuyTriggerWithNoThreshold,
     constantMultipleSellTriggerCloseToStopLossTrigger,
     addingConstantMultipleWhenAutoSellOrBuyEnabled,
     constantMultipleAutoSellTriggeredImmediately,


### PR DESCRIPTION
# [CM max price input warning when no threshold](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added the same validation to constant multiple form as in auto-buy form when max buy price is not set 
  
## How to test 🧪
  <Please explain how to test your changes>

- use CM feature toggle and click on `Set No Threshold` next to max buy price input. Warning should pop up.
