### PR TITLE
Disable Constant Multiple form if there are no eligible multipliers

### DIFF
--- a/features/automation/optimization/common/helpers.ts
+++ b/features/automation/optimization/common/helpers.ts
@@ -13,12 +13,10 @@ export function getConstantMutliplyMinMaxValues({
   ilkData,
   autoBuyTriggerData,
   stopLossTriggerData,
-  lockedCollateralUSD,
 }: {
   ilkData: IlkData
   autoBuyTriggerData: BasicBSTriggerData
   stopLossTriggerData: StopLossTriggerData
-  lockedCollateralUSD: BigNumber
 }) {
   return {
     min: getBasicSellMinMaxValues({
@@ -26,12 +24,7 @@ export function getConstantMutliplyMinMaxValues({
       stopLossTriggerData,
       ilkData,
     }).min,
-    max: BigNumber.minimum(
-      lockedCollateralUSD.div(ilkData.debtFloor),
-      DEFAULT_BASIC_BS_MAX_SLIDER_VALUE,
-    )
-      .times(100)
-      .decimalPlaces(0, BigNumber.ROUND_DOWN),
+    max: DEFAULT_BASIC_BS_MAX_SLIDER_VALUE.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN),
   }
 }
 

--- a/features/automation/optimization/common/multipliers.ts
+++ b/features/automation/optimization/common/multipliers.ts
@@ -8,7 +8,7 @@ interface GetConstantMultipleMultipliersProps {
 }
 
 interface GetDefaultMultiplierProps {
-  acceptableMultipliers: number[]
+  multipliers: number[]
   minColRatio: BigNumber
   maxColRatio: BigNumber
 }
@@ -73,11 +73,11 @@ export function getConstantMultipleMultipliers({
 }
 
 export function getDefaultMultiplier({
-  acceptableMultipliers,
+  multipliers,
   minColRatio,
   maxColRatio,
 }: GetDefaultMultiplierProps): number {
-  const midIndex = Math.ceil(acceptableMultipliers.length / 2) - 1
+  const midIndex = Math.ceil(multipliers.length / 2) - 1
   const minMultiplier = calculateMultipleFromTargetCollRatio(
     maxColRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
   ).toNumber()
@@ -85,20 +85,15 @@ export function getDefaultMultiplier({
     minColRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
   ).toNumber()
 
-  if (
-    acceptableMultipliers[midIndex] >= minMultiplier &&
-    acceptableMultipliers[midIndex] <= maxMultiplier
-  )
-    return acceptableMultipliers[midIndex]
+  if (multipliers[midIndex] >= minMultiplier && multipliers[midIndex] <= maxMultiplier)
+    return multipliers[midIndex]
   else {
     for (let i = midIndex; i >= 0; i--) {
-      if (acceptableMultipliers[i] >= minMultiplier && acceptableMultipliers[i] <= maxMultiplier)
-        return acceptableMultipliers[i]
+      if (multipliers[i] >= minMultiplier && multipliers[i] <= maxMultiplier) return multipliers[i]
     }
-    for (let i = midIndex; i < acceptableMultipliers.length; i++) {
-      if (acceptableMultipliers[i] >= minMultiplier && acceptableMultipliers[i] <= maxMultiplier)
-        return acceptableMultipliers[i]
+    for (let i = midIndex; i < multipliers.length; i++) {
+      if (multipliers[i] >= minMultiplier && multipliers[i] <= maxMultiplier) return multipliers[i]
     }
-    return acceptableMultipliers[midIndex]
+    return multipliers[midIndex]
   }
 }

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -3,6 +3,7 @@ import { IlkData } from 'blockchain/ilks'
 import { ActionPills } from 'components/ActionPills'
 import { useAppContext } from 'components/AppContextProvider'
 import { AppLink } from 'components/Links'
+import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
 import { MultipleRangeSlider } from 'components/vault/MultipleRangeSlider'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
@@ -13,6 +14,7 @@ import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPrice
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import {
   ACCEPTABLE_FEE_DIFF,
+  calculateCollRatioFromMultiple,
   calculateMultipleFromTargetCollRatio,
 } from 'features/automation/common/helpers'
 import {
@@ -20,6 +22,7 @@ import {
   prepareConstantMultipleResetData,
 } from 'features/automation/optimization/common/constantMultipleTriggerData'
 import { MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/optimization/common/multipliers'
+import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import {
   CONSTANT_MULTIPLE_FORM_CHANGE,
   ConstantMultipleFormChange,
@@ -32,8 +35,9 @@ import {
   extractConstantMultipleCommonWarnings,
   extractConstantMultipleSliderWarnings,
 } from 'helpers/messageMappers'
+import { useHash } from 'helpers/useHash'
 import { zero } from 'helpers/zero'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Text } from 'theme-ui'
 
@@ -74,16 +78,21 @@ export function SidebarConstantMultipleEditingStage({
   estimatedBuyFee,
   estimatedSellFee,
 }: SidebaConstantMultiplerEditingStageProps) {
-  const { uiChanges } = useAppContext()
   const { t } = useTranslation()
+  const { uiChanges } = useAppContext()
+  const [, setHash] = useHash()
+
   const maxMultiplier = calculateMultipleFromTargetCollRatio(
     constantMultipleState.minTargetRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
   ).toNumber()
   const minMultiplier = calculateMultipleFromTargetCollRatio(
     constantMultipleState.maxTargetRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
   ).toNumber()
+  const eligibleMultipliers = constantMultipleState.multipliers.filter((item) => {
+    return item >= minMultiplier && item <= maxMultiplier
+  })
 
-  return (
+  return eligibleMultipliers.length ? (
     <>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
         {t('constant-multiple.set-trigger-description', {
@@ -103,10 +112,10 @@ export function SidebarConstantMultipleEditingStage({
         <ActionPills
           active={constantMultipleState.multiplier.toString()}
           variant="secondary"
-          items={constantMultipleState.acceptableMultipliers.map((multiplier) => ({
+          items={constantMultipleState.multipliers.map((multiplier) => ({
             id: multiplier.toString(),
             label: `${multiplier}x`,
-            disabled: multiplier < minMultiplier || multiplier > maxMultiplier,
+            disabled: !eligibleMultipliers.includes(multiplier),
             action: () => {
               uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
                 type: 'is-editing',
@@ -288,6 +297,30 @@ export function SidebarConstantMultipleEditingStage({
         </>
       )}
     </>
+  ) : (
+    <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
+      <Trans
+        i18nKey="constant-multiple.sl-too-high"
+        components={[
+          <Text
+            as="span"
+            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
+            onClick={() => {
+              uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+                type: 'Protection',
+                currentProtectionFeature: 'stopLoss',
+              })
+              setHash(VaultViewMode.Protection)
+            }}
+          />,
+        ]}
+        values={{
+          maxStopLoss: calculateCollRatioFromMultiple(constantMultipleState.multipliers[0]).minus(
+            MIX_MAX_COL_RATIO_TRIGGER_OFFSET * 2,
+          ),
+        }}
+      />
+    </Text>
   )
 }
 

--- a/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
+++ b/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
@@ -17,7 +17,7 @@ export type ConstantMultipleChangeAction =
   | { type: 'is-editing'; isEditing: boolean }
   | {
       type: 'form-defaults'
-      acceptableMultipliers: number[]
+      multipliers: number[]
       defaultMultiplier: number
       defaultCollRatio: BigNumber
       minTargetRatio: BigNumber
@@ -32,7 +32,7 @@ export type ConstantMultipleFormChange = AutomationFormChange & {
   sellExecutionCollRatio: BigNumber
   buyWithThreshold: boolean
   sellWithThreshold: boolean
-  acceptableMultipliers: number[]
+  multipliers: number[]
   defaultMultiplier: number
   defaultCollRatio: BigNumber
   multiplier: number
@@ -82,7 +82,7 @@ export function constantMultipleFormChangeReducer(
     case 'form-defaults':
       return {
         ...state,
-        acceptableMultipliers: action.acceptableMultipliers,
+        multipliers: action.multipliers,
         defaultMultiplier: action.defaultMultiplier,
         defaultCollRatio: action.defaultCollRatio,
         minTargetRatio: action.minTargetRatio,

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -43,16 +43,15 @@ export function useConstantMultipleStateInitialization(
     autoBuyTriggerData,
     stopLossTriggerData,
     ilkData,
-    lockedCollateralUSD: vault.lockedCollateralUSD,
   })
 
-  const acceptableMultipliers = getConstantMultipleMultipliers({
+  const multipliers = getConstantMultipleMultipliers({
     ilk: ilkData.ilk,
     minColRatio: min,
     maxColRatio: max,
   })
   const defaultMultiplier = getDefaultMultiplier({
-    acceptableMultipliers,
+    multipliers,
     minColRatio: min,
     maxColRatio: max,
   })
@@ -61,7 +60,7 @@ export function useConstantMultipleStateInitialization(
   useEffect(() => {
     uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
       type: 'form-defaults',
-      acceptableMultipliers,
+      multipliers,
       defaultMultiplier,
       defaultCollRatio,
       minTargetRatio: min,

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1563,7 +1563,8 @@
     "adjusting-constant-multiple": "Adjusting Constant Multiple trigger",
     "removing-constant-multiple": "Removing Constant Multiple trigger",
     "setting-constant-multiple": "Setting up your Constant Multiple",
-    "cancelling-constant-multiple": "Cancelling your Constant Multiple"
+    "cancelling-constant-multiple": "Cancelling your Constant Multiple",
+    "sl-too-high": "Constant Multiple is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Constant Multiple."
   },
   "ref": {
     "banner": "Refer a Friend. Earn DAI today",


### PR DESCRIPTION
# [Disable Constant Multiple form if there are no eligible multipliers](https://app.shortcut.com/oazo-apps/story/5764/disable-constant-multiple-if-no-eligible-multipliers-are-found)
  
## Changes 👷‍♀️

- Display appropriate message for user if their Stop-Loss* is causing no multiplier to be legal in current state of the vault,
- Changed max slider value to be hardcoded at 500%, no longer calculated based on vault debt.

\*Stop-Loss is the only reason why multiplier may be disabled, so currently there is only one message.

![image](https://user-images.githubusercontent.com/16230404/185617620-adf4d4c8-6949-4e98-9436-8aaca8f73537.png)
  
## How to test 🧪

- Set up Stop-Loss to 500%+ in any vault and see if Constant Multiple vault is hidden.
