### PR TITLE
Remove sidebar dropdown on non-multiply vaults

### DIFF
--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -177,6 +177,7 @@ export function OptimizationControl({
             editForm={
               <OptimizationFormControl
                 vault={vault}
+                vaultType={vaultType}
                 automationTriggersData={automationTriggers}
                 ilkData={ilkData}
                 txHelpers={txHelpersData}

--- a/features/automation/optimization/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/controls/AutoBuyFormControl.tsx
@@ -31,6 +31,7 @@ import {
   BASIC_BUY_FORM_CHANGE,
   BasicBSFormChange,
 } from 'features/automation/protection/common/UITypes/basicBSFormChange'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { TX_DATA_CHANGE } from 'helpers/gasEstimate'
 import { useUIChanges } from 'helpers/uiChangesHook'
@@ -38,6 +39,7 @@ import React, { useEffect, useMemo } from 'react'
 
 interface AutoBuyFormControlProps {
   vault: Vault
+  vaultType: VaultType
   ilkData: IlkData
   balanceInfo: BalanceInfo
   autoSellTriggerData: BasicBSTriggerData
@@ -54,6 +56,7 @@ interface AutoBuyFormControlProps {
 
 export function AutoBuyFormControl({
   vault,
+  vaultType,
   ilkData,
   balanceInfo,
   autoSellTriggerData,
@@ -215,6 +218,7 @@ export function AutoBuyFormControl({
   return (
     <SidebarSetupAutoBuy
       vault={vault}
+      vaultType={vaultType}
       ilkData={ilkData}
       balanceInfo={balanceInfo}
       autoSellTriggerData={autoSellTriggerData}

--- a/features/automation/optimization/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/controls/OptimizationFormControl.tsx
@@ -16,6 +16,7 @@ import {
   AutomationChangeFeature,
 } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React, { useEffect } from 'react'
@@ -25,6 +26,7 @@ import { ConstantMultipleFormControl } from './ConstantMultipleFormControl'
 interface OptimizationFormControlProps {
   automationTriggersData: TriggersData
   vault: Vault
+  vaultType: VaultType
   ilkData: IlkData
   txHelpers?: TxHelpers
   context: Context
@@ -35,6 +37,7 @@ interface OptimizationFormControlProps {
 export function OptimizationFormControl({
   automationTriggersData,
   vault,
+  vaultType,
   ilkData,
   txHelpers,
   context,
@@ -83,6 +86,7 @@ export function OptimizationFormControl({
     <>
       <AutoBuyFormControl
         vault={vault}
+        vaultType={vaultType}
         ilkData={ilkData}
         balanceInfo={balanceInfo}
         autoSellTriggerData={autoSellTriggerData}

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -16,6 +16,7 @@ import {
 import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { BasicBSFormChange } from 'features/automation/protection/common/UITypes/basicBSFormChange'
 import { SidebarAutomationFeatureCreationStage } from 'features/automation/sidebars/SidebarAutomationFeatureCreationStage'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { getPrimaryButtonLabel } from 'features/sidebar/getPrimaryButtonLabel'
 import { getSidebarStatus } from 'features/sidebar/getSidebarStatus'
@@ -32,6 +33,7 @@ import { SidebarAutoBuyRemovalEditingStage } from './SidebarAutoBuyRemovalEditin
 
 interface SidebarSetupAutoBuyProps {
   vault: Vault
+  vaultType: VaultType
   ilkData: IlkData
   balanceInfo: BalanceInfo
   autoSellTriggerData: BasicBSTriggerData
@@ -57,6 +59,7 @@ interface SidebarSetupAutoBuyProps {
 
 export function SidebarSetupAutoBuy({
   vault,
+  vaultType,
   ilkData,
   balanceInfo,
   context,
@@ -88,6 +91,7 @@ export function SidebarSetupAutoBuy({
 
   const { uiChanges } = useAppContext()
   const constantMultipleEnabled = useFeatureToggle('ConstantMultiple')
+  const isMultiplyVault = vaultType === VaultType.Multiply
 
   const flow: SidebarFlow = isRemoveForm
     ? 'cancelBasicBuy'
@@ -138,13 +142,14 @@ export function SidebarSetupAutoBuy({
 
     const sidebarSectionProps: SidebarSectionProps = {
       title: t('auto-buy.form-title'),
-      ...(constantMultipleEnabled && {
-        dropdown: {
-          forcePanel: 'autoBuy',
-          disabled: isDropdownDisabled({ stage }),
-          items: commonOptimizationDropdownItems(uiChanges, t),
-        },
-      }),
+      ...(constantMultipleEnabled &&
+        isMultiplyVault && {
+          dropdown: {
+            forcePanel: 'autoBuy',
+            disabled: isDropdownDisabled({ stage }),
+            items: commonOptimizationDropdownItems(uiChanges, t),
+          },
+        }),
       content: (
         <Grid gap={3}>
           {(stage === 'editing' || stage === 'txFailure') && (


### PR DESCRIPTION
# Remove sidebar dropdown on non-multiply vaults
  
## Changes 👷‍♀️

User should not be able to enable Constant Multiple in non multiply vaults, but it was possible to change context of optimization form from sidebar. Removed that option.
  
## How to test 🧪

Check if you can switch form context in optimization in both borrow and multiply vaults. 