### PR TITLE
Add DisableSidebarScroll feature flag

### DIFF
--- a/components/sidebar/SidebarSectionContent.tsx
+++ b/components/sidebar/SidebarSectionContent.tsx
@@ -1,3 +1,4 @@
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React, { Fragment, useEffect, useRef, useState } from 'react'
 import { theme } from 'theme'
 import { Box } from 'theme-ui'
@@ -13,6 +14,7 @@ export interface SidebarSectionContentProps {
 }
 
 export function SidebarSectionContent({ activePanel, content }: SidebarSectionContentProps) {
+  const disableSidebarScrollEnabled = useFeatureToggle('DisableSidebarScroll')
   const contanierRef = useRef<HTMLDivElement>(null)
   const [overflowedConent, setOverflowedConent] = useState(false)
 
@@ -42,12 +44,12 @@ export function SidebarSectionContent({ activePanel, content }: SidebarSectionCo
           backgroundColor: theme.colors.secondary60,
           borderRadius: theme.radii.large,
         },
-        maxHeight: 490,
         overflowY: 'auto',
         overflowX: 'hidden',
         mr: overflowedConent ? '8px' : '0px',
         p: '24px',
         pr: overflowedConent ? '10px' : '24px',
+        ...(!disableSidebarScrollEnabled && { maxHeight: 490 }),
       }}
     >
       <Box>

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -17,6 +17,7 @@ export type Feature =
   | 'Referrals'
   | 'ConstantMultiple'
   | 'ConstantMultipleReadOnly'
+  | 'DisableSidebarScroll'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -32,6 +33,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   Referrals: true,
   ConstantMultiple: false,
   ConstantMultipleReadOnly: false,
+  DisableSidebarScroll: false,
   // your feature here....
 }
 


### PR DESCRIPTION
# Add `DisableSidebarScroll` feature flag

`DisableSidebarScroll` feature flag allows to display whole sidebar without internal scroll that makes testing a little bit easier.

`DisableSidebarScroll: false`
![image](https://user-images.githubusercontent.com/16230404/186174461-0dc4ea82-6782-4ccb-b0f2-94f965c1cb09.png)

`DisableSidebarScroll: true`
![image](https://user-images.githubusercontent.com/16230404/186174594-e902f6c0-069f-422f-bdd2-ff8f94bcffa5.png)
  
## Changes 👷‍♀️

- Added `DisableSidebarScroll` feature set to `false` by default.
  
## How to test 🧪

- Compare different sidebars forms with `DisableSidebarScroll` flag set to `true` and to `false`.
