### PR TITLE
Ades/gas estimation/account for proxy actions

### DIFF
--- a/features/multiply/manage/pipes/manageMultiplyVaultTransactions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultTransactions.ts
@@ -653,7 +653,7 @@ export function applyEstimateGas(
           swap?.status === 'SUCCESS'
             ? exchangeAction === 'BUY_COLLATERAL'
               ? swap.daiAmount.div(one.minus(OAZO_FEE))
-              : swap.daiAmount
+              : swap.daiAmount.times(one.minus(OAZO_FEE)).times(one.minus(SLIPPAGE))
             : zero
 
         const collateralAmount =

--- a/features/multiply/manage/pipes/manageMultiplyVaultTransactions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultTransactions.ts
@@ -653,7 +653,7 @@ export function applyEstimateGas(
           swap?.status === 'SUCCESS'
             ? exchangeAction === 'BUY_COLLATERAL'
               ? swap.daiAmount.div(one.minus(OAZO_FEE))
-              : swap.daiAmount.times(one.minus(OAZO_FEE)).times(one.minus(SLIPPAGE))
+              : swap.daiAmount.times(one.minus(OAZO_FEE)).times(one.minus(SLIPPAGE)) // accounts for proxy actions
             : zero
 
         const collateralAmount =


### PR DESCRIPTION
# [Shortcut](https://app.shortcut.com/oazo-apps/story/5120/bug-gas-estimate-continuously-fails-when-decreasing-multiple)

Accounts for this line in proxyActions: https://github.com/OasisDEX/oasis-borrow/blob/dev/blockchain/calls/proxyActions/proxyActions.ts#L314-L317
  
## How to test 🧪

Gas estimation should work when

- open/close position
- adjust position
- decrease/multiple, including withdraw and deposit actions