### PR TITLE
Adjusted auto sell immediately validation

### DIFF
--- a/features/automation/optimization/common/multipliers.ts
+++ b/features/automation/optimization/common/multipliers.ts
@@ -76,7 +76,7 @@ export function getDefaultMultiplier({
   multipliers,
   minColRatio,
   maxColRatio,
-}: GetDefaultMultiplierProps): number {
+}: GetDefaultMultiplierProps): number | undefined {
   const midIndex = Math.ceil(multipliers.length / 2) - 1
   const minMultiplier = calculateMultipleFromTargetCollRatio(
     maxColRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),

--- a/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/controls/ConstantMultipleFormControl.tsx
@@ -247,6 +247,13 @@ export function ConstantMultipleFormControl({
     collateral: lockedCollateral,
     vaultDebt: debt,
   })
+
+  const sellPriceAtCurrentCollRatio = collateralPriceAtRatio({
+    colRatio: vault.collateralizationRatio,
+    collateral: lockedCollateral,
+    vaultDebt: debt,
+  })
+
   const {
     collateralDelta: collateralToBePurchased,
     debtDelta: debtDeltaAfterBuy,
@@ -266,6 +273,15 @@ export function ConstantMultipleFormControl({
     execCollRatio: constantMultipleState.sellExecutionCollRatio,
     deviation: constantMultipleState.deviation,
     executionPrice: nextSellPrice,
+    lockedCollateral,
+    debt,
+  })
+
+  const { debtDelta: debtDeltaWhenSellAtCurrentCollRatio } = getBasicBSVaultChange({
+    targetCollRatio: constantMultipleState.targetCollRatio,
+    execCollRatio: vault.collateralizationRatio.times(100),
+    deviation: constantMultipleState.deviation,
+    executionPrice: sellPriceAtCurrentCollRatio,
     lockedCollateral,
     debt,
   })
@@ -309,6 +325,8 @@ export function ConstantMultipleFormControl({
       textButtonHandler={textButtonHandler}
       txHandler={txHandler}
       vault={vault}
+      debtDeltaWhenSellAtCurrentCollRatio={debtDeltaWhenSellAtCurrentCollRatio}
+      debtDeltaAfterSell={debtDeltaAfterSell}
     />
   )
 }

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -204,6 +204,12 @@ export function SidebarConstantMultipleEditingStage({
         warningMessages={extractConstantMultipleSliderWarnings(warnings)}
         ilkData={ilkData}
       />
+      <VaultErrors
+        errorMessages={errors.filter(
+          (item) => item === 'targetCollRatioExceededDustLimitCollRatio',
+        )}
+        ilkData={ilkData}
+      />
       <VaultActionInput
         action={t('auto-buy.set-max-buy-price')}
         amount={constantMultipleState?.maxBuyPrice}

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -17,7 +17,6 @@ import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerDat
 import {
   ACCEPTABLE_FEE_DIFF,
   calculateCollRatioFromMultiple,
-  getEligibleMultipliers,
 } from 'features/automation/common/helpers'
 import {
   ConstantMultipleTriggerData,
@@ -108,18 +107,7 @@ export function SidebarConstantMultipleEditingStage({
     )
   }
 
-  const eligibleMultipliers = getEligibleMultipliers({
-    multipliers: constantMultipleState.multipliers,
-    collateralizationRatio: vault.collateralizationRatio,
-    lockedCollateral: vault.lockedCollateral,
-    debt: vault.debt,
-    debtFloor: ilkData.debtFloor,
-    deviation: constantMultipleState.deviation,
-    minTargetRatio: constantMultipleState.minTargetRatio,
-    maxTargetRatio: constantMultipleState.maxTargetRatio,
-  })
-
-  return eligibleMultipliers.length ? (
+  return constantMultipleState.eligibleMultipliers.length ? (
     <>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
         {t('constant-multiple.set-trigger-description', {
@@ -145,7 +133,7 @@ export function SidebarConstantMultipleEditingStage({
           items={constantMultipleState.multipliers.map((multiplier) => ({
             id: multiplier.toString(),
             label: `${multiplier}x`,
-            disabled: !eligibleMultipliers.includes(multiplier),
+            disabled: !constantMultipleState.eligibleMultipliers.includes(multiplier),
             action: () => {
               uiChanges.publish(CONSTANT_MULTIPLE_FORM_CHANGE, {
                 type: 'is-editing',

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -156,7 +156,6 @@ export function SidebarSetupConstantMultiple({
                   errors={errors}
                   warnings={warnings}
                   token={vault.token}
-                  lockedCollateralUSD={vault.lockedCollateralUSD}
                   constantMultipleState={constantMultipleState}
                   autoSellTriggerData={autoSellTriggerData}
                   constantMultipleTriggerData={constantMultipleTriggerData}

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -50,6 +50,8 @@ interface SidebarSetupConstantMultipleProps {
   isRemoveForm: boolean
   nextBuyPrice: BigNumber
   nextSellPrice: BigNumber
+  debtDeltaWhenSellAtCurrentCollRatio: BigNumber
+  debtDeltaAfterSell: BigNumber
   stage: SidebarVaultStages
   stopLossTriggerData: StopLossTriggerData
   textButtonHandler: () => void
@@ -84,6 +86,8 @@ export function SidebarSetupConstantMultiple({
   textButtonHandler,
   txHandler,
   vault,
+  debtDeltaWhenSellAtCurrentCollRatio,
+  debtDeltaAfterSell,
 }: SidebarSetupConstantMultipleProps) {
   const { t } = useTranslation()
 
@@ -105,9 +109,17 @@ export function SidebarSetupConstantMultiple({
   })
 
   const primaryButtonLabel = getPrimaryButtonLabel({ flow, stage })
-  const errors = errorsConstantMultipleValidation({ constantMultipleState, isRemoveForm })
+  const errors = errorsConstantMultipleValidation({
+    constantMultipleState,
+    isRemoveForm,
+    debtDeltaWhenSellAtCurrentCollRatio,
+    debtDeltaAfterSell,
+    debtFloor: ilkData.debtFloor,
+    debt: vault.debt,
+  })
   const warnings = warningsConstantMultipleValidation({
     vault,
+    debtFloor: ilkData.debtFloor,
     gasEstimationUsd: gasEstimation?.usdValue,
     ethBalance: balanceInfo.ethBalance,
     ethPrice: ethMarketPrice,
@@ -116,6 +128,7 @@ export function SidebarSetupConstantMultiple({
     isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
     constantMultipleState,
+    debtDeltaWhenSellAtCurrentCollRatio,
   })
 
   const cancelConstantMultipleErrors = extractCancelBSErrors(errors)

--- a/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
+++ b/features/automation/protection/common/UITypes/constantMultipleFormChange.ts
@@ -18,6 +18,7 @@ export type ConstantMultipleChangeAction =
   | {
       type: 'form-defaults'
       multipliers: number[]
+      eligibleMultipliers: number[]
       defaultMultiplier: number
       defaultCollRatio: BigNumber
       minTargetRatio: BigNumber
@@ -33,6 +34,7 @@ export type ConstantMultipleFormChange = AutomationFormChange & {
   buyWithThreshold: boolean
   sellWithThreshold: boolean
   multipliers: number[]
+  eligibleMultipliers: number[]
   defaultMultiplier: number
   defaultCollRatio: BigNumber
   multiplier: number
@@ -84,6 +86,7 @@ export function constantMultipleFormChangeReducer(
         ...state,
         multipliers: action.multipliers,
         defaultMultiplier: action.defaultMultiplier,
+        eligibleMultipliers: action.eligibleMultipliers,
         defaultCollRatio: action.defaultCollRatio,
         minTargetRatio: action.minTargetRatio,
         maxTargetRatio: action.maxTargetRatio,

--- a/features/automation/protection/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/controls/AutoSellFormControl.tsx
@@ -200,11 +200,27 @@ export function AutoSellFormControl({
     collateral: vault.lockedCollateral,
     vaultDebt: vault.debt,
   })
+
+  const executionPriceAtCurrentCollRatio = collateralPriceAtRatio({
+    colRatio: vault.collateralizationRatio,
+    collateral: vault.lockedCollateral,
+    vaultDebt: vault.debt,
+  })
+
   const { debtDelta, collateralDelta } = getBasicBSVaultChange({
     targetCollRatio: basicSellState.targetCollRatio,
     execCollRatio: basicSellState.execCollRatio,
     deviation: basicSellState.deviation,
     executionPrice,
+    lockedCollateral: vault.lockedCollateral,
+    debt: vault.debt,
+  })
+
+  const { debtDelta: debtDeltaAtCurrentCollRatio } = getBasicBSVaultChange({
+    targetCollRatio: basicSellState.targetCollRatio,
+    execCollRatio: vault.collateralizationRatio.times(100),
+    deviation: basicSellState.deviation,
+    executionPrice: executionPriceAtCurrentCollRatio,
     lockedCollateral: vault.lockedCollateral,
     debt: vault.debt,
   })
@@ -231,6 +247,7 @@ export function AutoSellFormControl({
       isDisabled={isDisabled}
       isFirstSetup={isFirstSetup}
       debtDelta={debtDelta}
+      debtDeltaAtCurrentCollRatio={debtDeltaAtCurrentCollRatio}
       collateralDelta={collateralDelta}
     />
   )

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -50,6 +50,7 @@ interface SidebarSetupAutoSellProps {
   isDisabled: boolean
   isFirstSetup: boolean
   debtDelta: BigNumber
+  debtDeltaAtCurrentCollRatio: BigNumber
   collateralDelta: BigNumber
 }
 
@@ -78,6 +79,7 @@ export function SidebarSetupAutoSell({
   isFirstSetup,
 
   debtDelta,
+  debtDeltaAtCurrentCollRatio,
   collateralDelta,
 }: SidebarSetupAutoSellProps) {
   const { t } = useTranslation()
@@ -105,6 +107,7 @@ export function SidebarSetupAutoSell({
     ilkData,
     vault,
     debtDelta,
+    debtDeltaAtCurrentCollRatio,
     basicSellState,
     autoBuyTriggerData,
     constantMultipleTriggerData,
@@ -128,6 +131,8 @@ export function SidebarSetupAutoSell({
     basicSellState,
     sliderMin: min,
     sliderMax: max,
+    debtDeltaAtCurrentCollRatio,
+    debtFloor: ilkData.debtFloor,
   })
 
   const cancelAutoSellWarnings = extractCancelBSWarnings(warnings)

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -65,11 +65,12 @@ export function useConstantMultipleStateInitialization(
     maxTargetRatio: max,
   })
 
-  const defaultMultiplier = getDefaultMultiplier({
-    multipliers: eligibleMultipliers,
-    minColRatio: min,
-    maxColRatio: max,
-  })
+  const defaultMultiplier =
+    getDefaultMultiplier({
+      multipliers: eligibleMultipliers,
+      minColRatio: min,
+      maxColRatio: max,
+    }) || multipliers[0] // fallback to not break data preparation
 
   const defaultCollRatio = calculateCollRatioFromMultiple(defaultMultiplier)
 

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -78,6 +78,7 @@ export function useConstantMultipleStateInitialization(
       type: 'form-defaults',
       multipliers,
       defaultMultiplier,
+      eligibleMultipliers,
       defaultCollRatio,
       minTargetRatio: min,
       maxTargetRatio: max,

--- a/features/automation/protection/useConstantMultipleStateInitialization.ts
+++ b/features/automation/protection/useConstantMultipleStateInitialization.ts
@@ -4,7 +4,10 @@ import { InstiVault } from 'blockchain/instiVault'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { extractBasicBSData } from 'features/automation/common/basicBSTriggerData'
-import { calculateCollRatioFromMultiple } from 'features/automation/common/helpers'
+import {
+  calculateCollRatioFromMultiple,
+  getEligibleMultipliers,
+} from 'features/automation/common/helpers'
 import {
   extractConstantMultipleData,
   prepareConstantMultipleResetData,
@@ -50,11 +53,24 @@ export function useConstantMultipleStateInitialization(
     minColRatio: min,
     maxColRatio: max,
   })
-  const defaultMultiplier = getDefaultMultiplier({
+
+  const eligibleMultipliers = getEligibleMultipliers({
     multipliers,
+    collateralizationRatio: vault.collateralizationRatio,
+    lockedCollateral: vault.lockedCollateral,
+    debt: vault.debt,
+    debtFloor: ilkData.debtFloor,
+    deviation: constantMultipleTriggerData.deviation,
+    minTargetRatio: min,
+    maxTargetRatio: max,
+  })
+
+  const defaultMultiplier = getDefaultMultiplier({
+    multipliers: eligibleMultipliers,
     minColRatio: min,
     maxColRatio: max,
   })
+
   const defaultCollRatio = calculateCollRatioFromMultiple(defaultMultiplier)
 
   useEffect(() => {


### PR DESCRIPTION
# [Adjusted auto sell immediately validation](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- immediately validation in Auto Sell and Constant Multiply form now takes into account current vault state
- added validation to Constant Multiply regarding dust limit
  
## How to test 🧪
  <Please explain how to test your changes>

- try to setup (both in Auto Sell form and in CM form) trigger that would hit dust limit at current vault state or in future (error message should be visible)
- warning regarding immediately execution in both form should be displayed only if trigger is eligible based on current vault state
