### PR TITLE
Added sell execution range simulation to get eligible multipliers

### DIFF
--- a/components/vault/sidebar/SidebarVaultSLTriggered.tsx
+++ b/components/vault/sidebar/SidebarVaultSLTriggered.tsx
@@ -54,7 +54,6 @@ export function SidebarVaultSLTriggered({ closeEvent }: SidebarVaultSLTriggeredP
         tokensSold={sold}
         totalFee={fee}
         collRatio={beforeCollateralizationRatio}
-        slippage={new BigNumber(2)} // TODO missing info in cache
       />
     </>
   )

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -6,7 +6,6 @@ import { BasicBSFormChange } from 'features/automation/protection/common/UITypes
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
 import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
-import { arrayRange } from 'helpers/arrayRange'
 import { LOAN_FEE, OAZO_FEE } from 'helpers/multiply/calculations'
 import { one, zero } from 'helpers/zero'
 
@@ -172,12 +171,12 @@ export function getEligibleMultipliers({
   return multipliers
     .filter((multiplier) => {
       const targetCollRatio = calculateCollRatioFromMultiple(multiplier)
-      const sellExecutionRange = arrayRange(
+      const sellExecutionExtremes = [
         minTargetRatio.toNumber(),
         targetCollRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).toNumber(),
-      )
+      ]
 
-      const verifiedSellRange = sellExecutionRange.map((exec) => {
+      const verifiedSellExtremes = sellExecutionExtremes.map((exec) => {
         const sellExecutionCollRatio = new BigNumber(exec)
         const sellExecutionPrice = collateralPriceAtRatio({
           colRatio: sellExecutionCollRatio.div(100),
@@ -199,7 +198,7 @@ export function getEligibleMultipliers({
 
       // IF following array is equal to [false] it means that whole range of sell execution coll ratio would lead
       // to dust limit issue and therefore multiplier should be disabled
-      const deduplicatedVerifiedSellRange = [...new Set(verifiedSellRange)]
+      const deduplicatedVerifiedSellExtremes = [...new Set(verifiedSellExtremes)]
 
       const executionPriceAtCurrentCollRatio = collateralPriceAtRatio({
         colRatio: collateralizationRatio,
@@ -218,7 +217,7 @@ export function getEligibleMultipliers({
 
       return !(
         debtFloor.gt(debt.plus(debtDeltaAtCurrentCollRatio)) ||
-        (deduplicatedVerifiedSellRange.length === 1 && !deduplicatedVerifiedSellRange[0])
+        (deduplicatedVerifiedSellExtremes.length === 1 && !deduplicatedVerifiedSellExtremes[0])
       )
     })
     .filter((item) => item >= minMultiplier && item <= maxMultiplier)

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -6,6 +6,7 @@ import { BasicBSFormChange } from 'features/automation/protection/common/UITypes
 import { TriggersData } from 'features/automation/protection/triggers/AutomationTriggersData'
 import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
+import { arrayRange } from 'helpers/arrayRange'
 import { LOAN_FEE, OAZO_FEE } from 'helpers/multiply/calculations'
 import { one, zero } from 'helpers/zero'
 
@@ -141,10 +142,6 @@ export function getShouldRemoveAllowance(automationTriggersData: TriggersData) {
   return automationTriggersData.triggers?.length === 1
 }
 
-function range(start: number, end: number) {
-  return [...Array(end + 1).keys()].filter((value) => end >= value && start <= value)
-}
-
 export function getEligibleMultipliers({
   multipliers,
   collateralizationRatio,
@@ -175,9 +172,9 @@ export function getEligibleMultipliers({
   return multipliers
     .filter((multiplier) => {
       const targetCollRatio = calculateCollRatioFromMultiple(multiplier)
-      const sellExecutionRange = range(
+      const sellExecutionRange = arrayRange(
         minTargetRatio.toNumber(),
-        targetCollRatio.minus(5).toNumber(),
+        targetCollRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).toNumber(),
       )
 
       const verifiedSellRange = sellExecutionRange.map((exec) => {

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -172,12 +172,11 @@ export function getEligibleMultipliers({
     .filter((multiplier) => {
       const targetCollRatio = calculateCollRatioFromMultiple(multiplier)
       const sellExecutionExtremes = [
-        minTargetRatio.toNumber(),
-        targetCollRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).toNumber(),
+        minTargetRatio,
+        targetCollRatio.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET),
       ]
 
-      const verifiedSellExtremes = sellExecutionExtremes.map((exec) => {
-        const sellExecutionCollRatio = new BigNumber(exec)
+      const verifiedSellExtremes = sellExecutionExtremes.map((sellExecutionCollRatio) => {
         const sellExecutionPrice = collateralPriceAtRatio({
           colRatio: sellExecutionCollRatio.div(100),
           collateral: lockedCollateral,

--- a/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -23,11 +23,13 @@ import {
   prepareConstantMultipleResetData,
 } from 'features/automation/optimization/common/constantMultipleTriggerData'
 import { MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/optimization/common/multipliers'
+import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import {
   CONSTANT_MULTIPLE_FORM_CHANGE,
   ConstantMultipleFormChange,
 } from 'features/automation/protection/common/UITypes/constantMultipleFormChange'
+import { TAB_CHANGE_SUBJECT } from 'features/automation/protection/common/UITypes/TabChange'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { handleNumericInput } from 'helpers/input'
@@ -54,6 +56,7 @@ interface SidebaConstantMultiplerEditingStageProps {
   constantMultipleState: ConstantMultipleFormChange
   autoSellTriggerData: BasicBSTriggerData
   constantMultipleTriggerData: ConstantMultipleTriggerData
+  stopLossTriggerData: StopLossTriggerData
   nextBuyPrice: BigNumber
   nextSellPrice: BigNumber
   collateralToBePurchased: BigNumber
@@ -74,6 +77,7 @@ export function SidebarConstantMultipleEditingStage({
   constantMultipleState,
   autoSellTriggerData,
   constantMultipleTriggerData,
+  stopLossTriggerData,
   nextBuyPrice,
   nextSellPrice,
   collateralToBePurchased,
@@ -323,27 +327,46 @@ export function SidebarConstantMultipleEditingStage({
     </>
   ) : (
     <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-      <Trans
-        i18nKey="constant-multiple.sl-too-high"
-        components={[
-          <Text
-            as="span"
-            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
-            onClick={() => {
-              uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
-                type: 'Protection',
-                currentProtectionFeature: 'stopLoss',
-              })
-              setHash(VaultViewMode.Protection)
-            }}
-          />,
-        ]}
-        values={{
-          maxStopLoss: calculateCollRatioFromMultiple(constantMultipleState.multipliers[0]).minus(
-            MIX_MAX_COL_RATIO_TRIGGER_OFFSET * 2,
-          ),
-        }}
-      />
+      {stopLossTriggerData?.isStopLossEnabled ? (
+        <Trans
+          i18nKey="constant-multiple.sl-too-high"
+          components={[
+            <Text
+              as="span"
+              sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
+              onClick={() => {
+                uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+                  type: 'Protection',
+                  currentProtectionFeature: 'stopLoss',
+                })
+                setHash(VaultViewMode.Protection)
+              }}
+            />,
+          ]}
+          values={{
+            maxStopLoss: calculateCollRatioFromMultiple(
+              constantMultipleState.eligibleMultipliers[0] || constantMultipleState.multipliers[0],
+            ).minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET * 2),
+          }}
+        />
+      ) : (
+        <Trans
+          i18nKey="constant-multiple.coll-ratio-too-close-to-dust-limit"
+          components={[
+            <Text
+              as="span"
+              sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
+              onClick={() => {
+                uiChanges.publish(TAB_CHANGE_SUBJECT, {
+                  type: 'change-tab',
+                  currentMode: VaultViewMode.Overview,
+                })
+                setHash(VaultViewMode.Protection)
+              }}
+            />,
+          ]}
+        />
+      )}
     </Text>
   )
 }

--- a/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupConstantMultiple.tsx
@@ -166,6 +166,7 @@ export function SidebarSetupConstantMultiple({
                   estimatedGasCostOnTrigger={estimatedGasCostOnTrigger}
                   estimatedBuyFee={estimatedBuyFee}
                   estimatedSellFee={estimatedSellFee}
+                  stopLossTriggerData={stopLossTriggerData}
                 />
               )}
               {isRemoveForm && (

--- a/helpers/arrayRange.ts
+++ b/helpers/arrayRange.ts
@@ -1,3 +1,0 @@
-export function arrayRange(start: number, end: number) {
-  return [...Array(end + 1).keys()].filter((value) => end >= value && start <= value)
-}

--- a/helpers/arrayRange.ts
+++ b/helpers/arrayRange.ts
@@ -1,0 +1,3 @@
+export function arrayRange(start: number, end: number) {
+  return [...Array(end + 1).keys()].filter((value) => end >= value && start <= value)
+}

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -30,7 +30,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   ReadOnlyBasicBS: false,
   Notifications: false,
   Referrals: true,
-  ConstantMultiple: false,
+  ConstantMultiple: true,
   ConstantMultipleReadOnly: false,
   // your feature here....
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1567,6 +1567,7 @@
     "adding-new-triggers-disabled": "Creation of the new Constant Multiple trigger is currently disabled.",
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Constant Multiple triggers",
     "sl-too-high": "Constant Multiple is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Constant Multiple.",
+    "coll-ratio-too-close-to-dust-limit": "Constant Multiple is not available as your current Col. Ratio is close to dust limit. Please <0>adjust your Col. Ratio</0> before using Constant Multiple.",
     "closed-vault-existing-trigger-header": "Your vault is closed but Constant Multiple is still active",
     "closed-vault-existing-trigger-description":"You can cancel your existing Constant Multiple here or deposit into your vault in overview tab"
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -865,7 +865,7 @@
     "vault-will-be-taken-under-min-active-col-ratio": "You cannot make adjustments to your vault which take it below your minimum active coll. ratio at current or next collateral price",
     "stop-loss-near-liquidation-ratio": "Your Stop-Loss Trigger Col. Ratio would cause closing vault immediately. If this is intended, close your vault",
     "stop-loss-max-debt": "The Stop-Loss cannot be created due to the high price impact of the order. Your total vault debt has to be less than 20m DAI",
-    "target-coll-ratio-exceeded-dust-limit-coll-ratio": "You cannot select a higher Target Collateralization Ratio, as it would result in the vault hitting the dust limit",
+    "target-coll-ratio-exceeded-dust-limit-coll-ratio": "Your selected parameters would result in your vault hitting the dust limit. Please adjust the parameters in order to continue",
     "auto-buy-max-price-requred": "Please enter a maximum buy price or select <1>Set No Threshold<1>",
     "minimum-sell-price-not-provided": "Please enter a minimum sell price or select <1>Set No Threshold<1>",
     "auto-sell-trigger-higher-than-auto-buy-target": "Setting your an Auto-Sell trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",


### PR DESCRIPTION
# [Added sell execution range simulation to get eligible multipliers](https://app.shortcut.com/oazo-apps/story/5830/cm-multipliers-bug)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added sell execution range simulation to get eligible multipliers
  
## How to test 🧪
  <Please explain how to test your changes>

- test it using different vaults in different state, there shouldn't be a case when multiplier is enabled but user is not able to create trigger using it
