### PR TITLE
handled too high c-ratio for ab

### DIFF
--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -91,32 +91,10 @@ export function SidebarAutoBuyEditingStage({
     .times(100)
     .gt(sliderMax)
 
-  if (isCurrentCollRatioHigherThanSliderMax) {
-    return (
-      <Trans
-        i18nKey="auto-buy.coll-ratio-too-high"
-        components={[
-          <Text
-            as="span"
-            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
-            onClick={() => {
-              uiChanges.publish(TAB_CHANGE_SUBJECT, {
-                type: 'change-tab',
-                currentMode: VaultViewMode.Overview,
-              })
-            }}
-          />,
-        ]}
-        values={{
-          maxAutoBuyCollRatio: sliderMax,
-        }}
-      />
-    )
-  }
-
-  const [, setHash] = useHash()
-
-  if (isStopLossEnabled && stopLossLevel.times(100).gt(sliderMin)) {
+  if (
+    isStopLossEnabled &&
+    stopLossLevel.times(100).plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.times(2)).gt(sliderMax)
+  ) {
     return (
       <Trans
         i18nKey="auto-buy.sl-too-high"
@@ -139,6 +117,31 @@ export function SidebarAutoBuyEditingStage({
       />
     )
   }
+
+  if (isCurrentCollRatioHigherThanSliderMax) {
+    return (
+      <Trans
+        i18nKey="auto-buy.coll-ratio-too-high"
+        components={[
+          <Text
+            as="span"
+            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
+            onClick={() => {
+              uiChanges.publish(TAB_CHANGE_SUBJECT, {
+                type: 'change-tab',
+                currentMode: VaultViewMode.Overview,
+              })
+            }}
+          />,
+        ]}
+        values={{
+          maxAutoBuyCollRatio: sliderMax.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.times(2)),
+        }}
+      />
+    )
+  }
+
+  const [, setHash] = useHash()
 
   if (readOnlyBasicBSEnabled && !isVaultEmpty) {
     return (

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -72,7 +72,11 @@ export function SidebarAutoBuyEditingStage({
     vaultDebt: vault.debt,
   })
 
-  adjustDefaultValuesIfOutsideSlider()
+  const { isStopLossEnabled, stopLossLevel } = stopLossTriggerData
+
+  if (!isStopLossEnabled) {
+    adjustDefaultValuesIfOutsideSlider()
+  }
 
   const isCurrentCollRatioHigherThanSliderMax = vault.collateralizationRatio
     .times(100)
@@ -101,29 +105,30 @@ export function SidebarAutoBuyEditingStage({
     )
   }
 
-  const { isStopLossEnabled, stopLossLevel } = stopLossTriggerData
   const [, setHash] = useHash()
 
-  if (isStopLossEnabled && stopLossLevel.gt(basicBuyState.execCollRatio)) {
-    ;<Trans
-      i18nKey="auto-buy.sl-too-high"
-      components={[
-        <Text
-          as="span"
-          sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
-          onClick={() => {
-            uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
-              type: 'Protection',
-              currentProtectionFeature: 'stopLoss',
-            })
-            setHash(VaultViewMode.Protection)
-          }}
-        />,
-      ]}
-      values={{
-        maxStopLoss: sliderMax.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.times(2)),
-      }}
-    />
+  if (isStopLossEnabled && stopLossLevel.times(100).lt(sliderMin)) {
+    return (
+      <Trans
+        i18nKey="auto-buy.sl-too-high"
+        components={[
+          <Text
+            as="span"
+            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
+            onClick={() => {
+              uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+                type: 'Protection',
+                currentProtectionFeature: 'stopLoss',
+              })
+              setHash(VaultViewMode.Protection)
+            }}
+          />,
+        ]}
+        values={{
+          maxStopLoss: sliderMax.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.times(2)),
+        }}
+      />
+    )
   }
 
   if (readOnlyBasicBSEnabled && !isVaultEmpty) {

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -15,7 +15,10 @@ import { AddAutoBuyInfoSection } from 'features/automation/basicBuySell/InfoSect
 import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { maxUint256, MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/common/consts'
-import { prepareBasicBSResetData } from 'features/automation/common/helpers'
+import {
+  adjustDefaultValuesIfOutsideSlider,
+  prepareBasicBSResetData,
+} from 'features/automation/common/helpers'
 import { StopLossTriggerData } from 'features/automation/protection/common/stopLossTriggerData'
 import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/protection/common/UITypes/AutomationFeatureChange'
 import {
@@ -30,7 +33,7 @@ import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useHash } from 'helpers/useHash'
 import { one, zero } from 'helpers/zero'
 import { Trans, useTranslation } from 'next-i18next'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Text } from 'theme-ui'
 
 interface SidebarAutoBuyEditingStageProps {
@@ -74,9 +77,15 @@ export function SidebarAutoBuyEditingStage({
 
   const { isStopLossEnabled, stopLossLevel } = stopLossTriggerData
 
-  if (!isStopLossEnabled) {
-    adjustDefaultValuesIfOutsideSlider()
-  }
+  useEffect(() => {
+    adjustDefaultValuesIfOutsideSlider({
+      basicBSState: basicBuyState,
+      sliderMax,
+      sliderMin,
+      uiChanges,
+      publishType: BASIC_BUY_FORM_CHANGE,
+    })
+  }, [vault.collateralizationRatio.toNumber()])
 
   const isCurrentCollRatioHigherThanSliderMax = vault.collateralizationRatio
     .times(100)
@@ -288,21 +297,6 @@ export function SidebarAutoBuyEditingStage({
       )}
     </>
   )
-
-  function adjustDefaultValuesIfOutsideSlider() {
-    if (basicBuyState.targetCollRatio.lt(sliderMin)) {
-      uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-        type: 'target-coll-ratio',
-        targetCollRatio: sliderMin,
-      })
-    }
-    if (basicBuyState.execCollRatio.gt(sliderMax)) {
-      uiChanges.publish(BASIC_BUY_FORM_CHANGE, {
-        type: 'execution-coll-ratio',
-        execCollRatio: sliderMax,
-      })
-    }
-  }
 }
 
 interface AutoBuyInfoSectionControlProps {

--- a/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -107,7 +107,7 @@ export function SidebarAutoBuyEditingStage({
 
   const [, setHash] = useHash()
 
-  if (isStopLossEnabled && stopLossLevel.times(100).lt(sliderMin)) {
+  if (isStopLossEnabled && stopLossLevel.times(100).gt(sliderMin)) {
     return (
       <Trans
         i18nKey="auto-buy.sl-too-high"

--- a/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/sidebars/SidebarSetupAutoBuy.tsx
@@ -166,6 +166,7 @@ export function SidebarSetupAutoBuy({
                   collateralDelta={collateralDelta}
                   sliderMin={min}
                   sliderMax={max}
+                  stopLossTriggerData={stopLossTriggerData}
                 />
               )}
               {isRemoveForm && (

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -138,7 +138,7 @@ export function SidebarAutoSellAddEditingStage({
     .times(100)
     .gt(sliderMax)
 
-  if (isCurrentCollRatioHigherThanSliderMax) {
+  if (isCurrentCollRatioHigherThanSliderMax || sliderMin.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).gt(sliderMax)) {
     return (
       <Trans
         i18nKey="auto-sell.coll-ratio-too-high"
@@ -163,7 +163,7 @@ export function SidebarAutoSellAddEditingStage({
 
   const [, setHash] = useHash()
 
-  if (isStopLossEnabled && stopLossLevel.times(100).gt(sliderMin)) {
+  if (isStopLossEnabled && stopLossLevel.times(100).plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).gt(sliderMax)) {
     return (
       <Trans
         i18nKey="auto-sell.sl-too-high"

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -347,13 +347,13 @@ export function SidebarAutoSellAddEditingStage({
     if (basicSellState.targetCollRatio.gt(sliderMax)) {
       uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
         type: 'target-coll-ratio',
-        targetCollRatio: sliderMin,
+        targetCollRatio: sliderMax,
       })
     }
     if (basicSellState.execCollRatio.lt(sliderMin)) {
       uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
         type: 'execution-coll-ratio',
-        execCollRatio: sliderMax,
+        execCollRatio: sliderMin,
       })
     }
   }

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -15,7 +15,10 @@ import { AddAutoSellInfoSection } from 'features/automation/basicBuySell/InfoSec
 import { MaxGasPriceSection } from 'features/automation/basicBuySell/MaxGasPriceSection/MaxGasPriceSection'
 import { BasicBSTriggerData } from 'features/automation/common/basicBSTriggerData'
 import { MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/common/consts'
-import { prepareBasicBSResetData } from 'features/automation/common/helpers'
+import {
+  adjustDefaultValuesIfOutsideSlider,
+  prepareBasicBSResetData,
+} from 'features/automation/common/helpers'
 import {
   BASIC_SELL_FORM_CHANGE,
   BasicBSFormChange,
@@ -27,7 +30,7 @@ import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useHash } from 'helpers/useHash'
 import { one } from 'helpers/zero'
 import { Trans, useTranslation } from 'next-i18next'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Text } from 'theme-ui'
 
 import { StopLossTriggerData } from '../../common/stopLossTriggerData'
@@ -121,9 +124,15 @@ export function SidebarAutoSellAddEditingStage({
 
   const { isStopLossEnabled, stopLossLevel } = stopLossTriggerData
 
-  if (!isStopLossEnabled) {
-    adjustDefaultValuesIfOutsideSlider()
-  }
+  useEffect(() => {
+    adjustDefaultValuesIfOutsideSlider({
+      basicBSState: basicSellState,
+      sliderMax,
+      sliderMin,
+      uiChanges,
+      publishType: BASIC_SELL_FORM_CHANGE,
+    })
+  }, [vault.collateralizationRatio.toNumber()])
 
   const isCurrentCollRatioHigherThanSliderMax = vault.collateralizationRatio
     .times(100)
@@ -342,19 +351,4 @@ export function SidebarAutoSellAddEditingStage({
       )}
     </>
   )
-
-  function adjustDefaultValuesIfOutsideSlider() {
-    if (basicSellState.targetCollRatio.gt(sliderMax)) {
-      uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
-        type: 'target-coll-ratio',
-        targetCollRatio: sliderMax,
-      })
-    }
-    if (basicSellState.execCollRatio.lt(sliderMin)) {
-      uiChanges.publish(BASIC_SELL_FORM_CHANGE, {
-        type: 'execution-coll-ratio',
-        execCollRatio: sliderMin,
-      })
-    }
-  }
 }

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -138,32 +138,10 @@ export function SidebarAutoSellAddEditingStage({
     .times(100)
     .gt(sliderMax)
 
-  if (isCurrentCollRatioHigherThanSliderMax || sliderMin.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).gt(sliderMax)) {
-    return (
-      <Trans
-        i18nKey="auto-sell.coll-ratio-too-high"
-        components={[
-          <Text
-            as="span"
-            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
-            onClick={() => {
-              uiChanges.publish(TAB_CHANGE_SUBJECT, {
-                type: 'change-tab',
-                currentMode: VaultViewMode.Overview,
-              })
-            }}
-          />,
-        ]}
-        values={{
-          maxAutoBuyCollRatio: sliderMax,
-        }}
-      />
-    )
-  }
-
-  const [, setHash] = useHash()
-
-  if (isStopLossEnabled && stopLossLevel.times(100).plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET).gt(sliderMax)) {
+  if (
+    isStopLossEnabled &&
+    stopLossLevel.times(100).plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.times(2)).gt(sliderMax)
+  ) {
     return (
       <Trans
         i18nKey="auto-sell.sl-too-high"
@@ -186,6 +164,31 @@ export function SidebarAutoSellAddEditingStage({
       />
     )
   }
+
+  if (isCurrentCollRatioHigherThanSliderMax) {
+    return (
+      <Trans
+        i18nKey="auto-sell.coll-ratio-too-high"
+        components={[
+          <Text
+            as="span"
+            sx={{ fontWeight: 'semiBold', color: 'interactive100', cursor: 'pointer' }}
+            onClick={() => {
+              uiChanges.publish(TAB_CHANGE_SUBJECT, {
+                type: 'change-tab',
+                currentMode: VaultViewMode.Overview,
+              })
+            }}
+          />,
+        ]}
+        values={{
+          maxAutoBuyCollRatio: sliderMax.minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.times(2)),
+        }}
+      />
+    )
+  }
+
+  const [, setHash] = useHash()
 
   if (readOnlyBasicBSEnabled && !isVaultEmpty) {
     return (

--- a/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarAutoSellAddEditingStage.tsx
@@ -154,7 +154,7 @@ export function SidebarAutoSellAddEditingStage({
 
   const [, setHash] = useHash()
 
-  if (isStopLossEnabled && stopLossLevel.times(100).lt(sliderMin)) {
+  if (isStopLossEnabled && stopLossLevel.times(100).gt(sliderMin)) {
     return (
       <Trans
         i18nKey="auto-sell.sl-too-high"

--- a/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupAutoSell.tsx
@@ -167,6 +167,7 @@ export function SidebarSetupAutoSell({
                   collateralDelta={collateralDelta}
                   sliderMin={min}
                   sliderMax={max}
+                  stopLossTriggerData={stopLossTriggerData}
                 />
               )}
               {isRemoveForm && (

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1526,7 +1526,9 @@
     "setting-auto-buy": "Setting up your Auto-Buy",
     "cancelling-auto-buy": "Cancelling your Auto-Buy",
     "set-trigger-description": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}, with a Max Buy price of ${{minBuyPrice}}/{{token}}. Learn More ",
-    "set-trigger-description-no-threshold": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}. With no min buy price. Learn More "
+    "set-trigger-description-no-threshold": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}. With no min buy price. Learn More ",
+    "sl-too-high": "Auto Buy is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Auto Buy.",
+    "coll-ratio-too-high": "Auto Buy is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}} before using Auto Buy."
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1482,7 +1482,7 @@
     "remove-content": "Your Auto-Sell cancellation is in progress. Once the transaction is complete. Your Auto-Sell trigger will be removed.",
     "remove-complete-content": "Your Auto-Sell has been successfully cancelled.",
     "sl-too-high": "Auto-Sell is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Auto-Sell.",
-    "coll-ratio-too-high": "Auto-Sell is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}} before using Auto-Sell.",
+    "coll-ratio-too-high": "Auto-Sell is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}}% before using Auto-Sell.",
     "banner": {
       "header": "Set up Auto Sell",
       "content": "Set up an Auto-Sell to keep your vault’s collateralization ratio above a certain level. This may be beneficial, for example, in a bear market where the value of your collateral is decreasing. Find out more about how this works",
@@ -1530,7 +1530,7 @@
     "set-trigger-description": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}, with a Max Buy price of ${{minBuyPrice}}/{{token}}. Learn More ",
     "set-trigger-description-no-threshold": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}. With no min buy price. Learn More ",
     "sl-too-high": "Auto-Buy is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Auto-Buy.",
-    "coll-ratio-too-high": "Auto-Buy is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}} before using Auto-Buy."
+    "coll-ratio-too-high": "Auto-Buy is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}}% before using Auto-Buy."
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1481,6 +1481,8 @@
     "add-complete-content": "You have successfully set up an Auto-Sell on your vault. Find out more about how this works",
     "remove-content": "Your Auto-Sell cancellation is in progress. Once the transaction is complete. Your Auto-Sell trigger will be removed.",
     "remove-complete-content": "Your Auto-Sell has been successfully cancelled.",
+    "sl-too-high": "Auto-Sell is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Auto-Sell.",
+    "coll-ratio-too-high": "Auto-Sell is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}} before using Auto-Sell.",
     "banner": {
       "header": "Set up Auto Sell",
       "content": "Set up an Auto-Sell to keep your vault’s collateralization ratio above a certain level. This may be beneficial, for example, in a bear market where the value of your collateral is decreasing. Find out more about how this works",
@@ -1527,8 +1529,8 @@
     "cancelling-auto-buy": "Cancelling your Auto-Buy",
     "set-trigger-description": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}, with a Max Buy price of ${{minBuyPrice}}/{{token}}. Learn More ",
     "set-trigger-description-no-threshold": "You are creating a recurring Buy action to trigger at a collateralization ratio of {{execCollRatio}}%, Reducing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}. With no min buy price. Learn More ",
-    "sl-too-high": "Auto Buy is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Auto Buy.",
-    "coll-ratio-too-high": "Auto Buy is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}} before using Auto Buy."
+    "sl-too-high": "Auto-Buy is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Auto-Buy.",
+    "coll-ratio-too-high": "Auto-Buy is not available as your Collateral Ratio is too high. Please <0>lower your collateral ratio</0> below {{maxAutoBuyCollRatio}} before using Auto-Buy."
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",

--- a/scripts/docker/launch.sh
+++ b/scripts/docker/launch.sh
@@ -12,4 +12,4 @@ docker-compose "$@" pull
 (sleep 10 && cd ../.. && DATABASE_URL="postgresql://user:pass@localhost:5432/db?schema=public" yarn migrate)&
 
 export DATABASE_URL="postgresql://user:pass@postgres-oasis-borrow:5432/db?schema=public"
-docker-compose -p oasis-borrow --env-file ../../.env --env-file ../../.env.local "$@" up
+docker-compose -p oasis-borrow --env-file ../../.env "$@" up


### PR DESCRIPTION
# [When SL is close to max and/or c-reatio above 500 AB/AS show up with illegal values by default](https://app.shortcut.com/oazo-apps/story/5935/when-sl-is-close-to-max-ab-as-show-up-with-illegal-values-by-default)

  
## Changes 👷‍♀️
  <Please add short list of changes>
- item 1
  
## How to test 🧪
  <Please explain how to test your changes>
- Case coll ratio too high in AB:

![image](https://user-images.githubusercontent.com/6871923/188633088-78afb4dc-aced-4008-a664-404a2c7432d1.png)


click redirects, if c-ratio is lower than slider max user is able to set trigger
![image](https://user-images.githubusercontent.com/6871923/188642856-70cdee5d-48ac-444d-985c-2ba397a01c6f.png)


AB - check for sl too high
![image](https://user-images.githubusercontent.com/6871923/188687652-2122aa57-9f19-4089-a30e-ef4530863dfb.png)
redirects to protection 
![image](https://user-images.githubusercontent.com/6871923/188687885-1dd2ca19-f193-4177-a8d2-a8f97a078bd7.png)

disappears after adjusting 
![image](https://user-images.githubusercontent.com/6871923/188688001-a92b164c-6463-4d03-869b-d96a7f44b251.png)

SL too high for AS example
![image](https://user-images.githubusercontent.com/6871923/188850323-e8e4d26f-5863-4075-8de8-ced5bb2a3928.png)

coll ratio too high example
![image](https://user-images.githubusercontent.com/6871923/188857801-b6786191-258e-492c-adb6-0482d9fa9bde.png)

