### PR TITLE
Hide unused subscription types

### DIFF
--- a/features/notifications/consts.ts
+++ b/features/notifications/consts.ts
@@ -25,16 +25,17 @@ export const notificationPreferences = [
     description: 'notifications.info-notifications-description',
     notificationType: NotificationSubscriptionTypes.VAULT_INFO_NOTIFICATIONS,
   },
-  {
-    heading: 'notifications.user-communication-notifications',
-    description: 'notifications.user-communication-notifications-description',
-    notificationType: NotificationSubscriptionTypes.OASIS_DIRECT_NOTIFICATIONS,
-  },
-  {
-    heading: 'notifications.news-notifications',
-    description: 'notifications.news-notifications-description',
-    notificationType: NotificationSubscriptionTypes.OASIS_NEWS_NOTIFICATIONS,
-  },
+  // TODO UNCOMMENTED WHEN WE WILL HAVE THESE SUBSCRIPTION TYPES IMPLEMENTED
+  // {
+  //   heading: 'notifications.user-communication-notifications',
+  //   description: 'notifications.user-communication-notifications-description',
+  //   notificationType: NotificationSubscriptionTypes.OASIS_DIRECT_NOTIFICATIONS,
+  // },
+  // {
+  //   heading: 'notifications.news-notifications',
+  //   description: 'notifications.news-notifications-description',
+  //   notificationType: NotificationSubscriptionTypes.OASIS_NEWS_NOTIFICATIONS,
+  // },
 ]
 
 export const maxNumberOfNotifications = 50

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -968,7 +968,7 @@
       },
       "more-info": {
           "text1": "更多关于奖励的信息",
-          "link-text": "这里",  
+          "link-text": "这里",
           "text2": "。"
       }
   },
@@ -1702,7 +1702,7 @@
       "action-notifications": "金库操作通知",
       "action-notifications-description": "你将会收到关于自动化触发、清算和开启金库的通知。",
       "info-notifications": "金库信息通知",
-      "info-notifications-description": "Something explains users will get the latest updates if they turn on notifications",
+      "info-notifications-description": "Get notified when your positions get within 5% of the Stop Loss or liquidation price.",
       "user-communication-notifications": "Oasis.app  用户沟通通知",
       "user-communication-notifications-description": "Something explains users will get the latest updates if they turn on notifications",
       "news-notifications": "Oasis.app 新消息通知",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1658,7 +1658,7 @@
     "action-notifications": "Vault action notifications",
     "action-notifications-description": "You will be able to receive notifications when triggering Automation, Liquidation, or opening a vault.",
     "info-notifications": "Vault info notifications",
-    "info-notifications-description": "Something explains users will get the latest updates if they turn on notifications",
+    "info-notifications-description": "Get notified when your positions get within 5% of the Stop Loss or liquidation price.",
     "user-communication-notifications": "Oasis.app user communication notifications",
     "user-communication-notifications-description": "Something explains users will get the latest updates if they turn on notifications",
     "news-notifications": "Oasis.app news notifications",


### PR DESCRIPTION
# [Hide unused subscription types](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- hidden unused subscription types
  
## How to test 🧪
  <Please explain how to test your changes>

- use feature toggle `Notifications`, only `Vault action notifications` and `Vault info notifications` in notification config should be visible
