### PR TITLE
AutoBS, set slider defaults when coll ratio above zero

### DIFF
--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -84,14 +84,16 @@ export function prepareBasicBSSliderDefaults({
   )
 
   return {
-    execCollRatio: execCollRatio.isZero()
-      ? publishKey === 'BASIC_SELL_FORM_CHANGE'
-        ? defaultTriggerForSell.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
-        : defaultTriggerForBuy.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
-      : execCollRatio,
-    targetCollRatio: targetCollRatio.isZero()
-      ? defaultTargetCollRatio.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
-      : targetCollRatio,
+    execCollRatio:
+      execCollRatio.isZero() && collateralizationRatio.gt(zero)
+        ? publishKey === 'BASIC_SELL_FORM_CHANGE'
+          ? defaultTriggerForSell.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
+          : defaultTriggerForBuy.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
+        : execCollRatio,
+    targetCollRatio:
+      targetCollRatio.isZero() && collateralizationRatio.gt(zero)
+        ? defaultTargetCollRatio.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
+        : targetCollRatio,
   }
 }
 


### PR DESCRIPTION
# [AutoBS, set slider defaults when coll ratio above zero](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- auto BS slider defaults logic will take into account if coll ratio is above zero
  
## How to test 🧪
  <Please explain how to test your changes>

- vault with n/a collaterization ratio shouldn't throw error when user go to protection tab
- verify it using following vault https://staging.oasis.app/374?network=goerli#protection

