### PR TITLE
Update afterpills on trigger removal

### DIFF
--- a/blockchain/vault.maths.ts
+++ b/blockchain/vault.maths.ts
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js'
-
-import { HOUR, SECONDS_PER_YEAR } from '../components/constants'
-import { one, zero } from '../helpers/zero'
+import { HOUR, SECONDS_PER_YEAR } from 'components/constants'
+import { one, zero } from 'helpers/zero'
 
 const defaultDebtOffset = new BigNumber('1e-18')
 
@@ -156,7 +155,7 @@ export function collateralPriceAtRatio({
   collateral,
   vaultDebt,
 }: CollateralPriceAtRatioThresholdArgs): BigNumber {
-  return collateral.isZero() || vaultDebt.isZero()
+  return collateral.isZero() || vaultDebt.isZero() || colRatio.isZero()
     ? zero
     : vaultDebt.times(colRatio).div(collateral)
 }

--- a/components/vault/detailsSection/ContentCardEstTokenOnTrigger.tsx
+++ b/components/vault/detailsSection/ContentCardEstTokenOnTrigger.tsx
@@ -77,26 +77,26 @@ export function ContentCardEstTokenOnTrigger({
     .times(liquidationPrice)
     .minus(debt.multipliedBy(one.plus(liquidationPenalty)))
     .div(liquidationPrice)
-  const afterMaxToken = lockedCollateral
-    .times(afterDynamicStopPrice)
-    .minus(debt)
-    .div(afterDynamicStopPrice)
+  const afterMaxToken = afterDynamicStopPrice.isZero()
+    ? zero
+    : lockedCollateral.times(afterDynamicStopPrice).minus(debt).div(afterDynamicStopPrice)
+
   const savingCompareToLiquidation = maxToken.minus(ethDuringLiquidation)
   const symbol = isCollateralActive ? token : 'DAI'
 
-  const formatTokenOrDai = (val: BigNumber): string => {
+  const formatTokenOrDai = (val: BigNumber, stopPrice: BigNumber): string => {
     return isCollateralActive
       ? `${formatAmount(val, token)} ${token}`
-      : `${formatAmount(val.multipliedBy(dynamicStopPrice), 'USD')} DAI`
+      : `${formatAmount(val.multipliedBy(stopPrice), 'USD')} DAI`
   }
 
   const formatted = {
     title: t('manage-multiply-vault.card.max-token-on-stop-loss-trigger', {
       token: symbol,
     }),
-    maxTokenOrDai: formatTokenOrDai(maxToken),
-    savingTokenOrDai: formatTokenOrDai(savingCompareToLiquidation),
-    afterMaxTokenOrDai: formatTokenOrDai(afterMaxToken),
+    maxTokenOrDai: formatTokenOrDai(maxToken, dynamicStopPrice),
+    savingTokenOrDai: formatTokenOrDai(savingCompareToLiquidation, dynamicStopPrice),
+    afterMaxTokenOrDai: formatTokenOrDai(afterMaxToken, afterDynamicStopPrice),
     liquidationPenalty: formatPercent(liquidationPenalty.multipliedBy(100), {
       precision: 2,
     }),

--- a/features/automation/protection/common/helpers.ts
+++ b/features/automation/protection/common/helpers.ts
@@ -27,10 +27,7 @@ export function getIsEditingProtection({
   collateralActive?: boolean
   isToCollateral?: boolean
 }) {
-  if (
-    (collateralActive === undefined && isToCollateral === undefined) ||
-    selectedSLValue.isZero()
-  ) {
+  if (collateralActive === undefined && isToCollateral === undefined) {
     return false
   }
 

--- a/features/automation/protection/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/controls/ProtectionFormControl.tsx
@@ -64,7 +64,13 @@ export function ProtectionFormControl({
         currentProtectionFeature: 'autoSell',
       })
     }
-  }, [])
+    if (isStopLossActive) {
+      uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+        type: 'Protection',
+        currentProtectionFeature: 'stopLoss',
+      })
+    }
+  }, [autoSellTriggerData.isTriggerEnabled, stopLossTriggerData.isStopLossEnabled])
 
   return (
     <>

--- a/features/automation/protection/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/controls/StopLossDetailsControl.tsx
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js'
 import { IlkData } from 'blockchain/ilks'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
@@ -39,9 +38,7 @@ export function StopLossDetailsControl({
       {isStopLossActive ? (
         <StopLossDetailsLayout
           slRatio={stopLossTriggerData.stopLossLevel}
-          afterSlRatio={
-            stopLossState ? stopLossState.selectedSLValue?.dividedBy(100) : new BigNumber(0)
-          }
+          afterSlRatio={stopLossState.selectedSLValue.dividedBy(100)}
           vaultDebt={vault.debt}
           isStopLossEnabled={stopLossTriggerData.isStopLossEnabled}
           lockedCollateral={vault.lockedCollateral}
@@ -56,9 +53,7 @@ export function StopLossDetailsControl({
             stopLossLevel: stopLossTriggerData.stopLossLevel,
             collateralActive: stopLossState.collateralActive,
             isToCollateral: stopLossTriggerData.isToCollateral,
-            // TODO to be updated when working on details section remove state
-            isRemoveForm: false,
-            // isRemoveForm: stopLossState.currentForm === 'remove',
+            isRemoveForm: stopLossState.currentForm === 'remove',
           })}
           collateralizationRatio={vault.collateralizationRatio}
         />

--- a/features/automation/protection/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/controls/StopLossFormControl.tsx
@@ -32,6 +32,7 @@ import { SidebarSetupStopLoss } from 'features/automation/protection/controls/si
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
+import { zero } from 'helpers/zero'
 import React, { useMemo } from 'react'
 
 import { failedStatuses, progressStatuses } from '../../common/txStatues'
@@ -204,12 +205,21 @@ export function StopLossFormControl({
   }
 
   const executionPrice = collateralPriceAtRatio({
-    colRatio: stopLossState.selectedSLValue.div(100), // TODO potentialy div by 100
+    colRatio: stopLossState.selectedSLValue.div(100),
     collateral: vault.lockedCollateral,
     vaultDebt: vault.debt,
   })
 
   const isFirstSetup = stopLossTriggerData.triggerId.isZero()
+
+  function textButtonHandlerExtension() {
+    if (isAddForm) {
+      uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
+        type: 'stop-loss',
+        stopLoss: zero,
+      })
+    }
+  }
 
   return (
     <AddAndRemoveTriggerControl
@@ -225,6 +235,7 @@ export function StopLossFormControl({
       currentForm={stopLossState.currentForm}
       triggersId={[triggerId.toNumber()]}
       isActiveFlag={isStopLossActive}
+      textButtonHandlerExtension={textButtonHandlerExtension}
     >
       {(txHandler, textButtonHandler) => (
         <SidebarSetupStopLoss

--- a/features/automation/protection/controls/sidebar/SidebarCancelStopLossEditingStage.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarCancelStopLossEditingStage.tsx
@@ -10,7 +10,6 @@ import {
 } from 'components/vault/VaultChangesInformation'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
-import { StopLossFormChange } from 'features/automation/protection/common/UITypes/StopLossFormChange'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
@@ -62,7 +61,7 @@ interface SidebarCancelStopLossEditingStageProps {
   ilkData: IlkData
   errors: VaultErrorMessage[]
   warnings: VaultWarningMessage[]
-  stopLossState: StopLossFormChange
+  stopLossLevel: BigNumber
 }
 
 export function SidebarCancelStopLossEditingStage({
@@ -70,7 +69,7 @@ export function SidebarCancelStopLossEditingStage({
   ilkData,
   errors,
   warnings,
-  stopLossState,
+  stopLossLevel,
 }: SidebarCancelStopLossEditingStageProps) {
   const { t } = useTranslation()
 
@@ -83,7 +82,7 @@ export function SidebarCancelStopLossEditingStage({
       <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
       <CancelDownsideProtectionInformation
         liquidationPrice={vault.liquidationPrice}
-        selectedSLValue={stopLossState.selectedSLValue}
+        selectedSLValue={stopLossLevel.times(100)}
       />
       <MessageCard
         messages={[

--- a/features/automation/protection/controls/sidebar/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/controls/sidebar/SidebarSetupStopLoss.tsx
@@ -176,7 +176,7 @@ export function SidebarSetupStopLoss({
                       ilkData={ilkData}
                       errors={cancelStopLossErrors}
                       warnings={cancelStopLossWarnings}
-                      stopLossState={stopLossState}
+                      stopLossLevel={stopLossTriggerData.stopLossLevel}
                     />
                   )}
                 </>


### PR DESCRIPTION
# [Update afterpills on trigger removal](https://app.shortcut.com/oazo-apps/story/5783/update-afterpills-on-trigger-removal)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated afterpills on trigger removal in stop loss details section
- fixed issue when SL has been deleted and SL form and details section lost their active status
  
## How to test 🧪
  <Please explain how to test your changes>

- add stop loss trigger then try to remove it -> after pills with zeros should be visible in details section
- after SL removal form and detail section shouldn't lose active status
