### PR TITLE
Changed the OG images path to absolute + added twitter:creator

### DIFF
--- a/components/HeadTags.tsx
+++ b/components/HeadTags.tsx
@@ -2,6 +2,7 @@ import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useTranslation } from 'next-i18next'
 import Head from 'next/head'
 import React from 'react'
+import { v4 as uuid } from 'uuid'
 
 import { useTheme } from '../theme/useThemeUI'
 
@@ -87,17 +88,18 @@ export function PageSEOTags({
 
       <meta
         property="og:image"
-        content={staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.ogImage}`)}
+        content={staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.ogImage}?${uuid()}`)}
       />
       <meta
         property="og:image:secure_url"
-        content={staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.ogImage}`)}
+        content={staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.ogImage}?${uuid()}`)}
       />
       <meta
         name="twitter:image"
-        content={staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.twitterImage}`)}
+        content={staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.twitterImage}?${uuid()}`)}
       />
       <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:creator" content="@oasisdotapp" />
 
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Oasis" />

--- a/runtime.config.js
+++ b/runtime.config.js
@@ -1,12 +1,10 @@
-const basePath = 'http://oasis.app'
-
 const publicRuntimeConfig = {
   // Will be available on both server and client
   buildHash: process.env.COMMIT_SHA,
   buildDate: Date.now(),
   apiHost: process.env.API_HOST,
   notificationsHost: process.env.NOTIFICATIONS_HOST,
-  basePath,
+  basePath: process.env.APP_FULL_DOMAIN,
   mixpanelEnv: process.env.MIXPANEL_ENV,
   mixpanelAPIKey: process.env.MIXPANEL_KEY,
   adRollAdvId: process.env.ADROLL_ADV_ID,

--- a/runtime.config.js
+++ b/runtime.config.js
@@ -15,7 +15,8 @@ const publicRuntimeConfig = {
   infuraProjectId: process.env.INFURA_PROJECT_ID,
   etherscanAPIKey: process.env.ETHERSCAN_API_KEY,
   sentryRelease: process.env.SENTRY_RELEASE,
-  exchangeAddress: process.env.USE_DUMMY === '1' ? process.env.DUMMY_EXCHANGE : process.env.EXCHANGE,
+  exchangeAddress:
+    process.env.USE_DUMMY === '1' ? process.env.DUMMY_EXCHANGE : process.env.EXCHANGE,
   multiplyProxyActions: process.env.MULTIPLY_PROXY_ACTIONS,
   mainnetCacheURL: process.env.MAINNET_CACHE_URL,
   operationExecutorTemp: process.env.OPERATION_EXECUTOR_TEMP,

--- a/runtime.config.js
+++ b/runtime.config.js
@@ -1,4 +1,4 @@
-const basePath = ''
+const basePath = 'http://oasis.app'
 
 const publicRuntimeConfig = {
   // Will be available on both server and client
@@ -17,8 +17,7 @@ const publicRuntimeConfig = {
   infuraProjectId: process.env.INFURA_PROJECT_ID,
   etherscanAPIKey: process.env.ETHERSCAN_API_KEY,
   sentryRelease: process.env.SENTRY_RELEASE,
-  exchangeAddress:
-    process.env.USE_DUMMY === '1' ? process.env.DUMMY_EXCHANGE : process.env.EXCHANGE,
+  exchangeAddress: process.env.USE_DUMMY === '1' ? process.env.DUMMY_EXCHANGE : process.env.EXCHANGE,
   multiplyProxyActions: process.env.MULTIPLY_PROXY_ACTIONS,
   mainnetCacheURL: process.env.MAINNET_CACHE_URL,
   operationExecutorTemp: process.env.OPERATION_EXECUTOR_TEMP,


### PR DESCRIPTION
# Changed the OG images path to absolute + added twitter:creator

## Changes 👷‍♀️
- this fixed the twitter share OG image which requires an absolute path to the image (publicRuntimeConfig.basePath change) and twitter:creator tag
 - publicRuntimeConfig.basePath now pulls value from env `APP_FULL_DOMAIN`
  
## How to test 🧪
Go to twitter.com and share `https://oasis.app/` or `https://oasis.app/borrow`, there should be a matching image
