### PR TITLE
Undo banner for vaults affected by latest Auto-Sell SC change

### DIFF
--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -8,7 +8,6 @@ import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Dictionary } from 'ts-essentials'
 
-const SupportLink = <AppLink sx={{ color: 'warning100' }} href="mailto:support@oasis.app" />
 const ConstantMultipleKBLink = (
   <AppLink
     sx={{ color: 'warning100' }}
@@ -81,9 +80,6 @@ export function VaultWarnings({
         return translate('auto-buy-triggered-immediately')
       case 'autoSellTriggeredImmediately':
         return translate('auto-sell-triggered-immediately')
-      // TEMPORARY override message as banner in overview details
-      case 'autoSellOverride':
-        return <Trans i18nKey="vault-warnings.auto-sell-override" components={[SupportLink]} />
       case 'constantMultipleAutoSellTriggeredImmediately':
         return translate('constant-multiple-auto-sell-triggered-immediately')
       case 'constantMultipleAutoBuyTriggeredImmediately':

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -1,5 +1,3 @@
-import { Box } from '@theme-ui/components'
-import { IlkData } from 'blockchain/ilks'
 import { getToken } from 'blockchain/tokensMetadata'
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { DetailsSection } from 'components/DetailsSection'
@@ -19,12 +17,9 @@ import {
   VaultDetailsSummaryContainer,
   VaultDetailsSummaryItem,
 } from 'components/vault/VaultDetails'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
-import { overrideWarningAutoSellTriggerIds } from 'features/automation/common/consts'
 import { GetProtectionBannerControl } from 'features/automation/protection/controls/GetProtectionBannerControl'
 import { formatAmount } from 'helpers/formatters/format'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
-import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -132,7 +127,6 @@ export function ManageVaultDetails(
     inputAmountsEmpty,
     stage,
     stopLossTriggered,
-    basicSellData,
   } = props
   const { t } = useTranslation()
   const { stopLossTriggerData } = useAutomationContext()
@@ -143,55 +137,43 @@ export function ManageVaultDetails(
   const stopLossReadEnabled = useFeatureToggle('StopLossRead')
   const stopLossWriteEnabled = useFeatureToggle('StopLossWrite')
 
-  const basicSellTriggerId = basicSellData?.triggerId.toNumber() || 0
-
   return (
     <Grid>
       {stopLossReadEnabled && <>{stopLossTriggered && <StopLossTriggeredBannerControl />}</>}
       <DetailsSection
         title={t('system.overview')}
         content={
-          <>
-            {overrideWarningAutoSellTriggerIds.includes(basicSellTriggerId) && (
-              <Box mb={3}>
-                <VaultWarnings
-                  warningMessages={['autoSellOverride']}
-                  ilkData={{ debtFloor: zero } as IlkData}
-                />
-              </Box>
-            )}
-            <DetailsSectionContentCardWrapper>
-              <ContentCardLiquidationPrice
+          <DetailsSectionContentCardWrapper>
+            <ContentCardLiquidationPrice
+              liquidationPrice={liquidationPrice}
+              liquidationRatio={liquidationRatio}
+              liquidationPriceCurrentPriceDifference={liquidationPriceCurrentPriceDifference}
+              afterLiquidationPrice={afterLiquidationPrice}
+              changeVariant={changeVariant}
+            />
+            <ContentCardCollateralizationRatio
+              collateralizationRatio={collateralizationRatio}
+              collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
+              afterCollateralizationRatio={afterCollateralizationRatio}
+              changeVariant={changeVariant}
+            />
+            <ContentCardCollateralLocked
+              token={token}
+              lockedCollateralUSD={lockedCollateralUSD}
+              lockedCollateral={lockedCollateral}
+              afterLockedCollateralUSD={afterLockedCollateralUSD}
+              changeVariant={changeVariant}
+            />
+            {stopLossTriggerData.isStopLossEnabled && (
+              <ContentCardDynamicStopPriceWithColRatio
+                slData={stopLossTriggerData}
                 liquidationPrice={liquidationPrice}
-                liquidationRatio={liquidationRatio}
-                liquidationPriceCurrentPriceDifference={liquidationPriceCurrentPriceDifference}
                 afterLiquidationPrice={afterLiquidationPrice}
+                liquidationRatio={liquidationRatio}
                 changeVariant={changeVariant}
               />
-              <ContentCardCollateralizationRatio
-                collateralizationRatio={collateralizationRatio}
-                collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
-                afterCollateralizationRatio={afterCollateralizationRatio}
-                changeVariant={changeVariant}
-              />
-              <ContentCardCollateralLocked
-                token={token}
-                lockedCollateralUSD={lockedCollateralUSD}
-                lockedCollateral={lockedCollateral}
-                afterLockedCollateralUSD={afterLockedCollateralUSD}
-                changeVariant={changeVariant}
-              />
-              {stopLossTriggerData.isStopLossEnabled && (
-                <ContentCardDynamicStopPriceWithColRatio
-                  slData={stopLossTriggerData}
-                  liquidationPrice={liquidationPrice}
-                  afterLiquidationPrice={afterLiquidationPrice}
-                  liquidationRatio={liquidationRatio}
-                  changeVariant={changeVariant}
-                />
-              )}
-            </DetailsSectionContentCardWrapper>
-          </>
+            )}
+          </DetailsSectionContentCardWrapper>
         }
         footer={
           <DetailsSectionFooterItemWrapper>

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -20,7 +20,6 @@ export type VaultWarningMessage =
   | 'autoBuyTargetCloseToAutoSellTrigger'
   | 'autoBuyTriggeredImmediately'
   | 'autoSellTriggeredImmediately'
-  | 'autoSellOverride'
   | 'constantMultipleSellTriggerCloseToStopLossTrigger'
   | 'stopLossTriggerCloseToConstantMultipleSellTrigger'
   | 'addingConstantMultipleWhenAutoSellOrBuyEnabled'

--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -1,5 +1,3 @@
-import { Box } from '@theme-ui/components'
-import { IlkData } from 'blockchain/ilks'
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { DetailsSection } from 'components/DetailsSection'
 import {
@@ -13,11 +11,8 @@ import { ContentCardLiquidationPrice } from 'components/vault/detailsSection/Con
 import { ContentCardNetValue } from 'components/vault/detailsSection/ContentCardNetValue'
 import { ContentFooterItemsMultiply } from 'components/vault/detailsSection/ContentFooterItemsMultiply'
 import { getCollRatioColor } from 'components/vault/VaultDetails'
-import { VaultWarnings } from 'components/vault/VaultWarnings'
-import { overrideWarningAutoSellTriggerIds } from 'features/automation/common/consts'
 import { GetProtectionBannerControl } from 'features/automation/protection/controls/GetProtectionBannerControl'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
-import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -48,7 +43,6 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
     totalGasSpentUSD,
     priceInfo,
     stopLossTriggered,
-    basicSellData,
   } = props
   const { t } = useTranslation()
   const { stopLossTriggerData } = useAutomationContext()
@@ -60,62 +54,50 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
   const changeVariant = showAfterPill ? getChangeVariant(afterCollRatioColor) : undefined
   const oraclePrice = priceInfo.currentCollateralPrice
 
-  const basicSellTriggerId = basicSellData?.triggerId.toNumber() || 0
-
   return (
     <Grid>
       {stopLossReadEnabled && <>{stopLossTriggered && <StopLossTriggeredBannerControl />}</>}
       <DetailsSection
         title={t('system.overview')}
         content={
-          <>
-            {overrideWarningAutoSellTriggerIds.includes(basicSellTriggerId) && (
-              <Box mb={3}>
-                <VaultWarnings
-                  warningMessages={['autoSellOverride']}
-                  ilkData={{ debtFloor: zero } as IlkData}
-                />
-              </Box>
-            )}
-            <DetailsSectionContentCardWrapper>
-              <ContentCardLiquidationPrice
+          <DetailsSectionContentCardWrapper>
+            <ContentCardLiquidationPrice
+              liquidationPrice={liquidationPrice}
+              liquidationRatio={liquidationRatio}
+              liquidationPriceCurrentPriceDifference={liquidationPriceCurrentPriceDifference}
+              afterLiquidationPrice={afterLiquidationPrice}
+              changeVariant={changeVariant}
+            />
+            <ContentCardBuyingPower
+              token={token}
+              buyingPower={buyingPower}
+              buyingPowerUSD={buyingPowerUSD}
+              afterBuyingPowerUSD={afterBuyingPowerUSD}
+              changeVariant={changeVariant}
+            />
+            <ContentCardNetValue
+              token={token}
+              oraclePrice={oraclePrice}
+              marketPrice={marketPrice}
+              netValueUSD={netValueUSD}
+              afterNetValueUSD={afterNetValueUSD}
+              totalGasSpentUSD={totalGasSpentUSD}
+              currentPnL={currentPnL}
+              lockedCollateral={lockedCollateral}
+              lockedCollateralUSD={lockedCollateralUSD}
+              debt={debt}
+              changeVariant={changeVariant}
+            />
+            {stopLossTriggerData.isStopLossEnabled && (
+              <ContentCardDynamicStopPriceWithColRatio
+                slData={stopLossTriggerData}
                 liquidationPrice={liquidationPrice}
-                liquidationRatio={liquidationRatio}
-                liquidationPriceCurrentPriceDifference={liquidationPriceCurrentPriceDifference}
                 afterLiquidationPrice={afterLiquidationPrice}
+                liquidationRatio={liquidationRatio}
                 changeVariant={changeVariant}
               />
-              <ContentCardBuyingPower
-                token={token}
-                buyingPower={buyingPower}
-                buyingPowerUSD={buyingPowerUSD}
-                afterBuyingPowerUSD={afterBuyingPowerUSD}
-                changeVariant={changeVariant}
-              />
-              <ContentCardNetValue
-                token={token}
-                oraclePrice={oraclePrice}
-                marketPrice={marketPrice}
-                netValueUSD={netValueUSD}
-                afterNetValueUSD={afterNetValueUSD}
-                totalGasSpentUSD={totalGasSpentUSD}
-                currentPnL={currentPnL}
-                lockedCollateral={lockedCollateral}
-                lockedCollateralUSD={lockedCollateralUSD}
-                debt={debt}
-                changeVariant={changeVariant}
-              />
-              {stopLossTriggerData.isStopLossEnabled && (
-                <ContentCardDynamicStopPriceWithColRatio
-                  slData={stopLossTriggerData}
-                  liquidationPrice={liquidationPrice}
-                  afterLiquidationPrice={afterLiquidationPrice}
-                  liquidationRatio={liquidationRatio}
-                  changeVariant={changeVariant}
-                />
-              )}
-            </DetailsSectionContentCardWrapper>
-          </>
+            )}
+          </DetailsSectionContentCardWrapper>
         }
         footer={
           <DetailsSectionFooterItemWrapper>


### PR DESCRIPTION
# [Undo banner for vaults affected by latest Auto-Sell SC change](https://app.shortcut.com/oazo-apps/story/5393/undo-banner-for-vaults-affected-by-latest-auto-sell-sc-contract-change)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed banner saying that users should recreate auto sell trigger due to contract change
  
## How to test 🧪
  <Please explain how to test your changes>

- vaults 1935 and 28734 shouldn't have banner in overview details section 
