### PR TITLE
Updated AB / AS target ratio color (slider)

### DIFF
--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -211,13 +211,13 @@ export function SidebarAutoBuyEditingStage({
           value1: autoBuyState.execCollRatio.toNumber(),
         }}
         valueColors={{
-          value0: 'warning100',
+          value0: 'primary100',
           value1: 'success100',
         }}
         step={1}
         leftDescription={t('auto-buy.target-coll-ratio')}
         rightDescription={t('auto-buy.trigger-coll-ratio')}
-        leftThumbColor="warning100"
+        leftThumbColor="primary100"
         rightThumbColor="success100"
       />
       <VaultActionInput

--- a/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
@@ -267,13 +267,13 @@ export function SidebarAutoSellAddEditingStage({
         }}
         valueColors={{
           value0: 'warning100',
-          value1: 'success100',
+          value1: 'primary100',
         }}
         step={1}
         leftDescription={t('auto-sell.sell-trigger-ratio')}
         rightDescription={t('auto-sell.target-coll-ratio')}
         leftThumbColor="warning100"
-        rightThumbColor="success100"
+        rightThumbColor="primary100"
       />
       <VaultActionInput
         action={t('auto-sell.set-min-sell-price')}


### PR DESCRIPTION
# [Updated AB / AS target ratio color (slider)](https://app.shortcut.com/oazo-apps/story/5818/ab-as-colour-change-for-target-ratio)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated color of slider dots and values in auto buy and sell forms
  
## How to test 🧪
  <Please explain how to test your changes>

- go to auto sell and auto buy sidebars, verify whether slider dot and value colors (target coll ratio) are as described in story (both for auto buy and sell target coll ratio value and dot should be black)
