### PR TITLE
Unified default values in details section

### DIFF
--- a/components/vault/detailsSection/ContentCardTargetColRatioAfterBuy.tsx
+++ b/components/vault/detailsSection/ContentCardTargetColRatioAfterBuy.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 interface ContentCardTargetColRatioAfterBuyProps {
   targetColRatio?: BigNumber
   afterTargetColRatio?: BigNumber
-  threshold: BigNumber
+  threshold?: BigNumber
   changeVariant?: ChangeVariantType
   token: string
 }
@@ -39,7 +39,9 @@ export function ContentCardTargetColRatioAfterBuy({
         precision: 2,
         roundMode: BigNumber.ROUND_DOWN,
       }),
-    threshold: threshold.isEqualTo(maxUint256)
+    threshold: !threshold
+      ? undefined
+      : threshold.isEqualTo(maxUint256)
       ? t('unlimited')
       : `$${formatAmount(threshold, 'USD')}`,
   }
@@ -54,13 +56,14 @@ export function ContentCardTargetColRatioAfterBuy({
       value: `${formatted.afterTargetColRatio} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     }
+
   if (threshold)
     contentCardSettings.footnote = t('auto-buy.continual-buy-threshold', {
       amount: formatted.threshold,
       token,
     })
 
-  if (!threshold || threshold.isEqualTo(maxUint256) || threshold.isZero())
+  if (threshold?.isEqualTo(maxUint256) || threshold?.isZero())
     contentCardSettings.footnote = t('auto-buy.continual-buy-no-threshold')
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/components/vault/detailsSection/ContentCardTargetColRatioAfterSell.tsx
+++ b/components/vault/detailsSection/ContentCardTargetColRatioAfterSell.tsx
@@ -51,14 +51,14 @@ export function ContentCardTargetColRatioAfterSell({
       value: `${formatted.afterTargetColRatio} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     }
+
   if (threshold)
     contentCardSettings.footnote = t('auto-sell.continual-sell-threshold', {
       amount: formatted.threshold,
       token,
     })
 
-  if (!threshold || threshold?.isZero())
-    contentCardSettings.footnote = t('auto-sell.continual-sell-no-threshold')
+  if (threshold?.isZero()) contentCardSettings.footnote = t('auto-sell.continual-sell-no-threshold')
 
   return <DetailsSectionContentCard {...contentCardSettings} />
 }

--- a/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
@@ -20,7 +20,12 @@ interface AutoBuyDetailsControlProps {
 export function AutoBuyDetailsControl({ vault, autoBuyTriggerData }: AutoBuyDetailsControlProps) {
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const [autoBuyState] = useUIChanges<AutoBSFormChange>(AUTO_BUY_FORM_CHANGE)
-  const { execCollRatio, targetCollRatio, maxBuyOrMinSellPrice } = autoBuyTriggerData
+  const {
+    execCollRatio,
+    targetCollRatio,
+    maxBuyOrMinSellPrice,
+    isTriggerEnabled,
+  } = autoBuyTriggerData
   const isDebtZero = vault.debt.isZero()
 
   const executionPrice = collateralPriceAtRatio({
@@ -36,6 +41,12 @@ export function AutoBuyDetailsControl({ vault, autoBuyTriggerData }: AutoBuyDeta
   })
 
   const autoBuyDetailsLayoutOptionalParams = {
+    ...(isTriggerEnabled && {
+      triggerColRatio: execCollRatio,
+      nextBuyPrice: executionPrice,
+      targetColRatio: targetCollRatio,
+      threshold: maxBuyOrMinSellPrice,
+    }),
     ...(isEditing && {
       afterTriggerColRatio: autoBuyState.execCollRatio,
       afterTargetColRatio: autoBuyState.targetCollRatio,
@@ -54,10 +65,6 @@ export function AutoBuyDetailsControl({ vault, autoBuyTriggerData }: AutoBuyDeta
     <Grid>
       <AutoBuyDetailsLayout
         token={vault.token}
-        triggerColRatio={execCollRatio}
-        nextBuyPrice={executionPrice}
-        targetColRatio={targetCollRatio}
-        threshold={maxBuyOrMinSellPrice}
         autoBuyTriggerData={autoBuyTriggerData}
         {...autoBuyDetailsLayoutOptionalParams}
       />

--- a/features/automation/optimization/autoBuy/controls/AutoBuyDetailsLayout.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyDetailsLayout.tsx
@@ -18,11 +18,11 @@ import { Grid } from 'theme-ui'
 
 export interface AutoBuyDetailsLayoutProps {
   token: string
-  triggerColRatio: BigNumber
-  nextBuyPrice: BigNumber
-  targetColRatio: BigNumber
-  threshold: BigNumber
   autoBuyTriggerData: AutoBSTriggerData
+  triggerColRatio?: BigNumber
+  nextBuyPrice?: BigNumber
+  targetColRatio?: BigNumber
+  threshold?: BigNumber
   afterTriggerColRatio?: BigNumber
   afterTargetColRatio?: BigNumber
 }

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
@@ -32,7 +32,12 @@ export function AutoSellDetailsControl({
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const [autoSellState] = useUIChanges<AutoBSFormChange>(AUTO_SELL_FORM_CHANGE)
   const { uiChanges } = useAppContext()
-  const { execCollRatio, targetCollRatio, maxBuyOrMinSellPrice } = autoSellTriggerData
+  const {
+    execCollRatio,
+    targetCollRatio,
+    maxBuyOrMinSellPrice,
+    isTriggerEnabled,
+  } = autoSellTriggerData
   const isDebtZero = vault.debt.isZero()
 
   const executionPrice = collateralPriceAtRatio({
@@ -48,6 +53,12 @@ export function AutoSellDetailsControl({
   })
 
   const autoSellDetailsLayoutOptionalParams = {
+    ...(isTriggerEnabled && {
+      triggerColRatio: execCollRatio,
+      nextSellPrice: executionPrice,
+      targetColRatio: targetCollRatio,
+      threshold: maxBuyOrMinSellPrice,
+    }),
     ...(isEditing && {
       afterTriggerColRatio: autoSellState.execCollRatio,
       afterTargetColRatio: autoSellState.targetCollRatio,
@@ -67,10 +78,6 @@ export function AutoSellDetailsControl({
       {isAutoSellActive ? (
         <AutoSellDetailsLayout
           token={vault.token}
-          triggerColRatio={execCollRatio}
-          nextSellPrice={executionPrice}
-          targetColRatio={targetCollRatio}
-          threshold={maxBuyOrMinSellPrice}
           autoSellTriggerData={autoSellTriggerData}
           {...autoSellDetailsLayoutOptionalParams}
         />

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsLayout.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsLayout.tsx
@@ -9,11 +9,11 @@ import React from 'react'
 
 interface AutoSellDetailsLayoutProps {
   token: string
-  triggerColRatio: BigNumber
-  nextSellPrice: BigNumber
-  targetColRatio: BigNumber
-  threshold: BigNumber
   autoSellTriggerData: AutoBSTriggerData
+  triggerColRatio?: BigNumber
+  nextSellPrice?: BigNumber
+  targetColRatio?: BigNumber
+  threshold?: BigNumber
   afterTriggerColRatio?: BigNumber
   afterTargetColRatio?: BigNumber
 }


### PR DESCRIPTION
# [Unified default values in details section](https://app.shortcut.com/oazo-apps/story/5782/unify-default-values-in-details-section)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- details cards in automation scope will show `-` instead of `0` when trigger is not enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- go to auto buy and sell forms and check whether detail cards show `-` as value
