### PR TITLE
Remove dummy notifications emit

### DIFF
--- a/components/notifications/NotificationsPrefrenceCardWrapper.tsx
+++ b/components/notifications/NotificationsPrefrenceCardWrapper.tsx
@@ -46,10 +46,6 @@ export function NotificationPreferenceCardWrapper({
             subscriptionType,
           ],
         })
-        // TODO to be removed
-        socket?.emit('createdummy', {
-          address: account,
-        })
       } else {
         const afterSubscriptions = notificationsState.allActiveSubscriptions
           .filter((item) => item.id !== subscriptionType)


### PR DESCRIPTION
# [Remove dummy notifications emit](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed emit which was responsible for generating dummy notifications
  
## How to test 🧪
  <Please explain how to test your changes>

- setting up preferences in notifications config should no longer generate dummy notifications (test using notification feature toggle, use staging)
