### PR TITLE
Lw/5781 default state sl open flow

### DIFF
--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -126,7 +126,7 @@ export function getDataForStopLoss(
       collateralActive: stopLossCloseType === 'collateral',
       currentForm: 'add',
     } as StopLossFormChange,
-    isEditing: !stopLossLevel.isZero(),
+    isEditing: true,
     closePickerConfig: {
       optionNames: closeVaultOptions,
       onclickHandler: (optionName: string) => setStopLossCloseType(optionName as CloseVaultTo),

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -167,6 +167,7 @@ export function SidebarAdjustStopLossEditingStage({
   const selectedStopLossCollRatioIfTriggerDoesntExist = sliderMin.plus(
     DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE,
   )
+
   const initialSlRatioWhenTriggerDoesntExist = getStartingSlRatio({
     stopLossLevel: stopLossTriggerData.stopLossLevel,
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,

--- a/features/borrow/open/pipes/openVault.ts
+++ b/features/borrow/open/pipes/openVault.ts
@@ -12,6 +12,10 @@ import { isSupportedAutomationIlk } from 'blockchain/tokensMetadata'
 import { AddGasEstimationFunction, TxHelpers } from 'components/AppContext'
 import { setAllowance } from 'features/allowance/setAllowance'
 import {
+  DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE,
+  MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
+} from 'features/automation/common/consts'
+import {
   applyOpenVaultStopLoss,
   OpenVaultStopLossChanges,
   StopLossOpenFlowStages,
@@ -379,6 +383,12 @@ export function createOpenVault$(
                       : false
 
                     const totalSteps = calculateInitialTotalSteps(proxyAddress, token, allowance)
+                    const stopLossSliderMin = ilkData.liquidationRatio.plus(
+                      MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100),
+                    )
+                    const initialStopLossSelected = stopLossSliderMin
+                      .plus(DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE)
+                      .times(100)
 
                     const initialState: OpenVaultState = {
                       ...defaultMutableOpenVaultState,
@@ -390,7 +400,7 @@ export function createOpenVault$(
                       setStopLossLevel: (level: BigNumber) =>
                         change({ kind: 'stopLossLevel', level }),
                       stopLossCloseType: 'dai',
-                      stopLossLevel: zero,
+                      stopLossLevel: initialStopLossSelected,
                       priceInfo,
                       balanceInfo,
                       ilkData,

--- a/features/multiply/open/pipes/openMultiplyVault.ts
+++ b/features/multiply/open/pipes/openMultiplyVault.ts
@@ -6,6 +6,10 @@ import { ContextConnected } from 'blockchain/network'
 import { isSupportedAutomationIlk } from 'blockchain/tokensMetadata'
 import { AddGasEstimationFunction, TxHelpers } from 'components/AppContext'
 import {
+  DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE,
+  MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
+} from 'features/automation/common/consts'
+import {
   applyOpenVaultStopLoss,
   OpenVaultStopLossChanges,
   StopLossOpenFlowStages,
@@ -386,6 +390,12 @@ export function createOpenMultiplyVault$(
                       : false
 
                     const totalSteps = calculateInitialTotalSteps(proxyAddress, token, allowance)
+                    const stopLossSliderMin = ilkData.liquidationRatio.plus(
+                      MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100),
+                    )
+                    const initialStopLossSelected = stopLossSliderMin
+                      .plus(DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE)
+                      .times(100)
 
                     const initialState: OpenMultiplyVaultState = {
                       ...defaultMutableOpenMultiplyVaultState,
@@ -397,7 +407,7 @@ export function createOpenMultiplyVault$(
                       setStopLossLevel: (level: BigNumber) =>
                         change({ kind: 'stopLossLevel', level }),
                       stopLossCloseType: 'dai',
-                      stopLossLevel: zero,
+                      stopLossLevel: initialStopLossSelected,
                       priceInfo,
                       balanceInfo,
                       ilkData,


### PR DESCRIPTION
# [Added initial state of sl when opening vault(s)](https://app.shortcut.com/oazo-apps/story/6019/add-default-state-to-stop-loss-during-vault-creation-flow)

  
## Changes 👷‍♀️
-added default sl selected for opening borrow and multiply vault
  
## How to test 🧪
Try to open vault, generate DAI and see if initial values of sl selected will make sense
- Test for multiply vault 
![image](https://user-images.githubusercontent.com/6871923/189923169-97f30d2e-1cfa-4c91-811b-ee57adbb0617.png)

- Test for borrow vault
![image](https://user-images.githubusercontent.com/6871923/189923552-cfeab792-f809-45f1-9869-954673d8ebe8.png)
