### PR TITLE
Disable access to Auto-sell and Auto-buy UI when Constant Multiple is enabled

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -29,8 +29,6 @@ type BannerProps = {
 
 export function Banner({ title, description, button, image, sx }: BannerProps) {
   const descriptionsArray = Array.isArray(description) ? description : [description]
-  console.log(description)
-  console.log(descriptionsArray)
 
   return (
     <Card sx={{ borderRadius: 'large', border: 'lightMuted', p: 2, ...sx }}>

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -1,6 +1,6 @@
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import React, { ReactNode } from 'react'
-import { Box, Button, Card, Flex, Heading, Image, SxProps, Text } from 'theme-ui'
+import { Box, Button, Card, Flex, Grid, Heading, Image, SxProps, Text } from 'theme-ui'
 
 import { AppSpinner } from '../helpers/AppSpinner'
 
@@ -21,13 +21,17 @@ type BannerButtonProps = {
 
 type BannerProps = {
   title: string | ReactNode
-  description: ReactNode
+  description: ReactNode | ReactNode[]
   button?: BannerButtonProps
   image?: { src: string; backgroundColor?: string; backgroundColorEnd?: string }
   sx?: SxProps
 }
 
 export function Banner({ title, description, button, image, sx }: BannerProps) {
+  const descriptionsArray = Array.isArray(description) ? description : [description]
+  console.log(description)
+  console.log(descriptionsArray)
+
   return (
     <Card sx={{ borderRadius: 'large', border: 'lightMuted', p: 2, ...sx }}>
       <Flex
@@ -48,20 +52,23 @@ export function Banner({ title, description, button, image, sx }: BannerProps) {
             flexGrow: 1,
           }}
         >
-          <Heading as="p" variant="boldParagraph1" sx={{ mb: 1 }}>
+          <Heading as="h3" variant="boldParagraph1" sx={{ mb: 1 }}>
             {title}
           </Heading>
-          <Text
-            as="p"
-            sx={{
-              mb: 3,
-              fontSize: 2,
-              lineHeight: 1.571,
-              color: 'neutral80',
-            }}
-          >
-            {description}
-          </Text>
+          <Grid gap={2} mb={3}>
+            {descriptionsArray.map((item) => (
+              <Text
+                as="p"
+                sx={{
+                  fontSize: 2,
+                  lineHeight: 1.571,
+                  color: 'neutral80',
+                }}
+              >
+                {item}
+              </Text>
+            ))}
+          </Grid>
           <Button disabled={button?.disabled} variant="tertiary" onClick={button?.action}>
             {button?.isLoading ? (
               <AppSpinner

--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -16,7 +16,7 @@ interface GetAutoFeaturesSidebarDropdownProps {
   isStopLossEnabled?: boolean
   isAutoSellEnabled?: boolean
   isAutoBuyEnabled?: boolean
-  isAutoConstantMultipleEnabled?: boolean
+  isAutoConstantMultipleEnabled: boolean
 }
 interface GetAutoFeaturesSidebarDropdownItemProps {
   translationKey: string
@@ -31,8 +31,8 @@ function getAutoFeaturesSidebarDropdownItem({
   panel,
   isFeatureEnabled,
 }: GetAutoFeaturesSidebarDropdownItemProps): SidebarSectionHeaderSelectItem {
-  const { t } = useTranslation()
   const { uiChanges } = useAppContext()
+  const { t } = useTranslation()
 
   return {
     label: `${t(isFeatureEnabled ? 'manage' : 'setup')} ${t(translationKey)}`,
@@ -62,43 +62,49 @@ export function getAutoFeaturesSidebarDropdown({
   isAutoSellEnabled,
   isAutoBuyEnabled,
   isAutoConstantMultipleEnabled,
-}: GetAutoFeaturesSidebarDropdownProps): SidebarSectionHeaderDropdown {
-  return {
-    forcePanel,
-    disabled,
-    items: [
-      ...(type === 'Protection'
-        ? [
-            getAutoFeaturesSidebarDropdownItem({
-              translationKey: 'system.stop-loss',
-              type: 'Protection',
-              panel: 'stopLoss',
-              isFeatureEnabled: isStopLossEnabled,
-            }),
-            getAutoFeaturesSidebarDropdownItem({
-              translationKey: 'system.basic-sell',
-              type: 'Protection',
-              panel: 'autoSell',
-              isFeatureEnabled: isAutoSellEnabled,
-            }),
-          ]
-        : []),
-      ...(type === 'Optimization'
-        ? [
-            getAutoFeaturesSidebarDropdownItem({
-              translationKey: 'system.basic-buy',
-              type: 'Optimization',
-              panel: 'autoBuy',
-              isFeatureEnabled: isAutoBuyEnabled,
-            }),
-            getAutoFeaturesSidebarDropdownItem({
-              translationKey: 'system.constant-multiple',
-              type: 'Optimization',
-              panel: 'constantMultiple',
-              isFeatureEnabled: isAutoConstantMultipleEnabled,
-            }),
-          ]
-        : []),
-    ],
-  }
+}: GetAutoFeaturesSidebarDropdownProps): SidebarSectionHeaderDropdown | undefined {
+  const stopLossDropdownItem = getAutoFeaturesSidebarDropdownItem({
+    translationKey: 'system.stop-loss',
+    type: 'Protection',
+    panel: 'stopLoss',
+    isFeatureEnabled: isStopLossEnabled,
+  })
+  const autoSellDropdownItem = getAutoFeaturesSidebarDropdownItem({
+    translationKey: 'system.basic-sell',
+    type: 'Protection',
+    panel: 'autoSell',
+    isFeatureEnabled: isAutoSellEnabled,
+  })
+  const basicBuyDropdownItem = getAutoFeaturesSidebarDropdownItem({
+    translationKey: 'system.basic-buy',
+    type: 'Optimization',
+    panel: 'autoBuy',
+    isFeatureEnabled: isAutoBuyEnabled,
+  })
+  const constantMultipleDropdownItem = getAutoFeaturesSidebarDropdownItem({
+    translationKey: 'system.constant-multiple',
+    type: 'Optimization',
+    panel: 'constantMultiple',
+    isFeatureEnabled: isAutoConstantMultipleEnabled,
+  })
+
+  const items = [
+    ...(type === 'Protection'
+      ? [stopLossDropdownItem, ...(!isAutoConstantMultipleEnabled ? [autoSellDropdownItem] : [])]
+      : []),
+    ...(type === 'Optimization'
+      ? [
+          ...(!isAutoConstantMultipleEnabled ? [basicBuyDropdownItem] : []),
+          constantMultipleDropdownItem,
+        ]
+      : []),
+  ]
+
+  return items.length > 1
+    ? {
+        forcePanel,
+        disabled,
+        items,
+      }
+    : undefined
 }

--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -31,8 +31,8 @@ function getAutoFeaturesSidebarDropdownItem({
   panel,
   isFeatureEnabled,
 }: GetAutoFeaturesSidebarDropdownItemProps): SidebarSectionHeaderSelectItem {
-  const { uiChanges } = useAppContext()
   const { t } = useTranslation()
+  const { uiChanges } = useAppContext()
 
   return {
     label: `${t(isFeatureEnabled ? 'manage' : 'setup')} ${t(translationKey)}`,

--- a/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
@@ -15,9 +15,14 @@ import { Grid } from 'theme-ui'
 interface AutoBuyDetailsControlProps {
   vault: Vault
   autoBuyTriggerData: AutoBSTriggerData
+  isconstantMultipleEnabled: boolean
 }
 
-export function AutoBuyDetailsControl({ vault, autoBuyTriggerData }: AutoBuyDetailsControlProps) {
+export function AutoBuyDetailsControl({
+  vault,
+  autoBuyTriggerData,
+  isconstantMultipleEnabled,
+}: AutoBuyDetailsControlProps) {
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const [autoBuyState] = useUIChanges<AutoBSFormChange>(AUTO_BUY_FORM_CHANGE)
   const {
@@ -66,6 +71,7 @@ export function AutoBuyDetailsControl({ vault, autoBuyTriggerData }: AutoBuyDeta
       <AutoBuyDetailsLayout
         token={vault.token}
         autoBuyTriggerData={autoBuyTriggerData}
+        isconstantMultipleEnabled={isconstantMultipleEnabled}
         {...autoBuyDetailsLayoutOptionalParams}
       />
     </Grid>

--- a/features/automation/optimization/autoBuy/controls/AutoBuyDetailsLayout.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyDetailsLayout.tsx
@@ -14,7 +14,7 @@ import {
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Grid } from 'theme-ui'
+import { Grid, Text } from 'theme-ui'
 
 export interface AutoBuyDetailsLayoutProps {
   token: string
@@ -25,6 +25,7 @@ export interface AutoBuyDetailsLayoutProps {
   threshold?: BigNumber
   afterTriggerColRatio?: BigNumber
   afterTargetColRatio?: BigNumber
+  isconstantMultipleEnabled: boolean
 }
 
 export function AutoBuyDetailsLayout({
@@ -36,6 +37,7 @@ export function AutoBuyDetailsLayout({
   targetColRatio,
   afterTriggerColRatio,
   afterTargetColRatio,
+  isconstantMultipleEnabled,
 }: AutoBuyDetailsLayoutProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
@@ -70,14 +72,21 @@ export function AutoBuyDetailsLayout({
       ) : (
         <Banner
           title={t('auto-buy.banner.header')}
-          description={
+          description={[
             <>
               {t('auto-buy.banner.content')}{' '}
               <AppLink href="https://kb.oasis.app/help/auto-buy-and-auto-sell" sx={{ fontSize: 2 }}>
                 {t('here')}.
               </AppLink>
-            </>
-          }
+            </>,
+            ...(isconstantMultipleEnabled
+              ? [
+                  <Text as="span" sx={{ color: 'primary100', fontWeight: 'semiBold' }}>
+                    {t('auto-buy.banner.cm-warning')}
+                  </Text>,
+                ]
+              : []),
+          ]}
           image={{
             src: '/static/img/setup-banner/auto-buy.svg',
             backgroundColor: bannerGradientPresets.autoBuy[0],
@@ -91,6 +100,7 @@ export function AutoBuyDetailsLayout({
               })
             },
             text: t('auto-buy.banner.button'),
+            disabled: isconstantMultipleEnabled,
           }}
         />
       )}

--- a/features/automation/optimization/common/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationDetailsControl.tsx
@@ -26,7 +26,11 @@ export function OptimizationDetailsControl({
 
   return (
     <>
-      <AutoBuyDetailsControl vault={vault} autoBuyTriggerData={autoBuyTriggerData} />
+      <AutoBuyDetailsControl
+        vault={vault}
+        autoBuyTriggerData={autoBuyTriggerData}
+        isconstantMultipleEnabled={constantMultipleTriggerData.isTriggerEnabled}
+      />
       {constantMultipleEnabled && (
         <ConstantMultipleDetailsControl
           vault={vault}

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
@@ -15,18 +15,20 @@ import { useUIChanges } from 'helpers/uiChangesHook'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Grid } from 'theme-ui'
+import { Grid, Text } from 'theme-ui'
 
 interface AutoSellDetailsControlProps {
   vault: Vault
   autoSellTriggerData: AutoBSTriggerData
   isAutoSellActive: boolean
+  isconstantMultipleEnabled: boolean
 }
 
 export function AutoSellDetailsControl({
   vault,
   autoSellTriggerData,
   isAutoSellActive,
+  isconstantMultipleEnabled,
 }: AutoSellDetailsControlProps) {
   const { t } = useTranslation()
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
@@ -84,14 +86,21 @@ export function AutoSellDetailsControl({
       ) : (
         <Banner
           title={t('auto-sell.banner.header')}
-          description={
+          description={[
             <>
               {t('auto-sell.banner.content')}{' '}
               <AppLink href="https://kb.oasis.app/help/auto-buy-and-auto-sell" sx={{ fontSize: 2 }}>
                 {t('here')}.
               </AppLink>
-            </>
-          }
+            </>,
+            ...(isconstantMultipleEnabled
+              ? [
+                  <Text as="span" sx={{ color: 'primary100', fontWeight: 'semiBold' }}>
+                    {t('auto-sell.banner.cm-warning')}
+                  </Text>,
+                ]
+              : []),
+          ]}
           image={{
             src: '/static/img/setup-banner/auto-sell.svg',
             backgroundColor: bannerGradientPresets.autoSell[0],
@@ -105,6 +114,7 @@ export function AutoSellDetailsControl({
               })
             },
             text: t('auto-sell.banner.button'),
+            disabled: isconstantMultipleEnabled,
           }}
         />
       )}

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -155,6 +155,7 @@ export function SidebarSetupAutoSell({
     disabled: isDropdownDisabled({ stage }),
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
+    isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
   })
 
   if (isAutoSellActive) {

--- a/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
@@ -18,7 +18,11 @@ interface ProtectionDetailsControlProps {
 }
 
 export function ProtectionDetailsControl({ vault, ilkData }: ProtectionDetailsControlProps) {
-  const { stopLossTriggerData, autoSellTriggerData } = useAutomationContext()
+  const {
+    stopLossTriggerData,
+    autoSellTriggerData,
+    constantMultipleTriggerData,
+  } = useAutomationContext()
 
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const autoBSEnabled = useFeatureToggle('BasicBS')
@@ -43,6 +47,7 @@ export function ProtectionDetailsControl({ vault, ilkData }: ProtectionDetailsCo
           vault={vault}
           autoSellTriggerData={autoSellTriggerData}
           isAutoSellActive={isAutoSellActive}
+          isconstantMultipleEnabled={constantMultipleTriggerData.isTriggerEnabled}
         />
       )}
     </>

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -130,6 +130,7 @@ export function SidebarSetupStopLoss({
     disabled: isDropdownDisabled({ stage }),
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
+    isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
   })
 
   const cancelStopLossWarnings = extractCancelBSWarnings(warnings)

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1499,6 +1499,7 @@
     "banner": {
       "header": "Stop scrambling to manage a position",
       "content": "Get peace of mind and setup Auto-Sell to automatically protect your Vault. Sell collateral to repay your debt when you most need it. Find out more about how this works",
+      "cm-warning": "Auto-Sell cannot be used if you have Constant Multiple enabled.",
       "button": "Setup Auto-Sell"
     }
   },
@@ -1544,6 +1545,7 @@
     "banner": {
       "header": "Stop missing buying opportunities",
       "content": "Setup Auto-Buy to automatically buy additional collateral with your Vaults debt when the price of your collateral is increasing so you never miss a buying opportunity again. Find out more about how this works",
+      "cm-warning": "Auto-Buy cannot be used if you have Constant Multiple enabled.",
       "button": "Setup Auto-Buy"
     },
     "setting-auto-buy": "Setting up your Auto-Buy",


### PR DESCRIPTION
# [Disable access to Auto-sell and Auto-buy UI when Constant Multiple is enabled](https://app.shortcut.com/oazo-apps/story/6042/disable-auto-buy-and-auto-sell-banners-when-user-has-active-constant-multiple)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- Updated `Banner` component so it accepts more than one paragraph of text with nice spacing between then,
- updated `getAutoFeaturesSidebarDropdown` method to not display Auto-buy and Auto-sell options if Constant Multiple is enabled, also do not display any dropdown if it would have only one item,
- disabled CTA buttons in Auto-buy and Auto-sell banners and added explanation messages to them why they are disabled.

![image](https://user-images.githubusercontent.com/16230404/190108070-44cde836-dd1c-422f-bbb6-712d9c255871.png)
  
## How to test 🧪

Test on a vault with and without Constant Multiple enabled if you can get access to Auto-sell and Auto-buy UI.
