### PR TITLE
disable proxy creation

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -35,7 +35,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   ConstantMultiple: true,
   ConstantMultipleReadOnly: false,
   DisableSidebarScroll: false,
-  ProxyCreationDisabled: false,
+  ProxyCreationDisabled: true,
   // your feature here....
 }
 


### PR DESCRIPTION
disables proxy creation - used to prevent reorg consequences with transactions send to new proxys that later end up being someone else's around merge time