### PR TITLE
Fix Stop-loss UI display

### DIFF
--- a/components/dumb/SliderValuePicker.tsx
+++ b/components/dumb/SliderValuePicker.tsx
@@ -1,7 +1,7 @@
 import { Box, Grid, Slider, Text } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
 import React from 'react'
-import { SxStyleProp, useThemeUI } from 'theme-ui'
+import { Flex, SxStyleProp, useThemeUI } from 'theme-ui'
 
 export interface SliderValuePickerProps {
   sliderPercentageFill: BigNumber
@@ -14,8 +14,8 @@ export interface SliderValuePickerProps {
   maxBoundry: BigNumber
   lastValue: BigNumber
   disabled: boolean
-  leftBoundryStyling: SxStyleProp
-  rightBoundryStyling: SxStyleProp
+  leftBoundryStyling?: SxStyleProp
+  rightBoundryStyling?: SxStyleProp
   step: number
   leftLabel?: string
   rightLabel?: string
@@ -36,27 +36,28 @@ export function SliderValuePicker(props: SliderValuePickerProps) {
 
   return (
     <Grid gap={2}>
-      <Box>
-        <Grid
-          columns={2}
-          gap={2}
-          sx={{
-            variant: 'text.paragraph4',
-            justifyContent: 'space-between',
-            fontWeight: 'semiBold',
-            color: 'neutral80',
-          }}
-        >
-          <Text>{props.leftLabel}</Text>
-          <Text>{props.rightLabel}</Text>
-          <Text variant="paragraph1" sx={{ fontWeight: 'semiBold' }}>
+      <Flex
+        sx={{
+          variant: 'text.paragraph4',
+          justifyContent: 'space-between',
+          fontWeight: 'semiBold',
+          color: 'neutral80',
+          alignItems: 'flex-end',
+        }}
+      >
+        <Grid gap={2}>
+          {props.leftLabel && <Text as="span">{props.leftLabel}</Text>}
+          <Text as="span" variant="boldParagraph1" sx={props.leftBoundryStyling}>
             {props.leftBoundryFormatter(props.leftBoundry)}
           </Text>
-          <Text variant="paragraph1" sx={props.leftBoundryStyling}>
+        </Grid>
+        <Grid gap={2} sx={{ textAlign: 'right' }}>
+          {props.rightLabel && <Text as="span">{props.rightLabel}</Text>}
+          <Text as="span" variant="boldParagraph1" sx={props.rightBoundryStyling}>
             {props.rightBoundryFormatter(props.rightBoundry)}
           </Text>
         </Grid>
-      </Box>
+      </Flex>
       <Box my={1}>
         <Slider
           sx={{ ...props.rightBoundryStyling, background }}

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -17,6 +17,7 @@ import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { zero } from 'helpers/zero'
+import { useTranslation } from 'next-i18next'
 
 export type OpenVaultStopLossLevelChange = {
   kind: 'stopLossLevel'
@@ -70,6 +71,8 @@ export function getDataForStopLoss(
   },
   feature: 'borrow' | 'multiply',
 ) {
+  const { t } = useTranslation()
+
   const {
     token,
     priceInfo: { currentEthPrice, nextCollateralPrice },
@@ -137,6 +140,8 @@ export function getDataForStopLoss(
     sliderConfig: {
       ...stopLossSliderBasicConfig,
       sliderPercentageFill,
+      leftLabel: t('slider.set-stoploss.left-label'),
+      rightLabel: t('slider.set-stoploss.right-label'),
       leftBoundry: stopLossLevel,
       rightBoundry: afterNewLiquidationPrice,
       lastValue: stopLossLevel,

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -176,8 +176,6 @@ export function SidebarAdjustStopLossEditingStage({
     .times(100)
     .decimalPlaces(0, BigNumber.ROUND_DOWN)
 
-  console.log(sliderConfig)
-
   return (
     <>
       {!vault.debt.isZero() ? (

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -176,6 +176,8 @@ export function SidebarAdjustStopLossEditingStage({
     .times(100)
     .decimalPlaces(0, BigNumber.ROUND_DOWN)
 
+  console.log(sliderConfig)
+
   return (
     <>
       {!vault.debt.isZero() ? (
@@ -187,11 +189,7 @@ export function SidebarAdjustStopLossEditingStage({
               {t('here')}.
             </AppLink>
           </Text>
-          <SliderValuePicker
-            {...sliderConfig}
-            leftLabel={t('slider.set-stoploss.left-label')}
-            rightLabel={t('slider.set-stoploss.right-label')}
-          />
+          <SliderValuePicker {...sliderConfig} />
         </Grid>
       ) : (
         <SidebarFormInfo

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -162,6 +162,8 @@ export function SidebarSetupStopLoss({
   const sliderConfig: SliderValuePickerProps = {
     ...stopLossSliderBasicConfig,
     sliderPercentageFill,
+    leftLabel: t('slider.set-stoploss.left-label'),
+    rightLabel: t('slider.set-stoploss.right-label'),
     leftBoundry: stopLossState.stopLossLevel,
     rightBoundry: afterNewLiquidationPrice,
     lastValue: stopLossState.stopLossLevel,

--- a/features/automation/protection/stopLoss/sliderConfig.ts
+++ b/features/automation/protection/stopLoss/sliderConfig.ts
@@ -1,16 +1,9 @@
 import BigNumber from 'bignumber.js'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
-import { SxStyleProp } from 'theme-ui'
 
 export const stopLossSliderBasicConfig = {
   disabled: false,
   leftBoundryFormatter: (x: BigNumber) => (x.isZero() ? '-' : formatPercent(x)),
-  leftBoundryStyling: { fontWeight: 'semiBold', textAlign: 'right' } as SxStyleProp,
   rightBoundryFormatter: (x: BigNumber) => (x.isZero() ? '-' : '$ ' + formatAmount(x, 'USD')),
-  rightBoundryStyling: {
-    fontWeight: 'semiBold',
-    textAlign: 'right',
-    color: 'primary100',
-  } as SxStyleProp,
   step: 1,
 }

--- a/features/earn/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/earn/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -236,12 +236,6 @@ function SettingMultipleView({ state, send }: OpenAaveStateProps) {
           maxBoundry={maxRisk}
           lastValue={state.context.multiply!}
           disabled={false}
-          leftBoundryStyling={{ fontWeight: 'semiBold', textAlign: 'right' }}
-          rightBoundryStyling={{
-            fontWeight: 'semiBold',
-            textAlign: 'right',
-            color: 'primary100',
-          }}
           step={0.01}
           leftLabel={t('open-earn.aave.vault-form.configure-multiple.liquidation-price')}
         />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -686,7 +686,7 @@
       "right-footer": "Increase risk"
     },
     "set-stoploss": {
-      "left-label": "Stop-Loss coll.ratio",
+      "left-label": "Stop-Loss collateral ratio",
       "right-label": "Dynamic stop price",
       "left-footer": "Bigger loss",
       "right-footer": "More likely execution"


### PR DESCRIPTION
# Fix Stop-loss UI display
  
Before:
![image](https://user-images.githubusercontent.com/16230404/190397350-030cd173-c90c-4956-b2ef-19afcc2d2f3e.png)
After:
![image](https://user-images.githubusercontent.com/16230404/190397387-83c8241f-493d-42bf-811b-c9878d137b78.png)


## Changes 👷‍♀️

- Brought back previous html structure as it is the same in rest of the sliders used in automation features,
- marked `leftBoundryStyling` and `rightBoundryStyling` as optional and removed its usage as all of them were already redundant and duplicated default slider styles,
- added `as` props to `theme.ui` components to fix semantics of slider component,
- fixed styling of a slider so it could be used without right label.
  
## How to test 🧪

Check out pages that uses `SliderValuePicker` component:
- Any vault on Protection tab,
- AAVE stETH: `/earn/open/aave-steth`.
