### PR TITLE
Added AutoBS and CM validation for inputs

### DIFF
--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -154,6 +154,10 @@ export function VaultErrors({
         return translate('stop-loss-trigger-higher-than-auto-buy-target')
       case 'cantSetupAutoBuyOrSellWhenConstantMultipleEnabled':
         return translate('cant-setup-auto-buy-or-sell-when-constant-multiple-enabled', { autoType })
+      case 'minSellPriceWillPreventSellTrigger':
+        return translate('min-sell-price-will-prevent-sell-trigger')
+      case 'maxBuyPriceWillPreventBuyTrigger':
+        return translate('max-buy-price-will-prevent-buy-trigger')
       case 'autoBuyMaxBuyPriceNotSpecified':
         return (
           <Trans

--- a/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
@@ -74,7 +74,14 @@ export function AutoBuyFormControl({
     txStatus: autoBuyState.txDetails?.txStatus,
     vaultController: vault.controller,
   })
-  const { collateralDelta, debtDelta, isDisabled, isEditing, resetData } = getAutoBSStatus({
+  const {
+    collateralDelta,
+    debtDelta,
+    isDisabled,
+    isEditing,
+    resetData,
+    executionPrice,
+  } = getAutoBSStatus({
     autoBSState: autoBuyState,
     autoBSTriggerData: autoBuyTriggerData,
     isAddForm,
@@ -136,6 +143,7 @@ export function AutoBuyFormControl({
           txHandler={txHandler}
           vault={vault}
           vaultType={vaultType}
+          executionPrice={executionPrice}
         />
       )}
     </AddAndRemoveTriggerControl>

--- a/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
@@ -53,6 +53,7 @@ interface SidebarSetupAutoBuyProps {
   isFirstSetup: boolean
   debtDelta: BigNumber
   collateralDelta: BigNumber
+  executionPrice: BigNumber
   isAutoBuyActive: boolean
   feature: AutomationFeatures
 }
@@ -84,6 +85,7 @@ export function SidebarSetupAutoBuy({
 
   debtDelta,
   collateralDelta,
+  executionPrice,
   isAutoBuyActive,
 }: SidebarSetupAutoBuyProps) {
   const gasEstimation = useGasEstimationContext()
@@ -136,6 +138,7 @@ export function SidebarSetupAutoBuy({
     autoSellTriggerData,
     constantMultipleTriggerData,
     isRemoveForm,
+    executionPrice,
   })
   const cancelAutoBuyWarnings = extractCancelBSWarnings(warnings)
   const cancelAutoBuyErrors = extractCancelBSErrors(errors)

--- a/features/automation/optimization/autoBuy/validators.ts
+++ b/features/automation/optimization/autoBuy/validators.ts
@@ -7,6 +7,7 @@ import { ConstantMultipleTriggerData } from 'features/automation/optimization/co
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
 import { warningMessagesHandler } from 'features/form/warningMessagesHandler'
+import { zero } from 'helpers/zero'
 
 export function warningsAutoBuyValidation({
   vault,
@@ -63,11 +64,13 @@ export function errorsAutoBuyValidation({
   autoSellTriggerData,
   constantMultipleTriggerData,
   isRemoveForm,
+  executionPrice,
 }: {
   autoBuyState: AutoBSFormChange
   autoSellTriggerData: AutoBSTriggerData
   constantMultipleTriggerData: ConstantMultipleTriggerData
   isRemoveForm: boolean
+  executionPrice: BigNumber
 }) {
   const { maxBuyOrMinSellPrice, txDetails, withThreshold, execCollRatio } = autoBuyState
   const insufficientEthFundsForTx = ethFundsForTxValidator({ txError: txDetails?.txError })
@@ -82,10 +85,14 @@ export function errorsAutoBuyValidation({
   const cantSetupAutoBuyOrSellWhenConstantMultipleEnabled =
     constantMultipleTriggerData.isTriggerEnabled
 
+  const maxBuyPriceWillPreventBuyTrigger =
+    maxBuyOrMinSellPrice?.gt(zero) && maxBuyOrMinSellPrice.lt(executionPrice)
+
   return errorMessagesHandler({
     insufficientEthFundsForTx,
     autoBuyMaxBuyPriceNotSpecified,
     autoBuyTriggerLowerThanAutoSellTarget,
     cantSetupAutoBuyOrSellWhenConstantMultipleEnabled,
+    maxBuyPriceWillPreventBuyTrigger,
   })
 }

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -36,6 +36,8 @@ import { handleNumericInput } from 'helpers/input'
 import {
   extractConstantMultipleCommonErrors,
   extractConstantMultipleCommonWarnings,
+  extractConstantMultipleMaxBuyErrors,
+  extractConstantMultipleMinSellErrors,
   extractConstantMultipleSliderWarnings,
 } from 'helpers/messageMappers'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
@@ -229,10 +231,7 @@ export function SidebarConstantMultipleEditingStage({
         toggleOffPlaceholder={t('protection.no-threshold')}
         defaultToggle={constantMultipleState?.buyWithThreshold}
       />
-      <VaultErrors
-        errorMessages={errors.filter((item) => item === 'autoBuyMaxBuyPriceNotSpecified')}
-        ilkData={ilkData}
-      />
+      <VaultErrors errorMessages={extractConstantMultipleMaxBuyErrors(errors)} ilkData={ilkData} />
       <VaultWarnings
         warningMessages={warnings.filter((item) => item === 'settingAutoBuyTriggerWithNoThreshold')}
         ilkData={ilkData}
@@ -269,10 +268,7 @@ export function SidebarConstantMultipleEditingStage({
         toggleOffLabel={t('protection.set-threshold')}
         toggleOffPlaceholder={t('protection.no-threshold')}
       />
-      <VaultErrors
-        errorMessages={errors.filter((item) => item === 'minimumSellPriceNotProvided')}
-        ilkData={ilkData}
-      />
+      <VaultErrors errorMessages={extractConstantMultipleMinSellErrors(errors)} ilkData={ilkData} />
       <VaultWarnings
         warningMessages={extractConstantMultipleCommonWarnings(warnings)}
         ilkData={ilkData}

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
@@ -127,6 +127,8 @@ export function SidebarSetupConstantMultiple({
     debtDeltaAfterSell,
     debtFloor: ilkData.debtFloor,
     debt: vault.debt,
+    nextBuyPrice,
+    nextSellPrice,
   })
   const warnings = warningsConstantMultipleValidation({
     vault,

--- a/features/automation/optimization/constantMultiple/validators.ts
+++ b/features/automation/optimization/constantMultiple/validators.ts
@@ -4,6 +4,7 @@ import { ConstantMultipleFormChange } from 'features/automation/optimization/con
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
 import { warningMessagesHandler } from 'features/form/warningMessagesHandler'
+import { zero } from 'helpers/zero'
 
 export function warningsConstantMultipleValidation({
   vault,
@@ -79,6 +80,8 @@ export function errorsConstantMultipleValidation({
   debtFloor,
   debtDeltaAfterSell,
   debtDeltaWhenSellAtCurrentCollRatio,
+  nextBuyPrice,
+  nextSellPrice,
 }: {
   constantMultipleState: ConstantMultipleFormChange
   isRemoveForm: boolean
@@ -86,6 +89,8 @@ export function errorsConstantMultipleValidation({
   debtFloor: BigNumber
   debt: BigNumber
   debtDeltaWhenSellAtCurrentCollRatio: BigNumber
+  nextBuyPrice: BigNumber
+  nextSellPrice: BigNumber
 }) {
   const {
     minSellPrice,
@@ -107,10 +112,16 @@ export function errorsConstantMultipleValidation({
     (debtFloor.gt(debt.plus(debtDeltaAfterSell)) ||
       debtFloor.gt(debt.plus(debtDeltaWhenSellAtCurrentCollRatio)))
 
+  const maxBuyPriceWillPreventBuyTrigger = maxBuyPrice?.gt(zero) && maxBuyPrice.lt(nextBuyPrice)
+  const minSellPriceWillPreventSellTrigger =
+    minSellPrice?.gt(zero) && minSellPrice.gt(nextSellPrice)
+
   return errorMessagesHandler({
     insufficientEthFundsForTx,
     autoBuyMaxBuyPriceNotSpecified,
     minimumSellPriceNotProvided,
     targetCollRatioExceededDustLimitCollRatio,
+    maxBuyPriceWillPreventBuyTrigger,
+    minSellPriceWillPreventSellTrigger,
   })
 }

--- a/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
@@ -76,6 +76,7 @@ export function AutoSellFormControl({
     isDisabled,
     isEditing,
     resetData,
+    executionPrice,
   } = getAutoBSStatus({
     autoBSState: autoSellState,
     autoBSTriggerData: autoSellTriggerData,
@@ -137,6 +138,7 @@ export function AutoSellFormControl({
           textButtonHandler={textButtonHandler}
           txHandler={txHandler}
           vault={vault}
+          executionPrice={executionPrice}
         />
       )}
     </AddAndRemoveTriggerControl>

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -53,6 +53,7 @@ interface SidebarSetupAutoSellProps {
   debtDelta: BigNumber
   debtDeltaAtCurrentCollRatio: BigNumber
   collateralDelta: BigNumber
+  executionPrice: BigNumber
   feature: AutomationFeatures
 }
 
@@ -84,6 +85,7 @@ export function SidebarSetupAutoSell({
   debtDelta,
   debtDeltaAtCurrentCollRatio,
   collateralDelta,
+  executionPrice,
 }: SidebarSetupAutoSellProps) {
   const gasEstimation = useGasEstimationContext()
 
@@ -135,6 +137,7 @@ export function SidebarSetupAutoSell({
     ilkData,
     vault,
     debtDelta,
+    executionPrice,
     debtDeltaAtCurrentCollRatio,
     autoSellState,
     autoBuyTriggerData,

--- a/features/automation/protection/autoSell/validators.ts
+++ b/features/automation/protection/autoSell/validators.ts
@@ -8,6 +8,7 @@ import { ConstantMultipleTriggerData } from 'features/automation/optimization/co
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { errorMessagesHandler } from 'features/form/errorMessagesHandler'
 import { warningMessagesHandler } from 'features/form/warningMessagesHandler'
+import { zero } from 'helpers/zero'
 
 export function warningsAutoSellValidation({
   vault,
@@ -67,6 +68,7 @@ export function errorsAutoSellValidation({
   vault,
   ilkData,
   debtDelta,
+  executionPrice,
   debtDeltaAtCurrentCollRatio,
   isRemoveForm,
   autoSellState,
@@ -76,6 +78,7 @@ export function errorsAutoSellValidation({
   vault: Vault
   ilkData: IlkData
   debtDelta: BigNumber
+  executionPrice: BigNumber
   debtDeltaAtCurrentCollRatio: BigNumber
   isRemoveForm: boolean
   autoSellState: AutoBSFormChange
@@ -107,11 +110,15 @@ export function errorsAutoSellValidation({
   const cantSetupAutoBuyOrSellWhenConstantMultipleEnabled =
     constantMultipleTriggerData.isTriggerEnabled
 
+  const minSellPriceWillPreventSellTrigger =
+    maxBuyOrMinSellPrice?.gt(zero) && maxBuyOrMinSellPrice.gt(executionPrice)
+
   return errorMessagesHandler({
     insufficientEthFundsForTx,
     targetCollRatioExceededDustLimitCollRatio,
     minimumSellPriceNotProvided,
     autoSellTriggerHigherThanAutoBuyTarget,
     cantSetupAutoBuyOrSellWhenConstantMultipleEnabled,
+    minSellPriceWillPreventSellTrigger,
   })
 }

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -44,6 +44,8 @@ export type VaultErrorMessage =
   | 'autoBuyTriggerLowerThanAutoSellTarget'
   | 'stopLossTriggerHigherThanAutoBuyTarget'
   | 'cantSetupAutoBuyOrSellWhenConstantMultipleEnabled'
+  | 'minSellPriceWillPreventSellTrigger'
+  | 'maxBuyPriceWillPreventBuyTrigger'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -90,6 +92,8 @@ interface ErrorMessagesHandler {
   autoBuyTriggerLowerThanAutoSellTarget?: boolean
   stopLossTriggerHigherThanAutoBuyTarget?: boolean
   cantSetupAutoBuyOrSellWhenConstantMultipleEnabled?: boolean
+  minSellPriceWillPreventSellTrigger?: boolean
+  maxBuyPriceWillPreventBuyTrigger?: boolean
 }
 
 export function errorMessagesHandler({
@@ -137,6 +141,8 @@ export function errorMessagesHandler({
   autoBuyTriggerLowerThanAutoSellTarget,
   stopLossTriggerHigherThanAutoBuyTarget,
   cantSetupAutoBuyOrSellWhenConstantMultipleEnabled,
+  minSellPriceWillPreventSellTrigger,
+  maxBuyPriceWillPreventBuyTrigger,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -313,6 +319,14 @@ export function errorMessagesHandler({
 
   if (cantSetupAutoBuyOrSellWhenConstantMultipleEnabled) {
     errorMessages.push('cantSetupAutoBuyOrSellWhenConstantMultipleEnabled')
+  }
+
+  if (minSellPriceWillPreventSellTrigger) {
+    errorMessages.push('minSellPriceWillPreventSellTrigger')
+  }
+
+  if (maxBuyPriceWillPreventBuyTrigger) {
+    errorMessages.push('maxBuyPriceWillPreventBuyTrigger')
   }
 
   return errorMessages

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -131,3 +131,21 @@ const constantMultipleCommonErrors = ['insufficientEthFundsForTx']
 export function extractConstantMultipleCommonErrors(errorMessages: VaultErrorMessage[]) {
   return errorMessages.filter((message) => constantMultipleCommonErrors.includes(message))
 }
+
+const constantMultipleMaxBuyInputErrors = [
+  'maxBuyPriceWillPreventBuyTrigger',
+  'autoBuyMaxBuyPriceNotSpecified',
+]
+
+export function extractConstantMultipleMaxBuyErrors(errorMessages: VaultErrorMessage[]) {
+  return errorMessages.filter((message) => constantMultipleMaxBuyInputErrors.includes(message))
+}
+
+const constantMultipleMinSellInputErrors = [
+  'minSellPriceWillPreventSellTrigger',
+  'minimumSellPriceNotProvided',
+]
+
+export function extractConstantMultipleMinSellErrors(errorMessages: VaultErrorMessage[]) {
+  return errorMessages.filter((message) => constantMultipleMinSellInputErrors.includes(message))
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -886,7 +886,9 @@
     "auto-sell-trigger-higher-than-auto-buy-target": "Setting your an Auto-Sell trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",
     "stop-loss-trigger-higher-than-auto-buy-target": "Setting your an Stop-Loss trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first",
     "auto-buy-trigger-lower-than-auto-sell-target": "Setting your an Auto-Buy trigger at this level could result in it being executed by your Auto-Sell. Please adjust your Auto-Sell Target ratio first",
-    "cant-setup-auto-buy-or-sell-when-constant-multiple-enabled": "You cannot set up an {{autoType}} if you have an existing Constant Multiple set up. Please remove your Constant Multiple before continuing."
+    "cant-setup-auto-buy-or-sell-when-constant-multiple-enabled": "You cannot set up an {{autoType}} if you have an existing Constant Multiple set up. Please remove your Constant Multiple before continuing.",
+    "min-sell-price-will-prevent-sell-trigger": "This Min Sell Price will prevent the Sell Trigger from executing",
+    "max-buy-price-will-prevent-buy-trigger": "This Max Buy Price will prevent the Buy Trigger from executing"
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",


### PR DESCRIPTION
# [Added AutoBS and CM validation for inputs](https://app.shortcut.com/oazo-apps/story/6067/cb-ab-as-validating-max-buy-and-min-sell-price-when-setting-up-cm-trigger-to-ensure-trigger-will-execute)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added validation to AutoBS and CM forms for max buy price and min sell price inputs which verify whether trigger will be eligible for execution 
  
## How to test 🧪
  <Please explain how to test your changes>

- in AutoBS and CM forms try to setup different values in inputs and see wether errors about eligibility are shown
