### PR TITLE
Auto-Take Profit Overview Box

### DIFF
--- a/components/vault/detailsSection/ContentCardTriggerColPrice.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColPrice.tsx
@@ -1,0 +1,50 @@
+import BigNumber from 'bignumber.js'
+import {
+  ChangeVariantType,
+  ContentCardProps,
+  DetailsSectionContentCard,
+} from 'components/DetailsSectionContentCard'
+import { formatAmount } from 'helpers/formatters/format'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+interface ContentCardTriggerColPriceProps {
+  token: string
+  triggerColPrice?: BigNumber
+  afterTriggerColPrice?: BigNumber
+  estimatedProfit?: BigNumber
+  changeVariant?: ChangeVariantType
+}
+
+export function ContentCardTriggerColPrice({
+  token,
+  triggerColPrice,
+  afterTriggerColPrice,
+  estimatedProfit,
+  changeVariant,
+}: ContentCardTriggerColPriceProps) {
+  const { t } = useTranslation()
+
+  const formatted = {
+    triggerColPrice: triggerColPrice && `$${formatAmount(triggerColPrice, 'USD')}`,
+    afterTriggerColPrice: afterTriggerColPrice && `$${formatAmount(afterTriggerColPrice, 'USD')}`,
+    estimatedProfit: estimatedProfit && `$${formatAmount(estimatedProfit, 'USD')}`,
+  }
+
+  const contentCardSettings: ContentCardProps = {
+    title: t('auto-take-profit.trigger-col-price', { token }),
+  }
+
+  if (triggerColPrice) contentCardSettings.value = formatted.triggerColPrice
+  if (afterTriggerColPrice && changeVariant)
+    contentCardSettings.change = {
+      value: `${formatted.afterTriggerColPrice} ${t('system.cards.common.after')}`,
+      variant: changeVariant,
+    }
+  if (estimatedProfit)
+    contentCardSettings.footnote = t('auto-take-profit.estimated-profit', {
+      amount: formatted.estimatedProfit,
+    })
+
+  return <DetailsSectionContentCard {...contentCardSettings} />
+}

--- a/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
@@ -1,0 +1,60 @@
+import BigNumber from 'bignumber.js'
+import {
+  ChangeVariantType,
+  ContentCardProps,
+  DetailsSectionContentCard,
+} from 'components/DetailsSectionContentCard'
+import { formatPercent } from 'helpers/formatters/format'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+interface ContentCardTriggerColRatioProps {
+  triggerColRatio?: BigNumber
+  afterTriggerColRatio?: BigNumber
+  currentColRatio: BigNumber
+  changeVariant?: ChangeVariantType
+}
+
+export function ContentCardTriggerColRatio({
+  triggerColRatio,
+  afterTriggerColRatio,
+  currentColRatio,
+  changeVariant,
+}: ContentCardTriggerColRatioProps) {
+  const { t } = useTranslation()
+
+  const formatted = {
+    triggerColRatio:
+      triggerColRatio &&
+      formatPercent(triggerColRatio, {
+        precision: 2,
+        roundMode: BigNumber.ROUND_DOWN,
+      }),
+    afterTriggerColRatio:
+      afterTriggerColRatio &&
+      formatPercent(afterTriggerColRatio, {
+        precision: 2,
+        roundMode: BigNumber.ROUND_DOWN,
+      }),
+    currentColRatio: formatPercent(currentColRatio, {
+      precision: 2,
+      roundMode: BigNumber.ROUND_DOWN,
+    }),
+  }
+
+  const contentCardSettings: ContentCardProps = {
+    title: t('auto-take-profit.trigger-col-ratio'),
+  }
+
+  if (triggerColRatio) contentCardSettings.value = formatted.triggerColRatio
+  if (afterTriggerColRatio && changeVariant)
+    contentCardSettings.change = {
+      value: `${formatted.afterTriggerColRatio} ${t('system.cards.common.after')}`,
+      variant: changeVariant,
+    }
+  contentCardSettings.footnote = t('auto-take-profit.current-col-ratio', {
+    amount: formatted.currentColRatio,
+  })
+
+  return <DetailsSectionContentCard {...contentCardSettings} />
+}

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -16,17 +16,26 @@ export function AutoTakeProfitDetailsControl({ vault }: AutoTakeProfitDetailsCon
   const triggerColPrice = new BigNumber(1904)
   const afterTriggerColPrice = new BigNumber(1964)
   const estimatedProfit = new BigNumber(399040200)
-  // TODO: TDAutoTakeProfit | to be replaced with data from checkIfIsEditingAutoTakeProfit
-  const isEditing = false
+  const triggerColRatio = new BigNumber(210.37)
+  const afterTriggerColRatio = new BigNumber(222.32)
+  // TODO: TDAutoTakeProfit | commented out due to not being used right now
+  // const isEditing = false
 
   const autoTakeProfitDetailsLayoutOptionalParams = {
-    ...(isTriggerEnabled && {
-      triggerColPrice,
-      estimatedProfit,
-    }),
-    ...(isEditing && {
-      afterTriggerColPrice,
-    }),
+    // TODO: TDAutoTakeProfit | shoule be passed only when trigger is enabled, can't be done in current state because var is always false and it causes typescript error
+    // Spread types may only be created from object types.ts(2698)
+    // ...(isTriggerEnabled && {
+    triggerColPrice,
+    estimatedProfit,
+    triggerColRatio,
+    // }),
+    // TODO: TDAutoTakeProfit | shoule be passed only when is in editing stage, can't be done in current state because var is always false and it causes typescript error
+    // Spread types may only be created from object types.ts(2698)
+    // ...(isEditing && {
+    afterTriggerColPrice,
+    afterTriggerColRatio,
+    // }),
+    currentColRatio: vault.collateralizationRatio.times(100),
   }
 
   if (isDebtZero) return null

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -1,4 +1,3 @@
-import { Grid } from '@theme-ui/components'
 import { Vault } from 'blockchain/vaults'
 import React from 'react'
 
@@ -9,9 +8,8 @@ interface AutoTakeProfitDetailsControlProps {
 }
 
 export function AutoTakeProfitDetailsControl({ vault }: AutoTakeProfitDetailsControlProps) {
-  return (
-    <Grid>
-      <AutoTakeProfitDetailsLayout token={vault.token} />
-    </Grid>
-  )
+  //TODO: TDAutoTakeProfit | to be replaced with data from autoTakeProfitTriggerData when its available
+  const isTriggerEnabled = false
+
+  return <AutoTakeProfitDetailsLayout isTriggerEnabled={isTriggerEnabled} token={vault.token} />
 }

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { Vault } from 'blockchain/vaults'
 import React from 'react'
 
@@ -8,8 +9,33 @@ interface AutoTakeProfitDetailsControlProps {
 }
 
 export function AutoTakeProfitDetailsControl({ vault }: AutoTakeProfitDetailsControlProps) {
-  //TODO: TDAutoTakeProfit | to be replaced with data from autoTakeProfitTriggerData when its available
+  const isDebtZero = vault.debt.isZero()
+  // TODO: TDAutoTakeProfit | to be replaced with data from autoTakeProfitTriggerData or autoTakeProfitState
+  // or from calculations based on those states
   const isTriggerEnabled = false
+  const triggerColPrice = new BigNumber(1904)
+  const afterTriggerColPrice = new BigNumber(1964)
+  const estimatedProfit = new BigNumber(399040200)
+  // TODO: TDAutoTakeProfit | to be replaced with data from checkIfIsEditingAutoTakeProfit
+  const isEditing = false
 
-  return <AutoTakeProfitDetailsLayout isTriggerEnabled={isTriggerEnabled} token={vault.token} />
+  const autoTakeProfitDetailsLayoutOptionalParams = {
+    ...(isTriggerEnabled && {
+      triggerColPrice,
+      estimatedProfit,
+    }),
+    ...(isEditing && {
+      afterTriggerColPrice,
+    }),
+  }
+
+  if (isDebtZero) return null
+
+  return (
+    <AutoTakeProfitDetailsLayout
+      isTriggerEnabled={isTriggerEnabled}
+      token={vault.token}
+      {...autoTakeProfitDetailsLayoutOptionalParams}
+    />
+  )
 }

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
@@ -51,8 +51,8 @@ export function AutoTakeProfitDetailsLayout({
               <ContentCardTriggerColPrice
                 token={token}
                 triggerColPrice={triggerColPrice}
-                afterTriggerColPrice={estimatedProfit}
-                estimatedProfit={afterTriggerColPrice}
+                afterTriggerColPrice={afterTriggerColPrice}
+                estimatedProfit={estimatedProfit}
                 changeVariant="positive"
               />
               <ContentCardTriggerColRatio

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
@@ -15,11 +15,17 @@ import { Grid } from 'theme-ui'
 
 export interface AutoTakeProfitDetailsLayoutProps {
   isTriggerEnabled: boolean
+  triggerColPrice?: BigNumber
+  estimatedProfit?: BigNumber
+  afterTriggerColPrice?: BigNumber
   token: string
 }
 
 export function AutoTakeProfitDetailsLayout({
   isTriggerEnabled,
+  triggerColPrice,
+  estimatedProfit,
+  afterTriggerColPrice,
   token,
 }: AutoTakeProfitDetailsLayoutProps) {
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
@@ -37,11 +43,10 @@ export function AutoTakeProfitDetailsLayout({
             <DetailsSectionContentCardWrapper>
               <ContentCardTriggerColPrice
                 token={token}
-                //TODO: TDAutoTakeProfit | to be replaced with data from state
-                triggerColPrice={new BigNumber(1904)}
-                afterTriggerColPrice={new BigNumber(1964)}
-                estimatedProfit={new BigNumber(399040200)}
-                changeVariant='positive'
+                triggerColPrice={triggerColPrice}
+                afterTriggerColPrice={estimatedProfit}
+                estimatedProfit={afterTriggerColPrice}
+                changeVariant="positive"
               />
             </DetailsSectionContentCardWrapper>
           }

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
@@ -4,6 +4,7 @@ import { Banner, bannerGradientPresets } from 'components/Banner'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { ContentCardTriggerColPrice } from 'components/vault/detailsSection/ContentCardTriggerColPrice'
+import { ContentCardTriggerColRatio } from 'components/vault/detailsSection/ContentCardTriggerColRatio'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
@@ -18,6 +19,9 @@ export interface AutoTakeProfitDetailsLayoutProps {
   triggerColPrice?: BigNumber
   estimatedProfit?: BigNumber
   afterTriggerColPrice?: BigNumber
+  triggerColRatio?: BigNumber
+  afterTriggerColRatio?: BigNumber
+  currentColRatio: BigNumber
   token: string
 }
 
@@ -26,6 +30,9 @@ export function AutoTakeProfitDetailsLayout({
   triggerColPrice,
   estimatedProfit,
   afterTriggerColPrice,
+  triggerColRatio,
+  afterTriggerColRatio,
+  currentColRatio,
   token,
 }: AutoTakeProfitDetailsLayoutProps) {
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
@@ -46,6 +53,12 @@ export function AutoTakeProfitDetailsLayout({
                 triggerColPrice={triggerColPrice}
                 afterTriggerColPrice={estimatedProfit}
                 estimatedProfit={afterTriggerColPrice}
+                changeVariant="positive"
+              />
+              <ContentCardTriggerColRatio
+                triggerColRatio={triggerColRatio}
+                afterTriggerColRatio={afterTriggerColRatio}
+                currentColRatio={currentColRatio}
                 changeVariant="positive"
               />
             </DetailsSectionContentCardWrapper>

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsLayout.tsx
@@ -1,8 +1,9 @@
+import BigNumber from 'bignumber.js'
 import { useAppContext } from 'components/AppContextProvider'
 import { Banner, bannerGradientPresets } from 'components/Banner'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
-import { AppLink } from 'components/Links'
+import { ContentCardTriggerColPrice } from 'components/vault/detailsSection/ContentCardTriggerColPrice'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
@@ -13,39 +14,42 @@ import React from 'react'
 import { Grid } from 'theme-ui'
 
 export interface AutoTakeProfitDetailsLayoutProps {
+  isTriggerEnabled: boolean
   token: string
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function AutoTakeProfitDetailsLayout({ token }: AutoTakeProfitDetailsLayoutProps) {
+export function AutoTakeProfitDetailsLayout({
+  isTriggerEnabled,
+  token,
+}: AutoTakeProfitDetailsLayoutProps) {
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
 
   return (
     <Grid>
-      {activeAutomationFeature?.currentOptimizationFeature === 'autoTakeProfit' ? (
+      {isTriggerEnabled ||
+      activeAutomationFeature?.currentOptimizationFeature === 'autoTakeProfit' ? (
         <DetailsSection
           title={t('auto-take-profit.title')}
-          badge={false}
+          badge={isTriggerEnabled}
           content={
             <DetailsSectionContentCardWrapper>
-              {/* TODO -ŁW details TBD */}
-              {/* <DetailsSectionContentCard title={t('example')} /> */}
+              <ContentCardTriggerColPrice
+                token={token}
+                //TODO: TDAutoTakeProfit | to be replaced with data from state
+                triggerColPrice={new BigNumber(1904)}
+                afterTriggerColPrice={new BigNumber(1964)}
+                estimatedProfit={new BigNumber(399040200)}
+                changeVariant='positive'
+              />
             </DetailsSectionContentCardWrapper>
           }
         />
       ) : (
         <Banner
           title={t('auto-take-profit.banner.header')}
-          description={
-            <>
-              {t('auto-take-profit.banner.content')}{' '}
-              <AppLink href="https://kb.oasis.app/help/auto-buy-and-auto-sell" sx={{ fontSize: 2 }}>
-                {t('here')}.
-              </AppLink>
-            </>
-          }
+          description={t('auto-take-profit.banner.content')}
           image={{
             src: '/static/img/setup-banner/auto-buy.svg',
             backgroundColor: bannerGradientPresets.autoTakeProfit[0],

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1562,9 +1562,13 @@
     "form-title": "Auto-Take Profit Setup",
     "banner": {
       "header": "Set up Auto-Take Profit",
-      "content": "Auto-Take Profit allows you to set up an exit strategy that will automatically close your vault and take profits when your collateral hits your target price",
+      "content": "Auto-Take Profit allows you to set up an exit strategy that will automatically close your vault and take profits when your collateral hits your target price.",
       "button": "Setup Auto-Take Profit"
-    }
+    },
+    "trigger-col-price": "Trigger {{token}} Price",
+    "estimated-profit": "Estimated Profit at close {{amount}}",
+    "trigger-col-ratio": "Trigger Collateral Ratio",
+    "current-col-ratio": "Current Collateral Ratio {{amount}}"
   },
 
   "automation": {


### PR DESCRIPTION
# [Auto-Take Profit Overview Box](https://app.shortcut.com/oazo-apps/story/5514/ui-auto-take-profit-overview-box)

Does not include getting data from any data source since none of them exist at this point, but already assumes some logic that could be used when data is available.
Does not include popups, they are in the scope of different story.
![image](https://user-images.githubusercontent.com/16230404/190626633-ef9e37a3-ba7c-4889-bca1-dbc84e060fc9.png)
  
## Changes 👷‍♀️

- Created `ContentCardTriggerColPrice` and `ContentCardTriggerColRatio` components,
- added some boilerplate logic to Auto take profit details controller.
  
## How to test 🧪

Check out Optimization tab on vault page with `AutoTakeProfit` feature flag enabled.
