### PR TITLE
fix wstETH-B automation support

### DIFF
--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -669,7 +669,7 @@ const ALLOWED_AUTOMATION_ILKS: Record<string, string[]> = {
     'WBTC-B',
     'WBTC-C',
     'WSTETH-A',
-    'WSTETH-C',
+    'WSTETH-B',
     'RENBTC-A',
     'YFI-A',
     'UNI-A',

--- a/features/notifications/types.ts
+++ b/features/notifications/types.ts
@@ -7,9 +7,9 @@ export enum NotificationTypes {
   APPROACHING_AUTO_SELL = 6,
   APPROACHING_LIQUIDATION = 7,
   APPROACHING_STOP_LOSS = 8,
-  ORACLE_PRICE_CHANGED = 9,//not existing yet
-  CONSTANT_MULTIPLE_TRIGGERED = 10,//not existing yet
-  APPROACHING_CONSTANT_MULTIPLE = 11,//not existing yet
+  ORACLE_PRICE_CHANGED = 9, //not existing yet
+  CONSTANT_MULTIPLE_TRIGGERED = 10, //not existing yet
+  APPROACHING_CONSTANT_MULTIPLE = 11, //not existing yet
 }
 
 export enum NotificationSubscriptionTypes {


### PR DESCRIPTION
Automation is now not on for wstETH-B vaults, see: https://oasis.app/29519#overview

It does work (and is on) for wstETH-A vaults, see: https://oasis.app/27564#overview

#  https://app.shortcut.com/oazo-apps/story/6083/bug-automations-are-not-available-on-wsteth-b-vaults
  
## How to test 🧪

Automation is now also on for wstETH-B vaults, check on staging for example: https://staging.oasis.app/29519#overview
