### PR TITLE
Auto-Take Profit Overview Box - Pop-ups

### DIFF
--- a/components/vault/detailsSection/ContentCardTriggerColPrice.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColPrice.tsx
@@ -7,6 +7,7 @@ import {
 import { formatAmount } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { Grid, Heading, Text } from 'theme-ui'
 
 interface ContentCardTriggerColPriceProps {
   token: string
@@ -14,6 +15,24 @@ interface ContentCardTriggerColPriceProps {
   afterTriggerColPrice?: BigNumber
   estimatedProfit?: BigNumber
   changeVariant?: ChangeVariantType
+}
+interface ContentCardTriggerColPriceModalProps {
+  token: string
+}
+
+function ContentCardTriggerColPriceModal({ token }: ContentCardTriggerColPriceModalProps) {
+  const { t } = useTranslation()
+  return (
+    <Grid gap={2}>
+      <Heading variant="header3">{t('auto-take-profit.trigger-col-price', { token })}</Heading>
+      <Text as="p" variant="paragraph2">
+        {t('auto-take-profit.trigger-col-price-explanation', { token })}
+      </Text>
+      <Text as="p" variant="paragraph2">
+        {t('auto-take-profit.estimated-profit-explanation', { token })}
+      </Text>
+    </Grid>
+  )
 }
 
 export function ContentCardTriggerColPrice({
@@ -33,6 +52,7 @@ export function ContentCardTriggerColPrice({
 
   const contentCardSettings: ContentCardProps = {
     title: t('auto-take-profit.trigger-col-price', { token }),
+    modal: <ContentCardTriggerColPriceModal token={token} />,
   }
 
   if (triggerColPrice) contentCardSettings.value = formatted.triggerColPrice

--- a/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
@@ -21,7 +21,9 @@ function ContentCardTriggerColRatioModal() {
   return (
     <Grid gap={2}>
       <Heading variant="header3">{t('auto-take-profit.trigger-col-ratio')}</Heading>
-      <Text as="p" variant="paragraph2">{t('auto-take-profit.trigger-col-ratio-explanation')}</Text>
+      <Text as="p" variant="paragraph2">
+        {t('auto-take-profit.trigger-col-ratio-explanation')}
+      </Text>
     </Grid>
   )
 }

--- a/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardTriggerColRatio.tsx
@@ -7,12 +7,23 @@ import {
 import { formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { Grid, Heading, Text } from 'theme-ui'
 
 interface ContentCardTriggerColRatioProps {
   triggerColRatio?: BigNumber
   afterTriggerColRatio?: BigNumber
   currentColRatio: BigNumber
   changeVariant?: ChangeVariantType
+}
+
+function ContentCardTriggerColRatioModal() {
+  const { t } = useTranslation()
+  return (
+    <Grid gap={2}>
+      <Heading variant="header3">{t('auto-take-profit.trigger-col-ratio')}</Heading>
+      <Text as="p" variant="paragraph2">{t('auto-take-profit.trigger-col-ratio-explanation')}</Text>
+    </Grid>
+  )
 }
 
 export function ContentCardTriggerColRatio({
@@ -44,6 +55,7 @@ export function ContentCardTriggerColRatio({
 
   const contentCardSettings: ContentCardProps = {
     title: t('auto-take-profit.trigger-col-ratio'),
+    modal: <ContentCardTriggerColRatioModal />,
   }
 
   if (triggerColRatio) contentCardSettings.value = formatted.triggerColRatio

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1569,8 +1569,11 @@
       "button": "Setup Auto-Take Profit"
     },
     "trigger-col-price": "Trigger {{token}} Price",
+    "trigger-col-price-explanation": "The price that {{token}} must reach in order to execute the Auto-Take profit.",
     "estimated-profit": "Estimated Profit at close {{amount}}",
+    "estimated-profit-explanation": "Estimated Profit at Close = Collateral value (USD) at trigger - Debt value to be repaid - estimated Tx Fees",
     "trigger-col-ratio": "Trigger Collateral Ratio",
+    "trigger-col-ratio-explanation": "The collateralization ratio that your Vault must reach in order to execute the Auto-Take profit.",
     "current-col-ratio": "Current Collateral Ratio {{amount}}"
   },
 


### PR DESCRIPTION
# [Auto-Take Profit Overview Box - Pop-ups](https://app.shortcut.com/oazo-apps/story/5515/ui-auto-take-profit-overview-box-pop-ups)

![image](https://user-images.githubusercontent.com/16230404/192246455-f0134cc9-edce-4113-a7e7-5eb38bd6a644.png)
![image](https://user-images.githubusercontent.com/16230404/192246490-d3e4c94d-e020-48a1-a512-8bb07f99a997.png)

  
## Changes 👷‍♀️

Added modals to both Auto Take Profit overview cards. I took the liberty of changing title a little bit from "[Col. asset] Price Trigger" to "Trigger [Col. asset] Price" so I can reuse title from the card which is basically the same.
  
## How to test 🧪

Go to Optimization tab and see if you can open modals on overview cards.
