### PR TITLE
Auto-Take Profit Expected DAI/Col at trigger

### DIFF
--- a/components/EstimationOnClose.tsx
+++ b/components/EstimationOnClose.tsx
@@ -1,0 +1,32 @@
+import { Icon } from '@makerdao/dai-ui-icons'
+import React, { ReactNode } from 'react'
+import { Text } from 'theme-ui'
+
+interface EstimationOnCloseProps {
+  iconCircle: string
+  label: string
+  value: ReactNode
+}
+
+export function EstimationOnClose({ iconCircle, label, value }: EstimationOnCloseProps) {
+  return (
+    <Text
+      as="p"
+      variant="paragraph3"
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontWeight: 'semiBold',
+      }}
+    >
+      <Text as="span" sx={{ display: 'flex', color: 'neutral80' }}>
+        <Icon name={iconCircle} size="24px" sx={{ mt: '-1px', mr: 1 }} />
+        {label}
+      </Text>
+      <Text as="span" sx={{ display: 'block', height: '100%' }}>
+        {value}
+      </Text>
+    </Text>
+  )
+}

--- a/features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState.tsx
+++ b/features/earn/guni/manage/sidebars/SidebarManageGuniVaultEditingState.tsx
@@ -1,5 +1,5 @@
-import { Icon } from '@makerdao/dai-ui-icons'
 import { getToken } from 'blockchain/tokensMetadata'
+import { EstimationOnClose } from 'components/EstimationOnClose'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { GuniManageMultiplyVaultChangesInformation } from 'features/earn/guni/manage/containers/GuniManageMultiplyVaultChangesInformation'
@@ -49,27 +49,11 @@ export function SidebarManageGuniVaultEditingState(props: ManageMultiplyVaultSta
             {t('vault-info-messages.closing')}
           </Text>
           {!debt.isZero() && (
-            <>
-              <Text
-                as="p"
-                variant="paragraph3"
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  mt: 2,
-                  fontWeight: 'semiBold',
-                }}
-              >
-                <Text
-                  as="span"
-                  sx={{ display: 'flex', alignItems: 'flex-end', color: 'neutral80' }}
-                >
-                  <Icon name={getToken('DAI').iconCircle} size="20px" sx={{ mr: 1 }} />
-                  {t('minimum')} {t('after-closing', { token: 'DAI' })}
-                </Text>
-                <Text as="span">{formatCryptoBalance(afterCloseToDai)} DAI</Text>
-              </Text>
-            </>
+            <EstimationOnClose
+              iconCircle={getToken('DAI').iconCircle}
+              label={`${t('minimum')} ${t('after-closing', { token: 'DAI' })}`}
+              value={`${formatCryptoBalance(afterCloseToDai)} DAI`}
+            />
           )}
         </>
       )}

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
@@ -1,7 +1,7 @@
-import { Icon } from '@makerdao/dai-ui-icons'
 import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
 import { ActionPills } from 'components/ActionPills'
+import { EstimationOnClose } from 'components/EstimationOnClose'
 import {
   extractFieldDepositCollateralData,
   extractFieldDepositDaiData,
@@ -81,6 +81,13 @@ function SidebarManageMultiplyVaultEditingStageClose(props: ManageMultiplyVaultS
 
   const isClosingToCollateral = closeVaultTo === 'collateral'
   const closeToTokenSymbol = isClosingToCollateral ? token : 'DAI'
+  const amountOnClose = (
+    <>
+      {formatCryptoBalance(isClosingToCollateral ? afterCloseToCollateral : afterCloseToDai)}{' '}
+      {closeToTokenSymbol}{' '}
+      {isClosingToCollateral && `($${formatAmount(afterCloseToCollateralUSD, 'USD')})`}
+    </>
+  )
 
   return (
     <>
@@ -106,21 +113,11 @@ function SidebarManageMultiplyVaultEditingStageClose(props: ManageMultiplyVaultS
       <Text as="p" variant="paragraph3" sx={{ mt: 2, color: 'neutral80' }}>
         {t('vault-info-messages.closing')}
       </Text>
-      <Text
-        as="p"
-        variant="paragraph3"
-        sx={{ display: 'flex', justifyContent: 'space-between', mt: 2, fontWeight: 'semiBold' }}
-      >
-        <Text as="span" sx={{ display: 'flex', alignItems: 'flex-end', color: 'neutral80' }}>
-          <Icon name={getToken(closeToTokenSymbol).iconCircle} size="20px" sx={{ mr: 1 }} />
-          {t('after-closing', { token: closeToTokenSymbol })}
-        </Text>
-        <Text as="span">
-          {formatCryptoBalance(isClosingToCollateral ? afterCloseToCollateral : afterCloseToDai)}{' '}
-          {closeToTokenSymbol}{' '}
-          {isClosingToCollateral && `($${formatAmount(afterCloseToCollateralUSD, 'USD')})`}
-        </Text>
-      </Text>
+      <EstimationOnClose
+        iconCircle={getToken(closeToTokenSymbol).iconCircle}
+        label={t('after-closing', { token: closeToTokenSymbol })}
+        value={amountOnClose}
+      />
     </>
   )
 }


### PR DESCRIPTION
# [Auto-Take Profit Expected DAI/Col at trigger](https://app.shortcut.com/oazo-apps/story/5543/ui-auto-take-profit-expected-dai-col-at-trigger)

This is only creation of components that allows to display data that would be calculated somewhere later. Does not include calculations and usage of component in proper place since that place (Auto-Take Profit sidebar) doesn't exist yet.

Example usage with dummy data from Figma
![image](https://user-images.githubusercontent.com/16230404/192278149-a0ecdb56-b794-4ca5-a180-d116ff055458.png)

Actual usage during close multiply vault feature
![image](https://user-images.githubusercontent.com/16230404/192278348-d764b66b-a82b-40fe-a4d8-b1cabf92626a.png)
  
## Changes 👷‍♀️

- Created new component `EstimationOnClose` based on something very similar that was already scattered in application,
- edited sidebars steps of closing multiply vault and GUNI vault to be using new unified component.
  
## How to test 🧪

- Check out closing vault step,
- to see in more Auto-Take Profit like environment, use this snipped in any place in any sidebar:
```
<EstimationOnClose
  iconCircle={getToken('DAI').iconCircle}
  label="Estimated DAI at Trigger"
  value="$3,990,402.00 DAI"
/>
```
