### PR TITLE
Auto-Take Profit Form Order Summary Box

### DIFF
--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -8,6 +8,7 @@ import {
   AutomationProtectionFeatures,
 } from 'features/automation/common/state/automationFeatureChange'
 import { AutomationFeatures } from 'features/automation/common/types'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 
 interface GetAutoFeaturesSidebarDropdownProps {
@@ -66,6 +67,8 @@ export function getAutoFeaturesSidebarDropdown({
   isAutoConstantMultipleEnabled,
   isAutoTakeProfitEnabled,
 }: GetAutoFeaturesSidebarDropdownProps): SidebarSectionHeaderDropdown | undefined {
+  const autoTakeProfitEnabled = useFeatureToggle('AutoTakeProfit')
+
   const stopLossDropdownItem = getAutoFeaturesSidebarDropdownItem({
     translationKey: 'system.stop-loss',
     type: 'Protection',
@@ -105,7 +108,7 @@ export function getAutoFeaturesSidebarDropdown({
       ? [
           ...(!isAutoConstantMultipleEnabled ? [basicBuyDropdownItem] : []),
           constantMultipleDropdownItem,
-          ...(!isAutoTakeProfitEnabled ? [autoTakeProfitDropdownItem] : []),
+          ...(autoTakeProfitEnabled ? [autoTakeProfitDropdownItem] : []),
         ]
       : []),
   ]

--- a/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
@@ -7,11 +7,12 @@ import { Text } from 'theme-ui'
 
 interface AddAutoTakeProfitInfoSectionProps {
   debtRepaid: BigNumber
-  estimatedMaxGasFee: BigNumber
+  estimatedGasFee: BigNumber
   estimatedOasisFee: BigNumber
   ethPrice: BigNumber
   ethPriceImpact: BigNumber
   setupTransactionCost: BigNumber
+  token: string
   totalTransactionCost: BigNumber
   triggerColPrice: BigNumber
   triggerColRatio: BigNumber
@@ -19,11 +20,12 @@ interface AddAutoTakeProfitInfoSectionProps {
 
 export function AddAutoTakeProfitInfoSection({
   debtRepaid,
-  estimatedMaxGasFee,
+  estimatedGasFee,
   estimatedOasisFee,
   ethPrice,
   ethPriceImpact,
   setupTransactionCost,
+  token,
   totalTransactionCost,
   triggerColPrice,
   triggerColRatio,
@@ -32,22 +34,22 @@ export function AddAutoTakeProfitInfoSection({
 
   return (
     <InfoSection
-      title={t('General summary')}
+      title={t('auto-take-profit.vault-changes.general-summary')}
       items={[
         {
-          label: t('Trigger ETH Price'),
+          label: t('auto-take-profit.vault-changes.trigger-col-price', { token }),
           value: `$${formatAmount(triggerColPrice, 'USD')}`,
         },
         {
-          label: t('Trigger Collateral Ratio'),
+          label: t('auto-take-profit.vault-changes.trigger-collateral-ratio'),
           value: `${triggerColRatio}%`,
         },
         {
-          label: t('Debt Repaid'),
+          label: t('auto-take-profit.vault-changes.debt-repaid'),
           value: `$${formatAmount(debtRepaid, 'USD')}`,
         },
         {
-          label: t('ETH Price (impact)'),
+          label: t('auto-take-profit.vault-changes.col-price-impact', { token }),
           value: (
             <>
               ${formatAmount(ethPrice, 'USD')}
@@ -61,21 +63,21 @@ export function AddAutoTakeProfitInfoSection({
           ),
         },
         {
-          label: t('Total transaction cost on trigger'),
+          label: t('auto-take-profit.vault-changes.total-transaction-cost'),
           value: `$${formatAmount(totalTransactionCost, 'USD')}`,
           dropdownValues: [
             {
-              label: t('Estimated Oasis fee'),
+              label: t('auto-take-profit.vault-changes.estimated-oasis-fee'),
               value: `$${formatAmount(estimatedOasisFee, 'USD')}`,
             },
             {
-              label: t('Estimated max gas fee'),
-              value: `$${formatAmount(estimatedMaxGasFee, 'USD')}`,
+              label: t('auto-take-profit.vault-changes.estimated-gas-fee'),
+              value: `$${formatAmount(estimatedGasFee, 'USD')}`,
             },
           ],
         },
         {
-          label: t('Setup transaction cost'),
+          label: t('auto-take-profit.vault-changes.setup-transaction-cost'),
           value: `$${formatAmount(setupTransactionCost, 'USD')}`,
         },
       ]}

--- a/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
@@ -1,0 +1,84 @@
+import BigNumber from 'bignumber.js'
+import { InfoSection } from 'components/infoSection/InfoSection'
+import { formatAmount } from 'helpers/formatters/format'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Text } from 'theme-ui'
+
+interface AddAutoTakeProfitInfoSectionProps {
+  debtRepaid: BigNumber
+  estimatedMaxGasFee: BigNumber
+  estimatedOasisFee: BigNumber
+  ethPrice: BigNumber
+  ethPriceImpact: BigNumber
+  setupTransactionCost: BigNumber
+  totalTransactionCost: BigNumber
+  triggerColPrice: BigNumber
+  triggerColRatio: BigNumber
+}
+
+export function AddAutoTakeProfitInfoSection({
+  debtRepaid,
+  estimatedMaxGasFee,
+  estimatedOasisFee,
+  ethPrice,
+  ethPriceImpact,
+  setupTransactionCost,
+  totalTransactionCost,
+  triggerColPrice,
+  triggerColRatio,
+}: AddAutoTakeProfitInfoSectionProps) {
+  const { t } = useTranslation()
+
+  return (
+    <InfoSection
+      title={t('General summary')}
+      items={[
+        {
+          label: t('Trigger ETH Price'),
+          value: `$${formatAmount(triggerColPrice, 'USD')}`,
+        },
+        {
+          label: t('Trigger Collateral Ratio'),
+          value: `${triggerColRatio}%`,
+        },
+        {
+          label: t('Debt Repaid'),
+          value: `$${formatAmount(debtRepaid, 'USD')}`,
+        },
+        {
+          label: t('ETH Price (impact)'),
+          value: (
+            <>
+              ${formatAmount(ethPrice, 'USD')}
+              <Text
+                as="span"
+                sx={{ ml: 1, color: ethPriceImpact.isPositive() ? 'success100' : 'critical100' }}
+              >
+                ({ethPriceImpact.toFixed(2)}%)
+              </Text>
+            </>
+          ),
+        },
+        {
+          label: t('Total transaction cost on trigger'),
+          value: `$${formatAmount(totalTransactionCost, 'USD')}`,
+          dropdownValues: [
+            {
+              label: t('Estimated Oasis fee'),
+              value: `$${formatAmount(estimatedOasisFee, 'USD')}`,
+            },
+            {
+              label: t('Estimated max gas fee'),
+              value: `$${formatAmount(estimatedMaxGasFee, 'USD')}`,
+            },
+          ],
+        },
+        {
+          label: t('Setup transaction cost'),
+          value: `$${formatAmount(setupTransactionCost, 'USD')}`,
+        },
+      ]}
+    />
+  )
+}

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -1,0 +1,29 @@
+import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
+import { AutomationFeatures } from 'features/automation/common/types'
+import { SidebarSetupAutoTakeProfit } from 'features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit'
+import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
+import React from 'react'
+
+interface AutoTakeProfitFormControlProps {
+  autoBuyTriggerData: AutoBSTriggerData
+  constantMultipleTriggerData: ConstantMultipleTriggerData
+  isAutoTakeProfitActive: boolean
+}
+
+export function AutoTakeProfitFormControl({
+  autoBuyTriggerData,
+  constantMultipleTriggerData,
+  isAutoTakeProfitActive,
+}: AutoTakeProfitFormControlProps) {
+  const feature = AutomationFeatures.AUTO_TAKE_PROFIT
+
+  return (
+    // TODO: TDAutoTakeProfit | should be used with AddAndRemoveTriggerControl as a wrapper when there is enough data
+    <SidebarSetupAutoTakeProfit
+      autoBuyTriggerData={autoBuyTriggerData}
+      constantMultipleTriggerData={constantMultipleTriggerData}
+      feature={feature}
+      isAutoTakeProfitActive={isAutoTakeProfitActive}
+    />
+  )
+}

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -1,3 +1,4 @@
+import { Vault } from 'blockchain/vaults'
 import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
 import { AutomationFeatures } from 'features/automation/common/types'
 import { SidebarSetupAutoTakeProfit } from 'features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit'
@@ -8,12 +9,14 @@ interface AutoTakeProfitFormControlProps {
   autoBuyTriggerData: AutoBSTriggerData
   constantMultipleTriggerData: ConstantMultipleTriggerData
   isAutoTakeProfitActive: boolean
+  vault: Vault
 }
 
 export function AutoTakeProfitFormControl({
   autoBuyTriggerData,
   constantMultipleTriggerData,
   isAutoTakeProfitActive,
+  vault,
 }: AutoTakeProfitFormControlProps) {
   const feature = AutomationFeatures.AUTO_TAKE_PROFIT
 
@@ -24,6 +27,7 @@ export function AutoTakeProfitFormControl({
       constantMultipleTriggerData={constantMultipleTriggerData}
       feature={feature}
       isAutoTakeProfitActive={isAutoTakeProfitActive}
+      vault={vault}
     />
   )
 }

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -29,8 +29,6 @@ interface AutoTakeProfitInfoSectionControlProps {
   token: string
 }
 
-// TODO: TDAutoTakeProfit | temporary disable before neede interface props are known
-// eslint-disable-next-line no-empty-pattern
 function AutoTakeProfitInfoSectionControl({ token }: AutoTakeProfitInfoSectionControlProps) {
   // TODO: TDAutoTakeProfit | to be replaced with data from parent component
   const triggerColPrice = new BigNumber(2500)

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -1,0 +1,54 @@
+import BigNumber from 'bignumber.js'
+import { getToken } from 'blockchain/tokensMetadata'
+import { EstimationOnClose } from 'components/EstimationOnClose'
+import { AddAutoTakeProfitInfoSection } from 'features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection'
+import React from 'react'
+
+interface SidebarAutoTakeProfitEditingStageProps {}
+
+// TODO: TDAutoTakeProfit | temporary disable before neede interface props are known 
+// eslint-disable-next-line no-empty-pattern
+export function SidebarAutoTakeProfitEditingStage({}: SidebarAutoTakeProfitEditingStageProps) {
+  return (
+    <>
+      Form placeholder
+      <EstimationOnClose
+        iconCircle={getToken('DAI').iconCircle}
+        label="Estimated DAI at Trigger"
+        value="$3,990,402.00 DAI"
+      />
+      <AutoTakeProfitInfoSectionControl />
+    </>
+  )
+}
+
+interface AutoTakeProfitInfoSectionControlProps {}
+
+// TODO: TDAutoTakeProfit | temporary disable before neede interface props are known
+// eslint-disable-next-line no-empty-pattern
+function AutoTakeProfitInfoSectionControl({}: AutoTakeProfitInfoSectionControlProps) {
+  // TODO: TDAutoTakeProfit | to be replaced with data from parent component
+  const triggerColPrice = new BigNumber(2500)
+  const triggerColRatio = new BigNumber(400)
+  const debtRepaid = new BigNumber(45003407)
+  const ethPrice = new BigNumber(1925)
+  const ethPriceImpact = new BigNumber(-0.25)
+  const setupTransactionCost = new BigNumber(3.24)
+  const totalTransactionCost = new BigNumber(388.26)
+  const estimatedOasisFee = new BigNumber(371.75)
+  const estimatedMaxGasFee = new BigNumber(16.51)
+
+  return (
+    <AddAutoTakeProfitInfoSection
+      debtRepaid={debtRepaid}
+      estimatedMaxGasFee={estimatedMaxGasFee}
+      estimatedOasisFee={estimatedOasisFee}
+      ethPrice={ethPrice}
+      ethPriceImpact={ethPriceImpact}
+      setupTransactionCost={setupTransactionCost}
+      totalTransactionCost={totalTransactionCost}
+      triggerColPrice={triggerColPrice}
+      triggerColRatio={triggerColRatio}
+    />
+  )
+}

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -1,14 +1,17 @@
 import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
+import { Vault } from 'blockchain/vaults'
 import { EstimationOnClose } from 'components/EstimationOnClose'
 import { AddAutoTakeProfitInfoSection } from 'features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection'
 import React from 'react'
 
-interface SidebarAutoTakeProfitEditingStageProps {}
+interface SidebarAutoTakeProfitEditingStageProps {
+  vault: Vault
+}
 
-// TODO: TDAutoTakeProfit | temporary disable before neede interface props are known 
-// eslint-disable-next-line no-empty-pattern
-export function SidebarAutoTakeProfitEditingStage({}: SidebarAutoTakeProfitEditingStageProps) {
+export function SidebarAutoTakeProfitEditingStage({
+  vault,
+}: SidebarAutoTakeProfitEditingStageProps) {
   return (
     <>
       Form placeholder
@@ -17,16 +20,18 @@ export function SidebarAutoTakeProfitEditingStage({}: SidebarAutoTakeProfitEditi
         label="Estimated DAI at Trigger"
         value="$3,990,402.00 DAI"
       />
-      <AutoTakeProfitInfoSectionControl />
+      <AutoTakeProfitInfoSectionControl token={vault.token} />
     </>
   )
 }
 
-interface AutoTakeProfitInfoSectionControlProps {}
+interface AutoTakeProfitInfoSectionControlProps {
+  token: string
+}
 
 // TODO: TDAutoTakeProfit | temporary disable before neede interface props are known
 // eslint-disable-next-line no-empty-pattern
-function AutoTakeProfitInfoSectionControl({}: AutoTakeProfitInfoSectionControlProps) {
+function AutoTakeProfitInfoSectionControl({ token }: AutoTakeProfitInfoSectionControlProps) {
   // TODO: TDAutoTakeProfit | to be replaced with data from parent component
   const triggerColPrice = new BigNumber(2500)
   const triggerColRatio = new BigNumber(400)
@@ -36,16 +41,17 @@ function AutoTakeProfitInfoSectionControl({}: AutoTakeProfitInfoSectionControlPr
   const setupTransactionCost = new BigNumber(3.24)
   const totalTransactionCost = new BigNumber(388.26)
   const estimatedOasisFee = new BigNumber(371.75)
-  const estimatedMaxGasFee = new BigNumber(16.51)
+  const estimatedGasFee = new BigNumber(16.51)
 
   return (
     <AddAutoTakeProfitInfoSection
       debtRepaid={debtRepaid}
-      estimatedMaxGasFee={estimatedMaxGasFee}
+      estimatedGasFee={estimatedGasFee}
       estimatedOasisFee={estimatedOasisFee}
       ethPrice={ethPrice}
       ethPriceImpact={ethPriceImpact}
       setupTransactionCost={setupTransactionCost}
+      token={token}
       totalTransactionCost={totalTransactionCost}
       triggerColPrice={triggerColPrice}
       triggerColRatio={triggerColRatio}

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -1,0 +1,60 @@
+import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
+import { getAutoFeaturesSidebarDropdown } from 'features/automation/common/sidebars/getAutoFeaturesSidebarDropdown'
+import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
+import { AutomationFeatures } from 'features/automation/common/types'
+import { SidebarAutoTakeProfitEditingStage } from 'features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage'
+import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Grid } from 'theme-ui'
+
+interface SidebarSetupAutoTakeProfitProps {
+  autoBuyTriggerData: AutoBSTriggerData
+  constantMultipleTriggerData: ConstantMultipleTriggerData
+  isAutoTakeProfitActive: boolean
+  feature: AutomationFeatures
+}
+
+export function SidebarSetupAutoTakeProfit({
+  autoBuyTriggerData,
+  constantMultipleTriggerData,
+  isAutoTakeProfitActive,
+  feature,
+}: SidebarSetupAutoTakeProfitProps) {
+  const { t } = useTranslation()
+
+  // TODO: TDAutoTakeProfit | replace with sidebarTitle method when data is available
+  const sidebarTitle = t(sidebarAutomationFeatureCopyMap[feature])
+  const dropdown = getAutoFeaturesSidebarDropdown({
+    type: 'Optimization',
+    forcePanel: AutomationFeatures.AUTO_TAKE_PROFIT,
+    // TODO: TDAutoTakeProfit | replace with isDropdownDisabled method when stage prop is available
+    disabled: false,
+    isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
+    isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
+    // TODO: TDAutoTakeProfit | to be replaced with data from autoTakeProfitTriggerData
+    isAutoTakeProfitEnabled: false,
+  })
+  // TODO: TDAutoTakeProfit | replace with getAutomationPrimaryButtonLabel method when data is available
+  const primaryButtonLabel = 'Temp CTA'
+
+  if (isAutoTakeProfitActive) {
+    const sidebarSectionProps: SidebarSectionProps = {
+      title: sidebarTitle,
+      dropdown,
+      content: (
+        <Grid gap={3}>
+          {/* TODO: Should be displayed based on current form state */}
+          <SidebarAutoTakeProfitEditingStage />
+        </Grid>
+      ),
+      primaryButton: {
+        label: primaryButtonLabel,
+      },
+    }
+
+    return <SidebarSection {...sidebarSectionProps} />
+  }
+  return null
+}

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -1,3 +1,4 @@
+import { Vault } from 'blockchain/vaults'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
 import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
 import { getAutoFeaturesSidebarDropdown } from 'features/automation/common/sidebars/getAutoFeaturesSidebarDropdown'
@@ -14,6 +15,7 @@ interface SidebarSetupAutoTakeProfitProps {
   constantMultipleTriggerData: ConstantMultipleTriggerData
   isAutoTakeProfitActive: boolean
   feature: AutomationFeatures
+  vault: Vault
 }
 
 export function SidebarSetupAutoTakeProfit({
@@ -21,6 +23,7 @@ export function SidebarSetupAutoTakeProfit({
   constantMultipleTriggerData,
   isAutoTakeProfitActive,
   feature,
+  vault,
 }: SidebarSetupAutoTakeProfitProps) {
   const { t } = useTranslation()
 
@@ -46,7 +49,7 @@ export function SidebarSetupAutoTakeProfit({
       content: (
         <Grid gap={3}>
           {/* TODO: Should be displayed based on current form state */}
-          <SidebarAutoTakeProfitEditingStage />
+          <SidebarAutoTakeProfitEditingStage vault={vault} />
         </Grid>
       ),
       primaryButton: {

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -46,19 +46,28 @@ export function OptimizationFormControl({
     automationTriggersData,
   } = useAutomationContext()
 
+  // TODO: TDAutoTakeProfit | to be replaced with data from autoTakeProfitTriggerData from useAutomationContext method
+  const autoTakeProfitTriggerData = {
+    isTriggerEnabled: false
+  }
+
   const { uiChanges } = useAppContext()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
 
   const { isConstantMultipleActive, isAutoBuyActive } = getActiveOptimizationFeature({
     currentOptimizationFeature: activeAutomationFeature?.currentOptimizationFeature,
-    isAutoBuyOn: autoBuyTriggerData.isTriggerEnabled,
-    isConstantMultipleOn: constantMultipleTriggerData.isTriggerEnabled,
     section: 'form',
   })
 
   const shouldRemoveAllowance = getShouldRemoveAllowance(automationTriggersData)
 
   useEffect(() => {
+    if (autoTakeProfitTriggerData.isTriggerEnabled) {
+      uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
+        type: 'Optimization',
+        currentOptimizationFeature: AutomationFeatures.AUTO_TAKE_PROFIT,
+      })
+    }
     if (autoBuyTriggerData.isTriggerEnabled) {
       uiChanges.publish(AUTOMATION_CHANGE_FEATURE, {
         type: 'Optimization',

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -123,6 +123,7 @@ export function OptimizationFormControl({
         autoBuyTriggerData={autoBuyTriggerData}
         constantMultipleTriggerData={constantMultipleTriggerData}
         isAutoTakeProfitActive={isAutoTakeProfitActive}
+        vault={vault}
       />
     </>
   )

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -12,6 +12,7 @@ import {
 } from 'features/automation/common/state/automationFeatureChange'
 import { AutomationFeatures } from 'features/automation/common/types'
 import { AutoBuyFormControl } from 'features/automation/optimization/autoBuy/controls/AutoBuyFormControl'
+import { AutoTakeProfitFormControl } from 'features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl'
 import { getActiveOptimizationFeature } from 'features/automation/optimization/common/helpers'
 import { ConstantMultipleFormControl } from 'features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl'
 import { VaultType } from 'features/generalManageVault/vaultType'
@@ -20,41 +21,45 @@ import { useUIChanges } from 'helpers/uiChangesHook'
 import React, { useEffect } from 'react'
 
 interface OptimizationFormControlProps {
-  vault: Vault
-  vaultType: VaultType
+  balanceInfo: BalanceInfo
+  context: Context
+  ethMarketPrice: BigNumber
   ilkData: IlkData
   txHelpers?: TxHelpers
-  context: Context
-  balanceInfo: BalanceInfo
-  ethMarketPrice: BigNumber
+  vault: Vault
+  vaultType: VaultType
 }
 
 export function OptimizationFormControl({
-  vault,
-  vaultType,
+  balanceInfo,
+  context,
+  ethMarketPrice,
   ilkData,
   txHelpers,
-  context,
-  balanceInfo,
-  ethMarketPrice,
+  vault,
+  vaultType,
 }: OptimizationFormControlProps) {
   const {
-    stopLossTriggerData,
-    autoSellTriggerData,
     autoBuyTriggerData,
-    constantMultipleTriggerData,
     automationTriggersData,
+    autoSellTriggerData,
+    constantMultipleTriggerData,
+    stopLossTriggerData,
   } = useAutomationContext()
 
   // TODO: TDAutoTakeProfit | to be replaced with data from autoTakeProfitTriggerData from useAutomationContext method
   const autoTakeProfitTriggerData = {
-    isTriggerEnabled: false
+    isTriggerEnabled: false,
   }
 
   const { uiChanges } = useAppContext()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
 
-  const { isConstantMultipleActive, isAutoBuyActive } = getActiveOptimizationFeature({
+  const {
+    isAutoBuyActive,
+    isAutoTakeProfitActive,
+    isConstantMultipleActive,
+  } = getActiveOptimizationFeature({
     currentOptimizationFeature: activeAutomationFeature?.currentOptimizationFeature,
     section: 'form',
   })
@@ -85,34 +90,39 @@ export function OptimizationFormControl({
   return (
     <>
       <AutoBuyFormControl
+        autoBuyTriggerData={autoBuyTriggerData}
+        autoSellTriggerData={autoSellTriggerData}
+        balanceInfo={balanceInfo}
+        constantMultipleTriggerData={constantMultipleTriggerData}
+        context={context}
+        ethMarketPrice={ethMarketPrice}
+        ilkData={ilkData}
+        isAutoBuyActive={isAutoBuyActive}
+        isAutoBuyOn={autoBuyTriggerData.isTriggerEnabled}
+        shouldRemoveAllowance={shouldRemoveAllowance}
+        stopLossTriggerData={stopLossTriggerData}
+        txHelpers={txHelpers}
         vault={vault}
         vaultType={vaultType}
-        ilkData={ilkData}
-        balanceInfo={balanceInfo}
-        autoSellTriggerData={autoSellTriggerData}
-        autoBuyTriggerData={autoBuyTriggerData}
-        stopLossTriggerData={stopLossTriggerData}
-        constantMultipleTriggerData={constantMultipleTriggerData}
-        isAutoBuyOn={autoBuyTriggerData.isTriggerEnabled}
-        context={context}
-        txHelpers={txHelpers}
-        ethMarketPrice={ethMarketPrice}
-        isAutoBuyActive={isAutoBuyActive}
-        shouldRemoveAllowance={shouldRemoveAllowance}
       />
       <ConstantMultipleFormControl
+        autoBuyTriggerData={autoBuyTriggerData}
+        autoSellTriggerData={autoSellTriggerData}
+        balanceInfo={balanceInfo}
+        constantMultipleTriggerData={constantMultipleTriggerData}
         context={context}
-        isConstantMultipleActive={isConstantMultipleActive}
-        txHelpers={txHelpers}
-        vault={vault}
         ethMarketPrice={ethMarketPrice}
         ilkData={ilkData}
-        autoSellTriggerData={autoSellTriggerData}
-        autoBuyTriggerData={autoBuyTriggerData}
-        stopLossTriggerData={stopLossTriggerData}
-        constantMultipleTriggerData={constantMultipleTriggerData}
-        balanceInfo={balanceInfo}
+        isConstantMultipleActive={isConstantMultipleActive}
         shouldRemoveAllowance={shouldRemoveAllowance}
+        stopLossTriggerData={stopLossTriggerData}
+        txHelpers={txHelpers}
+        vault={vault}
+      />
+      <AutoTakeProfitFormControl
+        autoBuyTriggerData={autoBuyTriggerData}
+        constantMultipleTriggerData={constantMultipleTriggerData}
+        isAutoTakeProfitActive={isAutoTakeProfitActive}
       />
     </>
   )

--- a/features/automation/optimization/common/helpers.ts
+++ b/features/automation/optimization/common/helpers.ts
@@ -1,45 +1,29 @@
 import { AutomationOptimizationFeatures } from 'features/automation/common/state/automationFeatureChange'
 import { AutomationFeatures } from 'features/automation/common/types'
-import { useFeatureToggle } from 'helpers/useFeatureToggle'
 
 export function getActiveOptimizationFeature({
+  currentOptimizationFeature,
   isAutoBuyOn,
   isConstantMultipleOn,
   section,
-  currentOptimizationFeature,
 }: {
-  isAutoBuyOn: boolean
-  isConstantMultipleOn: boolean
-  section: 'form' | 'details'
   currentOptimizationFeature?: AutomationOptimizationFeatures
+  isAutoBuyOn?: boolean
+  isConstantMultipleOn?: boolean
+  isAutoTakeProfitOn?: boolean
+  section: 'form' | 'details'
 }) {
-  const constantMultipleEnabled = useFeatureToggle('ConstantMultiple')
-
-  if (section === 'form') {
-    return {
-      isAutoBuyActive:
-        (isAutoBuyOn &&
-          !isConstantMultipleOn &&
-          currentOptimizationFeature !== AutomationFeatures.CONSTANT_MULTIPLE) ||
-        currentOptimizationFeature === AutomationFeatures.AUTO_BUY,
-      isConstantMultipleActive:
-        (isConstantMultipleOn && currentOptimizationFeature !== AutomationFeatures.AUTO_BUY) ||
-        currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
-    }
-  }
-
-  if (section === 'details') {
-    return {
-      isAutoBuyActive: isAutoBuyOn || currentOptimizationFeature === AutomationFeatures.AUTO_BUY,
-      isConstantMultipleActive:
-        isConstantMultipleOn ||
-        currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE ||
-        !constantMultipleEnabled,
-    }
-  }
-
-  return {
-    isAutoBuyActive: false,
-    isConstantMultipleActive: false,
-  }
+  return section === 'details'
+    ? {
+        isAutoBuyActive: isAutoBuyOn || currentOptimizationFeature === AutomationFeatures.AUTO_BUY,
+        isConstantMultipleActive:
+          isConstantMultipleOn ||
+          currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
+      }
+    : {
+        isAutoBuyActive: currentOptimizationFeature === AutomationFeatures.AUTO_BUY,
+        isConstantMultipleActive:
+          currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
+        isAutoTakeProfitOn: currentOptimizationFeature === AutomationFeatures.AUTO_TAKE_PROFIT,
+      }
 }

--- a/features/automation/optimization/common/helpers.ts
+++ b/features/automation/optimization/common/helpers.ts
@@ -4,13 +4,14 @@ import { AutomationFeatures } from 'features/automation/common/types'
 export function getActiveOptimizationFeature({
   currentOptimizationFeature,
   isAutoBuyOn,
+  isAutoTakeProfitOn,
   isConstantMultipleOn,
   section,
 }: {
   currentOptimizationFeature?: AutomationOptimizationFeatures
   isAutoBuyOn?: boolean
-  isConstantMultipleOn?: boolean
   isAutoTakeProfitOn?: boolean
+  isConstantMultipleOn?: boolean
   section: 'form' | 'details'
 }) {
   return section === 'details'
@@ -19,11 +20,13 @@ export function getActiveOptimizationFeature({
         isConstantMultipleActive:
           isConstantMultipleOn ||
           currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
+        isAutoTakeProfitActive:
+          isAutoTakeProfitOn || currentOptimizationFeature === AutomationFeatures.AUTO_TAKE_PROFIT,
       }
     : {
         isAutoBuyActive: currentOptimizationFeature === AutomationFeatures.AUTO_BUY,
         isConstantMultipleActive:
           currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
-        isAutoTakeProfitOn: currentOptimizationFeature === AutomationFeatures.AUTO_TAKE_PROFIT,
+        isAutoTakeProfitActive: currentOptimizationFeature === AutomationFeatures.AUTO_TAKE_PROFIT,
       }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1574,7 +1574,18 @@
     "estimated-profit-explanation": "Estimated Profit at Close = Collateral value (USD) at trigger - Debt value to be repaid - estimated Tx Fees",
     "trigger-col-ratio": "Trigger Collateral Ratio",
     "trigger-col-ratio-explanation": "The collateralization ratio that your Vault must reach in order to execute the Auto-Take profit.",
-    "current-col-ratio": "Current Collateral Ratio {{amount}}"
+    "current-col-ratio": "Current Collateral Ratio {{amount}}",
+    "vault-changes": {
+      "general-summary": "General summary",
+      "trigger-col-price": "Trigger {{token}} Price",
+      "trigger-collateral-ratio": "Trigger Collateral Ratio",
+      "debt-repaid": "Debt Repaid",
+      "col-price-impact": "ETH Price (impact)",
+      "total-transaction-cost": "Total transaction cost on trigger",
+      "estimated-oasis-fee": "Estimated Oasis fee",
+      "estimated-gas-fee": "Estimated gas fee",
+      "setup-transaction-cost": "Setup transaction cost"
+    }
   },
 
   "automation": {


### PR DESCRIPTION
# [Auto-Take Profit Form Order Summary Box](https://app.shortcut.com/oazo-apps/story/5545/ui-auto-take-profit-form-order-summary-box)

Does not contain actual data, left a lot of TODO comments to remind about that.
![image](https://user-images.githubusercontent.com/16230404/192511706-839ad05f-f199-4fc4-bea3-0e4e189cde3d.png)
  
## Changes 👷‍♀️

- Added component to display changes information for Auto-Take Profit,
- added empty sidebars and all wrapping components needed for final structure to ease editing that later,
- added checking for feature toggle in Optimization sidebar dropdown as currently I think you could see ATP item with Auto-Take Profit feature turned off?,
- simplified `OptimizationFormControl` method.
  
## How to test 🧪

Compare Auto-Take Profit sidebar with figma designs.

Please note that there are some intentional changes. Numbers are displayed in full notations since we aren't using short notation anywhere, slippage is removed as it was pointed out in shortcut task and estimated transaction costs are different (see: https://discord.com/channels/837076147694207067/839057646480785438/1024272474562633838).
