### PR TITLE
Incorrect links on notifications

### DIFF
--- a/components/notifications/NotificationCard.tsx
+++ b/components/notifications/NotificationCard.tsx
@@ -116,28 +116,28 @@ export function NotificationCard({
       >
         {humanDate}
       </Text>
-      {isCritical && (
-        <Flex sx={{ justifyContent: 'flex-start', gap: 2 }}>
+      <Flex sx={{ justifyContent: 'flex-start', gap: 2 }}>
+        {additionalData.vaultId && linkHash && (
           <AppLink href={`/${additionalData.vaultId}`} hash={linkHash}>
             <Button
               variant="bean"
               sx={{ px: '24px', py: 1, height: '28px' }}
               onClick={() => editHandler(id)}
             >
-              {t('edit-vault')}
+              {t('go-to-vault-generic')}
             </Button>
           </AppLink>
-          {!isRead && (
-            <Button
-              variant="textual"
-              sx={{ color: 'primary', fontSize: 1, py: 1 }}
-              onClick={() => markReadHandler(id)}
-            >
-              {t('mark-as-read')}
-            </Button>
-          )}
-        </Flex>
-      )}
+        )}
+        {isCritical && !isRead && (
+          <Button
+            variant="textual"
+            sx={{ color: 'primary', fontSize: 1, py: 1 }}
+            onClick={() => markReadHandler(id)}
+          >
+            {t('mark-as-read')}
+          </Button>
+        )}
+      </Flex>
     </Card>
   )
 }

--- a/features/notifications/helpers.tsx
+++ b/features/notifications/helpers.tsx
@@ -1,7 +1,5 @@
 import { BigNumber } from 'bignumber.js'
 import { amountFromWei } from 'blockchain/utils'
-import { AppLink } from 'components/Links'
-import { WithArrow } from 'components/WithArrow'
 import {
   Notification,
   NotificationAdditionalData,
@@ -10,13 +8,6 @@ import {
 import { formatAmount } from 'helpers/formatters/format'
 import { Trans } from 'next-i18next'
 import React from 'react'
-
-function getLinkComponents(href: string) {
-  return {
-    1: <AppLink href={href} sx={{ fontSize: 2, fontWeight: 'semiBold' }} />,
-    2: <WithArrow sx={{ display: 'inline', color: 'interactive100', fontWeight: 'semiBold' }} />,
-  }
-}
 
 export function getNotificationTitle({
   type,
@@ -39,7 +30,6 @@ export function getNotificationTitle({
 
   const humanDate = new Date(lastModified).toLocaleDateString('en-US', options)
   const vaultId = additionalData?.vaultId || 'n/a'
-  const linkComponents = getLinkComponents(`/${vaultId}`)
 
   switch (type) {
     case NotificationTypes.VAULT_LIQUIDATED:
@@ -111,7 +101,6 @@ export function getNotificationTitle({
         <Trans
           i18nKey="notifications.approaching-trigger"
           values={{ vaultId, trigger: 'Auto-Buy' }}
-          components={linkComponents}
         />
       )
     case NotificationTypes.APPROACHING_AUTO_SELL:
@@ -119,7 +108,6 @@ export function getNotificationTitle({
         <Trans
           i18nKey="notifications.approaching-trigger"
           values={{ vaultId, trigger: 'Auto-Sell' }}
-          components={linkComponents}
         />
       )
     case NotificationTypes.APPROACHING_STOP_LOSS:
@@ -127,7 +115,6 @@ export function getNotificationTitle({
         <Trans
           i18nKey="notifications.approaching-trigger"
           values={{ vaultId, trigger: 'Stop-Loss' }}
-          components={linkComponents}
         />
       )
     case NotificationTypes.APPROACHING_CONSTANT_MULTIPLE:
@@ -135,7 +122,6 @@ export function getNotificationTitle({
         <Trans
           i18nKey="notifications.approaching-trigger"
           values={{ vaultId, trigger: 'Constant-Multiple' }}
-          components={linkComponents}
         />
       )
     default:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -224,6 +224,7 @@
   "get-dai": "Get Dai",
   "get-started": "Get Started",
   "go-to-vault": "Go to Vault #{{id}}",
+  "go-to-vault-generic": "Go to Vault",
   "here": "here",
   "from:": "From",
   "full": "Full",


### PR DESCRIPTION
# [Incorrect links on notifications](https://app.shortcut.com/oazo-apps/story/6110/bug-incorrect-links-on-notifications)

Bug found by Sam.

![image](https://user-images.githubusercontent.com/16230404/192538061-3f1eb6d1-7bce-4569-a462-3b285455c073.png)

## Changes 👷‍♀️

- Removed links from notification copy,
- changed notification button label,
- removed condition to display buttons, they are going to be visible always if notification has vault ID, not only for critical notifications.
  
## How to test 🧪

See if all vaults has "Go to Vault" button and "View Vault" link is removed from notification content.
