### PR TITLE
Add support for additional Notifications & Ignore inrecognized Notifications

### DIFF
--- a/components/notifications/NotificationCardsWrapper.tsx
+++ b/components/notifications/NotificationCardsWrapper.tsx
@@ -2,6 +2,7 @@ import { NotificationCard } from 'components/notifications/NotificationCard'
 import { useNotificationSocket } from 'components/NotificationSocketProvider'
 import { getNotificationTitle } from 'features/notifications/helpers'
 import { NOTIFICATION_CHANGE, NotificationChange } from 'features/notifications/notificationChange'
+import { NotificationTypes } from 'features/notifications/types'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React from 'react'
 
@@ -30,19 +31,21 @@ export function NotificationCardsWrapper({ account }: NotificationCardsWrapperPr
 
   return (
     <>
-      {notificationsState.allNotifications.map((item) => (
-        <NotificationCard
-          key={item.id}
-          {...item}
-          title={getNotificationTitle({
-            type: item.notificationType,
-            lastModified: item.lastModified,
-            additionalData: item.additionalData,
-          })}
-          markReadHandler={markReadHandler}
-          editHandler={editHandler}
-        />
-      ))}
+      {notificationsState.allNotifications
+        .filter((item) => item.notificationType in NotificationTypes)
+        .map((item) => (
+          <NotificationCard
+            key={item.id}
+            {...item}
+            title={getNotificationTitle({
+              type: item.notificationType,
+              lastModified: item.lastModified,
+              additionalData: item.additionalData,
+            })}
+            markReadHandler={markReadHandler}
+            editHandler={editHandler}
+          />
+        ))}
     </>
   )
 }

--- a/features/notifications/helpers.tsx
+++ b/features/notifications/helpers.tsx
@@ -86,6 +86,17 @@ export function getNotificationTitle({
           }}
         />
       )
+    case NotificationTypes.CONSTANT_MULTIPLE_TRIGGERED:
+      return (
+        <Trans
+          i18nKey="notifications.constant-multiple-executed"
+          values={{
+            vaultId,
+            usdPrice,
+            humanDate,
+          }}
+        />
+      )
     case NotificationTypes.APPROACHING_LIQUIDATION:
       return (
         <Trans

--- a/features/notifications/types.ts
+++ b/features/notifications/types.ts
@@ -8,8 +8,8 @@ export enum NotificationTypes {
   APPROACHING_LIQUIDATION = 7,
   APPROACHING_STOP_LOSS = 8,
   ORACLE_PRICE_CHANGED = 9, //not existing yet
-  CONSTANT_MULTIPLE_TRIGGERED = 10, //not existing yet
-  APPROACHING_CONSTANT_MULTIPLE = 11, //not existing yet
+  CONSTANT_MULTIPLE_TRIGGERED = 10,
+  APPROACHING_CONSTANT_MULTIPLE = 11,
 }
 
 export enum NotificationSubscriptionTypes {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1728,6 +1728,7 @@
     "stop-loss-executed": "Your Stop-Loss Protection on vault #{{vaultId}} was executed on {{humanDate}} at ${{usdPrice}}.",
     "auto-buy-executed": "Your Auto-Buy on vault #{{vaultId}} was executed on {{humanDate}} at ${{usdPrice}}.",
     "auto-sell-executed": "Your Auto-Sell on vault #{{vaultId}} was executed on {{humanDate}} at ${{usdPrice}}.",
+    "constant-multiple-executed": "Your Constant Multiple on vault #{{vaultId}} was executed on {{humanDate}} at ${{usdPrice}}.",
     "oracle-price-changed": "Oracle price changed ${{usdPrice}}.",
     "action-notifications": "Vault action notifications",
     "action-notifications-description": "Receive a notification when an action occurs on your Vault.",


### PR DESCRIPTION
# [Add support for additional Notifications & Ignore inrecognized Notifications](https://app.shortcut.com/oazo-apps/story/6153/add-support-for-additional-notifications-ignore-inrecognized-notifications)

Constant Multiple notifications were already partially handled, needed just final polish.
  
## Changes 👷‍♀️

- Added support for additional notification types:
```
CONSTANT_MULTIPLE_TRIGGERED = 10
APPROACHING_CONSTANT_MULTIPLE = 11
```
- notification list will now ignore and skip notifications of unknown types that aren't defined in `enum`.
  
## How to test 🧪

I don't know if testing is even possible at this state, I'm not sure if backend is already pushing CM notifications. One thing that could be done is doing a little bit of cheating to see if it's going to work.

To test Constant Multiple notification go to `components/notifications/NotificationCardsWrapper.tsx` and after line `30` add something like 
```
notificationsState.allNotifications[0].notificationType = 10
```
or
```
notificationsState.allNotifications[0].notificationType = 11
```
To see new types. That assumes that you actually have at least one notification on your wallet that can be overwriten.

To test skipping unsupported types you can try the same thing:
```
notificationsState.allNotifications[0].notificationType = 10
```
And see if notification is skipped in the list.
