### PR TITLE
Handle empty notifications list

### DIFF
--- a/components/notifications/NotificationCardsWrapper.tsx
+++ b/components/notifications/NotificationCardsWrapper.tsx
@@ -1,4 +1,5 @@
 import { NotificationCard } from 'components/notifications/NotificationCard'
+import { NotificationsEmptyList } from 'components/notifications/NotificationsEmptyList'
 import { useNotificationSocket } from 'components/NotificationSocketProvider'
 import { getNotificationTitle } from 'features/notifications/helpers'
 import { NOTIFICATION_CHANGE, NotificationChange } from 'features/notifications/notificationChange'
@@ -13,6 +14,10 @@ interface NotificationCardsWrapperProps {
 export function NotificationCardsWrapper({ account }: NotificationCardsWrapperProps) {
   const { socket } = useNotificationSocket()
   const [notificationsState] = useUIChanges<NotificationChange>(NOTIFICATION_CHANGE)
+
+  const validNotifications = notificationsState.allNotifications.filter(
+    (item) => item.notificationType in NotificationTypes,
+  )
 
   function markReadHandler(notificationId: number) {
     socket?.emit('markread', {
@@ -31,21 +36,25 @@ export function NotificationCardsWrapper({ account }: NotificationCardsWrapperPr
 
   return (
     <>
-      {notificationsState.allNotifications
-        .filter((item) => item.notificationType in NotificationTypes)
-        .map((item) => (
-          <NotificationCard
-            key={item.id}
-            {...item}
-            title={getNotificationTitle({
-              type: item.notificationType,
-              lastModified: item.lastModified,
-              additionalData: item.additionalData,
-            })}
-            markReadHandler={markReadHandler}
-            editHandler={editHandler}
-          />
-        ))}
+      {validNotifications.length > 0 ? (
+        <>
+          {validNotifications.map((item) => (
+            <NotificationCard
+              key={item.id}
+              {...item}
+              title={getNotificationTitle({
+                type: item.notificationType,
+                lastModified: item.lastModified,
+                additionalData: item.additionalData,
+              })}
+              markReadHandler={markReadHandler}
+              editHandler={editHandler}
+            />
+          ))}
+        </>
+      ) : (
+        <NotificationsEmptyList />
+      )}
     </>
   )
 }

--- a/components/notifications/NotificationsEmptyList.tsx
+++ b/components/notifications/NotificationsEmptyList.tsx
@@ -1,0 +1,31 @@
+import { NOTIFICATION_CHANGE, NotificationChange } from 'features/notifications/notificationChange'
+import { useUIChanges } from 'helpers/uiChangesHook'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Heading, Text } from 'theme-ui'
+
+export function NotificationsEmptyList() {
+  const { t } = useTranslation()
+  const [notificationsState] = useUIChanges<NotificationChange>(NOTIFICATION_CHANGE)
+
+  return (
+    <>
+      <Heading as="h3" variant="boldParagraph3">
+        {t('notifications.welcome-to-notifications')}
+      </Heading>
+      <Text
+        as="p"
+        variant="paragraph3"
+        sx={{
+          color: 'neutral80',
+        }}
+      >
+        {t(
+          notificationsState.allActiveSubscriptions.length > 0
+            ? 'notifications.zero-notifications'
+            : 'notifications.zero-notifications-no-active-subscriptions',
+        )}
+      </Text>
+    </>
+  )
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1738,7 +1738,10 @@
     "user-communication-notifications-description": "Something explains users will get the latest updates if they turn on notifications",
     "news-notifications": "Oasis.app news notifications",
     "news-notifications-description": "Something explains users will get the latest updates if they turn on notifications",
-    "service-not-available": "Notification service not available, please try again later."
+    "service-not-available": "Notification service not available, please try again later.",
+    "welcome-to-notifications": "Welcome to your Notification Center!",
+    "zero-notifications": "When available, your notifications will appear here.",
+    "zero-notifications-no-active-subscriptions": "Enable notifications in settings to allow them to appear here."
   },
   "manage-earn": {
     "aave": {


### PR DESCRIPTION
# [Handle empty notifications list](https://app.shortcut.com/oazo-apps/story/6147/0-notifications-copy)

Please note that ultimately that panel will look a little bit different when #1494 is merged.
![image](https://user-images.githubusercontent.com/16230404/192795324-bac52498-979f-4e81-9d70-44b1844bd26e.png)
  
## Changes 👷‍♀️

- Added handler for empty notifications list: different message depending if user has 0 notifications because his list is empty or he has notifications disabled in settings.
  
## How to test 🧪

- Open notifications panel with two different wallets, one that is suppose to have notifications and one without any.
