### PR TITLE
Notifications preferences panel tweaks

### DIFF
--- a/components/notifications/NotificationsCenter.tsx
+++ b/components/notifications/NotificationsCenter.tsx
@@ -34,7 +34,7 @@ export function NotificationsCenter({ isOpen }: { isOpen: boolean }) {
 
   useEffect(() => {
     setShowPrefencesTab(false)
-  }, [account])
+  }, [account, isOpen])
 
   return (
     <Box

--- a/components/notifications/NotificationsCenterHeader.tsx
+++ b/components/notifications/NotificationsCenterHeader.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Button, Flex, Text } from 'theme-ui'
 
@@ -11,6 +12,8 @@ export function NotificationsCenterHeader({
   onButtonClick,
   showPreferencesTab,
 }: NotificationsCenterHeaderProps) {
+  const { t } = useTranslation()
+
   return (
     <Flex
       sx={{
@@ -27,7 +30,11 @@ export function NotificationsCenterHeader({
           fontSize: '18px',
         }}
       >
-        Notifications
+        {t(
+          showPreferencesTab
+            ? 'notifications.notifications-preferences'
+            : 'notifications.notifications-center',
+        )}
       </Text>
 
       <Button
@@ -48,9 +55,9 @@ export function NotificationsCenterHeader({
         onClick={onButtonClick}
       >
         <Icon
-          name={showPreferencesTab ? 'close' : 'settings'}
+          name={showPreferencesTab ? 'arrow_left' : 'settings'}
           size="auto"
-          width="16"
+          width={showPreferencesTab ? '20' : '16'}
           color="neutral80"
         />
       </Button>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1713,6 +1713,8 @@
     }
   },
   "notifications": {
+    "notifications-center": "Notifications",
+    "notifications-preferences": "Notifications preferences",
     "enable-notifications-email-heading": "Enable email notifications",
     "enable-notifications-email-description": "You are able to receive the email updates on Oasis.app",
     "enable-notifications-email-placeholder": "Enter email...",


### PR DESCRIPTION
# Notifications preferences panel tweaks

![image](https://user-images.githubusercontent.com/16230404/193017396-21dd756f-f6ea-4752-87c9-5dd173eacf2a.png)
  
## Changes 👷‍♀️

- Changed cross icon to arrow icon to avoid confusions - icon isn't closing panel back is getting user back to notifications main panel,
- added different notifications panel title if user is in preferences,
- preferences will now close automatically when users closes entire notifications window.
  
## How to test 🧪

Just check out notifications preferences panel.