### PR TITLE
add tag to wstETH-B

### DIFF
--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -216,6 +216,7 @@ export const productCardsConfig: {
       'ETH-C': 'lowest-fees-for-borrowing',
       'WBTC-C': 'lowest-fees-for-borrowing',
       'WSTETH-A': 'staking-rewards',
+      'WSTETH-B': 'staking-rewards',
       'CRVV1ETHSTETH-A': 'staking-rewards',
     },
   },


### PR DESCRIPTION
This is done as it confuses users about wstETH-B

<img width="948" alt="image" src="https://user-images.githubusercontent.com/11577750/193064874-98419711-73ff-4c52-b527-a3e0b1bc7045.png">
