### PR TITLE
Auto-take Profit min/max on slider

### DIFF
--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -19,6 +19,7 @@ export interface TokenConfig {
   token0?: string
   token1?: string
   coinbaseTicker?: string
+  coinGeckoId?: string
   background?: string
   digitsInstant?: number
 }
@@ -99,6 +100,7 @@ export const tokens = [
     iconColor: 'ether_color',
     coinpaprikaTicker: 'eth-ethereum',
     coinbaseTicker: 'eth-usd',
+    coinGeckoId: 'ethereum',
     color: '#667FE3',
     background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/eth.png'),
@@ -131,6 +133,7 @@ export const tokens = [
     iconCircle: 'wbtc_circle_color',
     iconColor: 'wbtc_circle_color',
     coinpaprikaTicker: 'wbtc-wrapped-bitcoin',
+    coinGeckoId: 'wrapped-bitcoin',
     color: '#f09242',
     background: 'linear-gradient(147.66deg, #FEF1E1 0%, #FDF2CA 88.25%)',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/wbtc.png'),
@@ -150,6 +153,7 @@ export const tokens = [
     iconCircle: 'renbtc_circle_color',
     iconColor: 'renbtc_circle_color',
     coinpaprikaTicker: 'renbtc-renbtc',
+    coinGeckoId: 'renbtc',
     color: '#838489',
     background: 'linear-gradient(160.47deg, #F1F5F5 0.35%, #E5E7E8 99.18%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/renBTC.png'),
@@ -195,6 +199,7 @@ export const tokens = [
     iconColor: 'mana_color',
     color: '#f05',
     coinbaseTicker: 'MANA-USD',
+    coinGeckoId: 'decentraland',
     background: 'linear-gradient(160.26deg, #FFEAEA 5.25%, #FFF5EA 100%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/mana.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/mana.gif'),
@@ -266,6 +271,7 @@ export const tokens = [
     iconColor: 'chainlink_color',
     color: '#375bd2',
     coinbaseTicker: 'LINK-USD',
+    coinGeckoId: 'chainlink',
     background: 'linear-gradient(160.47deg, #E0E8F5 0.35%, #F0FBFD 99.18%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/link.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/link.gif'),
@@ -281,6 +287,7 @@ export const tokens = [
     iconColor: 'gemini_color',
     color: '#25ddfb',
     coinpaprikaTicker: 'gusd-gemini-dollar',
+    coinGeckoId: 'gemini-dollar',
     background: 'linear-gradient(158.87deg, #E2F7F9 0%, #D3F3F5 100%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/gusd.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/gusd.gif'),
@@ -342,6 +349,7 @@ export const tokens = [
     iconCircle: 'yfi_circle_color',
     iconColor: 'yfi_circle_color',
     coinbaseTicker: 'YFI-USD',
+    coinGeckoId: 'yearn-finance',
     color: '#0657f9',
     background: 'linear-gradient(160.47deg, #E0E8F5 0.35%, #F0FBFD 99.18%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/yfi.png'),
@@ -574,6 +582,7 @@ export const tokens = [
     iconColor: 'matic_circle_color',
     color: '#ff077d',
     coinbaseTicker: 'MATIC-USD',
+    coinGeckoId: 'polygon',
     background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/matic.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/matic.gif'),
@@ -589,6 +598,7 @@ export const tokens = [
     iconCircle: 'wsteth_circle_color',
     iconColor: 'wsteth_circle_color',
     coinGeckoTicker: 'wrapped-steth',
+    coinGeckoId: 'wrapped-steth',
     color: '#ff077d',
     background: 'linear-gradient(158.87deg, #E2F7F9 0%, #D3F3F5 100%), #FFFFFF',
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/wstETH.png'),

--- a/blockchain/vault.maths.ts
+++ b/blockchain/vault.maths.ts
@@ -159,3 +159,20 @@ export function collateralPriceAtRatio({
     ? zero
     : vaultDebt.times(colRatio).div(collateral)
 }
+
+type RatioAtCollateralPriceArgs = {
+  lockedCollateral: BigNumber
+  collateralPriceUSD: BigNumber
+  vaultDebt: BigNumber
+}
+
+// the collateral price at which the collateral ratio is reached
+export function ratioAtCollateralPrice({
+  lockedCollateral,
+  collateralPriceUSD,
+  vaultDebt,
+}: RatioAtCollateralPriceArgs): BigNumber {
+  return lockedCollateral.isZero() || collateralPriceUSD.isZero()
+    ? zero
+    : lockedCollateral.times(collateralPriceUSD).div(vaultDebt).times(100)
+}

--- a/blockchain/vault.maths.ts
+++ b/blockchain/vault.maths.ts
@@ -166,7 +166,6 @@ type RatioAtCollateralPriceArgs = {
   vaultDebt: BigNumber
 }
 
-// the collateral price at which the collateral ratio is reached
 export function ratioAtCollateralPrice({
   lockedCollateral,
   collateralPriceUSD,

--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -167,6 +167,7 @@ export function OptimizationControl({
                 context={context}
                 balanceInfo={balanceInfo}
                 ethMarketPrice={ethAndTokenPrices['ETH']}
+                tokenMarketPrice={ethAndTokenPrices[vault.token]}
               />
             }
           />

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { Vault } from 'blockchain/vaults'
 import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
 import { AutomationFeatures } from 'features/automation/common/types'
@@ -15,6 +16,7 @@ interface AutoTakeProfitFormControlProps {
   autoBuyTriggerData: AutoBSTriggerData
   constantMultipleTriggerData: ConstantMultipleTriggerData
   isAutoTakeProfitActive: boolean
+  tokenMarketPrice: BigNumber
   vault: Vault
 }
 
@@ -22,12 +24,13 @@ export function AutoTakeProfitFormControl({
   autoBuyTriggerData,
   constantMultipleTriggerData,
   isAutoTakeProfitActive,
+  tokenMarketPrice,
   vault,
 }: AutoTakeProfitFormControlProps) {
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
 
   const feature = AutomationFeatures.AUTO_TAKE_PROFIT
-  const { closePickerConfig } = getAutoTakeProfitStatus({ autoTakeProfitState, vault })
+  const { closePickerConfig } = getAutoTakeProfitStatus({ autoTakeProfitState, tokenMarketPrice, vault })
 
   return (
     // TODO: TDAutoTakeProfit | should be used with AddAndRemoveTriggerControl as a wrapper when there is enough data

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -30,18 +30,24 @@ export function AutoTakeProfitFormControl({
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
 
   const feature = AutomationFeatures.AUTO_TAKE_PROFIT
-  const { closePickerConfig } = getAutoTakeProfitStatus({ autoTakeProfitState, tokenMarketPrice, vault })
+  const { closePickerConfig, min, max } = getAutoTakeProfitStatus({
+    autoTakeProfitState,
+    tokenMarketPrice,
+    vault,
+  })
 
   return (
     // TODO: TDAutoTakeProfit | should be used with AddAndRemoveTriggerControl as a wrapper when there is enough data
     <SidebarSetupAutoTakeProfit
       autoBuyTriggerData={autoBuyTriggerData}
+      autoTakeProfitState={autoTakeProfitState}
+      closePickerConfig={closePickerConfig}
       constantMultipleTriggerData={constantMultipleTriggerData}
       feature={feature}
       isAutoTakeProfitActive={isAutoTakeProfitActive}
+      max={max}
+      min={min}
       vault={vault}
-      closePickerConfig={closePickerConfig}
-      autoTakeProfitState={autoTakeProfitState}
     />
   )
 }

--- a/features/automation/optimization/autoTakeProfit/state/autoTakeProfitFormChange.ts
+++ b/features/automation/optimization/autoTakeProfit/state/autoTakeProfitFormChange.ts
@@ -9,11 +9,12 @@ export const AUTO_TAKE_PROFIT_FORM_CHANGE = 'AUTO_TAKE_PROFIT_FORM_CHANGE'
 // >
 
 export type AutoTakeProfitFormChangeAction =
-  | { type: 'execution-coll-ratio'; executionCollRatio: BigNumber }
+  | { type: 'execution-price'; executionPrice: BigNumber; executionCollRatio: BigNumber }
   | { type: 'current-form'; currentForm: AutomationFormType }
   | { type: 'close-type'; toCollateral: boolean }
   | {
       type: 'form-defaults'
+      executionPrice: BigNumber
       executionCollRatio: BigNumber
       toCollateral: boolean
     }
@@ -26,12 +27,23 @@ export function autoTakeProfitFormChangeReducer(
   action: AutoTakeProfitFormChangeAction,
 ): AutoTakeProfitFormChange {
   switch (action.type) {
-    case 'execution-coll-ratio':
-      return { ...state, executionCollRatio: action.executionCollRatio }
+    case 'execution-price':
+      return {
+        ...state,
+        executionPrice: action.executionPrice,
+        executionCollRatio: action.executionCollRatio,
+      }
     case 'current-form':
       return { ...state, currentForm: action.currentForm }
     case 'close-type':
-      return { ...state, collateralActive: action.toCollateral }
+      return { ...state, toCollateral: action.toCollateral }
+    case 'form-defaults':
+      return {
+        ...state,
+        executionPrice: action.executionPrice,
+        executionCollRatio: action.executionCollRatio,
+        toCollateral: action.toCollateral,
+      }
     // TODO ŁW
     //     case 'reset':
     //       return { ...state, ...action.resetData }
@@ -41,8 +53,9 @@ export function autoTakeProfitFormChangeReducer(
 }
 
 export interface AutoTakeProfitFormChange {
+  executionPrice: BigNumber
   executionCollRatio: BigNumber
   currentForm: AutomationFormType
-  collateralActive: boolean
+  toCollateral: boolean
   // resetData: AutoTakeProfitResetData
 }

--- a/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
+++ b/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
@@ -5,6 +5,7 @@ import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { PickCloseStateProps } from 'components/dumb/PickCloseState'
 import { closeVaultOptions } from 'features/automation/common/consts'
+import { createTokenAth } from 'features/tokenAth/tokenAth'
 
 import { AUTO_TAKE_PROFIT_FORM_CHANGE, AutoTakeProfitFormChange } from './autoTakeProfitFormChange'
 
@@ -12,6 +13,7 @@ interface GetAutoTakeProfitStatusParams {
   // TODO ŁW
   // autoTakeProfitTriggerData: AutoTakeProfitTriggerData
   autoTakeProfitState: AutoTakeProfitFormChange
+  tokenMarketPrice: BigNumber
   vault: Vault
   // isRemoveForm: boolean
   // isProgressStage: boolean
@@ -20,12 +22,19 @@ interface GetAutoTakeProfitStatusParams {
 }
 
 interface AutoTakeProfitStatus {
-  executionPrice: BigNumber
   closePickerConfig: PickCloseStateProps
+  executionPrice: BigNumber
+  min: BigNumber
+  max: BigNumber
 }
+
+const MIN_MULTIPLIER = 1.05
+const MAX_MULTIPLIER_WITH_ATH = 2
+const MAX_MULTIPLIER_WITH_PRICE = 10
 
 export function getAutoTakeProfitStatus({
   autoTakeProfitState,
+  tokenMarketPrice,
   vault,
 }: GetAutoTakeProfitStatusParams): AutoTakeProfitStatus {
   const { uiChanges } = useAppContext()
@@ -47,8 +56,19 @@ export function getAutoTakeProfitStatus({
     collateralTokenSymbol: vault.token,
     collateralTokenIconCircle: getToken(vault.token).iconCircle,
   }
+  const tokenAth = createTokenAth(vault.token)
+  const min = tokenMarketPrice.times(MIN_MULTIPLIER)
+  const max = tokenAth
+    ? tokenAth.times(MAX_MULTIPLIER_WITH_ATH)
+    : tokenMarketPrice.times(MAX_MULTIPLIER_WITH_PRICE)
+
+  console.log(`tokenAth: ${tokenAth}`)
+  console.log(`${min}, ${max}`)
+
   return {
     executionPrice,
     closePickerConfig,
+    min,
+    max,
   }
 }

--- a/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
+++ b/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
-import { collateralPriceAtRatio } from 'blockchain/vault.maths'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { PickCloseStateProps } from 'components/dumb/PickCloseState'
@@ -23,7 +22,6 @@ interface GetAutoTakeProfitStatusParams {
 
 interface AutoTakeProfitStatus {
   closePickerConfig: PickCloseStateProps
-  executionPrice: BigNumber
   min: BigNumber
   max: BigNumber
 }
@@ -39,11 +37,6 @@ export function getAutoTakeProfitStatus({
 }: GetAutoTakeProfitStatusParams): AutoTakeProfitStatus {
   const { uiChanges } = useAppContext()
 
-  const executionPrice = collateralPriceAtRatio({
-    colRatio: autoTakeProfitState.executionCollRatio.div(100),
-    collateral: vault.lockedCollateral,
-    vaultDebt: vault.debt,
-  })
   const closePickerConfig = {
     optionNames: closeVaultOptions,
     onclickHandler: (optionName: string) => {
@@ -52,7 +45,7 @@ export function getAutoTakeProfitStatus({
         toCollateral: optionName === closeVaultOptions[0],
       })
     },
-    isCollateralActive: autoTakeProfitState.collateralActive,
+    isCollateralActive: autoTakeProfitState.toCollateral,
     collateralTokenSymbol: vault.token,
     collateralTokenIconCircle: getToken(vault.token).iconCircle,
   }
@@ -62,11 +55,7 @@ export function getAutoTakeProfitStatus({
     ? tokenAth.times(MAX_MULTIPLIER_WITH_ATH)
     : tokenMarketPrice.times(MAX_MULTIPLIER_WITH_PRICE)
 
-  console.log(`tokenAth: ${tokenAth}`)
-  console.log(`${min}, ${max}`)
-
   return {
-    executionPrice,
     closePickerConfig,
     min,
     max,

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -25,6 +25,7 @@ interface OptimizationFormControlProps {
   balanceInfo: BalanceInfo
   context: Context
   ethMarketPrice: BigNumber
+  tokenMarketPrice: BigNumber
   ilkData: IlkData
   txHelpers?: TxHelpers
   vault: Vault
@@ -35,6 +36,7 @@ export function OptimizationFormControl({
   balanceInfo,
   context,
   ethMarketPrice,
+  tokenMarketPrice,
   ilkData,
   txHelpers,
   vault,
@@ -126,11 +128,11 @@ export function OptimizationFormControl({
         txHelpers={txHelpers}
         vault={vault}
       />
-
       <AutoTakeProfitFormControl
         autoBuyTriggerData={autoBuyTriggerData}
         constantMultipleTriggerData={constantMultipleTriggerData}
         isAutoTakeProfitActive={isAutoTakeProfitActive}
+        tokenMarketPrice={tokenMarketPrice}
         vault={vault}
       />
     </>

--- a/features/tokenAth/tokenAth.ts
+++ b/features/tokenAth/tokenAth.ts
@@ -1,0 +1,12 @@
+import { getToken } from 'blockchain/tokensMetadata'
+import { getTokenAth$ } from 'features/tokenAth/tokenAthApi'
+import { useObservable } from 'helpers/observableHook'
+import { useMemo } from 'react'
+
+export function createTokenAth(token: string) {
+  const coinGeckoId = getToken(token).coinGeckoId || ''
+  const tokenAth$ = useMemo(() => getTokenAth$(coinGeckoId), [token])
+  const [tokenAth] = useObservable(tokenAth$)
+
+  return tokenAth?.ath
+}

--- a/features/tokenAth/tokenAthApi.ts
+++ b/features/tokenAth/tokenAthApi.ts
@@ -1,0 +1,20 @@
+import BigNumber from 'bignumber.js'
+import { of } from 'ramda'
+import { Observable } from 'rxjs'
+import { ajax } from 'rxjs/ajax'
+import { catchError, map } from 'rxjs/operators'
+
+export interface TokenAthResponse {
+  ath?: BigNumber
+  error?: string
+}
+
+export function getTokenAth$(coinGeckoId: string): Observable<TokenAthResponse> {
+  return ajax({
+    url: `https://api.coingecko.com/api/v3/coins/${coinGeckoId}?tickers=false&market_data=true&community_data=false&developer_data=false`,
+    method: 'GET',
+  }).pipe(
+    map(({ response }) => ({ ath: new BigNumber(response.market_data.ath.usd) })),
+    catchError((response) => of({ error: response.error })),
+  )
+}


### PR DESCRIPTION
# Auto-take Profit min/max on slider

Min value on slider: `current collateral price * 1.05`,
Max value on slider: `all time high collateral price * 2`, or, if API is not responding, `current collateral price * 10`,
Default value on slider: price of collateral based on `current collateral ratio * 1.2`.

![image](https://user-images.githubusercontent.com/16230404/193561916-9c3315a0-0215-4b13-b76b-051859d67b46.png)
  
## Changes 👷‍♀️

- created API endpoint to request for all time high price from coingecko,
- added slider min and max values to `getAutoTakeProfitStatus` method,
- forced Auto-take Profit slider to be based on potential price, not collateral ratio,
- updated `AUTO_TAKE_PROFIT_FORM_CHANGE` reduced with method that allows to set up default values and also removed `execution-coll-ratio` event and replaced it with `execution-price` since contract requires price, not col. ratio.
  
## How to test 🧪

Check out if slider min, max and default values on Auto-take Profit are working in a way I described them above.
