### PR TITLE
Discover oasis page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -442,14 +442,13 @@ const LINKS = {
   multiply: `/multiply`,
   borrow: `/borrow`,
   earn: '/earn',
-  discovery: '/discovery/high-risk-positions',
+  discovery: '/discovery',
 }
 
 function ConnectedHeader() {
   const { uiChanges } = useAppContext()
-  const { pathname } = useRouter()
-  const { t } = useTranslation()
   const onMobile = useOnMobile()
+
   const [widgetUiChanges] = useObservable(
     uiChanges.subscribe<SwapWidgetState>(SWAP_WIDGET_CHANGE_SUBJECT),
   )
@@ -467,132 +466,72 @@ function ConnectedHeader() {
           }}
           variant="appContainer"
         >
-          <Flex
-            sx={{
-              alignItems: 'center',
-              justifyContent: ['space-between', 'flex-start'],
-              width: ['100%', 'auto'],
-            }}
-          >
-            <Logo />
-            <Grid
-              as="ul"
-              sx={{
-                gridAutoFlow: 'column',
-                columnGap: '48px',
-                ml: '48px',
-                p: 0,
-                listStyle: 'none',
-              }}
-            >
-              <HeaderLink label={t('nav.products')}>
-                <HeaderList
-                  links={[
-                    { label: t('nav.multiply'), href: LINKS.multiply },
-                    { label: t('nav.borrow'), href: LINKS.borrow },
-                    { label: t('nav.earn'), href: LINKS.earn },
-                  ]}
-                />
-              </HeaderLink>
-              <HeaderLink label={t('nav.assets')} />
-              <HeaderLink label={t('nav.discovery')} href={LINKS.discovery} />
-              {/* <Box as="li">
-                <AppLink
-                  variant="links.navHeader"
-                  href={LINKS.multiply}
-                  sx={{
-                    mr: 4,
-                    color: navLinkColor(pathname.includes(LINKS.multiply)),
-                  }}
-                >
-                  {t('nav.multiply')}
-                </AppLink>
-              </Box>
-              <Box as="li">
-                <AppLink
-                  variant="links.navHeader"
-                  href={LINKS.borrow}
-                  sx={{ mr: 4, color: navLinkColor(pathname.includes(LINKS.borrow)) }}
-                >
-                  {t('nav.borrow')}
-                </AppLink>
-              </Box>
-              <Box as="li">
-                <AppLink
-                  variant="links.navHeader"
-                  href={LINKS.earn}
-                  sx={{ mr: 4, color: navLinkColor(pathname.includes(LINKS.earn)) }}
-                >
-                  {t('nav.earn')}
-                </AppLink>
-              </Box>
-              <AssetsDropdown /> */}
-            </Grid>
-          </Flex>
+          <MainNavigation />
           <UserDesktopMenu />
         </BasicHeader>
       ) : (
-        <>a</>
         // Mobile header
-        // <Box sx={{ mb: 5 }}>
-        //   <BasicHeader variant="appContainer">
-        //     <Flex sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
-        //       <Logo />
-        //     </Flex>
-        //     <Flex sx={{ flexShrink: 0 }}>
-        //       <PositionsButton sx={{ mr: 2 }} />
-        //       <Button
-        //         variant="menuButtonRound"
-        //         onClick={() => {
-        //           uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
-        //             type: 'open',
-        //           })
-        //         }}
-        //         sx={{
-        //           mr: 2,
-        //           '&, :focus': {
-        //             outline: widgetOpen ? '1px solid' : null,
-        //             outlineColor: 'primary100',
-        //           },
-        //           color: 'neutral80',
-        //           ':hover': { color: 'primary100' },
-        //         }}
-        //       >
-        //         <Icon
-        //           name="exchange"
-        //           size="auto"
-        //           width="20"
-        //           color={widgetOpen ? 'primary100' : 'inherit'}
-        //         />
-        //       </Button>
-        //       <UniswapWidgetShowHide
-        //         sxWrapper={{
-        //           position: 'fixed',
-        //           top: '50%',
-        //           left: '50%',
-        //           right: 'unset',
-        //           bottom: 'unset',
-        //           transform: 'translateX(-50%) translateY(-50%)',
-        //         }}
-        //       />
-        //       <MobileMenu />
-        //     </Flex>
-        //     <MobileSettings />
-        //   </BasicHeader>
-        // </Box>
+        <Box sx={{ mb: 5 }}>
+          <BasicHeader variant="appContainer">
+            <Flex sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
+              <Logo />
+            </Flex>
+            <Flex sx={{ flexShrink: 0 }}>
+              <PositionsButton sx={{ mr: 2 }} />
+              <Button
+                variant="menuButtonRound"
+                onClick={() => {
+                  uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+                    type: 'open',
+                  })
+                }}
+                sx={{
+                  mr: 2,
+                  '&, :focus': {
+                    outline: widgetOpen ? '1px solid' : null,
+                    outlineColor: 'primary100',
+                  },
+                  color: 'neutral80',
+                  ':hover': { color: 'primary100' },
+                }}
+              >
+                <Icon
+                  name="exchange"
+                  size="auto"
+                  width="20"
+                  color={widgetOpen ? 'primary100' : 'inherit'}
+                />
+              </Button>
+              <UniswapWidgetShowHide
+                sxWrapper={{
+                  position: 'fixed',
+                  top: '50%',
+                  left: '50%',
+                  right: 'unset',
+                  bottom: 'unset',
+                  transform: 'translateX(-50%) translateY(-50%)',
+                }}
+              />
+              <MobileMenu />
+            </Flex>
+            <MobileSettings />
+          </BasicHeader>
+        </Box>
       )}
     </>
   )
 }
 
-function HeaderLink({ label, href, children }: { label: string; href?: string } & WithChildren) {
+function HeaderLink({ label, link, children }: { label: string; link?: string } & WithChildren) {
+  const { asPath } = useRouter()
   const [isMouseOver, setIsMouseOver] = useState<boolean>(false)
+  const isActive = link ? asPath.includes(link) : false
   const itemSx: SxStyleProp = {
     position: 'relative',
     display: 'block',
     fontSize: 2,
     pr: children ? 3 : 0,
-    color: isMouseOver ? 'primary100' : 'neutral80',
+    color: isMouseOver || isActive ? 'primary100' : 'neutral80',
     fontWeight: 'semiBold',
     cursor: 'pointer',
     transition: '200ms color',
@@ -609,8 +548,8 @@ function HeaderLink({ label, href, children }: { label: string; href?: string } 
         setIsMouseOver(false)
       }}
     >
-      {href ? (
-        <AppLink href={href} sx={itemSx}>
+      {link ? (
+        <AppLink href={link} sx={itemSx}>
           {label}
         </AppLink>
       ) : (
@@ -621,7 +560,7 @@ function HeaderLink({ label, href, children }: { label: string; href?: string } 
               <Icon
                 name="caret_down"
                 size="8px"
-                sx={{ position: 'absolute', top: '6px', right: 0 }}
+                sx={{ position: 'absolute', top: '7px', right: 0 }}
               />
             )}
           </Text>
@@ -656,12 +595,41 @@ function HeaderLink({ label, href, children }: { label: string; href?: string } 
   )
 }
 
-function HeaderList({ links }: { links: { label: string; href: string }[] } & WithChildren) {
+function HeaderList({
+  links,
+  columns,
+}: {
+  links: { label: string; link: string; icon?: string }[]
+  columns?: number
+}) {
+  const { asPath } = useRouter()
+
   return (
-    <Box as="ul" sx={{ p: 0, listStyle: 'none' }}>
-      {links.map(({ label, href }, i) => (
+    <Box
+      as="ul"
+      sx={{ p: 0, listStyle: 'none', ...(columns && { columnCount: columns, columnGap: '24px' }) }}
+    >
+      {links.map(({ label, link, icon }, i) => (
         <Box as="li" sx={{ mt: i > 0 ? '24px' : 0 }}>
-          <AppLink href={href}>{label}</AppLink>
+          <AppLink
+            href={link}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              color: asPath.includes(link) ? 'primary100' : 'neutral80',
+              fontSize: 3,
+              fontWeight: 'regular',
+              transition: '200ms color',
+              '&:hover': {
+                color: 'primary100',
+              },
+            }}
+          >
+            {icon && <Icon name={icon} size={32} sx={{ mr: 2 }} />}
+            <Text as="span" sx={{ whiteSpace: 'pre' }}>
+              {label}
+            </Text>
+          </AppLink>
         </Box>
       ))}
     </Box>
@@ -797,6 +765,7 @@ function MobileMenu() {
     { labelKey: 'nav.multiply', url: LINKS.multiply },
     { labelKey: 'nav.borrow', url: LINKS.borrow },
     { labelKey: 'nav.earn', url: LINKS.earn },
+    { labelKey: 'nav.discovery', url: LINKS.discovery },
   ]
 
   const closeMenu = useCallback(() => setIsOpen(false), [])
@@ -907,37 +876,12 @@ function MobileMenu() {
 
 function DisconnectedHeader() {
   const { t } = useTranslation()
-  const { pathname } = useRouter()
 
   return (
     <>
       <Box sx={{ display: ['none', 'block'] }}>
         <BasicHeader variant="appContainer">
-          <Grid sx={{ alignItems: 'center', columnGap: [4, 4, 5], gridAutoFlow: 'column', mr: 3 }}>
-            <Logo />
-            <AppLink
-              variant="links.navHeader"
-              href={LINKS.multiply}
-              sx={{ color: navLinkColor(pathname.includes(LINKS.multiply)) }}
-            >
-              {t('nav.multiply')}
-            </AppLink>
-            <AppLink
-              variant="links.navHeader"
-              href={LINKS.borrow}
-              sx={{ color: navLinkColor(pathname.includes(LINKS.borrow)) }}
-            >
-              {t('nav.borrow')}
-            </AppLink>
-            <AppLink
-              variant="links.navHeader"
-              href={LINKS.earn}
-              sx={{ color: navLinkColor(pathname.includes(LINKS.earn)) }}
-            >
-              {t('nav.earn')}
-            </AppLink>
-            <AssetsDropdown />
-          </Grid>
+          <MainNavigation />
           <Grid sx={{ alignItems: 'center', columnGap: 3, gridAutoFlow: 'column' }}>
             <AppLink
               variant="buttons.secondary"
@@ -974,6 +918,79 @@ function DisconnectedHeader() {
         </BasicHeader>
       </Box>
     </>
+  )
+}
+
+function MainNavigation() {
+  const { t } = useTranslation()
+
+  const discoverOasisEnabled = useFeatureToggle('DiscoverOasis')
+  const { pathname } = useRouter()
+
+  return (
+    <Flex
+      sx={{
+        alignItems: 'center',
+        justifyContent: ['space-between', 'flex-start'],
+        width: ['100%', 'auto'],
+      }}
+    >
+      <Logo />
+      {!discoverOasisEnabled ? (
+        <Flex sx={{ ml: 5, zIndex: 1 }}>
+          <AppLink
+            variant="links.navHeader"
+            href={LINKS.multiply}
+            sx={{
+              mr: 4,
+              color: navLinkColor(pathname.includes(LINKS.multiply)),
+            }}
+          >
+            {t('nav.multiply')}
+          </AppLink>
+          <AppLink
+            variant="links.navHeader"
+            href={LINKS.borrow}
+            sx={{ mr: 4, color: navLinkColor(pathname.includes(LINKS.borrow)) }}
+          >
+            {t('nav.borrow')}
+          </AppLink>
+          <AppLink
+            variant="links.navHeader"
+            href={LINKS.earn}
+            sx={{ mr: 4, color: navLinkColor(pathname.includes(LINKS.earn)) }}
+          >
+            {t('nav.earn')}
+          </AppLink>
+          <AssetsDropdown />
+        </Flex>
+      ) : (
+        <Grid
+          as="ul"
+          sx={{
+            gridAutoFlow: 'column',
+            columnGap: ['24px', '24px', '24px', '48px'],
+            mx: ['24px', '24px', '24px', '48px'],
+            p: 0,
+            listStyle: 'none',
+          }}
+        >
+          <HeaderLink label={t('nav.products')}>
+            <HeaderList
+              links={[
+                { label: t('nav.multiply'), link: LINKS.multiply },
+                { label: t('nav.borrow'), link: LINKS.borrow },
+                { label: t('nav.earn'), link: LINKS.earn },
+              ]}
+            />
+          </HeaderLink>
+          <HeaderLink label={t('nav.assets')}>
+            <HeaderList links={LANDING_PILLS} columns={2} />
+          </HeaderLink>
+          <HeaderLink label={t('nav.discovery')} link={LINKS.discovery} />
+        </Grid>
+      )}
+    </Flex>
   )
 }
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -442,6 +442,7 @@ const LINKS = {
   multiply: `/multiply`,
   borrow: `/borrow`,
   earn: '/earn',
+  discovery: '/discovery/high-risk-positions',
 }
 
 function ConnectedHeader() {
@@ -456,7 +457,7 @@ function ConnectedHeader() {
   const widgetOpen = widgetUiChanges && widgetUiChanges.isOpen
 
   return (
-    <React.Fragment>
+    <>
       {!onMobile ? (
         <BasicHeader
           sx={{
@@ -466,16 +467,36 @@ function ConnectedHeader() {
           }}
           variant="appContainer"
         >
-          <>
-            <Flex
+          <Flex
+            sx={{
+              alignItems: 'center',
+              justifyContent: ['space-between', 'flex-start'],
+              width: ['100%', 'auto'],
+            }}
+          >
+            <Logo />
+            <Grid
+              as="ul"
               sx={{
-                alignItems: 'center',
-                justifyContent: ['space-between', 'flex-start'],
-                width: ['100%', 'auto'],
+                gridAutoFlow: 'column',
+                columnGap: '48px',
+                ml: '48px',
+                p: 0,
+                listStyle: 'none',
               }}
             >
-              <Logo />
-              <Flex sx={{ ml: 5, zIndex: 1 }}>
+              <HeaderLink label={t('nav.products')}>
+                <HeaderList
+                  links={[
+                    { label: t('nav.multiply'), href: LINKS.multiply },
+                    { label: t('nav.borrow'), href: LINKS.borrow },
+                    { label: t('nav.earn'), href: LINKS.earn },
+                  ]}
+                />
+              </HeaderLink>
+              <HeaderLink label={t('nav.assets')} />
+              <HeaderLink label={t('nav.discovery')} href={LINKS.discovery} />
+              {/* <Box as="li">
                 <AppLink
                   variant="links.navHeader"
                   href={LINKS.multiply}
@@ -486,6 +507,8 @@ function ConnectedHeader() {
                 >
                   {t('nav.multiply')}
                 </AppLink>
+              </Box>
+              <Box as="li">
                 <AppLink
                   variant="links.navHeader"
                   href={LINKS.borrow}
@@ -493,6 +516,8 @@ function ConnectedHeader() {
                 >
                   {t('nav.borrow')}
                 </AppLink>
+              </Box>
+              <Box as="li">
                 <AppLink
                   variant="links.navHeader"
                   href={LINKS.earn}
@@ -500,62 +525,146 @@ function ConnectedHeader() {
                 >
                   {t('nav.earn')}
                 </AppLink>
-                <AssetsDropdown />
-              </Flex>
-            </Flex>
-            <UserDesktopMenu />
-          </>
+              </Box>
+              <AssetsDropdown /> */}
+            </Grid>
+          </Flex>
+          <UserDesktopMenu />
         </BasicHeader>
       ) : (
+        <>a</>
         // Mobile header
-        <Box sx={{ mb: 5 }}>
-          <BasicHeader variant="appContainer">
-            <Flex sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Logo />
-            </Flex>
-            <Flex sx={{ flexShrink: 0 }}>
-              <PositionsButton sx={{ mr: 2 }} />
-              <Button
-                variant="menuButtonRound"
-                onClick={() => {
-                  uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
-                    type: 'open',
-                  })
-                }}
+        // <Box sx={{ mb: 5 }}>
+        //   <BasicHeader variant="appContainer">
+        //     <Flex sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
+        //       <Logo />
+        //     </Flex>
+        //     <Flex sx={{ flexShrink: 0 }}>
+        //       <PositionsButton sx={{ mr: 2 }} />
+        //       <Button
+        //         variant="menuButtonRound"
+        //         onClick={() => {
+        //           uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+        //             type: 'open',
+        //           })
+        //         }}
+        //         sx={{
+        //           mr: 2,
+        //           '&, :focus': {
+        //             outline: widgetOpen ? '1px solid' : null,
+        //             outlineColor: 'primary100',
+        //           },
+        //           color: 'neutral80',
+        //           ':hover': { color: 'primary100' },
+        //         }}
+        //       >
+        //         <Icon
+        //           name="exchange"
+        //           size="auto"
+        //           width="20"
+        //           color={widgetOpen ? 'primary100' : 'inherit'}
+        //         />
+        //       </Button>
+        //       <UniswapWidgetShowHide
+        //         sxWrapper={{
+        //           position: 'fixed',
+        //           top: '50%',
+        //           left: '50%',
+        //           right: 'unset',
+        //           bottom: 'unset',
+        //           transform: 'translateX(-50%) translateY(-50%)',
+        //         }}
+        //       />
+        //       <MobileMenu />
+        //     </Flex>
+        //     <MobileSettings />
+        //   </BasicHeader>
+        // </Box>
+      )}
+    </>
+  )
+}
+
+function HeaderLink({ label, href, children }: { label: string; href?: string } & WithChildren) {
+  const [isMouseOver, setIsMouseOver] = useState<boolean>(false)
+  const itemSx: SxStyleProp = {
+    position: 'relative',
+    display: 'block',
+    fontSize: 2,
+    pr: children ? 3 : 0,
+    color: isMouseOver ? 'primary100' : 'neutral80',
+    fontWeight: 'semiBold',
+    cursor: 'pointer',
+    transition: '200ms color',
+  }
+
+  return (
+    <Box
+      as="li"
+      sx={{ position: 'relative' }}
+      onMouseEnter={() => {
+        setIsMouseOver(true)
+      }}
+      onMouseLeave={() => {
+        setIsMouseOver(false)
+      }}
+    >
+      {href ? (
+        <AppLink href={href} sx={itemSx}>
+          {label}
+        </AppLink>
+      ) : (
+        <>
+          <Text as="span" sx={itemSx}>
+            {label}
+            {children && (
+              <Icon
+                name="caret_down"
+                size="8px"
+                sx={{ position: 'absolute', top: '6px', right: 0 }}
+              />
+            )}
+          </Text>
+          {children && (
+            <Box
+              sx={{
+                position: 'absolute',
+                top: '100%',
+                left: '-12px',
+                pt: '12px',
+                opacity: isMouseOver ? 1 : 0,
+                transform: isMouseOver ? 'translateY(0)' : 'translateY(-5px)',
+                pointerEvents: isMouseOver ? 'auto' : 'none',
+                transition: 'opacity 200ms, transform 200ms',
+              }}
+            >
+              <Box
                 sx={{
-                  mr: 2,
-                  '&, :focus': {
-                    outline: widgetOpen ? '1px solid' : null,
-                    outlineColor: 'primary100',
-                  },
-                  color: 'neutral80',
-                  ':hover': { color: 'primary100' },
+                  p: '24px',
+                  backgroundColor: 'neutral10',
+                  borderRadius: 'large',
+                  boxShadow: 'buttonMenu',
                 }}
               >
-                <Icon
-                  name="exchange"
-                  size="auto"
-                  width="20"
-                  color={widgetOpen ? 'primary100' : 'inherit'}
-                />
-              </Button>
-              <UniswapWidgetShowHide
-                sxWrapper={{
-                  position: 'fixed',
-                  top: '50%',
-                  left: '50%',
-                  right: 'unset',
-                  bottom: 'unset',
-                  transform: 'translateX(-50%) translateY(-50%)',
-                }}
-              />
-              <MobileMenu />
-            </Flex>
-            <MobileSettings />
-          </BasicHeader>
-        </Box>
+                {children}
+              </Box>
+            </Box>
+          )}
+        </>
       )}
-    </React.Fragment>
+    </Box>
+  )
+}
+
+function HeaderList({ links }: { links: { label: string; href: string }[] } & WithChildren) {
+  return (
+    <Box as="ul" sx={{ p: 0, listStyle: 'none' }}>
+      {links.map(({ label, href }, i) => (
+        <Box as="li" sx={{ mt: i > 0 ? '24px' : 0 }}>
+          <AppLink href={href}>{label}</AppLink>
+        </Box>
+      ))}
+    </Box>
   )
 }
 

--- a/features/discovery/common/DiscoveryWrapperWithIntro.tsx
+++ b/features/discovery/common/DiscoveryWrapperWithIntro.tsx
@@ -1,0 +1,36 @@
+import { AppLink } from 'components/Links'
+import { WithArrow } from 'components/WithArrow'
+import { WithChildren } from 'helpers/types'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Box, Heading, Text } from 'theme-ui'
+
+export function DiscoveryWrapperWithIntro({ children }: WithChildren) {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ width: '100%', mt: [4, 5], pb: [4, 6] }}>
+      <Box sx={{ mb: 90, textAlign: 'center' }}>
+        <Heading variant="header2" sx={{ mb: 2 }}>
+          {t('discovery.heading')}
+        </Heading>
+        <Text as="p" variant="paragraph1" sx={{ color: 'neutral80', maxWidth: 700, mx: 'auto' }}>
+          {t('discovery.intro')}{' '}
+          <AppLink href="https://kb.oasis.app/">
+            <WithArrow
+              sx={{
+                display: 'inline-block',
+                fontSize: 4,
+                color: 'interactive100',
+                fontWeight: 'regular',
+              }}
+            >
+              {t('discovery.intro-link')}
+            </WithArrow>
+          </AppLink>
+        </Text>
+      </Box>
+      {children}
+    </Box>
+  )
+}

--- a/features/discovery/helpers/layout.tsx
+++ b/features/discovery/helpers/layout.tsx
@@ -1,5 +1,6 @@
 import { PageSEOTags } from 'components/HeadTags'
 import { MarketingLayout } from 'components/Layouts'
+import React from 'react'
 
 export const discoveryPageLayout = MarketingLayout
 export const discoveryPageLayoutProps = {

--- a/features/discovery/helpers/layout.tsx
+++ b/features/discovery/helpers/layout.tsx
@@ -1,0 +1,14 @@
+import { PageSEOTags } from 'components/HeadTags'
+import { MarketingLayout } from 'components/Layouts'
+
+export const discoveryPageLayout = MarketingLayout
+export const discoveryPageLayoutProps = {
+  topBackground: 'lighter',
+}
+export const discoveryPageSeoTags = (
+  <PageSEOTags
+    title="seo.discovery.title"
+    description="seo.discovery.description"
+    url="/discovery"
+  />
+)

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -20,6 +20,7 @@ export type Feature =
   | 'DisableSidebarScroll'
   | 'ProxyCreationDisabled'
   | 'AutoTakeProfit'
+  | 'DiscoverOasis'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -38,6 +39,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   DisableSidebarScroll: false,
   ProxyCreationDisabled: false,
   AutoTakeProfit: false,
+  DiscoverOasis: false,
   // your feature here....
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -127,11 +127,6 @@ const conf = withBundleAnalyzer(
             destination: '/daiwallet/dashboard',
             permanent: true,
           },
-          {
-            source: '/discovery',
-            destination: '/discovery/high-risk-positions',
-            permanent: true,
-          },
         ]
       },
       async headers() {

--- a/next.config.js
+++ b/next.config.js
@@ -127,6 +127,11 @@ const conf = withBundleAnalyzer(
             destination: '/daiwallet/dashboard',
             permanent: true,
           },
+          {
+            source: '/discovery',
+            destination: '/discovery/high-risk-positions',
+            permanent: true,
+          },
         ]
       },
       async headers() {

--- a/pages/discovery/high-risk-positions.tsx
+++ b/pages/discovery/high-risk-positions.tsx
@@ -1,34 +1,19 @@
-import { PageSEOTags } from 'components/HeadTags'
-import { MarketingLayout } from 'components/Layouts'
-import { useTranslation } from 'next-i18next'
+import { DiscoveryWrapperWithIntro } from 'features/discovery/common/DiscoveryWrapperWithIntro'
+import {
+  discoveryPageLayout,
+  discoveryPageLayoutProps,
+  discoveryPageSeoTags,
+} from 'features/discovery/helpers/layout'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
-import { Box, Heading, Text } from 'theme-ui'
 
 function DiscoveryPage() {
-  const { t } = useTranslation()
-
-  return (
-    <Box sx={{ width: '100%', mt: [4, 5], pb: [4, 6] }}>
-      <Heading variant="header2" sx={{ textAlign: 'center', mb: 2 }}>
-        {t('security.heading')}
-      </Heading>
-      <Text variant="paragraph1" sx={{ color: 'neutral80', textAlign: 'center', mb: 90 }}>
-        {t('security.intro')}
-      </Text>
-    </Box>
-  )
+  return <DiscoveryWrapperWithIntro>Lorem ipsum</DiscoveryWrapperWithIntro>
 }
 
-DiscoveryPage.layout = MarketingLayout
-DiscoveryPage.layoutProps = {
-  topBackground: 'lighter',
-  variant: 'marketingSmallContainer',
-}
-DiscoveryPage.seoTags = (
-  <PageSEOTags title="seo.security.title" description="seo.security.description" url="/security" />
-)
-DiscoveryPage.theme = 'Landing'
+DiscoveryPage.layout = discoveryPageLayout
+DiscoveryPage.layoutProps = discoveryPageLayoutProps
+DiscoveryPage.seoTags = discoveryPageSeoTags
 
 export default DiscoveryPage
 

--- a/pages/discovery/high-risk-positions.tsx
+++ b/pages/discovery/high-risk-positions.tsx
@@ -1,0 +1,39 @@
+import { PageSEOTags } from 'components/HeadTags'
+import { MarketingLayout } from 'components/Layouts'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import React from 'react'
+import { Box, Heading, Text } from 'theme-ui'
+
+function DiscoveryPage() {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ width: '100%', mt: [4, 5], pb: [4, 6] }}>
+      <Heading variant="header2" sx={{ textAlign: 'center', mb: 2 }}>
+        {t('security.heading')}
+      </Heading>
+      <Text variant="paragraph1" sx={{ color: 'neutral80', textAlign: 'center', mb: 90 }}>
+        {t('security.intro')}
+      </Text>
+    </Box>
+  )
+}
+
+DiscoveryPage.layout = MarketingLayout
+DiscoveryPage.layoutProps = {
+  topBackground: 'lighter',
+  variant: 'marketingSmallContainer',
+}
+DiscoveryPage.seoTags = (
+  <PageSEOTags title="seo.security.title" description="seo.security.description" url="/security" />
+)
+DiscoveryPage.theme = 'Landing'
+
+export default DiscoveryPage
+
+export const getStaticProps = async ({ locale }: { locale: string }) => ({
+  props: {
+    ...(await serverSideTranslations(locale, ['common'])),
+  },
+})

--- a/pages/discovery/index.tsx
+++ b/pages/discovery/index.tsx
@@ -1,4 +1,5 @@
 import { GetServerSidePropsContext } from 'next'
+import React from 'react'
 
 export default function DiscoveryPage() {
   return <></>

--- a/pages/discovery/index.tsx
+++ b/pages/discovery/index.tsx
@@ -1,0 +1,16 @@
+import { GetServerSidePropsContext } from 'next'
+
+export default function DiscoveryPage() {
+  return <></>
+}
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const network = context.query.network ? `?network=${context.query.network}` : ''
+
+  return {
+    redirect: {
+      destination: `/discovery/high-risk-positions${network}`,
+      permanent: true,
+    },
+  }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -141,6 +141,17 @@
   "disconnect": "Disconnect",
   "disconnect-magic": "Log out",
   "disconnect-wallet": "Disconnect Wallet",
+  "discovery": {
+    "title": "Discover Oasis.app",
+    "description": "Discover and find the most interesting Vaults on Oasis.app. See in real-time and follow you favorites.",
+    "description-link": "Learn more about Discover",
+    "navigation": {
+      "high-risk-positions": "High-Risk Positions",
+      "highest-multiply-pnl": "Highest Multiply P&L",
+      "most-yield-earned": "Most Yield Earned",
+      "largest-debt": "Largest Debt"
+    }
+  },
   "earning": "Earning",
   "edit-token-allowance": "Edit {{token}} allowance",
   "edit-vault-details": "Edit Vault details",
@@ -578,7 +589,8 @@
     "cookie": "Cookie Policy",
     "bug-bounty": "Bug Bounty",
     "brand-assets": "Brand assets",
-    "security": "Security"
+    "security": "Security",
+    "discovery": "Discovery"
   },
   "new-to-ethereum": "New to Ethereum? ",
   "next": "Next",
@@ -670,6 +682,10 @@
     "security": {
       "title": "Security",
       "description": "Oasis.app is one of the oldest DeFi products with a rigorous approach to security. Users from all over the world trust us with billions of dollars of their funds."
+    },
+    "discovery": {
+      "title": "Discover Oasis.app",
+      "description": "Discover and find the most interesting Vaults on Oasis.app. See in real-time and follow you favorites."
     }
   },
   "set-allowance-for": "Set Allowance for {{token}}",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -142,9 +142,9 @@
   "disconnect-magic": "Log out",
   "disconnect-wallet": "Disconnect Wallet",
   "discovery": {
-    "title": "Discover Oasis.app",
-    "description": "Discover and find the most interesting Vaults on Oasis.app. See in real-time and follow you favorites.",
-    "description-link": "Learn more about Discover",
+    "heading": "Discover Oasis.app",
+    "intro": "Discover and find the most interesting Vaults on Oasis.app. See in real-time and follow you favorites.",
+    "intro-link": "Learn more about Discover",
     "navigation": {
       "high-risk-positions": "High-Risk Positions",
       "highest-multiply-pnl": "Highest Multiply P&L",


### PR DESCRIPTION
# Discover oasis page

I decided that instead of creating one `/discovery` page, from performance and SEO point of view, it would be better to create four different ones  for each type of table. For now I made only one page for "High risk positions", but main template already assumes that it is going to be used to create next ones.

If user goes directly to `/discovery`, he is going to be redirected to `/discovery/high-risk-positions` as it first options in navigation.

![image](https://user-images.githubusercontent.com/16230404/193812138-7718d435-916d-4ae6-a503-7061b6f526ba.png)
  
## Changes 👷‍♀️

- created new feature flag for Discovery: `DiscoverOasis`,
- updated main app navigation, tidied it a little bit, but without huge revolution since it looks like we might be working on bigger navigation redesign in near future (see: https://discord.com/channels/837076147694207067/839057646480785438/1026803561079787550),
- created empty page for Discovery pages,
  
## How to test 🧪

- Enable `DiscoverOasis` feature flag,
- compare if main navigation has "Discovery" only when feature flag is enabled,
- go to `/discovery` page to check if redirect works properly.

Discovery page itself for now is just an intro and lorem ipsum, so there is nothing to test inside of it.
