### PR TITLE
Fix incorrect Optimization tab indication

### DIFF
--- a/features/automation/optimization/autoTakeProfit/state/useAutoTakeProfitStateInitializator.ts
+++ b/features/automation/optimization/autoTakeProfit/state/useAutoTakeProfitStateInitializator.ts
@@ -54,6 +54,7 @@ export function useAutoTakeProfitStateInitializator(vault: Vault | InstiVault) {
   //   })
   // }, [collateralizationRatio])
 
-  const isAutoTakeProfitEnabled = true
+  // because this value was hardcoded as true, Optimization was always shown as "On", regardless of feature flag
+  const isAutoTakeProfitEnabled = false
   return isAutoTakeProfitEnabled
 }


### PR DESCRIPTION
# Fix incorrect Optimization tab indication

Optimization tab was always marked as "On", regardless of actual features state.
![image](https://user-images.githubusercontent.com/16230404/194241129-f84e22e8-5f92-4724-b7eb-173944722169.png)
  
## Changes 👷‍♀️

Changed `isAutoTakeProfitEnabled` hardcoded flag to `false` - in the future it's state is going to be loaded from cache.
  
## How to test 🧪

Go to vault page and see if Optimization tab is marked as "On" when all features from that tab are disabled.
