### PR TITLE
Speeds up AAVE stETH/ETH yields requests

### DIFF
--- a/features/earn/aave/open/components/AaveOpenHeader.tsx
+++ b/features/earn/aave/open/components/AaveOpenHeader.tsx
@@ -48,12 +48,12 @@ export function AaveOpenHeader({
       formatPercent(yieldVal, {
         precision: 2,
       })
-    const yield7DaysMin = minimumMultiple.times(simulationContext.yields.annualisedYield7days)
-    const yield7DaysMax = maximumMultiple.times(simulationContext.yields.annualisedYield7days)
+    const yield7DaysMin = minimumMultiple.times(simulationContext.yields.annualisedYield7days!)
+    const yield7DaysMax = maximumMultiple.times(simulationContext.yields.annualisedYield7days!)
 
     const yield7DaysDiff = maximumMultiple.times(
-      simulationContext.yields.annualisedYield7days.minus(
-        simulationContext.yields.annualisedYield7daysOffset,
+      simulationContext.yields.annualisedYield7days!.minus(
+        simulationContext.yields.annualisedYield7daysOffset!,
       ),
     )
 
@@ -71,7 +71,7 @@ export function AaveOpenHeader({
   }
   if (simulationContext.yields?.annualisedYield90days) {
     const yield90DaysDiff = maximumMultiple.times(
-      simulationContext.yields.annualisedYield90daysOffset.minus(
+      simulationContext.yields.annualisedYield90daysOffset!.minus(
         simulationContext.yields.annualisedYield90days,
       ),
     )

--- a/features/earn/aave/open/services/calculateSimulation.ts
+++ b/features/earn/aave/open/services/calculateSimulation.ts
@@ -11,14 +11,14 @@ export interface Simulation {
 }
 
 export interface CalculateSimulationResult {
-  breakEven: BigNumber
-  entryFees: BigNumber
-  apy: BigNumber
-  previous7Days: Simulation
-  previous30Days: Simulation
-  previous90Days: Simulation
-  previous1Year: Simulation
-  sinceInception: Simulation
+  breakEven?: BigNumber
+  entryFees?: BigNumber
+  apy?: BigNumber
+  previous7Days?: Simulation
+  previous30Days?: Simulation
+  previous90Days?: Simulation
+  previous1Year?: Simulation
+  sinceInception?: Simulation
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -34,36 +34,48 @@ export function calculateSimulation({
   riskRatio: IRiskRatio
   yields: AaveStEthYieldsResponse
 }): CalculateSimulationResult {
-  const earningsPerDay = amount.times(yields.annualisedYield1Year.plus(one)).minus(amount).div(365)
+  const earningsPerDay =
+    yields.annualisedYield1Year &&
+    amount.times(yields.annualisedYield1Year.plus(one)).minus(amount).div(365)
   return {
     apy: yields.annualisedYield1Year,
-    breakEven: (fees || zero).div(earningsPerDay),
+    breakEven: earningsPerDay && (fees || zero).div(earningsPerDay),
     entryFees: fees || zero,
-    previous7Days: getSimulation({
-      amount,
-      annualizedYield: yields.annualisedYield7days,
-      token,
-    }),
-    previous30Days: getSimulation({
-      amount,
-      annualizedYield: yields.annualisedYield30days,
-      token,
-    }),
-    previous90Days: getSimulation({
-      amount,
-      annualizedYield: yields.annualisedYield90days,
-      token,
-    }),
-    previous1Year: getSimulation({
-      amount,
-      annualizedYield: yields.annualisedYield1Year,
-      token,
-    }),
-    sinceInception: getSimulation({
-      amount,
-      annualizedYield: yields.annualisedYieldSinceInception,
-      token,
-    }),
+    previous7Days:
+      yields.annualisedYield7days &&
+      getSimulation({
+        amount,
+        annualizedYield: yields.annualisedYield7days,
+        token,
+      }),
+    previous30Days:
+      yields.annualisedYield30days &&
+      getSimulation({
+        amount,
+        annualizedYield: yields.annualisedYield30days,
+        token,
+      }),
+    previous90Days:
+      yields.annualisedYield90days &&
+      getSimulation({
+        amount,
+        annualizedYield: yields.annualisedYield90days,
+        token,
+      }),
+    previous1Year:
+      yields.annualisedYield1Year &&
+      getSimulation({
+        amount,
+        annualizedYield: yields.annualisedYield1Year,
+        token,
+      }),
+    sinceInception:
+      yields.annualisedYieldSinceInception &&
+      getSimulation({
+        amount,
+        annualizedYield: yields.annualisedYieldSinceInception,
+        token,
+      }),
   }
 }
 

--- a/features/earn/aave/open/services/getSthEthSimulationMachine.ts
+++ b/features/earn/aave/open/services/getSthEthSimulationMachine.ts
@@ -3,10 +3,13 @@ import BigNumber from 'bignumber.js'
 
 import { AaveStEthSimulateStateMachine, aaveStEthSimulateStateMachine } from '../state'
 import { calculateSimulation } from './calculateSimulation'
-import { AaveStEthYieldsResponse } from './stEthYield'
+import { AaveStEthYieldsResponse, FilterYieldFieldsType } from './stEthYield'
 
 export function getSthEthSimulationMachine(
-  getStEthYields: (riskRatio: IRiskRatio) => Promise<AaveStEthYieldsResponse>,
+  getStEthYields: (
+    riskRatio: IRiskRatio,
+    field: FilterYieldFieldsType[],
+  ) => Promise<AaveStEthYieldsResponse>,
 ): AaveStEthSimulateStateMachine {
   return aaveStEthSimulateStateMachine
     .withConfig({
@@ -20,7 +23,13 @@ export function getSthEthSimulationMachine(
           })
         },
         getYields: async (context) => {
-          return await getStEthYields(context.riskRatio!)
+          return await getStEthYields(context.riskRatio!, [
+            '7Days',
+            '7DaysOffset',
+            '30Days',
+            '90Days',
+            '90DaysOffset',
+          ])
         },
       },
     })

--- a/features/earn/aave/open/services/stEthYield.ts
+++ b/features/earn/aave/open/services/stEthYield.ts
@@ -5,6 +5,17 @@ import moment from 'moment/moment'
 import { Observable } from 'rxjs'
 import { first } from 'rxjs/operators'
 
+export type FilterYieldFieldsType =
+  | '7Days'
+  | '7DaysOffset'
+  | '30Days'
+  | '90Days'
+  | '90DaysOffset'
+  | '1Year'
+  | 'Inception'
+
+const yieldsDateFormat = 'YYYY-MM-DD'
+
 const aaveStEthYield = gql`
   mutation stEthYields(
     $currentDate: Date!
@@ -16,10 +27,17 @@ const aaveStEthYield = gql`
     $date90daysAgoOffset: Date!
     $date1yearAgo: Date!
     $multiply: BigFloat!
+    $include7Days: Boolean!
+    $include7DaysOffset: Boolean!
+    $include30Days: Boolean!
+    $include90Days: Boolean!
+    $include90DaysOffset: Boolean!
+    $include1Year: Boolean!
+    $includeInception: Boolean!
   ) {
     yield7days: aaveYieldRateStethEth(
       input: { startDate: $date7daysAgo, endDate: $currentDate, multiple: $multiply }
-    ) {
+    ) @include(if: $include7Days) {
       yield {
         netAnnualisedYield
       }
@@ -27,7 +45,7 @@ const aaveStEthYield = gql`
 
     yield7daysOffset: aaveYieldRateStethEth(
       input: { startDate: $date7daysAgoOffset, endDate: $currentDateOffset, multiple: $multiply }
-    ) {
+    ) @include(if: $include7DaysOffset) {
       yield {
         netAnnualisedYield
       }
@@ -35,7 +53,7 @@ const aaveStEthYield = gql`
 
     yield30days: aaveYieldRateStethEth(
       input: { startDate: $date30daysAgo, endDate: $currentDate, multiple: $multiply }
-    ) {
+    ) @include(if: $include30Days) {
       yield {
         netAnnualisedYield
       }
@@ -43,7 +61,7 @@ const aaveStEthYield = gql`
 
     yield90days: aaveYieldRateStethEth(
       input: { startDate: $date90daysAgo, endDate: $currentDate, multiple: $multiply }
-    ) {
+    ) @include(if: $include90Days) {
       yield {
         netAnnualisedYield
       }
@@ -51,7 +69,7 @@ const aaveStEthYield = gql`
 
     yield90daysOffset: aaveYieldRateStethEth(
       input: { startDate: $date90daysAgoOffset, endDate: $currentDateOffset, multiple: $multiply }
-    ) {
+    ) @include(if: $include90DaysOffset) {
       yield {
         netAnnualisedYield
       }
@@ -59,14 +77,14 @@ const aaveStEthYield = gql`
 
     yield1year: aaveYieldRateStethEth(
       input: { startDate: $date1yearAgo, endDate: $currentDate, multiple: $multiply }
-    ) {
+    ) @include(if: $include1Year) {
       yield {
         netAnnualisedYield
       }
     }
     yieldSinceInception: aaveYieldRateStethEth(
       input: { startDate: "2020-11-30", endDate: $currentDate, multiple: $multiply }
-    ) {
+    ) @include(if: $includeInception) {
       yield {
         netAnnualisedYield
       }
@@ -75,46 +93,62 @@ const aaveStEthYield = gql`
 `
 
 export interface AaveStEthYieldsResponse {
-  annualisedYield7days: BigNumber
-  annualisedYield7daysOffset: BigNumber
-  annualisedYield30days: BigNumber
-  annualisedYield90days: BigNumber
-  annualisedYield90daysOffset: BigNumber
-  annualisedYield1Year: BigNumber
-  annualisedYieldSinceInception: BigNumber
+  annualisedYield7days?: BigNumber
+  annualisedYield7daysOffset?: BigNumber
+  annualisedYield30days?: BigNumber
+  annualisedYield90days?: BigNumber
+  annualisedYield90daysOffset?: BigNumber
+  annualisedYield1Year?: BigNumber
+  annualisedYieldSinceInception?: BigNumber
 }
 
 export async function getAaveStEthYield(
   client: Observable<GraphQLClient>,
   currentDate: moment.Moment,
   riskRatio: IRiskRatio,
+  fields: FilterYieldFieldsType[],
 ): Promise<AaveStEthYieldsResponse> {
   const getClient = await client.pipe(first()).toPromise()
   const response = await getClient.request(aaveStEthYield, {
-    currentDate: currentDate.utc().format('YYYY-MM-DD'),
-    currentDateOffset: currentDate.utc().subtract(1, 'days').format('YYYY-MM-DD'),
-    date7daysAgo: currentDate.utc().clone().subtract(7, 'days').format('YYYY-MM-DD'),
+    multiply: riskRatio.multiple.toString(),
+    currentDate: currentDate.utc().format(yieldsDateFormat),
+    currentDateOffset: currentDate.utc().subtract(1, 'days').format(yieldsDateFormat),
+    date7daysAgo: currentDate.utc().clone().subtract(7, 'days').format(yieldsDateFormat),
     date7daysAgoOffset: currentDate
       .utc()
       .clone()
       .subtract(1, 'days')
       .subtract(7, 'days')
-      .format('YYYY-MM-DD'),
-    date30daysAgo: currentDate.utc().clone().subtract(30, 'days').format('YYYY-MM-DD'),
-    date90daysAgo: currentDate.utc().clone().subtract(90, 'days').format('YYYY-MM-DD'),
-    date90daysAgoOffset: currentDate.utc().clone().subtract(90, 'days').format('YYYY-MM-DD'),
-    date1yearAgo: currentDate.utc().clone().subtract(1, 'year').format('YYYY-MM-DD'),
-    multiply: riskRatio.multiple.toString(),
+      .format(yieldsDateFormat),
+    date30daysAgo: currentDate.utc().clone().subtract(30, 'days').format(yieldsDateFormat),
+    date90daysAgo: currentDate.utc().clone().subtract(90, 'days').format(yieldsDateFormat),
+    date90daysAgoOffset: currentDate.utc().clone().subtract(90, 'days').format(yieldsDateFormat),
+    date1yearAgo: currentDate.utc().clone().subtract(1, 'year').format(yieldsDateFormat),
+    include7Days: fields.length ? fields.includes('7Days') : true,
+    include7DaysOffset: fields.length ? fields.includes('7DaysOffset') : true,
+    include30Days: fields.length ? fields.includes('30Days') : true,
+    include90Days: fields.length ? fields.includes('90Days') : true,
+    include90DaysOffset: fields.length ? fields.includes('90DaysOffset') : true,
+    include1Year: fields.length ? fields.includes('1Year') : true,
+    includeInception: fields.length ? fields.includes('Inception') : true,
   })
   return {
-    annualisedYield7days: new BigNumber(response.yield7days.yield.netAnnualisedYield),
-    annualisedYield7daysOffset: new BigNumber(response.yield7daysOffset.yield.netAnnualisedYield),
-    annualisedYield30days: new BigNumber(response.yield30days.yield.netAnnualisedYield),
-    annualisedYield90days: new BigNumber(response.yield90days.yield.netAnnualisedYield),
-    annualisedYield90daysOffset: new BigNumber(response.yield90daysOffset.yield.netAnnualisedYield),
-    annualisedYield1Year: new BigNumber(response.yield1year.yield.netAnnualisedYield),
-    annualisedYieldSinceInception: new BigNumber(
-      response.yieldSinceInception.yield.netAnnualisedYield,
-    ),
+    annualisedYield7days:
+      response.yield7days && new BigNumber(response.yield7days.yield.netAnnualisedYield),
+    annualisedYield7daysOffset:
+      response.yield7daysOffset &&
+      new BigNumber(response.yield7daysOffset.yield.netAnnualisedYield),
+    annualisedYield30days:
+      response.yield30days && new BigNumber(response.yield30days.yield.netAnnualisedYield),
+    annualisedYield90days:
+      response.yield90days && new BigNumber(response.yield90days.yield.netAnnualisedYield),
+    annualisedYield90daysOffset:
+      response.yield90daysOffset &&
+      new BigNumber(response.yield90daysOffset.yield.netAnnualisedYield),
+    annualisedYield1Year:
+      response.yield1year && new BigNumber(response.yield1year.yield.netAnnualisedYield),
+    annualisedYieldSinceInception:
+      response.yieldSinceInception &&
+      new BigNumber(response.yieldSinceInception.yield.netAnnualisedYield),
   }
 }


### PR DESCRIPTION
# Speeds up stETH yields requests

AAVE stETH/ETH queries varied in response time (sometimes even timed out) so after @sennett made some tweaks on the cache side we needed some changes on the front. Now the query (if needed) takes a list of parameters, which cuts down on response time significantly. In addition to that they are memoized properly and downloaded only once (once on `/earn` page and once on the open position page).
  
## Changes 👷‍♀️
- moved graphql query initialization to appcontext
- moved yields query to appcontext
- added opt-in option to query selected fields on stEthYields
- added proper memoization for stEthYields query
  
## How to test 🧪
 - go to `/earn` and see how fast the yields are displayed
 - switch to any other page
 - go to `/earn` page again - the yields should be there with no additional request needed
 - same as above but on the open position page