### PR TITLE
Automation form title subtext fix

### DIFF
--- a/features/automation/common/sidebars/getAutomationFormTitle.ts
+++ b/features/automation/common/sidebars/getAutomationFormTitle.ts
@@ -122,7 +122,7 @@ export function getAutomationFormTitle({ flow, stage, feature }: AutomationSideb
     case 'txSuccess':
       const txSuccessKey = getSidebarTitleTxSuccessTranslationKey({ flow })
 
-      return t(txSuccessKey, { feature })
+      return t(txSuccessKey, { feature: t(sidebarAutomationFeatureCopyMap[feature]) })
     default:
       throw new UnreachableCaseError(stage)
   }


### PR DESCRIPTION
# [Automation form title subtext fix](https://app.shortcut.com/oazo-apps/story/6237/subtext-incorrect)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added missing mapping to automation form title handler
  
## How to test 🧪
  <Please explain how to test your changes>

- title was broken for all auto features in `txSuccess` state, verify if it is still a case