### PR TITLE
Fixes the AAVE yield calculations in the STETH/ETH view

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -511,7 +511,7 @@ export function setupAppContext() {
   )
   const aaveSthEthYieldsQuery = memoize(
     curry(getAaveStEthYield)(disconnectedGraphQLClient$, moment()),
-    (fields) => JSON.stringify({ fields }),
+    (riskRatio, fields) => JSON.stringify({ fields, riskRatio: riskRatio.multiple.toString() }),
   )
 
   const gasPrice$ = createGasPrice$(onEveryBlock$, context$)

--- a/features/earn/aave/AaveContext.ts
+++ b/features/earn/aave/AaveContext.ts
@@ -94,6 +94,8 @@ export function setupAaveContext({
     gasEstimation$,
   )
 
+  const aaveReserveStEthData$ = aaveReserveConfigurationData$({ token: 'STETH' })
+
   const openAaveStateMachineServices = getOpenAavePositionStateMachineServices(
     contextForAddress$,
     txHelpers$,
@@ -115,7 +117,7 @@ export function setupAaveContext({
 
   const transactionMachine = getOpenAaveTransactionMachine(txHelpers$, contextForAddress$)
 
-  const simulationMachine = getSthEthSimulationMachine(aaveSthEthYieldsQuery)
+  const simulationMachine = getSthEthSimulationMachine(aaveSthEthYieldsQuery, aaveReserveStEthData$)
 
   const aaveStateMachine$ = getOpenAaveStateMachine$(
     openAaveStateMachineServices,
@@ -148,7 +150,7 @@ export function setupAaveContext({
     aaveStateMachine$,
     aaveManageStateMachine$,
     aaveTotalValueLocked$,
-    aaveReserveStEthData$: aaveReserveConfigurationData$({ token: 'STETH' }),
+    aaveReserveStEthData$,
   }
 }
 

--- a/features/earn/aave/constants/index.ts
+++ b/features/earn/aave/constants/index.ts
@@ -1,1 +1,5 @@
+import { RiskRatio } from '@oasisdex/oasis-actions'
+import BigNumber from 'bignumber.js'
+
 export const aaveStrategiesList = ['AAVE-STETH']
+export const aaveStETHMinimumRiskRatio = new RiskRatio(new BigNumber(1.1), RiskRatio.TYPE.MULITPLE)

--- a/features/earn/aave/manage/containers/AaveManageStateMachineContext.tsx
+++ b/features/earn/aave/manage/containers/AaveManageStateMachineContext.tsx
@@ -1,10 +1,11 @@
 import { useInterpret } from '@xstate/react'
+import { env } from 'process'
 import React from 'react'
 
 import { ManageAaveStateMachine } from '../state'
 
 function setupManageAaveStateContext({ machine }: { machine: ManageAaveStateMachine }) {
-  const stateMachine = useInterpret(machine).start()
+  const stateMachine = useInterpret(machine, { devTools: env.NODE_ENV === 'development' }).start()
   return {
     stateMachine,
   }

--- a/features/earn/aave/open/components/AaveOpenHeader.tsx
+++ b/features/earn/aave/open/components/AaveOpenHeader.tsx
@@ -2,6 +2,7 @@ import { useActor, useSelector } from '@xstate/react'
 import BigNumber from 'bignumber.js'
 import { getPriceChangeColor } from 'components/vault/VaultDetails'
 import { VaultHeadline } from 'components/vault/VaultHeadline'
+import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatHugeNumbersToShortHuman, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
@@ -106,13 +107,15 @@ export function AaveOpenHeaderComponent({ strategyName }: { strategyName: string
 
   return (
     <WithErrorHandler error={[tvlStateError]}>
-      {tvlState && simulationMachine && (
-        <AaveOpenHeader
-          strategyName={strategyName}
-          simulationActor={simulationMachine}
-          aaveTVL={tvlState}
-        />
-      )}
+      <WithLoadingIndicator value={[tvlState, simulationMachine]} customLoader={<AppSpinner />}>
+        {([_tvlState, _simulationMachine]) => (
+          <AaveOpenHeader
+            strategyName={strategyName}
+            simulationActor={_simulationMachine}
+            aaveTVL={_tvlState}
+          />
+        )}
+      </WithLoadingIndicator>
     </WithErrorHandler>
   )
 }

--- a/features/earn/aave/open/components/AaveOpenHeader.tsx
+++ b/features/earn/aave/open/components/AaveOpenHeader.tsx
@@ -1,12 +1,10 @@
 import { useActor, useSelector } from '@xstate/react'
 import BigNumber from 'bignumber.js'
-import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
 import { getPriceChangeColor } from 'components/vault/VaultDetails'
 import { VaultHeadline } from 'components/vault/VaultHeadline'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatHugeNumbersToShortHuman, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
-import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { ActorRefFrom } from 'xstate'
@@ -16,18 +14,14 @@ import { PreparedAaveReserveData } from '../../helpers/aavePrepareAaveTotalValue
 import { useOpenAaveStateMachineContext } from '../containers/AaveOpenStateMachineContext'
 import { AaveStEthSimulateStateMachine } from '../state'
 
-const minimumMultiple = new BigNumber(1.1)
-
 export function AaveOpenHeader({
   simulationActor,
   strategyName,
   aaveTVL,
-  aaveReserveState,
 }: {
   simulationActor: ActorRefFrom<AaveStEthSimulateStateMachine>
   aaveTVL: PreparedAaveReserveData
   strategyName: string
-  aaveReserveState: AaveReserveConfigurationData
 }) {
   const { t } = useTranslation()
   const tokenPairList = {
@@ -40,21 +34,18 @@ export function AaveOpenHeader({
   const [simulationState] = useActor(simulationActor)
 
   const { context: simulationContext } = simulationState
-  const maximumMultiple = one.div(one.minus(aaveReserveState.ltv))
 
   const headlineDetails = []
-  if (simulationContext.yields) {
+  if (simulationContext.yieldsMin && simulationContext.yieldsMax) {
     const formatYield = (yieldVal: BigNumber) =>
       formatPercent(yieldVal, {
         precision: 2,
       })
-    const yield7DaysMin = minimumMultiple.times(simulationContext.yields.annualisedYield7days!)
-    const yield7DaysMax = maximumMultiple.times(simulationContext.yields.annualisedYield7days!)
+    const yield7DaysMin = simulationContext.yieldsMin.annualisedYield7days!
+    const yield7DaysMax = simulationContext.yieldsMax.annualisedYield7days!
 
-    const yield7DaysDiff = maximumMultiple.times(
-      simulationContext.yields.annualisedYield7days!.minus(
-        simulationContext.yields.annualisedYield7daysOffset!,
-      ),
+    const yield7DaysDiff = simulationContext.yieldsMax.annualisedYield7days!.minus(
+      simulationContext.yieldsMax.annualisedYield7daysOffset!,
     )
 
     headlineDetails.push({
@@ -69,15 +60,13 @@ export function AaveOpenHeader({
       }),
     })
   }
-  if (simulationContext.yields?.annualisedYield90days) {
-    const yield90DaysDiff = maximumMultiple.times(
-      simulationContext.yields.annualisedYield90daysOffset!.minus(
-        simulationContext.yields.annualisedYield90days,
-      ),
+  if (simulationContext.yieldsMax?.annualisedYield90days) {
+    const yield90DaysDiff = simulationContext.yieldsMax.annualisedYield90daysOffset!.minus(
+      simulationContext.yieldsMax.annualisedYield90days,
     )
     headlineDetails.push({
       label: t('open-earn.aave.product-header.90-day-avg-yield'),
-      value: formatPercent(maximumMultiple.times(simulationContext.yields.annualisedYield90days), {
+      value: formatPercent(simulationContext.yieldsMax.annualisedYield90days, {
         precision: 2,
       }),
       sub: formatPercent(yield90DaysDiff, {
@@ -112,18 +101,16 @@ export function AaveOpenHeaderComponent({ strategyName }: { strategyName: string
     return state.context.refSimulationMachine
   })
 
-  const { aaveTotalValueLocked$, aaveReserveStEthData$ } = useAaveContext()
+  const { aaveTotalValueLocked$ } = useAaveContext()
   const [tvlState, tvlStateError] = useObservable(aaveTotalValueLocked$)
-  const [aaveReserveState, aaveReserveStateError] = useObservable(aaveReserveStEthData$)
 
   return (
-    <WithErrorHandler error={[tvlStateError, aaveReserveStateError]}>
-      {tvlState && aaveReserveState && simulationMachine && (
+    <WithErrorHandler error={[tvlStateError]}>
+      {tvlState && simulationMachine && (
         <AaveOpenHeader
           strategyName={strategyName}
           simulationActor={simulationMachine}
           aaveTVL={tvlState}
-          aaveReserveState={aaveReserveState}
         />
       )}
     </WithErrorHandler>

--- a/features/earn/aave/open/containers/AaveOpenStateMachineContext.tsx
+++ b/features/earn/aave/open/containers/AaveOpenStateMachineContext.tsx
@@ -1,10 +1,11 @@
 import { useInterpret } from '@xstate/react'
+import { env } from 'process'
 import React from 'react'
 
 import { OpenAaveStateMachine } from '../state'
 
 function setupOpenAaveStateContext({ machine }: { machine: OpenAaveStateMachine }) {
-  const stateMachine = useInterpret(machine).start()
+  const stateMachine = useInterpret(machine, { devTools: env.NODE_ENV === 'development' }).start()
   return {
     stateMachine,
   }

--- a/features/earn/aave/open/services/getOpenAaveStateMachine.ts
+++ b/features/earn/aave/open/services/getOpenAaveStateMachine.ts
@@ -88,10 +88,10 @@ export function getOpenAaveStateMachine$(
   parametersMachine$: Observable<ParametersStateMachine>,
   proxyMachine$: Observable<ProxyStateMachine>,
   transactionStateMachine: TransactionStateMachine<OperationExecutorTxMeta>,
-  simulationMachine: AaveStEthSimulateStateMachine,
+  simulationMachine$: Observable<AaveStEthSimulateStateMachine>,
 ) {
-  return combineLatest(parametersMachine$, proxyMachine$).pipe(
-    map(([parametersMachine, proxyMachine]) => {
+  return combineLatest(parametersMachine$, proxyMachine$, simulationMachine$).pipe(
+    map(([parametersMachine, proxyMachine, simulationMachine]) => {
       return createOpenAaveStateMachine.withConfig({
         services: {
           ...services,

--- a/features/earn/aave/open/services/getSthEthSimulationMachine.ts
+++ b/features/earn/aave/open/services/getSthEthSimulationMachine.ts
@@ -1,6 +1,10 @@
 import { IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
+import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
+import { combineLatest, Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
 
+import { aaveStETHMinimumRiskRatio } from '../../constants'
 import { AaveStEthSimulateStateMachine, aaveStEthSimulateStateMachine } from '../state'
 import { calculateSimulation } from './calculateSimulation'
 import { AaveStEthYieldsResponse, FilterYieldFieldsType } from './stEthYield'
@@ -10,32 +14,41 @@ export function getSthEthSimulationMachine(
     riskRatio: IRiskRatio,
     field: FilterYieldFieldsType[],
   ) => Promise<AaveStEthYieldsResponse>,
-): AaveStEthSimulateStateMachine {
-  return aaveStEthSimulateStateMachine
-    .withConfig({
-      services: {
-        calculate: async (context) => {
-          return calculateSimulation({
-            amount: context.amount!,
-            token: context.token!,
-            yields: context.yields!,
-            riskRatio: context.riskRatio!,
-          })
-        },
-        getYields: async (context) => {
-          return await getStEthYields(context.riskRatio!, [
-            '7Days',
-            '7DaysOffset',
-            '30Days',
-            '90Days',
-            '90DaysOffset',
-          ])
-        },
-      },
-    })
-    .withContext({
-      amount: new BigNumber(100000),
-      token: 'ETH',
-      riskRatio: new RiskRatio(new BigNumber(0), RiskRatio.TYPE.LTV),
-    })
+  aaveReserveStEthData$: Observable<AaveReserveConfigurationData>,
+): Observable<AaveStEthSimulateStateMachine> {
+  return combineLatest(aaveReserveStEthData$).pipe(
+    map(([aaveReserveStEthData]) => {
+      return aaveStEthSimulateStateMachine
+        .withConfig({
+          services: {
+            calculate: async (context) => {
+              return calculateSimulation({
+                amount: context.amount!,
+                token: context.token!,
+                yields: context.yieldsMin!, // previously it was 'yields' and they were calculated using minimum risk ratio so i'll leave it like that
+                riskRatio: context.riskRatio!,
+              })
+            },
+            getYields: async (context) => {
+              const [yieldsMin, yieldsMax] = [
+                await getStEthYields(context.riskRatio!, ['7Days']),
+                await getStEthYields(context.riskRatioMax!, [
+                  '7Days',
+                  '7DaysOffset',
+                  '90Days',
+                  '90DaysOffset',
+                ]),
+              ]
+              return { yieldsMin, yieldsMax }
+            },
+          },
+        })
+        .withContext({
+          amount: new BigNumber(100000),
+          token: 'ETH',
+          riskRatio: aaveStETHMinimumRiskRatio,
+          riskRatioMax: new RiskRatio(aaveReserveStEthData.ltv, RiskRatio.TYPE.LTV),
+        })
+    }),
+  )
 }

--- a/features/earn/aave/open/services/getSthEthSimulationMachine.ts
+++ b/features/earn/aave/open/services/getSthEthSimulationMachine.ts
@@ -31,7 +31,13 @@ export function getSthEthSimulationMachine(
             },
             getYields: async (context) => {
               const [yieldsMin, yieldsMax] = [
-                await getStEthYields(context.riskRatio!, ['7Days']),
+                await getStEthYields(context.riskRatio!, [
+                  '7Days',
+                  '30Days',
+                  '90Days',
+                  '1Year',
+                  'Inception',
+                ]),
                 await getStEthYields(context.riskRatioMax!, [
                   '7Days',
                   '7DaysOffset',

--- a/features/earn/aave/open/services/getSthEthSimulationMachine.ts
+++ b/features/earn/aave/open/services/getSthEthSimulationMachine.ts
@@ -30,21 +30,21 @@ export function getSthEthSimulationMachine(
               })
             },
             getYields: async (context) => {
-              const [yieldsMin, yieldsMax] = [
-                await getStEthYields(context.riskRatio!, [
+              const [yieldsMin, yieldsMax] = await Promise.all([
+                getStEthYields(context.riskRatio!, [
                   '7Days',
                   '30Days',
                   '90Days',
                   '1Year',
                   'Inception',
                 ]),
-                await getStEthYields(context.riskRatioMax!, [
+                getStEthYields(context.riskRatioMax!, [
                   '7Days',
                   '7DaysOffset',
                   '90Days',
                   '90DaysOffset',
                 ]),
-              ]
+              ])
               return { yieldsMin, yieldsMax }
             },
           },

--- a/features/earn/aave/open/state/aaveStEthSimulateStateMachine.ts
+++ b/features/earn/aave/open/state/aaveStEthSimulateStateMachine.ts
@@ -7,10 +7,12 @@ import { MachineOptionsFrom } from 'xstate/lib/types'
 import { AaveStEthYieldsResponse, CalculateSimulationResult } from '../services'
 
 interface AaveStEthSimulateStateMachineContext {
-  yields?: AaveStEthYieldsResponse
+  yieldsMin?: AaveStEthYieldsResponse
+  yieldsMax?: AaveStEthYieldsResponse
   token?: string
   amount?: BigNumber
   riskRatio?: IRiskRatio
+  riskRatioMax?: IRiskRatio
   transactionFee?: BigNumber
   fee?: BigNumber
   simulation?: CalculateSimulationResult
@@ -36,7 +38,10 @@ export const aaveStEthSimulateStateMachine = createMachine(
       context: {} as AaveStEthSimulateStateMachineContext,
       services: {} as {
         getYields: {
-          data: AaveStEthYieldsResponse
+          data: {
+            yieldsMin: AaveStEthYieldsResponse
+            yieldsMax: AaveStEthYieldsResponse
+          }
         }
         calculate: {
           data: CalculateSimulationResult
@@ -92,7 +97,10 @@ export const aaveStEthSimulateStateMachine = createMachine(
   },
   {
     actions: {
-      assignYields: assign((context, event) => ({ yields: event.data })),
+      assignYields: assign((context, event) => ({
+        yieldsMin: event.data.yieldsMin,
+        yieldsMax: event.data.yieldsMax,
+      })),
       assignUserParameters: assign((context, event) => ({
         token: event.token,
         amount: event.amount,


### PR DESCRIPTION
# [Fixes the AAVE yield calculations in the STETH/ETH view](https://app.shortcut.com/oazo-apps/story/6171/optimizing-the-yield-calculation-for-steth)

Follow up to previous PR review made by @sennett - https://github.com/OasisDEX/oasis-borrow/pull/1517
  
## Changes 👷‍♀️
 - fixes the calculation done in the simulation machine
  
## How to test 🧪
 - should show proper yields in the AAVE STETH/ETH open header
