### PR TITLE
Auto-Take Profit safety switch

### DIFF
--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -60,18 +60,31 @@ function ZeroDebtOptimizationBanner({
 function getZeroDebtOptimizationBannerProps({
   readOnlyAutoBSEnabled,
   constantMultipleReadOnlyEnabled,
+  readOnlyAutoTakeProfitEnabled,
   isVaultDebtZero,
   vaultHasNoActiveBuyTrigger,
   vaultHasNoActiveConstantMultipleTriggers,
+  vaultHasNoActiveAutoTakeProfitTrigger,
 }: {
   readOnlyAutoBSEnabled: boolean
   constantMultipleReadOnlyEnabled: boolean
+  readOnlyAutoTakeProfitEnabled: boolean
   isVaultDebtZero: boolean
   vaultHasNoActiveBuyTrigger?: boolean
   vaultHasNoActiveConstantMultipleTriggers?: boolean
+  vaultHasNoActiveAutoTakeProfitTrigger?: boolean
 }): ZeroDebtOptimizationBannerProps {
-  if (!readOnlyAutoBSEnabled && !constantMultipleReadOnlyEnabled) {
-    if (isVaultDebtZero && vaultHasNoActiveBuyTrigger && vaultHasNoActiveConstantMultipleTriggers) {
+  if (
+    !readOnlyAutoBSEnabled &&
+    !constantMultipleReadOnlyEnabled &&
+    !readOnlyAutoTakeProfitEnabled
+  ) {
+    if (
+      isVaultDebtZero &&
+      vaultHasNoActiveBuyTrigger &&
+      vaultHasNoActiveConstantMultipleTriggers &&
+      vaultHasNoActiveAutoTakeProfitTrigger
+    ) {
       return {
         header: 'optimization.zero-debt-heading',
         description: 'optimization.zero-debt-description',
@@ -115,19 +128,28 @@ export function OptimizationControl({
   const [ethAndTokenPricesData, ethAndTokenPricesError] = useObservable(_tokenPriceUSD$)
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const constantMultipleReadOnlyEnabled = useFeatureToggle('ConstantMultipleReadOnly')
-  const { autoBuyTriggerData, constantMultipleTriggerData } = useAutomationContext()
+  const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
+  const {
+    autoBuyTriggerData,
+    constantMultipleTriggerData,
+    autoTakeProfitTriggerData,
+  } = useAutomationContext()
 
   const vaultHasActiveAutoBuyTrigger = autoBuyTriggerData.isTriggerEnabled
   const vaultHasActiveConstantMultipleTrigger = constantMultipleTriggerData.isTriggerEnabled
+  const vaultHasActiveAutoTakeProfitTrigger = autoTakeProfitTriggerData.isTriggerEnabled
 
   if (
     (!vaultHasActiveAutoBuyTrigger &&
       !vaultHasActiveConstantMultipleTrigger &&
+      !vaultHasActiveAutoTakeProfitTrigger &&
       vault.debt.isZero()) ||
     (!vaultHasActiveAutoBuyTrigger &&
       !vaultHasActiveConstantMultipleTrigger &&
+      !vaultHasActiveAutoTakeProfitTrigger &&
       readOnlyAutoBSEnabled &&
-      constantMultipleReadOnlyEnabled)
+      constantMultipleReadOnlyEnabled &&
+      readOnlyAutoTakeProfitEnabled)
   ) {
     return (
       <Container variant="vaultPageContainer" sx={{ zIndex: 0 }}>
@@ -137,7 +159,9 @@ export function OptimizationControl({
             isVaultDebtZero: vault.debt.isZero(),
             vaultHasNoActiveBuyTrigger: !vaultHasActiveAutoBuyTrigger,
             constantMultipleReadOnlyEnabled,
+            readOnlyAutoTakeProfitEnabled,
             vaultHasNoActiveConstantMultipleTriggers: !vaultHasActiveConstantMultipleTrigger,
+            vaultHasNoActiveAutoTakeProfitTrigger: !vaultHasActiveAutoTakeProfitTrigger,
           })}
         />
       </Container>

--- a/features/automation/common/sidebars/CancelAutoBSInfoSection.tsx
+++ b/features/automation/common/sidebars/CancelAutoBSInfoSection.tsx
@@ -12,6 +12,8 @@ interface CancelAutoBSInfoSectionProps {
   liquidationPrice: BigNumber
   debt: BigNumber
   title: string
+  targetLabel: string
+  triggerLabel: string
   autoBSState: AutoBSFormChange
 }
 
@@ -20,6 +22,8 @@ export function CancelAutoBSInfoSection({
   liquidationPrice,
   debt,
   title,
+  targetLabel,
+  triggerLabel,
   autoBSState,
 }: CancelAutoBSInfoSectionProps) {
   const { t } = useTranslation()
@@ -30,8 +34,8 @@ export function CancelAutoBSInfoSection({
   const collateralizationRatioFormatted = formatPercent(collateralizationRatio.times(100), {
     precision: 2,
   })
-  const ratioToPerformSellFormatted = formatPercent(autoBSState.execCollRatio, { precision: 2 })
-  const colRatioAfterSellFormatted = formatPercent(autoBSState.targetCollRatio, { precision: 2 })
+  const execCollRatioFormatted = formatPercent(autoBSState.execCollRatio, { precision: 2 })
+  const targetCollRatioFormatted = formatPercent(autoBSState.targetCollRatio, { precision: 2 })
 
   return (
     <InfoSection
@@ -40,13 +44,13 @@ export function CancelAutoBSInfoSection({
         ...(isDebtZero || readOnlyAutoBSEnabled
           ? [
               {
-                label: t('auto-sell.target-col-ratio-each-sell'),
-                value: colRatioAfterSellFormatted,
+                label: targetLabel,
+                value: targetCollRatioFormatted,
                 secondaryValue: '0%',
               },
               {
-                label: t('auto-sell.trigger-col-ratio-to-perfrom-sell'),
-                value: ratioToPerformSellFormatted,
+                label: triggerLabel,
+                value: execCollRatioFormatted,
                 secondaryValue: '0%',
               },
             ]

--- a/features/automation/optimization/autoBuy/controls/AddAutoBuyInfoSection.tsx
+++ b/features/automation/optimization/autoBuy/controls/AddAutoBuyInfoSection.tsx
@@ -64,7 +64,7 @@ export function AddAutoBuyInfoSection({
           value: `${multipleAfterBuy.toFixed(2)}x`,
         },
         {
-          label: t('auto-buy.trigger-col-ratio-to-perfrom-buy'),
+          label: t('auto-buy.trigger-col-ratio-to-perform-buy'),
           value: ratioToPerformBuyFormatted,
         },
         {

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
@@ -49,6 +49,8 @@ function AutoBuyInfoSectionControl({ vault, autoBuyState }: AutoBuyInfoSectionCo
       collateralizationRatio={vault.collateralizationRatio}
       liquidationPrice={vault.liquidationPrice}
       title={t('auto-buy.cancel-summary-title')}
+      targetLabel={t('auto-buy.target-col-ratio-each-buy')}
+      triggerLabel={t('auto-buy.trigger-col-ratio-to-perform-buy')}
       autoBSState={autoBuyState}
       debt={vault.debt}
     />

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -9,6 +9,7 @@ import {
 } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitFormChange'
 import { AutoTakeProfitTriggerData } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { useUIChanges } from 'helpers/uiChangesHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
 
 import { AutoTakeProfitDetailsLayout } from './AutoTakeProfitDetailsLayout'
@@ -25,6 +26,7 @@ export function AutoTakeProfitDetailsControl({
   vault,
 }: AutoTakeProfitDetailsControlProps) {
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
+  const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
 
   const { debt, debtOffset, lockedCollateral } = vault
   const { isTriggerEnabled, executionPrice } = autoTakeProfitTriggerData
@@ -62,7 +64,7 @@ export function AutoTakeProfitDetailsControl({
     currentColRatio: vault.collateralizationRatio.times(100),
   }
 
-  if (isDebtZero) return null
+  if (readOnlyAutoTakeProfitEnabled || isDebtZero) return null
 
   return (
     <AutoTakeProfitDetailsLayout

--- a/features/automation/optimization/autoTakeProfit/controls/CancelAutoTakeProfitInfoSection.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/CancelAutoTakeProfitInfoSection.tsx
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -9,31 +10,46 @@ interface CancelAutoTakeProfitInfoSectionProps {
   collateralizationRatio: BigNumber
   token: string
   triggerColPrice: BigNumber
+  debt: BigNumber
 }
 
 export function CancelAutoTakeProfitInfoSection({
   collateralizationRatio,
   token,
   triggerColPrice,
+  debt,
 }: CancelAutoTakeProfitInfoSectionProps) {
   const { t } = useTranslation()
+  const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
+
+  const isDebtZero = debt.isZero()
 
   return (
     <InfoSection
       title={t('constant-multiple.vault-changes.general-summary')}
       items={[
-        {
-          label: t('auto-take-profit.vault-changes.trigger-col-price', { token }),
-          value: `$${formatAmount(triggerColPrice, 'USD')}`,
-          secondaryValue: 'n/a',
-        },
-        {
-          label: t('system.collateral-ratio'),
-          value: formatPercent(collateralizationRatio, {
-            precision: 2,
-            roundMode: BigNumber.ROUND_DOWN,
-          }),
-        },
+        ...(isDebtZero || readOnlyAutoTakeProfitEnabled
+          ? [
+              {
+                label: t('auto-take-profit.vault-changes.trigger-col-price', { token }),
+                value: `$${formatAmount(triggerColPrice, 'USD')}`,
+                secondaryValue: 'n/a',
+              },
+            ]
+          : [
+              {
+                label: t('auto-take-profit.vault-changes.trigger-col-price', { token }),
+                value: `$${formatAmount(triggerColPrice, 'USD')}`,
+                secondaryValue: 'n/a',
+              },
+              {
+                label: t('system.collateral-ratio'),
+                value: formatPercent(collateralizationRatio, {
+                  precision: 2,
+                  roundMode: BigNumber.ROUND_DOWN,
+                }),
+              },
+            ]),
         {
           label: t('auto-sell.estimated-transaction-cost'),
           value: <GasEstimation />,

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -7,6 +7,7 @@ import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseSt
 import { SliderValuePicker, SliderValuePickerProps } from 'components/dumb/SliderValuePicker'
 import { EstimationOnClose } from 'components/EstimationOnClose'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
 import { getOnCloseEstimations } from 'features/automation/common/estimations/onCloseEstimations'
@@ -22,6 +23,7 @@ import {
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { formatAmount } from 'helpers/formatters/format'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -54,6 +56,9 @@ export function SidebarAutoTakeProfitEditingStage({
 }: SidebarAutoTakeProfitEditingStageProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
+  const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
+
+  const isVaultEmpty = vault.debt.isZero()
 
   const { estimatedProfitOnClose } = getOnCloseEstimations({
     colMarketPrice: autoTakeProfitState.executionPrice,
@@ -65,6 +70,24 @@ export function SidebarAutoTakeProfitEditingStage({
     toCollateral: autoTakeProfitState.toCollateral,
   })
   const closeToToken = autoTakeProfitState.toCollateral ? vault.token : 'DAI'
+
+  if (readOnlyAutoTakeProfitEnabled && !isVaultEmpty) {
+    return (
+      <SidebarFormInfo
+        title={t('auto-take-profit.adding-new-triggers-disabled')}
+        description={t('auto-take-profit.adding-new-triggers-disabled-description')}
+      />
+    )
+  }
+
+  if (isVaultEmpty && autoTakeProfitTriggerData.isTriggerEnabled) {
+    return (
+      <SidebarFormInfo
+        title={t('auto-take-profit.closed-vault-existing-trigger-header')}
+        description={t('auto-take-profit.closed-vault-existing-trigger-description')}
+      />
+    )
+  }
 
   return (
     <>

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
@@ -55,6 +55,7 @@ function AutoTakeProfitInfoSectionControl({
     <CancelAutoTakeProfitInfoSection
       collateralizationRatio={vault.collateralizationRatio.times(100)}
       token={vault.token}
+      debt={vault.debt}
       triggerColPrice={autoTakeProfitTriggerData.executionPrice}
     />
   )

--- a/features/automation/optimization/constantMultiple/controls/AddConstantMultipleInfoSection.tsx
+++ b/features/automation/optimization/constantMultiple/controls/AddConstantMultipleInfoSection.tsx
@@ -85,7 +85,7 @@ export function AddConstantMultipleInfoSection({
           isHeading: true,
           dropdownValues: [
             {
-              label: t('auto-buy.trigger-col-ratio-to-perfrom-buy'),
+              label: t('auto-buy.trigger-col-ratio-to-perform-buy'),
               value: `${buyExecutionCollRatio}%`,
             },
             {

--- a/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
+++ b/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
@@ -33,7 +33,7 @@ export function CancelConstantMultipleInfoSection({
                 secondaryValue: '0%',
               },
               {
-                label: t('auto-buy.trigger-col-ratio-to-perfrom-buy'),
+                label: t('auto-buy.trigger-col-ratio-to-perform-buy'),
                 value: `${constantMultipleTriggerData.buyExecutionCollRatio}%`,
                 secondaryValue: '0%',
               },

--- a/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
@@ -23,6 +23,8 @@ function AutoSellInfoSectionControl({ vault, autoSellState }: AutoSellInfoSectio
       liquidationPrice={vault.liquidationPrice}
       debt={vault.debt}
       title={t('auto-sell.cancel-summary-title')}
+      targetLabel={t('auto-sell.target-col-ratio-each-sell')}
+      triggerLabel={t('auto-sell.trigger-col-ratio-to-perfrom-sell')}
       autoBSState={autoSellState}
     />
   )

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -21,6 +21,7 @@ export type Feature =
   | 'ProxyCreationDisabled'
   | 'AutoTakeProfit'
   | 'UpdatedPnL'
+  | 'ReadOnlyAutoTakeProfit'
   | 'DiscoverOasis'
   | 'ShowAaveStETHETHProductCard'
 
@@ -42,6 +43,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   ProxyCreationDisabled: false,
   AutoTakeProfit: false,
   UpdatedPnL: false,
+  ReadOnlyAutoTakeProfit: false,
   DiscoverOasis: false,
   ShowAaveStETHETHProductCard: false,
   // your feature here....

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -1605,7 +1605,7 @@
     "buy-title": "基础 Auto-Buy 摘要",
     "target-col-ratio-each-buy": "每次购买后的目标抵押率",
     "target-multiple-each-buy": "每次购买后的目标倍率",
-    "trigger-col-ratio-to-perfrom-buy": "触发抵押率执行每次自动化购买",
+    "trigger-col-ratio-to-perform-buy": "触发抵押率执行每次自动化购买",
     "next-buy-prices": "下次购买价格",
     "total-cost-of-next-buy": "下次购买后 ETH 的总成本",
     "collateral-after-next-buy": "下次购买后的抵押品",
@@ -1797,7 +1797,6 @@
     "aave": {
       "vault-form": {
         "adjust-risk": "Adjust Risk",
-
         "deposit": "存入 ETH",
         "title": "你的 Earn 仓位",
         "close-title": "以 ETH 结算并关闭此仓位",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1627,7 +1627,7 @@
     "trigger-updated": "Auto-Buy Updated",
     "target-col-ratio-each-buy": "Target Col. Ratio after each buy",
     "target-multiple-each-buy": "Target Multiple after each buy",
-    "trigger-col-ratio-to-perfrom-buy": "Trigger Col. Ratio to perfrom each automated buy",
+    "trigger-col-ratio-to-perform-buy": "Trigger Col. Ratio to perform each automated buy",
     "next-buy-prices": "Next buy price(s)",
     "total-cost-of-next-buy": "Total cost of next ETH buy",
     "collateral-after-next-buy": "Collateral after next buy",
@@ -1685,7 +1685,11 @@
       "estimated-gas-fee": "Estimated gas fee",
       "setup-transaction-cost": "Setup transaction cost"
     },
-    "cancel-instructions": "To cancel the Take Profit you'll need to click the button below and confirm the transaction."
+    "cancel-instructions": "To cancel the Take Profit you'll need to click the button below and confirm the transaction.",
+    "adding-new-triggers-disabled": "Creation of the new Take Profit trigger is currently disabled.",
+    "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Take Profit triggers",
+    "closed-vault-existing-trigger-header": "Your vault is closed but Take Profit is still active",
+    "closed-vault-existing-trigger-description": "You can cancel your existing Take Profit here or deposit into your vault in overview tab"
   },
 
   "automation": {


### PR DESCRIPTION
# [Auto-Take Profit safety switch](https://app.shortcut.com/oazo-apps/story/5733/ui-auto-take-safety-switch)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added `ReadOnlyAutoTakeProfit` feature flag and its handling
  
## How to test 🧪
  <Please explain how to test your changes>

- ATP enabled, readonly flag enabled, vault empty - user should be able to remove ATP trigger
- ATP enabled, readonly flag enabled, vault not empty - user should be able to remove ATP trigger
- ATP not enabled, readonly flag enabled, vault not empty - user shouldn't be able to add ATP trigger
- ATP not enabled, readonly flag enabled, vault empty - user shouldn't be able to add ATP trigger