### PR TITLE
Auto-Take Profit dropdown and slider fix

### DIFF
--- a/components/vault/GeneralManageTabBar.tsx
+++ b/components/vault/GeneralManageTabBar.tsx
@@ -74,7 +74,12 @@ export function GeneralManageTabBar({
                 value: 'protection',
                 tag: { include: true, active: protectionEnabled },
                 content: (
-                  <ProtectionControl vault={vault} ilkData={ilkData} balanceInfo={balanceInfo} />
+                  <ProtectionControl
+                    vault={vault}
+                    ilkData={ilkData}
+                    balanceInfo={balanceInfo}
+                    vaultType={generalManageVault.type}
+                  />
                 ),
               },
             ]

--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -4,6 +4,7 @@ import { Vault } from 'blockchain/vaults'
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { ProtectionDetailsControl } from 'features/automation/protection/common/controls/ProtectionDetailsControl'
 import { ProtectionFormControl } from 'features/automation/protection/common/controls/ProtectionFormControl'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { VaultNotice } from 'features/notices/VaultsNoticesView'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { VaultContainerSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
@@ -60,6 +61,7 @@ interface ProtectionControlProps {
   vault: Vault
   ilkData: IlkData
   balanceInfo: BalanceInfo
+  vaultType: VaultType
 }
 
 function getZeroDebtProtectionBannerProps({
@@ -101,7 +103,12 @@ function getZeroDebtProtectionBannerProps({
   }
 }
 
-export function ProtectionControl({ vault, ilkData, balanceInfo }: ProtectionControlProps) {
+export function ProtectionControl({
+  vault,
+  ilkData,
+  balanceInfo,
+  vaultType,
+}: ProtectionControlProps) {
   const { priceInfo$, context$, txHelpers$, tokenPriceUSD$ } = useAppContext()
   const { stopLossTriggerData, autoSellTriggerData } = useAutomationContext()
 
@@ -141,6 +148,7 @@ export function ProtectionControl({ vault, ilkData, balanceInfo }: ProtectionCon
                   txHelpers={txHelpersData}
                   context={context}
                   ethMarketPrice={ethAndTokenPrices['ETH']}
+                  vaultType={vaultType}
                 />
               }
             />

--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -8,12 +8,14 @@ import {
   AutomationProtectionFeatures,
 } from 'features/automation/common/state/automationFeatureChange'
 import { AutomationFeatures } from 'features/automation/common/types'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 
 interface GetAutoFeaturesSidebarDropdownProps {
   type: AutomationKinds
   forcePanel: AutomationProtectionFeatures | AutomationOptimizationFeatures
+  vaultType: VaultType
   disabled?: boolean
   isStopLossEnabled?: boolean
   isAutoSellEnabled?: boolean
@@ -66,6 +68,7 @@ export function getAutoFeaturesSidebarDropdown({
   isAutoBuyEnabled,
   isAutoConstantMultipleEnabled,
   isAutoTakeProfitEnabled,
+  vaultType,
 }: GetAutoFeaturesSidebarDropdownProps): SidebarSectionHeaderDropdown | undefined {
   const autoTakeProfitEnabled = useFeatureToggle('AutoTakeProfit')
 
@@ -107,7 +110,7 @@ export function getAutoFeaturesSidebarDropdown({
     ...(type === 'Optimization'
       ? [
           ...(!isAutoConstantMultipleEnabled ? [basicBuyDropdownItem] : []),
-          constantMultipleDropdownItem,
+          ...(vaultType === VaultType.Multiply ? [constantMultipleDropdownItem] : []),
           ...(autoTakeProfitEnabled ? [autoTakeProfitDropdownItem] : []),
         ]
       : []),

--- a/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
@@ -96,8 +96,6 @@ export function SidebarSetupAutoBuy({
 }: SidebarSetupAutoBuyProps) {
   const gasEstimation = useGasEstimationContext()
 
-  const isMultiplyVault = vaultType === VaultType.Multiply
-
   const flow = getAutomationFormFlow({ isFirstSetup, isRemoveForm, feature })
   const sidebarTitle = getAutomationFormTitle({
     flow,
@@ -110,6 +108,8 @@ export function SidebarSetupAutoBuy({
     disabled: isDropdownDisabled({ stage }),
     isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
+    isAutoTakeProfitEnabled: autoTakeProfitTriggerData.isTriggerEnabled,
+    vaultType,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({ flow, stage, feature })
   const textButtonLabel = getAutomationTextButtonLabel({ isAddForm })
@@ -156,7 +156,7 @@ export function SidebarSetupAutoBuy({
   if (isAutoBuyActive) {
     const sidebarSectionProps: SidebarSectionProps = {
       title: sidebarTitle,
-      ...(isMultiplyVault && { dropdown }),
+      dropdown,
       content: (
         <Grid gap={3}>
           {(stage === 'editing' || stage === 'txFailure') && (

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -16,6 +16,7 @@ import { getAutoTakeProfitStatus } from 'features/automation/optimization/autoTa
 import { AutoTakeProfitTriggerData } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { getAutoTakeProfitTxHandlers } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTxHandlers'
 import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
@@ -34,6 +35,7 @@ interface AutoTakeProfitFormControlProps {
   priceInfo: PriceInfo
   txHelpers?: TxHelpers
   vault: Vault
+  vaultType: VaultType
   balanceInfo: BalanceInfo
 }
 
@@ -50,6 +52,7 @@ export function AutoTakeProfitFormControl({
   priceInfo: { nextCollateralPrice },
   txHelpers,
   vault,
+  vaultType,
   balanceInfo,
 }: AutoTakeProfitFormControlProps) {
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
@@ -132,6 +135,7 @@ export function AutoTakeProfitFormControl({
           vault={vault}
           nextCollateralPrice={nextCollateralPrice}
           ethBalance={balanceInfo.ethBalance}
+          vaultType={vaultType}
         />
       )}
     </AddAndRemoveTriggerControl>

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -30,6 +30,7 @@ import {
 } from 'features/automation/optimization/autoTakeProfit/validators'
 import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
 import { getSliderPercentageFill } from 'features/automation/protection/stopLoss/helpers'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import {
@@ -65,6 +66,7 @@ interface SidebarSetupAutoTakeProfitProps {
   txHandler: () => void
   vault: Vault
   ethBalance: BigNumber
+  vaultType: VaultType
 }
 
 export function SidebarSetupAutoTakeProfit({
@@ -92,6 +94,7 @@ export function SidebarSetupAutoTakeProfit({
   txHandler,
   vault,
   ethBalance,
+  vaultType,
 }: SidebarSetupAutoTakeProfitProps) {
   const { uiChanges } = useAppContext()
   const gasEstimation = useGasEstimationContext()
@@ -110,6 +113,7 @@ export function SidebarSetupAutoTakeProfit({
     isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     isAutoTakeProfitEnabled: autoTakeProfitTriggerData.isTriggerEnabled,
+    vaultType,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -134,7 +134,7 @@ export function SidebarSetupAutoTakeProfit({
   }
   const sliderPercentageFill = getSliderPercentageFill({
     value: autoTakeProfitState.executionPrice,
-    min: min,
+    min,
     max,
   })
   const targetColRatio = ratioAtCollateralPrice({

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -127,6 +127,7 @@ export function OptimizationFormControl({
         stopLossTriggerData={stopLossTriggerData}
         txHelpers={txHelpers}
         vault={vault}
+        vaultType={vaultType}
       />
       {autoTakeProfitEnabled && (
         <AutoTakeProfitFormControl
@@ -143,6 +144,7 @@ export function OptimizationFormControl({
           vault={vault}
           priceInfo={priceInfo}
           balanceInfo={balanceInfo}
+          vaultType={vaultType}
         />
       )}
     </>

--- a/features/automation/optimization/common/helpers.ts
+++ b/features/automation/optimization/common/helpers.ts
@@ -15,8 +15,6 @@ export function getActiveOptimizationFeature({
   currentOptimizationFeature?: AutomationOptimizationFeatures
   isAutoTakeProfitOn?: boolean
 }) {
-  // const constantMultipleEnabled = useFeatureToggle('ConstantMultiple')
-
   if (section === 'form') {
     return {
       isAutoBuyActive:
@@ -32,6 +30,7 @@ export function getActiveOptimizationFeature({
         currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
       isAutoTakeProfitActive:
         (isAutoTakeProfitOn &&
+          !isConstantMultipleOn &&
           currentOptimizationFeature !== AutomationFeatures.AUTO_BUY &&
           currentOptimizationFeature !== AutomationFeatures.CONSTANT_MULTIPLE) ||
         currentOptimizationFeature === AutomationFeatures.AUTO_TAKE_PROFIT,
@@ -52,9 +51,4 @@ export function getActiveOptimizationFeature({
           currentOptimizationFeature === AutomationFeatures.CONSTANT_MULTIPLE,
         isAutoTakeProfitActive: currentOptimizationFeature === AutomationFeatures.AUTO_TAKE_PROFIT,
       }
-
-  // return {
-  //   isAutoBuyActive: false,
-  //   isConstantMultipleActive: false,
-  // }
 }

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
@@ -17,6 +17,7 @@ import { getConstantMultipleStatus } from 'features/automation/optimization/cons
 import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
 import { getConstantMultipleTxHandlers } from 'features/automation/optimization/constantMultiple/state/constantMultipleTxHandlers'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React from 'react'
@@ -35,6 +36,7 @@ interface ConstantMultipleFormControlProps {
   stopLossTriggerData: StopLossTriggerData
   txHelpers?: TxHelpers
   vault: Vault
+  vaultType: VaultType
 }
 
 export function ConstantMultipleFormControl({
@@ -51,6 +53,7 @@ export function ConstantMultipleFormControl({
   stopLossTriggerData,
   txHelpers,
   vault,
+  vaultType,
 }: ConstantMultipleFormControlProps) {
   const [constantMultipleState] = useUIChanges<ConstantMultipleFormChange>(
     CONSTANT_MULTIPLE_FORM_CHANGE,
@@ -154,6 +157,7 @@ export function ConstantMultipleFormControl({
           textButtonHandler={textButtonHandler}
           txHandler={txHandler}
           vault={vault}
+          vaultType={vaultType}
         />
       )}
     </AddAndRemoveTriggerControl>

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
@@ -23,6 +23,7 @@ import {
   warningsConstantMultipleValidation,
 } from 'features/automation/optimization/constantMultiple/validators'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import {
@@ -63,6 +64,7 @@ interface SidebarSetupConstantMultipleProps {
   textButtonHandler: () => void
   txHandler: () => void
   vault: Vault
+  vaultType: VaultType
 }
 
 export function SidebarSetupConstantMultiple({
@@ -96,6 +98,7 @@ export function SidebarSetupConstantMultiple({
   vault,
   debtDeltaWhenSellAtCurrentCollRatio,
   debtDeltaAfterSell,
+  vaultType,
 }: SidebarSetupConstantMultipleProps) {
   const gasEstimation = useGasEstimationContext()
 
@@ -112,6 +115,7 @@ export function SidebarSetupConstantMultiple({
     isAutoBuyEnabled: autoBuyTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     isAutoTakeProfitEnabled: autoTakeProfitTriggerData.isTriggerEnabled,
+    vaultType,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,

--- a/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
@@ -17,6 +17,7 @@ import { AutomationFeatures } from 'features/automation/common/types'
 import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
 import { SidebarSetupAutoSell } from 'features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React from 'react'
@@ -34,6 +35,7 @@ interface AutoSellFormControlProps {
   stopLossTriggerData: StopLossTriggerData
   txHelpers?: TxHelpers
   vault: Vault
+  vaultType: VaultType
 }
 
 export function AutoSellFormControl({
@@ -49,6 +51,7 @@ export function AutoSellFormControl({
   stopLossTriggerData,
   txHelpers,
   vault,
+  vaultType,
 }: AutoSellFormControlProps) {
   const [autoSellState] = useUIChanges<AutoBSFormChange>(AUTO_SELL_FORM_CHANGE)
 
@@ -138,6 +141,7 @@ export function AutoSellFormControl({
           textButtonHandler={textButtonHandler}
           txHandler={txHandler}
           vault={vault}
+          vaultType={vaultType}
           executionPrice={executionPrice}
         />
       )}

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -24,6 +24,7 @@ import {
   warningsAutoSellValidation,
 } from 'features/automation/protection/autoSell/validators'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import {
@@ -35,6 +36,7 @@ import { Grid } from 'theme-ui'
 
 interface SidebarSetupAutoSellProps {
   vault: Vault
+  vaultType: VaultType
   ilkData: IlkData
   balanceInfo: BalanceInfo
   autoSellTriggerData: AutoBSTriggerData
@@ -62,6 +64,7 @@ interface SidebarSetupAutoSellProps {
 
 export function SidebarSetupAutoSell({
   vault,
+  vaultType,
   ilkData,
   balanceInfo,
   context,
@@ -105,6 +108,7 @@ export function SidebarSetupAutoSell({
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
+    vaultType,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({ flow, stage, feature })
   const textButtonLabel = getAutomationTextButtonLabel({ isAddForm })

--- a/features/automation/protection/common/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionFormControl.tsx
@@ -14,6 +14,7 @@ import { AutomationFeatures } from 'features/automation/common/types'
 import { AutoSellFormControl } from 'features/automation/protection/autoSell/controls/AutoSellFormControl'
 import { getActiveProtectionFeature } from 'features/automation/protection/common/helpers'
 import { StopLossFormControl } from 'features/automation/protection/stopLoss/controls/StopLossFormControl'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
@@ -23,6 +24,7 @@ interface ProtectionFormControlProps {
   ilkData: IlkData
   priceInfo: PriceInfo
   vault: Vault
+  vaultType: VaultType
   balanceInfo: BalanceInfo
   txHelpers?: TxHelpers
   context: Context
@@ -37,6 +39,7 @@ export function ProtectionFormControl({
   context,
   txHelpers,
   ethMarketPrice,
+  vaultType,
 }: ProtectionFormControlProps) {
   const {
     stopLossTriggerData,
@@ -89,6 +92,7 @@ export function ProtectionFormControl({
         txHelpers={txHelpers}
         ethMarketPrice={ethMarketPrice}
         shouldRemoveAllowance={shouldRemoveAllowance}
+        vaultType={vaultType}
       />
       <AutoSellFormControl
         vault={vault}
@@ -103,6 +107,7 @@ export function ProtectionFormControl({
         txHelpers={txHelpers}
         ethMarketPrice={ethMarketPrice}
         shouldRemoveAllowance={shouldRemoveAllowance}
+        vaultType={vaultType}
       />
     </>
   )

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -17,6 +17,7 @@ import {
 import { getStopLossStatus } from 'features/automation/protection/stopLoss/state/stopLossStatus'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { getStopLossTxHandlers } from 'features/automation/protection/stopLoss/state/stopLossTxHandlers'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { useUIChanges } from 'helpers/uiChangesHook'
@@ -36,6 +37,7 @@ interface StopLossFormControlProps {
   stopLossTriggerData: StopLossTriggerData
   txHelpers?: TxHelpers
   vault: Vault
+  vaultType: VaultType
 }
 
 export function StopLossFormControl({
@@ -52,6 +54,7 @@ export function StopLossFormControl({
   stopLossTriggerData,
   txHelpers,
   vault,
+  vaultType,
 }: StopLossFormControlProps) {
   const [stopLossState] = useUIChanges<StopLossFormChange>(STOP_LOSS_FORM_CHANGE)
 
@@ -134,6 +137,7 @@ export function StopLossFormControl({
           textButtonHandler={textButtonHandler}
           txHandler={txHandler}
           vault={vault}
+          vaultType={vaultType}
         />
       )}
     </AddAndRemoveTriggerControl>

--- a/features/automation/protection/stopLoss/helpers.ts
+++ b/features/automation/protection/stopLoss/helpers.ts
@@ -48,9 +48,7 @@ export function getSliderPercentageFill({
   min: BigNumber
   max: BigNumber
 }) {
-  return value
-    .minus(min.times(100))
-    .div(max.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN).div(100).minus(min))
+  return value.minus(min).times(100).div(max.minus(min))
 }
 
 export function checkIfIsDisabledStopLoss({

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -96,8 +96,8 @@ export function getDataForStopLoss(
 
   const sliderPercentageFill = getSliderPercentageFill({
     value: stopLossLevel,
-    min: ilkData.liquidationRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100)),
-    max: afterCollateralizationRatioAtNextPrice.minus(NEXT_COLL_RATIO_OFFSET.div(100)),
+    min: ilkData.liquidationRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100)).times(100),
+    max: afterCollateralizationRatioAtNextPrice.minus(NEXT_COLL_RATIO_OFFSET.div(100)).times(100),
   })
 
   const afterNewLiquidationPrice = stopLossLevel

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -153,8 +153,8 @@ export function SidebarSetupStopLoss({
 
   const sliderPercentageFill = getSliderPercentageFill({
     value: stopLossState.stopLossLevel,
-    min: ilkData.liquidationRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100)),
-    max,
+    min: ilkData.liquidationRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100)).times(100),
+    max: max.times(100),
   })
 
   const afterNewLiquidationPrice = stopLossState.stopLossLevel

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -37,6 +37,7 @@ import {
   warningsStopLossValidation,
 } from 'features/automation/protection/stopLoss/validators'
 import { TAB_CHANGE_SUBJECT } from 'features/generalManageVault/TabChange'
+import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import {
@@ -51,6 +52,7 @@ import { Grid, Text } from 'theme-ui'
 
 interface SidebarSetupStopLossProps {
   vault: Vault
+  vaultType: VaultType
   ilkData: IlkData
   balanceInfo: BalanceInfo
   autoSellTriggerData: AutoBSTriggerData
@@ -77,6 +79,7 @@ interface SidebarSetupStopLossProps {
 
 export function SidebarSetupStopLoss({
   vault,
+  vaultType,
   ilkData,
   balanceInfo,
   context,
@@ -126,6 +129,7 @@ export function SidebarSetupStopLoss({
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
+    vaultType,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js'
-import { VaultHistoryEvent } from 'features/vaultHistory/vaultHistory'
+import { mapAutomationEvents, VaultHistoryEvent } from 'features/vaultHistory/vaultHistory'
 
 import { maxUint256 } from '../../blockchain/calls/erc20'
 import { isNullish } from '../../helpers/functions'
@@ -485,11 +485,16 @@ export function stopLossTriggeredValidator({
 }: {
   vaultHistory: VaultHistoryEvent[]
 }) {
+  if (!vaultHistory.length) {
+    return false
+  }
+
+  const mappedAuto = mapAutomationEvents(vaultHistory)
+  const potentialExecutionEvent = mappedAuto[0]
+
   return (
-    !!vaultHistory[1] &&
-    'triggerId' in vaultHistory[1] &&
-    vaultHistory[1].eventType === 'executed' &&
-    (vaultHistory[0].kind === 'CLOSE_VAULT_TO_COLLATERAL' ||
-      vaultHistory[0].kind === 'CLOSE_VAULT_TO_DAI')
+    'autoKind' in potentialExecutionEvent &&
+    potentialExecutionEvent.autoKind === 'stop-loss' &&
+    potentialExecutionEvent.eventType === 'executed'
   )
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -311,7 +311,7 @@
     "stop-loss": "Stop-Loss trigger",
     "basic-buy": "Auto-Buy trigger",
     "basic-sell": "Auto-Sell trigger",
-    "auto-take-profit": "Auto-Take-Profit trigger",
+    "auto-take-profit": "Auto-Take Profit trigger",
     "constant-multiple": "Constant-Multiple trigger",
     "constant-multiple-buy": "Constant-Multiple Buy trigger",
     "constant-multiple-sell": "Constant-Multiple Sell trigger",


### PR DESCRIPTION
# [Auto-Take Profit dropdown and slider fix](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue with slider (missing fill color)
- fixed issue with optimization dropdown in borrow vaults
- fixed issue when CM and ATP were enabled (both forms were displayed)
  
## How to test 🧪
  <Please explain how to test your changes>

- ATP slider and SL slider should have correct fill color
- borrow vault should have dropdown when ATP feature toggle enabled (but without CM item to select)
- borrow vault shouldn't have dropdown when ATP feature toggle disabled
- enable ATP and CM and check if only one form is displayed
