### PR TITLE
Gf/add col updated col ratio

### DIFF
--- a/components/vault/DefaultVaultHeadline.tsx
+++ b/components/vault/DefaultVaultHeadline.tsx
@@ -42,7 +42,7 @@ export function DefaultVaultHeadline({
           subColor: priceChangeColor,
         },
         {
-          label: 'Collateral Ratio',
+          label: t('system.collateral-ratio'),
           value: `${colRatio}%`,
         },
       ]}

--- a/components/vault/DefaultVaultHeadline.tsx
+++ b/components/vault/DefaultVaultHeadline.tsx
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
@@ -11,12 +10,12 @@ export function DefaultVaultHeadline({
   header,
   token,
   priceInfo,
-  colRatio
+  colRatio,
 }: {
   header: VaultHeadlineProps['header']
   token: VaultHeadlineProps['token']
-  priceInfo: PriceInfo,
-  colRatio: string,
+  priceInfo: PriceInfo
+  colRatio: string
 }) {
   const { t } = useTranslation()
   const { currentCollateralPrice, nextCollateralPrice, collateralPricePercentageChange } = priceInfo

--- a/components/vault/DefaultVaultHeadline.tsx
+++ b/components/vault/DefaultVaultHeadline.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
@@ -10,10 +11,12 @@ export function DefaultVaultHeadline({
   header,
   token,
   priceInfo,
+  colRatio
 }: {
   header: VaultHeadlineProps['header']
   token: VaultHeadlineProps['token']
-  priceInfo: PriceInfo
+  priceInfo: PriceInfo,
+  colRatio: string,
 }) {
   const { t } = useTranslation()
   const { currentCollateralPrice, nextCollateralPrice, collateralPricePercentageChange } = priceInfo
@@ -38,6 +41,10 @@ export function DefaultVaultHeadline({
           value: `$${nextPrice}`,
           sub: priceChange,
           subColor: priceChangeColor,
+        },
+        {
+          label: 'Collateral Ratio',
+          value: `${colRatio}%`,
         },
       ]}
     />

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -33,6 +33,8 @@ export function GeneralManageLayout({ generalManageVault }: GeneralManageLayoutP
   const { t } = useTranslation()
   const { ilkData, vault, priceInfo } = generalManageVault.state
 
+  const colRatioPercnentage = vault.collateralizationRatio.times(100).toFixed(2)
+
   const showAutomationTabs = isSupportedAutomationIlk(getNetworkName(), vault.ilk)
   const isStopLossEnabled = useStopLossStateInitializator(ilkData, vault, stopLossTriggerData)
   const isAutoSellEnabled = useAutoBSstateInitialization(
@@ -70,6 +72,7 @@ export function GeneralManageLayout({ generalManageVault }: GeneralManageLayoutP
         header={t('vault.header', { ilk: vault.ilk, id: vault.id })}
         token={[vault.token]}
         priceInfo={priceInfo}
+        colRatio={colRatioPercnentage}
       />
     )
 


### PR DESCRIPTION
# [Added new Col ratio to vault details header](https://app.shortcut.com/oazo-apps/story/5016/update-designs-to-show-current-and-updated-col-ratio)
  
## Changes 👷‍♀️
- Added Col Ratio to vault overview header
  
## How to test 🧪
- Go to manage any vault, you will see a new Collatralization Ratio value next to Current and Next ETH prices
