### PR TITLE
Discovery table preloader

### DIFF
--- a/features/discovery/common/DiscoveryTable.tsx
+++ b/features/discovery/common/DiscoveryTable.tsx
@@ -2,6 +2,7 @@ import { DiscoveryTableBanner } from 'features/discovery/common/DiscoveryTableBa
 import { DiscoveryTableDataCellContent } from 'features/discovery/common/DiscoveryTableDataCellContent'
 import { DiscoveryBanner } from 'features/discovery/meta'
 import { DiscoveryPages, DiscoveryTableRowData } from 'features/discovery/types'
+import { AppSpinner } from 'helpers/AppSpinner'
 import { kebabCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React, { Fragment } from 'react'
@@ -9,12 +10,14 @@ import { Box, Text } from 'theme-ui'
 
 export function DiscoveryTable({
   banner,
+  isLoading,
   kind,
-  rows,
+  rows = [],
 }: {
   banner?: DiscoveryBanner
+  isLoading: boolean
   kind: DiscoveryPages
-  rows: DiscoveryTableRowData[]
+  rows?: DiscoveryTableRowData[]
 }) {
   const { t } = useTranslation()
 
@@ -24,6 +27,7 @@ export function DiscoveryTable({
         position: 'relative',
         px: 4,
         pb: 1,
+        minHeight: '80px',
         borderTop: '1px solid',
         borderTopColor: 'neutral20',
         ...(rows.length > 0 && {
@@ -39,8 +43,17 @@ export function DiscoveryTable({
         }),
       }}
     >
-      {rows.length > 0 ? (
-        <Box as="table" sx={{ width: '100%', borderSpacing: '0 20px' }}>
+      {rows.length > 0 && (
+        <Box
+          as="table"
+          sx={{
+            width: '100%',
+            borderSpacing: '0 20px',
+            opacity: isLoading ? 0.5 : 1,
+            pointerEvents: isLoading ? 'none' : 'auto',
+            transition: '200ms opacity',
+          }}
+        >
           <Box as="thead">
             <tr>
               {Object.keys(rows[0]).map((label, i) => (
@@ -63,10 +76,17 @@ export function DiscoveryTable({
             ))}
           </Box>
         </Box>
-      ) : (
+      )}
+      {rows.length === 0 && !isLoading && (
         <Text as="p" variant="paragraph2" sx={{ py: 4 }}>
           {t('discovery.table.no-entries')}
         </Text>
+      )}
+      {isLoading && (
+        <AppSpinner
+          sx={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, margin: 'auto' }}
+          variant="extraLarge"
+        />
       )}
     </Box>
   )

--- a/features/discovery/controllers/DiscoveryControl.tsx
+++ b/features/discovery/controllers/DiscoveryControl.tsx
@@ -5,7 +5,7 @@ import { getDefaultSettingsState } from 'features/discovery/helpers'
 import { discoveryPagesMeta } from 'features/discovery/meta'
 import { DiscoveryFiltersSettings, DiscoveryPages } from 'features/discovery/types'
 import { keyBy } from 'lodash'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box } from 'theme-ui'
 
 interface DiscoveryControlProps {
@@ -17,7 +17,12 @@ export function DiscoveryControl({ kind }: DiscoveryControlProps) {
   const [settings, setSettings] = useState<DiscoveryFiltersSettings>(
     getDefaultSettingsState({ filters }),
   )
+  const [isLoading, setIsLoading] = useState<boolean>(true)
   const discoveryData = getDiscoveryData(endpoint, settings)
+
+  useEffect(() => {
+    setIsLoading(false)
+  }, [discoveryData])
 
   return (
     <Box
@@ -31,15 +36,19 @@ export function DiscoveryControl({ kind }: DiscoveryControlProps) {
       <DiscoveryFilters
         filters={filters}
         onChange={(key, currentValue) => {
+          setIsLoading(true)
           setSettings({
             ...settings,
             [key]: currentValue.value,
           })
         }}
       />
-      {discoveryData?.data?.rows && (
-        <DiscoveryTable banner={banner} kind={kind} rows={discoveryData.data.rows} />
-      )}
+      <DiscoveryTable
+        banner={banner}
+        isLoading={isLoading}
+        kind={kind}
+        rows={discoveryData?.data?.rows}
+      />
     </Box>
   )
 }


### PR DESCRIPTION
# Discovery table preloader

![image](https://user-images.githubusercontent.com/16230404/195836279-596ea9c9-a7c6-4fdb-9ef4-78d4cdac711e.png)
  
## Changes 👷‍♀️

Added preloader to Oasis Discovery at the beginning, when there is no table to be displayed and while user changes something in filters triggering data reload.
  
## How to test 🧪

Try to change something in filters. Since it operates on mock json, it might require setting up a throttling to see it in effect.
