### PR TITLE
Changed annualisedYield1Year to annualisedYield7days

### DIFF
--- a/features/earn/aave/open/services/calculateSimulation.ts
+++ b/features/earn/aave/open/services/calculateSimulation.ts
@@ -38,7 +38,7 @@ export function calculateSimulation({
     yields.annualisedYield1Year &&
     amount.times(yields.annualisedYield1Year.plus(one)).minus(amount).div(365)
   return {
-    apy: yields.annualisedYield1Year,
+    apy: yields.annualisedYield7days,
     breakEven: earningsPerDay && (fees || zero).div(earningsPerDay),
     entryFees: fees || zero,
     previous7Days:


### PR DESCRIPTION
# Changed annualisedYield1Year to annualisedYield7days

Changes from the stETH/ETH strategy release discussion.

## Changes 👷‍♀️
With that change the header yields are no longer refreshed after amount change and the APY and header yields (based on minimum multiply, so the left one in Current yield) are the same.
