### PR TITLE
Vault numbers in Discovery table

### DIFF
--- a/features/discovery/common/DiscoveryTableDataCellContent.tsx
+++ b/features/discovery/common/DiscoveryTableDataCellContent.tsx
@@ -54,9 +54,9 @@ export function DiscoveryTableDataCellContent({
             <Text as="span" sx={{ fontSize: 4, fontWeight: 'semiBold' }}>
               {row.asset}
             </Text>
-            {row.cid && (
+            {row.cdpId && (
               <Text as="span" sx={{ fontSize: 2, color: 'neutral80', whiteSpace: 'pre' }}>
-                {t('discovery.table.vault-number', { cid: row.cid })}
+                {t('discovery.table.vault-number', { cdpId: row.cdpId })}
               </Text>
             )}
           </Flex>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -153,7 +153,7 @@
     },
     "table": {
       "no-entries": "There are no entries available for selected filters.",
-      "vault-number": "Vault #{{cid}}",
+      "vault-number": "Vault #{{cdpId}}",
       "view-position": "View Position",
       "header": {
         "30-day-avg-apy": "30 day avg. APY",


### PR DESCRIPTION
# Vault numbers in Discovery table

Due to rename of `cid` field to `cdpId`, vault ids weren't displayed in first column.
![image](https://user-images.githubusercontent.com/16230404/196158241-c388256b-6039-440a-a464-5e4d4a0f6a7f.png)
  
## Changes 👷‍♀️

- Changed all `cid` field name occurrences to `cdpId`.
  
## How to test 🧪

Check out if first column in Discovery tables contains vault id.