### PR TITLE
Generic select mobile handling

### DIFF
--- a/components/GenericSelect.tsx
+++ b/components/GenericSelect.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { ExpandableArrow } from 'components/dumb/ExpandableArrow'
 import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
+import { useToggle } from 'helpers/useToggle'
 import { keyBy } from 'lodash'
 import React, { useState } from 'react'
 import ReactSelect, { components } from 'react-select'
@@ -52,7 +53,7 @@ export function GenericSelect({
 }: GenericSelectProps) {
   const isMobile = useOnMobile() && window && 'ontouchstart' in window
   const componentRef = useOutsideElementClickHandler(() => setIsOpen(false))
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [isOpen, toggleIsOpen, setIsOpen] = useToggle(false)
   const [value, setValue] = useState<GenericSelectOption | undefined>(defaultValue)
 
   const optionsByValue = keyBy(options, 'value')
@@ -202,12 +203,7 @@ export function GenericSelect({
         components={{
           DropdownIndicator: null,
           Control: (props) => (
-            <Box
-              ref={componentRef}
-              onClick={() => {
-                setIsOpen(!isOpen)
-              }}
-            >
+            <Box ref={componentRef} onClick={toggleIsOpen}>
               <components.Control {...props} />
             </Box>
           ),

--- a/components/GenericSelect.tsx
+++ b/components/GenericSelect.tsx
@@ -1,9 +1,12 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { ExpandableArrow } from 'components/dumb/ExpandableArrow'
+import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
+import { keyBy } from 'lodash'
 import React, { useState } from 'react'
 import ReactSelect, { components } from 'react-select'
 import { theme } from 'theme'
 import { Box, SxProps, Text } from 'theme-ui'
+import { useOnMobile } from 'theme/useBreakpointIndex'
 
 import { styleFn, Styles } from 'react-select/src/styles'
 
@@ -47,20 +50,20 @@ export function GenericSelect({
   options,
   placeholder,
 }: GenericSelectProps) {
+  const isMobile = useOnMobile() && window && 'ontouchstart' in window
+  const componentRef = useOutsideElementClickHandler(() => setIsOpen(false))
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [value, setValue] = useState<GenericSelectOption | undefined>(defaultValue)
 
+  const optionsByValue = keyBy(options, 'value')
+
   const defaultStyles: ReactSelectSimplifiedStyles = {
-    control: ({ isFocused }) => ({
+    control: () => ({
       height: '54px',
-      border: `1px solid ${isFocused ? theme.colors.primary100 : theme.colors.secondary100}`,
+      border: 'none',
       boxShadow: 'none',
       borderRadius: theme.radii.medium,
       cursor: 'pointer',
-      transition: 'border-color 200ms',
-      '&:hover': {
-        borderColor: isFocused ? theme.colors.primary100 : theme.colors.neutral70,
-      },
     }),
     valueContainer: () => ({
       width: '100%',
@@ -148,7 +151,44 @@ export function GenericSelect({
     )
 
   return (
-    <Box sx={{ position: 'relative' }}>
+    <Box
+      sx={{
+        position: 'relative',
+        border: `1px solid ${isOpen ? theme.colors.primary100 : theme.colors.secondary100}`,
+        borderRadius: 'medium',
+        transition: 'border-color 2000ms',
+        '&:hover': {
+          borderColor: isOpen ? theme.colors.primary100 : theme.colors.neutral70,
+        },
+      }}
+    >
+      {isMobile && (
+        <select
+          name={name}
+          defaultValue={value?.value}
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            zIndex: 3,
+            opacity: 0,
+          }}
+          onChange={(e) => {
+            const currentValue = optionsByValue[e.target.value]
+
+            setValue(currentValue)
+            if (onChange) onChange(currentValue)
+          }}
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      )}
       <ReactSelect
         blurInputOnSelect={true}
         isDisabled={isDisabled}
@@ -161,6 +201,16 @@ export function GenericSelect({
         value={value}
         components={{
           DropdownIndicator: null,
+          Control: (props) => (
+            <Box
+              ref={componentRef}
+              onClick={() => {
+                setIsOpen(!isOpen)
+              }}
+            >
+              <components.Control {...props} />
+            </Box>
+          ),
           SingleValue: ({ children, data, ...props }) => (
             <components.SingleValue data={data} {...props}>
               {data.icon ? (
@@ -187,12 +237,6 @@ export function GenericSelect({
               {children}
             </components.Option>
           ),
-        }}
-        onBlur={() => {
-          setIsOpen(false)
-        }}
-        onFocus={() => {
-          setIsOpen(true)
         }}
         onChange={(option) => {
           const currentValue = option as GenericSelectOption

--- a/helpers/useToggle.ts
+++ b/helpers/useToggle.ts
@@ -1,0 +1,11 @@
+import { Dispatch, SetStateAction, useCallback, useState } from 'react'
+
+export function useToggle(
+  initialState: boolean,
+): [boolean, () => void, Dispatch<SetStateAction<boolean>>] {
+  const [state, setState] = useState<boolean>(initialState)
+
+  const toggle = useCallback(() => setState(!state), [])
+
+  return [state, toggle, setState]
+}


### PR DESCRIPTION
# Generic select mobile handling

Turns out `react-select` doesn't emmit focus event on mobile on DOM, so I had to add custom handling for mobile devices. Thanks to that generic select can utilize native select which makes using it on mobile much easier.
  
## Changes 👷‍♀️

- Moved open/close state management from focus to click on custom element,
- moved borders to custom element since `react-select` rerenders whole DOM on change, so it was impossible to use smooth animations,
- added native select that covers custom on for mobile devices.
