### PR TITLE
Added Take Profit validations in vault overview

### DIFF
--- a/components/vault/VaultErrors.tsx
+++ b/components/vault/VaultErrors.tsx
@@ -160,6 +160,8 @@ export function VaultErrors({
         return translate('max-buy-price-will-prevent-buy-trigger')
       case 'autoTakeProfitTriggeredImmediately':
         return translate('auto-take-profit-triggered-immediately')
+      case 'takeProfitWillTriggerImmediatelyAfterVaultReopen':
+        return translate('take-profit-will-trigger-immediately-after-vault-reopen')
       case 'autoBuyMaxBuyPriceNotSpecified':
         return (
           <Trans

--- a/components/vault/VaultWarnings.tsx
+++ b/components/vault/VaultWarnings.tsx
@@ -89,6 +89,8 @@ export function VaultWarnings({
         return translate('constant-multiple-auto-sell-triggered-immediately')
       case 'constantMultipleAutoBuyTriggeredImmediately':
         return translate('constant-multiple-auto-buy-triggered-immediately')
+      case 'existingTakeProfitTriggerAfterVaultReopen':
+        return translate('existing-take-profit-trigger-after-vault-reopen')
       case 'constantMultipleSellTriggerCloseToStopLossTrigger':
         return (
           <Trans

--- a/features/automation/api/automationTriggersData.ts
+++ b/features/automation/api/automationTriggersData.ts
@@ -8,7 +8,10 @@ import {
   AutoBSTriggerData,
   extractAutoBSData,
 } from 'features/automation/common/state/autoBSTriggerData'
-import { extractAutoTakeProfitData } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
+import {
+  AutoTakeProfitTriggerData,
+  extractAutoTakeProfitData,
+} from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import {
   ConstantMultipleTriggerData,
   extractConstantMultipleData,
@@ -94,4 +97,5 @@ export interface AutomationTriggersChange {
   autoSellData: AutoBSTriggerData
   autoBuyData: AutoBSTriggerData
   constantMultipleData: ConstantMultipleTriggerData
+  autoTakeProfitData: AutoTakeProfitTriggerData
 }

--- a/features/borrow/manage/pipes/manageVault.ts
+++ b/features/borrow/manage/pipes/manageVault.ts
@@ -16,6 +16,7 @@ import {
   TriggersData,
 } from 'features/automation/api/automationTriggersData'
 import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
+import { AutoTakeProfitTriggerData } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { calculateInitialTotalSteps } from 'features/borrow/open/pipes/openVaultConditions'
@@ -174,6 +175,7 @@ export type GenericManageBorrowVaultState<V extends Vault> = MutableManageVaultS
     autoBuyData?: AutoBSTriggerData
     autoSellData?: AutoBSTriggerData
     constantMultipleData?: ConstantMultipleTriggerData
+    autoTakeProfitData?: AutoTakeProfitTriggerData
   } & HasGasEstimation
 
 export type ManageStandardBorrowVaultState = GenericManageBorrowVaultState<Vault>

--- a/features/borrow/manage/pipes/manageVaultValidations.ts
+++ b/features/borrow/manage/pipes/manageVaultValidations.ts
@@ -33,6 +33,7 @@ export function validateErrors(
     afterCollRatioBelowConstantMultipleSellRatio,
     afterCollRatioAboveConstantMultipleBuyRatio,
     insufficientEthFundsForTx,
+    takeProfitWillTriggerImmediatelyAfterVaultReopen,
   } = state
 
   const errorMessages: VaultErrorMessage[] = []
@@ -58,6 +59,7 @@ export function validateErrors(
         afterCollRatioAboveAutoBuyRatio,
         afterCollRatioBelowConstantMultipleSellRatio,
         afterCollRatioAboveConstantMultipleBuyRatio,
+        takeProfitWillTriggerImmediatelyAfterVaultReopen,
       }),
     )
   }
@@ -109,6 +111,7 @@ export function validateWarnings(
     vaultWillBeAtRiskLevelWarningAtNextPrice,
     debtIsLessThanDebtFloor,
     potentialGenerateAmountLessThanDebtFloor,
+    existingTakeProfitTriggerAfterVaultReopen,
   } = state
 
   const warningMessages: VaultWarningMessage[] = []
@@ -124,6 +127,7 @@ export function validateWarnings(
         vaultWillBeAtRiskLevelDangerAtNextPrice,
         vaultWillBeAtRiskLevelWarning,
         vaultWillBeAtRiskLevelWarningAtNextPrice,
+        existingTakeProfitTriggerAfterVaultReopen,
       }),
     )
   }

--- a/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
+++ b/features/borrow/manage/pipes/viewStateTransforms/manageVaultEnvironment.ts
@@ -61,6 +61,7 @@ export function applyManageVaultEnvironment<VaultState extends ManageStandardBor
       autoSellData: change.autoSellData,
       autoBuyData: change.autoBuyData,
       constantMultipleData: change.constantMultipleData,
+      autoTakeProfitData: change.autoTakeProfitData,
     }
   }
 

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -465,6 +465,36 @@ export function afterCollRatioThresholdRatioValidator({
   }
 }
 
+export function vaultEmptyNextPriceAboveOrBelowTakeProfitPriceValidator({
+  debt,
+  afterDebt,
+  nextCollateralPrice,
+  type,
+  isTriggerEnabled,
+  executionPrice,
+}: {
+  debt: BigNumber
+  afterDebt: BigNumber
+  nextCollateralPrice: BigNumber
+  type: 'below' | 'above'
+  isTriggerEnabled?: boolean
+  executionPrice?: BigNumber
+}) {
+  if (!(isTriggerEnabled && executionPrice && debt.isZero() && !afterDebt.isZero())) {
+    return false
+  }
+
+  switch (type) {
+    case 'above':
+      return nextCollateralPrice.gte(executionPrice)
+    case 'below':
+      return nextCollateralPrice.lt(executionPrice)
+
+    default:
+      return false
+  }
+}
+
 export function automationTriggeredValidator({
   vaultHistory,
 }: {

--- a/features/form/errorMessagesHandler.ts
+++ b/features/form/errorMessagesHandler.ts
@@ -47,6 +47,7 @@ export type VaultErrorMessage =
   | 'minSellPriceWillPreventSellTrigger'
   | 'maxBuyPriceWillPreventBuyTrigger'
   | 'autoTakeProfitTriggeredImmediately'
+  | 'takeProfitWillTriggerImmediatelyAfterVaultReopen'
 
 interface ErrorMessagesHandler {
   generateAmountLessThanDebtFloor?: boolean
@@ -96,6 +97,7 @@ interface ErrorMessagesHandler {
   minSellPriceWillPreventSellTrigger?: boolean
   maxBuyPriceWillPreventBuyTrigger?: boolean
   autoTakeProfitTriggeredImmediately?: boolean
+  takeProfitWillTriggerImmediatelyAfterVaultReopen?: boolean
 }
 
 export function errorMessagesHandler({
@@ -146,6 +148,7 @@ export function errorMessagesHandler({
   minSellPriceWillPreventSellTrigger,
   maxBuyPriceWillPreventBuyTrigger,
   autoTakeProfitTriggeredImmediately,
+  takeProfitWillTriggerImmediatelyAfterVaultReopen,
 }: ErrorMessagesHandler) {
   const errorMessages: VaultErrorMessage[] = []
 
@@ -334,6 +337,10 @@ export function errorMessagesHandler({
 
   if (autoTakeProfitTriggeredImmediately) {
     errorMessages.push('autoTakeProfitTriggeredImmediately')
+  }
+
+  if (takeProfitWillTriggerImmediatelyAfterVaultReopen) {
+    errorMessages.push('takeProfitWillTriggerImmediatelyAfterVaultReopen')
   }
 
   return errorMessages

--- a/features/form/warningMessagesHandler.ts
+++ b/features/form/warningMessagesHandler.ts
@@ -29,6 +29,7 @@ export type VaultWarningMessage =
   | 'autoTakeProfitTriggerLowerThanConstantMultipleBuyTrigger'
   | 'autoBuyTriggerGreaterThanAutoTakeProfit'
   | 'constantMultipleBuyTriggerGreaterThanAutoTakeProfit'
+  | 'existingTakeProfitTriggerAfterVaultReopen'
 
 interface WarningMessagesHandler {
   potentialGenerateAmountLessThanDebtFloor?: boolean
@@ -59,6 +60,7 @@ interface WarningMessagesHandler {
   autoTakeProfitTriggerLowerThanConstantMultipleBuyTrigger?: boolean
   autoBuyTriggerGreaterThanAutoTakeProfit?: boolean
   constantMultipleBuyTriggerGreaterThanAutoTakeProfit?: boolean
+  existingTakeProfitTriggerAfterVaultReopen?: boolean
 }
 
 export function warningMessagesHandler({
@@ -88,6 +90,7 @@ export function warningMessagesHandler({
   autoTakeProfitTriggerLowerThanConstantMultipleBuyTrigger,
   autoBuyTriggerGreaterThanAutoTakeProfit,
   constantMultipleBuyTriggerGreaterThanAutoTakeProfit,
+  existingTakeProfitTriggerAfterVaultReopen,
 }: WarningMessagesHandler) {
   const warningMessages: VaultWarningMessage[] = []
 
@@ -192,6 +195,10 @@ export function warningMessagesHandler({
 
   if (constantMultipleBuyTriggerGreaterThanAutoTakeProfit) {
     warningMessages.push('constantMultipleBuyTriggerGreaterThanAutoTakeProfit')
+  }
+
+  if (existingTakeProfitTriggerAfterVaultReopen) {
+    warningMessages.push('existingTakeProfitTriggerAfterVaultReopen')
   }
 
   return warningMessages

--- a/features/multiply/manage/pipes/manageMultiplyVault.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVault.ts
@@ -10,6 +10,7 @@ import {
   TriggersData,
 } from 'features/automation/api/automationTriggersData'
 import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
+import { AutoTakeProfitTriggerData } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { ConstantMultipleTriggerData } from 'features/automation/optimization/constantMultiple/state/constantMultipleTriggerData'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { calculateInitialTotalSteps } from 'features/borrow/open/pipes/openVaultConditions'
@@ -265,6 +266,7 @@ export type ManageMultiplyVaultState = MutableManageMultiplyVaultState &
     autoBuyData?: AutoBSTriggerData
     autoSellData?: AutoBSTriggerData
     constantMultipleData?: ConstantMultipleTriggerData
+    autoTakeProfitData?: AutoTakeProfitTriggerData
   } & HasGasEstimation
 
 function addTransitions(

--- a/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultEnvironment.ts
@@ -70,6 +70,7 @@ export function applyManageVaultEnvironment<VS extends ManageMultiplyVaultState>
       autoSellData: change.autoSellData,
       autoBuyData: change.autoBuyData,
       constantMultipleData: change.constantMultipleData,
+      autoTakeProfitData: change.autoTakeProfitData,
     }
   }
 

--- a/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultValidations.ts
@@ -35,6 +35,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
     afterCollRatioBelowConstantMultipleSellRatio,
     afterCollRatioAboveConstantMultipleBuyRatio,
     insufficientEthFundsForTx,
+    takeProfitWillTriggerImmediatelyAfterVaultReopen,
   } = state
 
   const errorMessages: VaultErrorMessage[] = []
@@ -64,6 +65,7 @@ export function validateErrors(state: ManageMultiplyVaultState): ManageMultiplyV
         afterCollRatioAboveAutoBuyRatio,
         afterCollRatioBelowConstantMultipleSellRatio,
         afterCollRatioAboveConstantMultipleBuyRatio,
+        takeProfitWillTriggerImmediatelyAfterVaultReopen,
       }),
     )
   }
@@ -114,6 +116,7 @@ export function validateWarnings(state: ManageMultiplyVaultState): ManageMultipl
     vaultWillBeAtRiskLevelWarning,
     vaultWillBeAtRiskLevelWarningAtNextPrice,
     highSlippage,
+    existingTakeProfitTriggerAfterVaultReopen,
   } = state
 
   const warningMessages: VaultWarningMessage[] = []
@@ -130,6 +133,7 @@ export function validateWarnings(state: ManageMultiplyVaultState): ManageMultipl
         vaultWillBeAtRiskLevelWarning,
         vaultWillBeAtRiskLevelWarningAtNextPrice,
         highSlippage,
+        existingTakeProfitTriggerAfterVaultReopen,
       }),
     )
   }

--- a/helpers/messageMappers.ts
+++ b/helpers/messageMappers.ts
@@ -57,6 +57,7 @@ const commonErrors = [
   'afterCollRatioAboveConstantMultipleBuyRatio',
   'vaultWillBeTakenUnderMinActiveColRatio',
   'stopLossOnNearLiquidationRatio',
+  'takeProfitWillTriggerImmediatelyAfterVaultReopen',
 
   'customDaiAllowanceAmountLessThanPaybackAmount',
   'customAllowanceAmountExceedsMaxUint256',
@@ -88,6 +89,7 @@ const commonWarnings = [
   'vaultWillRemainUnderMinActiveColRatio',
   'potentialInsufficientEthFundsForTx',
   'nextCollRatioCloseToCurrentSl',
+  'existingTakeProfitTriggerAfterVaultReopen',
 ]
 
 export function extractCommonWarnings(warningMessages: VaultWarningMessage[]) {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -992,7 +992,8 @@
     "cant-setup-auto-buy-or-sell-when-constant-multiple-enabled": "You cannot set up an {{autoType}} if you have an existing Constant Multiple set up. Please remove your Constant Multiple before continuing.",
     "min-sell-price-will-prevent-sell-trigger": "This Min Sell Price will prevent the Sell Trigger from executing",
     "max-buy-price-will-prevent-buy-trigger": "This Max Buy Price will prevent the Buy Trigger from executing",
-    "auto-take-profit-triggered-immediately": "Please raise your trigger price. The current trigger price would cause your auto-profit sell to execute immediately."
+    "auto-take-profit-triggered-immediately": "Please raise your trigger price. The current trigger price would cause your auto-profit sell to execute immediately.",
+    "take-profit-will-trigger-immediately-after-vault-reopen": "You have an existing Take Profit Trigger that will trigger immediately on reopening this vault. Please remove your Take Profit Trigger before continuing."
   },
   "vault-warnings": {
     "potential-generate-amount-less-than-debt-floor": "Minimum Dai required to open a Vault is {{debtFloor}}. Please add more collateral to generate {{debtFloor}} Dai",
@@ -1023,7 +1024,8 @@
     "auto-take-profit-trigger-lower-than-auto-buy-trigger": "Setting your Target Price at this level may result in your Auto-Buy not executing. Find out more <0>here</0>.",
     "auto-take-profit-trigger-lower-than-constant-multiple-buy-trigger": "Setting your Target Price at this level may result in your Constant Multiple Buy Trigger not executing. Find out more <0>here</0>.",
     "auto-buy-trigger-greater-than-auto-take-profit": "Setting your trigger ratio at this level may result in your Auto-Buy Trigger not executing. Find out more <0>here</0>.",
-    "constant-multiple-buy-trigger-greater-than-auto-take-profit": "Setting your buy trigger ratio at this level may result in your Constant Multiple Buy Trigger not executing. Find out more <0>here</0>."
+    "constant-multiple-buy-trigger-greater-than-auto-take-profit": "Setting your buy trigger ratio at this level may result in your Constant Multiple Buy Trigger not executing. Find out more <0>here</0>.",
+    "existing-take-profit-trigger-after-vault-reopen": "You have an existing Take Profit Trigger, it will remain active after you reopen this vault."
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Added Take Profit validations in vault overview](https://app.shortcut.com/oazo-apps/story/6361/validation-the-atp-trigger-handling-on-when-reopening)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added error and warning messages to vault overview (borrow & multiply) when user tries to reopen vault when there is already ATP enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- setup ATP on vault, close vault, try to reopen position (generate debt) and see if warning or error (in that case you will most likely need to manually overwrite next price in code) regarding existing ATP is shown. Do it both on borrow and multiply vault. For error case user shouldn't be able to proceed without removing ATP first.
