### PR TITLE
navigation on mobile

### DIFF
--- a/components/GenericSelect.tsx
+++ b/components/GenericSelect.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import { SystemStyleObject } from '@styled-system/css'
 import { ExpandableArrow } from 'components/dumb/ExpandableArrow'
 import React, { useState } from 'react'
 import ReactSelect, { components } from 'react-select'
@@ -24,7 +25,7 @@ export interface GenericSelectProps {
   customStyles?: ReactSelectSimplifiedStyles
   defaultValue?: GenericSelectOption
   expandableArrowSize?: number
-  expandableArrowSx?: SxProps
+  expandableArrowSx?: SystemStyleObject & SxProps
   iconSize?: number
   isDisabled?: boolean
   isSearchable?: boolean
@@ -32,6 +33,7 @@ export interface GenericSelectProps {
   onChange?: (value: GenericSelectOption) => void
   options: GenericSelectOption[]
   placeholder?: string
+  wrapperSx?: SystemStyleObject & SxProps
 }
 
 export function GenericSelect({
@@ -46,6 +48,7 @@ export function GenericSelect({
   onChange,
   options,
   placeholder,
+  wrapperSx,
 }: GenericSelectProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [value, setValue] = useState<GenericSelectOption | undefined>(defaultValue)
@@ -148,7 +151,7 @@ export function GenericSelect({
     )
 
   return (
-    <Box sx={{ position: 'relative' }}>
+    <Box sx={{ position: 'relative', ...wrapperSx }}>
       <ReactSelect
         blurInputOnSelect={true}
         isDisabled={isDisabled}

--- a/components/GenericSelect.tsx
+++ b/components/GenericSelect.tsx
@@ -160,7 +160,7 @@ export function GenericSelect({
         position: 'relative',
         border: `1px solid ${isOpen ? theme.colors.primary100 : theme.colors.secondary100}`,
         borderRadius: 'medium',
-        transition: 'border-color 2000ms',
+        transition: 'border-color 200ms',
         '&:hover': {
           borderColor: isOpen ? theme.colors.primary100 : theme.colors.neutral70,
         },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import { trackingEvents } from 'analytics/analytics'
 import { ContextConnected } from 'blockchain/network'
 import { AppLink } from 'components/Links'
 import { LANDING_PILLS } from 'content/landing'
+import { DISCOVERY_URL } from 'features/discovery/helpers'
 import { getUnreadNotificationCount } from 'features/notifications/helpers'
 import { NOTIFICATION_CHANGE, NotificationChange } from 'features/notifications/notificationChange'
 import {
@@ -444,7 +445,7 @@ const LINKS = {
   multiply: `/multiply`,
   borrow: `/borrow`,
   earn: '/earn',
-  discovery: '/discovery',
+  discovery: DISCOVERY_URL,
 }
 
 function ConnectedHeader() {

--- a/features/discovery/common/DiscoveryNavigation.tsx
+++ b/features/discovery/common/DiscoveryNavigation.tsx
@@ -1,31 +1,59 @@
+import { GenericSelect } from 'components/GenericSelect'
 import { AppLink } from 'components/Links'
+import { DISCOVERY_URL } from 'features/discovery/helpers'
 import { DiscoveryPageMeta, discoveryPagesMeta } from 'features/discovery/meta'
 import { DiscoveryPages } from 'features/discovery/types'
+import { useRedirect } from 'helpers/useRedirect'
 import { useTranslation } from 'next-i18next'
 import React, { useState } from 'react'
 import { theme } from 'theme'
 import { Box, Flex, Text } from 'theme-ui'
+import { useOnMobile } from 'theme/useBreakpointIndex'
 
 interface DiscoveryNavigationProps {
   kind: DiscoveryPages
 }
 
 export function DiscoveryNavigation({ kind }: DiscoveryNavigationProps) {
+  const { t } = useTranslation()
+  const { push } = useRedirect()
+  const onMobile = useOnMobile()
+
+  const mobileLinks = discoveryPagesMeta.map((item) => ({
+    label: t(`discovery.navigation.${item.kind}`),
+    value: `${DISCOVERY_URL}/${item.kind}`,
+    kind: item.kind,
+  }))
+  const selectedLink = mobileLinks.filter((item) => item.kind === kind)[0]
+
   return (
-    <Flex
-      as="ul"
-      sx={{
-        flexWrap: 'wrap',
-        justifyContent: ['space-around', 'space-around', 'center'],
-        mb: '48px',
-        p: 0,
-        listStyle: 'none',
-      }}
-    >
-      {discoveryPagesMeta.map((item, i) => (
-        <DiscoveryNavigationItem key={i} isActive={kind === item.kind} {...item} />
-      ))}
-    </Flex>
+    <>
+      {onMobile ? (
+        <GenericSelect
+          options={mobileLinks}
+          defaultValue={selectedLink}
+          onChange={(currentValue) => {
+            push(currentValue.value)
+          }}
+          wrapperSx={{ mb: 3 }}
+        />
+      ) : (
+        <Flex
+          as="ul"
+          sx={{
+            flexWrap: 'wrap',
+            justifyContent: ['space-around', 'space-around', 'center'],
+            mb: '48px',
+            p: 0,
+            listStyle: 'none',
+          }}
+        >
+          {discoveryPagesMeta.map((item, i) => (
+            <DiscoveryNavigationItem key={i} isActive={kind === item.kind} {...item} />
+          ))}
+        </Flex>
+      )}
+    </>
   )
 }
 
@@ -50,7 +78,7 @@ export function DiscoveryNavigationItem({
       }}
     >
       <AppLink
-        href={`/discovery/${kind}`}
+        href={`${DISCOVERY_URL}/${kind}`}
         sx={{
           display: 'flex',
           flexDirection: 'column',

--- a/features/discovery/common/DiscoveryWrapperWithIntro.tsx
+++ b/features/discovery/common/DiscoveryWrapperWithIntro.tsx
@@ -9,8 +9,8 @@ export function DiscoveryWrapperWithIntro({ children }: WithChildren) {
   const { t } = useTranslation()
 
   return (
-    <Box sx={{ width: '100%', mt: [4, 5] }}>
-      <Box sx={{ mb: [4, 5], textAlign: 'center' }}>
+    <Box sx={{ width: '100%', mt: [0, 5] }}>
+      <Box sx={{ mb: ['48px', 5], textAlign: 'center' }}>
         <Heading variant="header2" sx={{ mb: 2 }}>
           {t('discovery.heading')}
         </Heading>

--- a/features/discovery/helpers.ts
+++ b/features/discovery/helpers.ts
@@ -1,5 +1,7 @@
 import { DiscoveryFiltersList } from 'features/discovery/meta'
 
+export const DISCOVERY_URL = '/discovery'
+
 export function getDefaultSettingsState({ filters }: { filters: DiscoveryFiltersList }) {
   return Object.keys(filters).reduce((o, key) => ({ ...o, [key]: filters[key][0].value }), {})
 }

--- a/helpers/useToggle.ts
+++ b/helpers/useToggle.ts
@@ -5,7 +5,7 @@ export function useToggle(
 ): [boolean, () => void, Dispatch<SetStateAction<boolean>>] {
   const [state, setState] = useState<boolean>(initialState)
 
-  const toggle = useCallback(() => setState(state => !state), []);
+  const toggle = useCallback(() => setState((state) => !state), [])
 
   return [state, toggle, setState]
 }

--- a/helpers/useToggle.ts
+++ b/helpers/useToggle.ts
@@ -5,7 +5,7 @@ export function useToggle(
 ): [boolean, () => void, Dispatch<SetStateAction<boolean>>] {
   const [state, setState] = useState<boolean>(initialState)
 
-  const toggle = useCallback(() => setState(!state), [])
+  const toggle = useCallback(() => setState(state => !state), []);
 
   return [state, toggle, setState]
 }

--- a/pages/discovery/index.tsx
+++ b/pages/discovery/index.tsx
@@ -1,3 +1,4 @@
+import { DISCOVERY_URL } from 'features/discovery/helpers'
 import { discoveryPagesMeta } from 'features/discovery/meta'
 import { GetServerSidePropsContext } from 'next'
 import React from 'react'
@@ -12,7 +13,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   return {
     redirect: {
-      destination: `/discovery/${defaultDiscoveryPage.kind}${network}`,
+      destination: `${DISCOVERY_URL}/${defaultDiscoveryPage.kind}${network}`,
       permanent: true,
     },
   }


### PR DESCRIPTION
# Discovery navigation on mobile

On mobile, instead of links with icon, navigation becomes a select.
![image](https://user-images.githubusercontent.com/16230404/196185516-a82a263f-c0c4-4de0-8912-b83a5883a39b.png)
  
## Changes 👷‍♀️

- Added select with navigation for small screens on Discovery pages,
- extracted Discovery URL as const to be reused in all places that links to it.
  
## How to test 🧪

Check out Discovery page on smaller screens.
