### PR TITLE
Pass table param to discovery filters query

### DIFF
--- a/features/discovery/controllers/DiscoveryControl.tsx
+++ b/features/discovery/controllers/DiscoveryControl.tsx
@@ -15,7 +15,7 @@ interface DiscoveryControlProps {
 export function DiscoveryControl({ kind }: DiscoveryControlProps) {
   const { banner, endpoint, filters } = keyBy(discoveryPagesMeta, 'kind')[kind]
   const [settings, setSettings] = useState<DiscoveryFiltersSettings>(
-    getDefaultSettingsState({ filters }),
+    getDefaultSettingsState({ filters, kind }),
   )
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const discoveryData = getDiscoveryData(endpoint, settings)

--- a/features/discovery/helpers.ts
+++ b/features/discovery/helpers.ts
@@ -1,5 +1,15 @@
 import { DiscoveryFiltersList } from 'features/discovery/meta'
+import { DiscoveryPages } from 'features/discovery/types'
 
-export function getDefaultSettingsState({ filters }: { filters: DiscoveryFiltersList }) {
-  return Object.keys(filters).reduce((o, key) => ({ ...o, [key]: filters[key][0].value }), {})
+export function getDefaultSettingsState({
+  filters,
+  kind,
+}: {
+  filters: DiscoveryFiltersList
+  kind: DiscoveryPages
+}) {
+  return {
+    ...Object.keys(filters).reduce((o, key) => ({ ...o, [key]: filters[key][0].value }), {}),
+    table: kind,
+  }
 }


### PR DESCRIPTION
# Pass `table` param to discovery filters query

![image](https://user-images.githubusercontent.com/16230404/196190264-0116384b-aeb8-44be-ab4c-f9a525cc8d49.png)
  
## Changes 👷‍♀️

- Added `table` param to all Discovery requests.
  
## How to test 🧪

Check if all requests for data for Discovery contains `table` param.
