### PR TITLE
AAVE stETH/ETH amount input fix

### DIFF
--- a/features/earn/aave/open/state/openAaveStateMachine.ts
+++ b/features/earn/aave/open/state/openAaveStateMachine.ts
@@ -1,4 +1,4 @@
-import { IRiskRatio, IStrategy, RiskRatio } from '@oasisdex/oasis-actions'
+import { IRiskRatio, IStrategy } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { ActorRefFrom, assign, createMachine, send, StateFrom } from 'xstate'
 import { cancel } from 'xstate/lib/actions'
@@ -10,6 +10,7 @@ import { zero } from '../../../../../helpers/zero'
 import { ProxyStateMachine } from '../../../../proxyNew/state'
 import { TransactionStateMachine } from '../../../../stateMachines/transaction'
 import { BaseAaveContext, IStrategyInfo } from '../../common/BaseAaveContext'
+import { aaveStETHMinimumRiskRatio } from '../../constants'
 import {
   AaveStEthSimulateStateMachine,
   AaveStEthSimulateStateMachineEvents,
@@ -214,7 +215,7 @@ export const createOpenAaveStateMachine = createMachine(
       initContextValues: assign((context) => ({
         currentStep: 1,
         totalSteps: context.proxyAddress ? 3 : 4,
-        riskRatio: new RiskRatio(new BigNumber(2), RiskRatio.TYPE.MULITPLE),
+        riskRatio: aaveStETHMinimumRiskRatio,
         token: 'ETH',
         inputDelay: 1000,
         strategyName: 'stETHeth',


### PR DESCRIPTION
# Fixes base risk ratio so there's no more two calls after inputting amount
  
## Changes 👷‍♀️
 - now base riskratio in open and simulate machine are the same
  
## How to test 🧪
 - go to open earn aave steth view
 - input amount, there should be no change in the header yield numbers
