### PR TITLE
Fixed the liquidation price ratio value so the block has appropriate color

### DIFF
--- a/features/earn/aave/manage/components/ManageSectionComponent.tsx
+++ b/features/earn/aave/manage/components/ManageSectionComponent.tsx
@@ -29,10 +29,13 @@ type ManageSectionComponentProps = {
 }
 
 const getLiquidationPriceRatioColor = (ratio: BigNumber) => {
-  if (ratio.isLessThanOrEqualTo(0.05)) {
+  const critical = new BigNumber(5)
+  const warning = new BigNumber(20)
+
+  if (ratio.isLessThanOrEqualTo(critical)) {
     return 'critical10'
   }
-  return ratio.isLessThanOrEqualTo(0.2) ? 'warning10' : 'success10'
+  return ratio.isLessThanOrEqualTo(warning) ? 'warning10' : 'success10'
 }
 
 export function ManageSectionComponent({
@@ -70,6 +73,7 @@ export function ManageSectionComponent({
     : zero
 
   const totalCollateralInStEth = oraclePrice.times(accountData.totalCollateralETH)
+  const belowCurrentRatio = oraclePrice.minus(managedPosition.liquidationPrice).times(100)
 
   return (
     <DetailsSection
@@ -133,12 +137,11 @@ export function ManageSectionComponent({
           <DetailsSectionContentCard
             title={t('manage-earn-vault.liquidation-price-ratio')}
             value={formatBigNumber(managedPosition.liquidationPrice, 2)}
-            unit={`(${formatPercent(
-              oraclePrice.minus(managedPosition.liquidationPrice).times(100),
-              {
+            unit={t('manage-earn-vault.below-current-ratio', {
+              percentage: formatPercent(belowCurrentRatio, {
                 precision: 0,
-              },
-            )} below current ratio)`}
+              }),
+            })}
             customUnitStyle={{
               fontSize: 3,
             }}
@@ -156,7 +159,7 @@ export function ManageSectionComponent({
                 }
               />
             }
-            customBackground={getLiquidationPriceRatioColor(managedPosition.liquidationPrice)}
+            customBackground={getLiquidationPriceRatioColor(belowCurrentRatio)}
             link={{
               label: t('manage-earn-vault.ratio-history'),
               url: 'https://dune.com/dataalways/stETH-De-Peg', // should we move this url to a file? an env?

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -602,6 +602,7 @@
     "position-eth-debt": "Position ETH Debt",
     "liquidation-price-ratio": "Liquidation price ratio",
     "liquidation-price-ratio-modal-aave": "The liquidation price ratio indicates to what price ratio stETH needs to drop in comparison to ETH in order to get liquidated on this position. If this comes within 5% it will be indicated as red, within 20% as orange, and above 20% as green. Liquidation results in a liquidation penalty. You can find the history of the ratio here: <0>Ratio history</0> <1/><1/> You can adjust your risk by using the adjust risk functionality.",
+    "below-current-ratio": "({{percentage}} below current ratio)",
     "has-asset-already": "There is an active AAVE position open in this address. Therefore, you cannot open a stETH earn position. Close your AAVE position first to continue.",
     "net-value-modal": "Net Value",
     "net-value-calculation": "The current net value is calculated based on the oracle price of {{stETHPrice}} stETH/ETH."


### PR DESCRIPTION
# Fixed the liquidation price ratio value so the block has appropriate color

## Changes 👷‍♀️
 - fixed the liquidation price ratio values on ManageSectionComponent
  
## How to test 🧪
  <Please explain how to test your changes>
 - go to your aave position
 - Liquidation price ratio box should have proper background color (pic rel)
![image](https://user-images.githubusercontent.com/5095527/196224452-425fb35e-423f-492d-815f-14e4c7a57d0b.png)
