### PR TITLE
Fixes AAVE position link (on position page)

### DIFF
--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -109,7 +109,7 @@ export function createAavePosition$(
             token: 'STETH',
             contentsUsd: netValue,
             title: 'AAVE-stETH-ETH',
-            url: `/earn/steth/${address}`,
+            url: `/aave/${address}`,
             netValue: netValue,
             liquidity: liquidity,
             pln: 'N/A',


### PR DESCRIPTION
# Fixes AAVE position link (on position page)
  
## Changes 👷‍♀️
 - fixed link to AAVE position (inv. changes in https://github.com/OasisDEX/oasis-borrow/pull/1564)  
## How to test 🧪
 - go to `My positions`
 - AAVE position link should work fine 👌 
