### PR TITLE
fix learn more link

### DIFF
--- a/features/content/faqs/aave/index.tsx
+++ b/features/content/faqs/aave/index.tsx
@@ -1,6 +1,10 @@
 import { TranslatedContent } from 'features/content'
 import React from 'react'
 
+import { useScrollToTop } from '../../../../helpers/useScrollToTop'
 import en from './en.mdx'
 
-export const aaveFaq = <TranslatedContent content={{ en /* es, pt */ }} />
+export const AaveFaq = () => {
+  useScrollToTop()
+  return <TranslatedContent content={{ en /* es, pt */ }} />
+}

--- a/features/earn/aave/manage/containers/AaveManageView.tsx
+++ b/features/earn/aave/manage/containers/AaveManageView.tsx
@@ -1,7 +1,7 @@
 import { useActor } from '@xstate/react'
 import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
 import { TabBar } from 'components/TabBar'
-import { aaveFaq } from 'features/content/faqs/aave'
+import { AaveFaq } from 'features/content/faqs/aave'
 import { useEarnContext } from 'features/earn/EarnContextProvider'
 import { AavePositionAlreadyOpenedNotice } from 'features/notices/VaultsNoticesView'
 import { Survey } from 'features/survey'
@@ -64,9 +64,13 @@ function AaveManageContainer({
               ),
             },
             {
-              value: 'faq',
-              label: t('system.faq'),
-              content: <Card variant="faq">{aaveFaq}</Card>,
+              value: 'position-info',
+              label: t('system.position-info'),
+              content: (
+                <Card variant="faq">
+                  <AaveFaq />
+                </Card>
+              ),
             },
           ]}
         />

--- a/features/earn/aave/open/components/SimulateSectionComponent.tsx
+++ b/features/earn/aave/open/components/SimulateSectionComponent.tsx
@@ -10,6 +10,7 @@ import { DetailsSectionContentTable } from '../../../../../components/DetailsSec
 import { DetailsSectionFooterItemWrapper } from '../../../../../components/DetailsSectionFooterItem'
 import { ContentFooterItemsEarnSimulate } from '../../../../../components/vault/detailsSection/ContentFooterItemsEarnSimulate'
 import { formatCryptoBalance } from '../../../../../helpers/formatters/format'
+import { useHash } from '../../../../../helpers/useHash'
 import { zero } from '../../../../../helpers/zero'
 import { useOpenAaveStateMachineContext } from '../containers/AaveOpenStateMachineContext'
 import { Simulation } from '../services'
@@ -27,6 +28,7 @@ function mapSimulation(simulation?: Simulation): string[] {
 function SimulationSection({ actor }: { actor: ActorRefFrom<AaveStEthSimulateStateMachine> }) {
   const [state] = useActor(actor)
   const { t } = useTranslation()
+  const [, setHash] = useHash<string>()
 
   const { simulation, amount, token } = state.context
 
@@ -69,7 +71,9 @@ function SimulationSection({ actor }: { actor: ActorRefFrom<AaveStEthSimulateSta
         description={t('vault-banners.what-are-the-risks.content')}
         button={{
           text: t('vault-banners.what-are-the-risks.button'),
-          action: () => {}, // TODO: Set proper action for this button to open the FAQ page
+          action: () => {
+            setHash('position-info')
+          },
         }}
         image={{
           src: '/static/img/setup-banner/stop-loss.svg',

--- a/features/earn/aave/open/containers/AaveOpenView.tsx
+++ b/features/earn/aave/open/containers/AaveOpenView.tsx
@@ -1,5 +1,5 @@
 import { TabBar } from 'components/TabBar'
-import { aaveFaq } from 'features/content/faqs/aave'
+import { AaveFaq } from 'features/content/faqs/aave'
 import { Survey } from 'features/survey'
 import { VaultContainerSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
@@ -47,9 +47,13 @@ function AaveOpenContainer({
               ),
             },
             {
-              value: 'faq',
-              label: t('system.faq'),
-              content: <Card variant="faq">{aaveFaq}</Card>,
+              value: 'position-info',
+              label: t('system.position-info'),
+              content: (
+                <Card variant="faq">
+                  <AaveFaq />
+                </Card>
+              ),
             },
           ]}
         />


### PR DESCRIPTION
# [fix learn more link](https://app.shortcut.com/oazo-apps/story/6364/link-to-learn-more-is-broken-rename-faq-to-position-info)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- rename FAQ tab to position info
- make the banner button work at the bottom of the open position page
- click the button and the position info tab top scrolls into view 

