### PR TITLE
delete some code

### DIFF
--- a/features/proxyNew/state/actions.ts
+++ b/features/proxyNew/state/actions.ts
@@ -14,13 +14,6 @@ const assignGasCostData = assign<ProxyContext, ProxyEvent>((_, event) => {
   }
 })
 
-const assignProxyConfirmations = assign<ProxyContext, ProxyEvent>((_, event) => {
-  if (event.type !== 'CONFIRMED') return {}
-  return {
-    proxyConfirmations: event.proxyConfirmations,
-  }
-})
-
 const assignTxHash = assign<ProxyContext, ProxyEvent>((_, event) => {
   if (event.type !== 'IN_PROGRESS') return {}
   return {
@@ -45,7 +38,6 @@ const assignTxError = assign<ProxyContext, ProxyEvent>((_, event) => {
 export const actions = {
   initGasData,
   assignGasCostData,
-  assignProxyConfirmations,
   assignTxHash,
   assignProxyAddress,
   assignTxError,

--- a/features/proxyNew/state/machine.ts
+++ b/features/proxyNew/state/machine.ts
@@ -63,9 +63,6 @@ export function createProxyStateMachine(
             onError: 'proxyFailure',
           },
           on: {
-            CONFIRMED: {
-              actions: [nameOfAction('assignProxyConfirmations')],
-            },
             IN_PROGRESS: {
               actions: [nameOfAction('assignTxHash')],
             },

--- a/features/proxyNew/state/services.ts
+++ b/features/proxyNew/state/services.ts
@@ -1,6 +1,6 @@
 /* eslint-disable func-style */
 import { TxStatus } from '@oasisdex/transactions'
-import { iif, of } from 'rxjs'
+import { of } from 'rxjs'
 import { filter, first, map, switchMap } from 'rxjs/operators'
 
 import { createDsProxy, CreateDsProxyData } from '../../../blockchain/calls/proxy'
@@ -35,22 +35,13 @@ const createProxy: ProxyObservableService = ({ dependencies }: ProxyContext, _: 
               ? txState.error
               : undefined,
         }),
-      (txState) =>
+      () =>
         proxyAddress$.pipe(
           filter((proxyAddress) => !!proxyAddress),
-          switchMap((proxyAddress) =>
-            iif(
-              () => (txState as any).confirmations > 0,
-              of({
-                type: 'CONFIRMED',
-                proxyConfirmations: (txState as any).confirmations,
-              }),
-              of({
-                type: 'SUCCESS',
-                proxyAddress: proxyAddress!,
-              }),
-            ),
-          ),
+          map((proxyAddress) => ({
+            type: 'SUCCESS',
+            proxyAddress: proxyAddress!,
+          })),
         ),
       safeConfirmations,
     ),


### PR DESCRIPTION
This was supposed to be for [this issue](https://app.shortcut.com/oazo-apps/story/6375/create-proxy-does-not-go-back-to-open-position-from-end-of-create-proxy-flow) but the problem seems to be deeper inside @oasisdex/transactions somewhere, and I don't want to meddle with it as we don't see this issue with positions and on non-hardhat chains.  But I removed some vestigial code, hence the PR.

## How to test 🧪
- open aave position with + without proxy
- test some non-happy paths (cancel proxy creation etc)
