### PR TITLE
Update ATP estimation labels

### DIFF
--- a/components/EstimationOnClose.tsx
+++ b/components/EstimationOnClose.tsx
@@ -1,14 +1,15 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import React, { ReactNode } from 'react'
-import { Text } from 'theme-ui'
+import { SxStyleProp, Text } from 'theme-ui'
 
 interface EstimationOnCloseProps {
-  iconCircle: string
   label: string
   value: ReactNode
+  iconCircle?: string
+  valueSx?: SxStyleProp
 }
 
-export function EstimationOnClose({ iconCircle, label, value }: EstimationOnCloseProps) {
+export function EstimationOnClose({ iconCircle, label, value, valueSx }: EstimationOnCloseProps) {
   return (
     <Text
       as="p"
@@ -21,10 +22,10 @@ export function EstimationOnClose({ iconCircle, label, value }: EstimationOnClos
       }}
     >
       <Text as="span" sx={{ display: 'flex', color: 'neutral80' }}>
-        <Icon name={iconCircle} size="24px" sx={{ mt: '-1px', mr: 1 }} />
+        {iconCircle && <Icon name={iconCircle} size="24px" sx={{ mt: '-1px', mr: 1 }} />}
         {label}
       </Text>
-      <Text as="span" sx={{ display: 'block', height: '100%' }}>
+      <Text as="span" sx={{ display: 'block', height: '100%', ...valueSx }}>
         {value}
       </Text>
     </Text>

--- a/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -12,6 +12,7 @@ interface AddAutoTakeProfitInfoSectionProps {
   token: string
   totalTriggerCost?: BigNumber
   triggerColPrice: BigNumber
+  triggerColRatio: BigNumber
 }
 
 export function AddAutoTakeProfitInfoSection({
@@ -21,6 +22,7 @@ export function AddAutoTakeProfitInfoSection({
   token,
   totalTriggerCost,
   triggerColPrice,
+  triggerColRatio,
 }: AddAutoTakeProfitInfoSectionProps) {
   const { t } = useTranslation()
 
@@ -31,6 +33,10 @@ export function AddAutoTakeProfitInfoSection({
         {
           label: t('auto-take-profit.vault-changes.trigger-col-price', { token }),
           value: `$${formatAmount(triggerColPrice, 'USD')}`,
+        },
+        {
+          label: t('auto-take-profit.vault-changes.trigger-collateral-ratio'),
+          value: `${formatPercent(triggerColRatio, { precision: 2 })}`,
         },
         {
           label: t('auto-take-profit.vault-changes.debt-repaid'),

--- a/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AddAutoTakeProfitInfoSection.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
-import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { formatAmount } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -12,7 +12,6 @@ interface AddAutoTakeProfitInfoSectionProps {
   token: string
   totalTriggerCost?: BigNumber
   triggerColPrice: BigNumber
-  triggerColRatio: BigNumber
 }
 
 export function AddAutoTakeProfitInfoSection({
@@ -22,7 +21,6 @@ export function AddAutoTakeProfitInfoSection({
   token,
   totalTriggerCost,
   triggerColPrice,
-  triggerColRatio,
 }: AddAutoTakeProfitInfoSectionProps) {
   const { t } = useTranslation()
 
@@ -33,10 +31,6 @@ export function AddAutoTakeProfitInfoSection({
         {
           label: t('auto-take-profit.vault-changes.trigger-col-price', { token }),
           value: `$${formatAmount(triggerColPrice, 'USD')}`,
-        },
-        {
-          label: t('auto-take-profit.vault-changes.trigger-collateral-ratio'),
-          value: `${formatPercent(triggerColRatio, { precision: 2 })}`,
         },
         {
           label: t('auto-take-profit.vault-changes.debt-repaid'),

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -4,7 +4,6 @@ import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseState'
 import { SliderValuePicker, SliderValuePickerProps } from 'components/dumb/SliderValuePicker'
-import { EstimationOnClose } from 'components/EstimationOnClose'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultErrors } from 'components/vault/VaultErrors'
@@ -21,11 +20,9 @@ import {
 } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
-import { formatPercent } from 'helpers/formatters/format'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { theme } from 'theme'
 interface SidebarAutoTakeProfitEditingStageProps {
   autoTakeProfitState: AutoTakeProfitFormChange
   autoTakeProfitTriggerData: AutoTakeProfitTriggerData
@@ -87,11 +84,6 @@ export function SidebarAutoTakeProfitEditingStage({
           <VaultWarnings warningMessages={warnings} ilkData={ilkData} />
         </>
       )}
-      <EstimationOnClose
-        label={t('automation.estimated-col-ratio-at-trigger')}
-        value={formatPercent(autoTakeProfitState.executionCollRatio, { precision: 2 })}
-        valueSx={{ color: theme.colors.success100 }}
-      />
       {isEditing && (
         <>
           <SidebarResetButton
@@ -114,6 +106,7 @@ export function SidebarAutoTakeProfitEditingStage({
             token={vault.token}
             tokenMarketPrice={tokenMarketPrice}
             triggerColPrice={autoTakeProfitState.executionPrice}
+            triggerColRatio={autoTakeProfitState.executionCollRatio}
           />
         </>
       )}
@@ -130,6 +123,7 @@ interface AutoTakeProfitInfoSectionControlProps {
   token: string
   tokenMarketPrice: BigNumber
   triggerColPrice: BigNumber
+  triggerColRatio: BigNumber
 }
 
 function AutoTakeProfitInfoSectionControl({
@@ -140,6 +134,7 @@ function AutoTakeProfitInfoSectionControl({
   toCollateral,
   token,
   triggerColPrice,
+  triggerColRatio,
 }: AutoTakeProfitInfoSectionControlProps) {
   const {
     estimatedGasFeeOnTrigger,
@@ -163,6 +158,7 @@ function AutoTakeProfitInfoSectionControl({
       token={token}
       totalTriggerCost={totalTriggerCost}
       triggerColPrice={triggerColPrice}
+      triggerColRatio={triggerColRatio}
     />
   )
 }

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js'
 import { IlkData } from 'blockchain/ilks'
-import { getToken } from 'blockchain/tokensMetadata'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
 import { PickCloseState, PickCloseStateProps } from 'components/dumb/PickCloseState'
@@ -22,11 +21,11 @@ import {
 } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatPercent } from 'helpers/formatters/format'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-
+import { theme } from 'theme'
 interface SidebarAutoTakeProfitEditingStageProps {
   autoTakeProfitState: AutoTakeProfitFormChange
   autoTakeProfitTriggerData: AutoTakeProfitTriggerData
@@ -60,17 +59,6 @@ export function SidebarAutoTakeProfitEditingStage({
 
   const isVaultEmpty = vault.debt.isZero()
 
-  const { estimatedProfitOnClose } = getOnCloseEstimations({
-    colMarketPrice: autoTakeProfitState.executionPrice,
-    colOraclePrice: autoTakeProfitState.executionPrice,
-    debt: vault.debt,
-    debtOffset: vault.debtOffset,
-    ethMarketPrice,
-    lockedCollateral: vault.lockedCollateral,
-    toCollateral: autoTakeProfitState.toCollateral,
-  })
-  const closeToToken = autoTakeProfitState.toCollateral ? vault.token : 'DAI'
-
   if (readOnlyAutoTakeProfitEnabled && !isVaultEmpty) {
     return (
       <SidebarFormInfo
@@ -100,9 +88,9 @@ export function SidebarAutoTakeProfitEditingStage({
         </>
       )}
       <EstimationOnClose
-        iconCircle={getToken(closeToToken).iconCircle}
-        label={t('auto-take-profit.estimated-at-trigger', { token: closeToToken })}
-        value={`${formatAmount(estimatedProfitOnClose, closeToToken)} ${closeToToken}`}
+        label={t('automation.estimated-col-ratio-at-trigger')}
+        value={formatPercent(autoTakeProfitState.executionCollRatio, { precision: 2 })}
+        valueSx={{ color: theme.colors.success100 }}
       />
       {isEditing && (
         <>
@@ -126,7 +114,6 @@ export function SidebarAutoTakeProfitEditingStage({
             token={vault.token}
             tokenMarketPrice={tokenMarketPrice}
             triggerColPrice={autoTakeProfitState.executionPrice}
-            triggerColRatio={autoTakeProfitState.executionCollRatio}
           />
         </>
       )}
@@ -143,7 +130,6 @@ interface AutoTakeProfitInfoSectionControlProps {
   token: string
   tokenMarketPrice: BigNumber
   triggerColPrice: BigNumber
-  triggerColRatio: BigNumber
 }
 
 function AutoTakeProfitInfoSectionControl({
@@ -154,7 +140,6 @@ function AutoTakeProfitInfoSectionControl({
   toCollateral,
   token,
   triggerColPrice,
-  triggerColRatio,
 }: AutoTakeProfitInfoSectionControlProps) {
   const {
     estimatedGasFeeOnTrigger,
@@ -178,7 +163,6 @@ function AutoTakeProfitInfoSectionControl({
       token={token}
       totalTriggerCost={totalTriggerCost}
       triggerColPrice={triggerColPrice}
-      triggerColRatio={triggerColRatio}
     />
   )
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -790,7 +790,7 @@
     },
     "set-auto-take-profit": {
       "left-label": "Trigger {{token}} price",
-      "right-label": "Trigger collateral ratio",
+      "right-label": "Estimated {{token}} at Close",
       "left-footer": "Lower price",
       "right-footer": "Higher price"
     }
@@ -1734,7 +1734,8 @@
     "trigger-executed-banner-description": "Your {{feature}} was triggered on your Vault. You can read the fully summary of the {{feature}} event on the right.",
     "summary": "{{feature}} summary",
     "what-happened-to-the-vault": "See below for a summary of what happened to the Vault.",
-    "trigger-executed": "Your {{feature}} was triggered"
+    "trigger-executed": "Your {{feature}} was triggered",
+    "estimated-col-ratio-at-trigger": "Estimated Coll. Ratio at Trigger"
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",


### PR DESCRIPTION
# [Update ATP estimation labels](https://app.shortcut.com/oazo-apps/story/6319/update-estimated-dai-trigger-col-ratio-location)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated slider right label in ATP form
- paragraph under slider shows now estimated col ratio at trigger
- removed trigger col ratio from summary information
  
## How to test 🧪
  <Please explain how to test your changes>

- in places described above correct labels and values should be present 
