### PR TITLE
🧭 Unique keys for Discovery tables

### DIFF
--- a/features/discovery/common/DiscoveryCards.tsx
+++ b/features/discovery/common/DiscoveryCards.tsx
@@ -1,5 +1,6 @@
 import { DiscoveryTableBanner } from 'features/discovery/common/DiscoveryTableBanner'
 import { DiscoveryTableDataCellContent } from 'features/discovery/common/DiscoveryTableDataCellContent'
+import { getRowKey } from 'features/discovery/helpers'
 import { DiscoveryBanner } from 'features/discovery/meta'
 import { DiscoveryPages, DiscoveryTableRowData } from 'features/discovery/types'
 import { kebabCase } from 'lodash'
@@ -47,7 +48,7 @@ export function DiscoveryCards({
         }}
       >
         {rows.map((row, i) => (
-          <Fragment key={i}>
+          <Fragment key={getRowKey(i, row)}>
             <DiscoveryCard row={row} />
             {banner && i === Math.floor((rows.length - 1) / 2) && (
               <Box as="li">

--- a/features/discovery/common/DiscoveryTable.tsx
+++ b/features/discovery/common/DiscoveryTable.tsx
@@ -1,5 +1,6 @@
 import { DiscoveryTableBanner } from 'features/discovery/common/DiscoveryTableBanner'
 import { DiscoveryTableDataCellContent } from 'features/discovery/common/DiscoveryTableDataCellContent'
+import { getRowKey } from 'features/discovery/helpers'
 import { DiscoveryBanner } from 'features/discovery/meta'
 import { DiscoveryPages, DiscoveryTableRowData } from 'features/discovery/types'
 import { kebabCase } from 'lodash'
@@ -47,7 +48,7 @@ export function DiscoveryTable({
         <Box as="thead">
           <tr>
             {Object.keys(rows[0]).map((label, i) => (
-              <DiscoveryTableHeaderCell key={i} label={label} />
+              <DiscoveryTableHeaderCell key={getRowKey(i, rows[0])} label={label} />
             ))}
           </tr>
         </Box>
@@ -61,7 +62,7 @@ export function DiscoveryTable({
           }}
         >
           {rows.map((row, i) => (
-            <Fragment key={i}>
+            <Fragment key={getRowKey(i, row)}>
               <DiscoveryTableDataRow row={row} />
               {banner && i === Math.floor((rows.length - 1) / 2) && (
                 <tr>
@@ -116,7 +117,7 @@ export function DiscoveryTableDataRow({ row }: { row: DiscoveryTableRowData }) {
       }}
     >
       {Object.keys(row).map((label, i) => (
-        <DiscoveryTableDataCell key={i} label={label} row={row} />
+        <DiscoveryTableDataCell key={getRowKey(i, row)} label={label} row={row} />
       ))}
     </Box>
   )

--- a/features/discovery/helpers.ts
+++ b/features/discovery/helpers.ts
@@ -1,5 +1,5 @@
 import { DiscoveryFiltersList } from 'features/discovery/meta'
-import { DiscoveryPages } from 'features/discovery/types'
+import { DiscoveryPages, DiscoveryTableRowData } from 'features/discovery/types'
 
 export const DISCOVERY_URL = '/discovery'
 
@@ -14,4 +14,8 @@ export function getDefaultSettingsState({
     ...Object.keys(filters).reduce((o, key) => ({ ...o, [key]: filters[key][0].value }), {}),
     table: kind,
   }
+}
+
+export function getRowKey(i: number, row: DiscoveryTableRowData) {
+  return [...(row.asset ? [row.asset] : []), ...(row.cdpId ? [row.cdpId] : []), i].join('-')
 }


### PR DESCRIPTION
# 🧭 Unique keys for Discovery tables
  
## Changes 👷‍♀️

- Created `getRowKey` method for generating keys for tables with dynamic data.