### PR TITLE
Added Net APY on current AAVE position

### DIFF
--- a/components/productCards/ProductCardEarnAave.tsx
+++ b/components/productCards/ProductCardEarnAave.tsx
@@ -7,7 +7,6 @@ import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatHugeNumbersToShortHuman, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
 import { useSimulation } from 'helpers/useSimulation'
-import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -30,11 +29,12 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
   const [aaveAvailableLiquidityETH, aaveAvailableLiquidityETHError] = useObservable(
     aaveAvailableLiquidityETH$,
   )
-  const maximumMultiple = aaveReserveState ? one.div(one.minus(aaveReserveState!.ltv)) : undefined
+  const maximumMultiple =
+    aaveReserveState?.ltv && new RiskRatio(aaveReserveState.ltv, RiskRatio.TYPE.LTV)
 
   const simulations = useSimulation({
     amount: aaveCalcValueBasis.amount,
-    riskRatio: maximumMultiple && new RiskRatio(maximumMultiple, RiskRatio.TYPE.MULITPLE),
+    riskRatio: maximumMultiple,
     fields: ['7Days', '90Days'],
   })
 
@@ -56,7 +56,7 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
                 token: aaveCalcValueBasis.token,
               }),
               description: t(`product-card-banner.aave.${cardData.symbol}`, {
-                value: _maximumMultiple.times(aaveCalcValueBasis.amount).toFormat(0),
+                value: _maximumMultiple.multiple.times(aaveCalcValueBasis.amount).toFormat(0),
                 token: cardData.symbol,
               }),
             }}

--- a/features/earn/aave/manage/components/ManageSectionComponent.tsx
+++ b/features/earn/aave/manage/components/ManageSectionComponent.tsx
@@ -2,6 +2,7 @@ import { Position } from '@oasisdex/oasis-actions'
 import { useActor } from '@xstate/react'
 import BigNumber from 'bignumber.js'
 import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
+import { useAppContext } from 'components/AppContextProvider'
 import {
   DetailsSectionContentCard,
   DetailsSectionContentCardWrapper,
@@ -15,11 +16,12 @@ import { AppSpinner } from 'helpers/AppSpinner'
 import { formatAmount, formatBigNumber, formatPercent } from 'helpers/formatters/format'
 import { zero } from 'helpers/zero'
 import { Trans, useTranslation } from 'next-i18next'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Grid, Text } from 'theme-ui'
 
 import { DetailsSection } from '../../../../../components/DetailsSection'
 import { PreparedAaveReserveData } from '../../helpers/aavePrepareReserveData'
+import { calculateSimulation } from '../../open/services'
 import { useManageAaveStateMachineContext } from '../containers/AaveManageStateMachineContext'
 import { ManageSectionModal } from './ManageSectionModal'
 
@@ -43,6 +45,7 @@ export function ManageSectionComponent({
   aaveReserveDataETH,
 }: ManageSectionComponentProps) {
   const { t } = useTranslation()
+  const { aaveSthEthYieldsQuery } = useAppContext()
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state] = useActor(stateMachine)
   const {
@@ -50,20 +53,40 @@ export function ManageSectionComponent({
     oraclePrice, // STETH price data
   } = state.context.protocolData || {}
 
+  const [simulations, setSimulations] = useState<ReturnType<typeof calculateSimulation>>()
+
+  const managedPosition =
+    accountData?.totalDebtETH &&
+    oraclePrice &&
+    new Position(
+      { amount: accountData.totalDebtETH },
+      { amount: accountData.totalCollateralETH },
+      oraclePrice, // oracle price for STETH, not needed/used to calculate liquidation price ratio
+      {
+        liquidationThreshold: aaveReserveState.liquidationThreshold,
+        dustLimit: new BigNumber(0), // not needed/used to calculate liquidation price ratio
+        maxLoanToValue: new BigNumber(0), // not needed/used to calculate liquidation price ratio
+      },
+    )
+
+  useEffect(() => {
+    if (!simulations && accountData?.totalCollateralETH && managedPosition?.liquidationPrice) {
+      void (async () => {
+        setSimulations(
+          calculateSimulation({
+            amount: accountData.totalCollateralETH,
+            token: 'ETH',
+            yields: await aaveSthEthYieldsQuery(managedPosition.riskRatio, ['7Days']),
+            riskRatio: managedPosition.riskRatio,
+          }),
+        )
+      })()
+    }
+  }, [accountData?.totalCollateralETH, managedPosition?.liquidationPrice])
+
   if (!accountData?.totalDebtETH || !aaveReserveState?.liquidationThreshold || !oraclePrice) {
     return <AppSpinner />
   }
-
-  const managedPosition = new Position(
-    { amount: accountData.totalDebtETH },
-    { amount: accountData.totalCollateralETH },
-    oraclePrice, // oracle price for STETH, not needed/used to calculate liquidation price ratio
-    {
-      liquidationThreshold: aaveReserveState.liquidationThreshold,
-      dustLimit: new BigNumber(0), // not needed/used to calculate liquidation price ratio
-      maxLoanToValue: new BigNumber(0), // not needed/used to calculate liquidation price ratio
-    },
-  )
 
   // Net value (= in ETH terms is:Calculated the same as for other earn positions,
   // but then in eth terms: stETH collateral times the stETH/ETH price, minus the ETH debt.)
@@ -73,7 +96,9 @@ export function ManageSectionComponent({
     : zero
 
   const totalCollateralInStEth = oraclePrice.times(accountData.totalCollateralETH)
-  const belowCurrentRatio = oraclePrice.minus(managedPosition.liquidationPrice).times(100)
+  const belowCurrentRatio = managedPosition
+    ? oraclePrice.minus(managedPosition.liquidationPrice).times(100)
+    : zero
 
   return (
     <DetailsSection
@@ -84,10 +109,6 @@ export function ManageSectionComponent({
             title={t('net-value')}
             value={formatBigNumber(netValue || zero, 2)}
             unit={state.context.token}
-            footnote={t('manage-earn-vault.pnl', {
-              value: 'n/a',
-              token: state.context.token,
-            })}
             modal={
               <ManageSectionModal
                 heading={t('net-value')}
@@ -125,8 +146,7 @@ export function ManageSectionComponent({
           />
           <DetailsSectionContentCard
             title={t('manage-earn-vault.net-apy')}
-            value="n/a"
-            footnote="To date: 'n/a'"
+            value={simulations?.apy ? formatPercent(simulations.apy, { precision: 2 }) : '-'}
             modal={
               <ManageSectionModal
                 heading={t('manage-earn-vault.net-apy')}
@@ -136,7 +156,7 @@ export function ManageSectionComponent({
           />
           <DetailsSectionContentCard
             title={t('manage-earn-vault.liquidation-price-ratio')}
-            value={formatBigNumber(managedPosition.liquidationPrice, 2)}
+            value={formatBigNumber(managedPosition ? managedPosition.liquidationPrice : zero, 2)}
             unit={t('manage-earn-vault.below-current-ratio', {
               percentage: formatPercent(belowCurrentRatio, {
                 precision: 0,

--- a/helpers/useSimulation.ts
+++ b/helpers/useSimulation.ts
@@ -1,0 +1,32 @@
+import { IRiskRatio } from '@oasisdex/oasis-actions'
+import BigNumber from 'bignumber.js'
+import { useAppContext } from 'components/AppContextProvider'
+import { calculateSimulation, FilterYieldFieldsType } from 'features/earn/aave/open/services'
+import { useEffect, useState } from 'react'
+
+type useSimulationParams = {
+  amount?: BigNumber
+  riskRatio?: IRiskRatio
+  fields: FilterYieldFieldsType[]
+}
+
+export function useSimulation({ amount, riskRatio, fields }: useSimulationParams) {
+  const [simulations, setSimulations] = useState<ReturnType<typeof calculateSimulation>>()
+  const { aaveSthEthYieldsQuery } = useAppContext()
+
+  useEffect(() => {
+    if (riskRatio && amount && !simulations) {
+      void (async () => {
+        setSimulations(
+          calculateSimulation({
+            amount,
+            token: 'ETH',
+            yields: await aaveSthEthYieldsQuery(riskRatio, fields),
+            riskRatio,
+          }),
+        )
+      })()
+    }
+  }, [amount, riskRatio])
+  return simulations
+}


### PR DESCRIPTION
# Added Net APY on current AAVE position

![image](https://user-images.githubusercontent.com/5095527/196497862-00cc7ffa-016d-4c55-aa74-d30eba97e086.png)
  
## Changes 👷‍♀️
 - added aaveSthEthYieldsQuery call to retrieve a single 7 day yield
  
## How to test 🧪
 - see image above
