### PR TITLE
Fixes Variable annual fee being off 100x

### DIFF
--- a/features/earn/aave/manage/components/ManageSectionComponent.tsx
+++ b/features/earn/aave/manage/components/ManageSectionComponent.tsx
@@ -183,7 +183,7 @@ export function ManageSectionComponent({
             title={t('system.variable-annual-fee')}
             value={
               aaveReserveDataETH?.variableBorrowRate
-                ? formatPercent(aaveReserveDataETH.variableBorrowRate, { precision: 2 })
+                ? formatPercent(aaveReserveDataETH.variableBorrowRate.times(100), { precision: 2 })
                 : zero.toString()
             }
           />


### PR DESCRIPTION
# [Fixes Variable annual fee being off 100x](https://app.shortcut.com/oazo-apps/story/6444/variable-annual-fee-is-off-by-factor-100)

## Changes 👷‍♀️
 - added multiplication by 100 to the blockchain data
  
## How to test 🧪
 - go to your aave steth position, Variable annual fee should be same as on https://app.aave.com/markets/
