### PR TITLE
Fix ok button from open position, and show loading spinner and block button

### DIFF
--- a/features/earn/aave/common/BaseAaveContext.ts
+++ b/features/earn/aave/common/BaseAaveContext.ts
@@ -20,6 +20,7 @@ export type IStrategyInfo = {
 export type BaseAaveEvent =
   | { type: 'PRICES_RECEIVED'; collateralPrice: BigNumber }
   | { type: 'USER_SETTINGS_CHANGED'; userSettings: UserSettingsState }
+  | { type: 'RESET_RISK_RATIO' }
 
 export interface BaseAaveContext {
   refPriceObservable?: ActorRef<BaseAaveEvent, BaseAaveEvent>
@@ -42,6 +43,7 @@ export interface BaseAaveContext {
   collateralPrice?: BigNumber
   slippage: BigNumber
   currentPosition: IPosition
+  loading: boolean
 }
 
 export type BaseViewProps<AaveEvent extends EventObject> = {

--- a/features/earn/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/earn/aave/common/components/SidebarAdjustRiskView.tsx
@@ -18,7 +18,7 @@ import { aaveStETHMinimumRiskRatio } from '../../constants'
 import { BaseViewProps } from '../BaseAaveContext'
 import { StrategyInformationContainer } from './informationContainer'
 
-type RaisedEvents = { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
+type RaisedEvents = { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio } | { type: 'RESET_RISK_RATIO' }
 
 type AdjustRiskViewProps = BaseViewProps<RaisedEvents> & {
   primaryButton: SidebarSectionFooterButtonSettings
@@ -32,7 +32,6 @@ export function AdjustRiskView({
   send,
   primaryButton,
   textButton,
-  resetRiskValue,
   viewLocked = false,
 }: AdjustRiskViewProps) {
   const { t } = useTranslation()
@@ -170,7 +169,7 @@ export function AdjustRiskView({
 
         <SidebarResetButton
           clear={() => {
-            send({ type: 'SET_RISK_RATIO', riskRatio: resetRiskValue })
+            send({ type: 'RESET_RISK_RATIO' })
           }}
           disabled={viewLocked}
         />

--- a/features/earn/aave/manage/services/getManageAaveStateMachine.ts
+++ b/features/earn/aave/manage/services/getManageAaveStateMachine.ts
@@ -124,6 +124,7 @@ export function getManageAaveStateMachine$(
           collateralToken: 'STETH',
           slippage: userSettings.slippage,
           currentPosition: EMPTY_POSITION,
+          loading: false,
         })
     }),
   )

--- a/features/earn/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/earn/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -181,7 +181,7 @@ export function SidebarManageAaveVault() {
           }
           send={send}
           primaryButton={{
-            isLoading: false,
+            isLoading: state.context.loading,
             disabled: !state.can('ADJUST_POSITION'),
             label: t('manage-earn.aave.vault-form.adjust-risk'),
             action: () => {

--- a/features/earn/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/earn/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -13,11 +13,7 @@ import { StrategyInformationContainer } from '../../common/components/informatio
 import { AdjustRiskView } from '../../common/components/SidebarAdjustRiskView'
 import { aaveStETHMinimumRiskRatio } from '../../constants'
 import { useManageAaveStateMachineContext } from '../containers/AaveManageStateMachineContext'
-import { ManageAaveEvent, ManageAaveStateMachine, ManageAaveStateMachineState } from '../state'
-
-export interface ManageAaveVaultProps {
-  readonly aaveStateMachine: ManageAaveStateMachine
-}
+import { ManageAaveEvent, ManageAaveStateMachineState } from '../state'
 
 interface ManageAaveStateProps {
   readonly state: ManageAaveStateMachineState
@@ -146,7 +142,7 @@ function ManageAaveFailureStateView({ state, send }: ManageAaveStateProps) {
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-function ManageAaveSuccessStateView({ state }: ManageAaveStateProps) {
+function ManageAaveSuccessStateView({ state, send }: ManageAaveStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -163,7 +159,7 @@ function ManageAaveSuccessStateView({ state }: ManageAaveStateProps) {
     ),
     primaryButton: {
       label: t('manage-earn.aave.vault-form.position-adjusted-btn'),
-      url: ``,
+      action: () => send('GO_TO_EDITING'),
     },
   }
 

--- a/features/earn/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/earn/aave/manage/state/manageAaveStateMachine.ts
@@ -125,7 +125,11 @@ export const createManageAaveStateMachine =
           },
         },
         editing: {
-          entry: ['spawnPricesObservable', 'spawnUserSettingsObservable'],
+          entry: [
+            //'clearTransactionParameters',
+            'spawnPricesObservable',
+            'spawnUserSettingsObservable',
+          ],
           invoke: [
             {
               src: 'getBalance',
@@ -199,7 +203,11 @@ export const createManageAaveStateMachine =
           },
         },
         txSuccess: {
-          type: 'final',
+          on: {
+            GO_TO_EDITING: {
+              target: 'editing',
+            },
+          },
         },
         reviewingClosing: {
           entry: [
@@ -283,6 +291,10 @@ export const createManageAaveStateMachine =
           transactionParameters: event.data?.adjustParams,
           estimatedGasPrice: event.data?.estimatedGasPrice,
         })),
+        // clearTransactionParameters: assign((context, event) => ({
+        //   transactionParameters: undefined,
+        //   estimatedGasPrice: undefined,
+        // })),
         assignClosingTransactionParameters: assign((context, event) => ({
           transactionParameters: event.parameters,
           estimatedGasPrice: event.estimatedGasPrice,

--- a/features/earn/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/earn/aave/manage/state/manageAaveStateMachine.ts
@@ -266,6 +266,14 @@ export const createManageAaveStateMachine =
         validTransactionParameters: ({ proxyAddress, transactionParameters }) => {
           return allDefined(proxyAddress, transactionParameters)
         },
+        newRiskInputted: (state) => {
+          return (
+            allDefined(state.userInput.riskRatio, state.protocolData) &&
+            !state.userInput.riskRatio!.loanToValue.eq(
+              state.protocolData!.position.riskRatio.loanToValue,
+            )
+          )
+        },
       },
       actions: {
         setLoadingTrue: assign((_) => ({ loading: true })),

--- a/features/earn/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/earn/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -107,7 +107,7 @@ function OpenAaveEditingStateView({ state, send }: OpenAaveStateProps) {
     ),
     primaryButton: {
       steps: [1, state.context.totalSteps!],
-      isLoading: false,
+      isLoading: state.context.loading,
       disabled: !state.can('NEXT_STEP') || (!hasProxy && isProxyCreationDisabled),
       label: hasProxy ? t('open-earn.aave.vault-form.open-btn') : t('create-proxy-btn'),
       action: () => send('NEXT_STEP'),
@@ -160,8 +160,8 @@ export function SidebarOpenAaveVault() {
           resetRiskValue={aaveStETHMinimumRiskRatio}
           primaryButton={{
             steps: [2, state.context.totalSteps!],
-            isLoading: false,
-            disabled: false,
+            isLoading: state.context.loading,
+            disabled: !state.can('NEXT_STEP'),
             label: t('open-earn.aave.vault-form.open-btn'),
             action: () => send('NEXT_STEP'),
           }}


### PR DESCRIPTION
Covers https://app.shortcut.com/oazo-apps/story/6380/ok-button-from-adjust-page-does-not-reload-position and https://app.shortcut.com/oazo-apps/story/6411/no-async-feedback-on-manage-page
  
## Changes 👷‍♀️
- OK button from manage page now goes back to the start of the machine.
- Button should be blocked when we are reading transaction data, and spinner shown.
  
## How to test 🧪
- adjust a position - button should now redirect back to the start of the user flow.  Edit the position again without reloading the page.  It should work.
- move the slider around a bunch when we are waiting for call data from maths lib. It should show loading spinner and block the UI from progressing.  Check for race conditions.  Check on mobile also.
