### PR TITLE
Fix earnings and net value of AAVE position, fix breakeven

### DIFF
--- a/features/earn/aave/open/services/calculateSimulation.ts
+++ b/features/earn/aave/open/services/calculateSimulation.ts
@@ -1,8 +1,11 @@
 import { IRiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
+import moment from 'moment/moment'
 
 import { one, zero } from '../../../../../helpers/zero'
 import { AaveStEthYieldsResponse } from './stEthYield'
+
+const AAVE_INCEPTION_DATE = moment('2022-02-28')
 
 export interface Simulation {
   earningAfterFees: BigNumber
@@ -21,7 +24,6 @@ export interface CalculateSimulationResult {
   sinceInception?: Simulation
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function calculateSimulation({
   amount,
   yields,
@@ -36,7 +38,7 @@ export function calculateSimulation({
 }): CalculateSimulationResult {
   const earningsPerDay =
     yields.annualisedYield1Year &&
-    amount.times(yields.annualisedYield1Year.plus(one)).minus(amount).div(365)
+    amount.times(yields.annualisedYield1Year.div(100).plus(one)).minus(amount).div(365)
   return {
     apy: yields.annualisedYield7days,
     breakEven: earningsPerDay && (fees || zero).div(earningsPerDay),
@@ -47,6 +49,7 @@ export function calculateSimulation({
         amount,
         annualizedYield: yields.annualisedYield7days,
         token,
+        days: 7,
       }),
     previous30Days:
       yields.annualisedYield30days &&
@@ -54,6 +57,7 @@ export function calculateSimulation({
         amount,
         annualizedYield: yields.annualisedYield30days,
         token,
+        days: 30,
       }),
     previous90Days:
       yields.annualisedYield90days &&
@@ -61,6 +65,7 @@ export function calculateSimulation({
         amount,
         annualizedYield: yields.annualisedYield90days,
         token,
+        days: 90,
       }),
     previous1Year:
       yields.annualisedYield1Year &&
@@ -68,6 +73,7 @@ export function calculateSimulation({
         amount,
         annualizedYield: yields.annualisedYield1Year,
         token,
+        days: 365,
       }),
     sinceInception:
       yields.annualisedYieldSinceInception &&
@@ -75,6 +81,7 @@ export function calculateSimulation({
         amount,
         annualizedYield: yields.annualisedYieldSinceInception,
         token,
+        days: moment().diff(AAVE_INCEPTION_DATE, 'days'),
       }),
   }
 }
@@ -83,12 +90,15 @@ function getSimulation({
   amount,
   annualizedYield,
   token,
+  days,
 }: {
   amount: BigNumber
   annualizedYield: BigNumber
   token: string
+  days: number
 }): Simulation {
-  const earnings = amount.times(annualizedYield.div(100))
+  const earningsPerDay = amount.times(annualizedYield.div(100).plus(one)).minus(amount).div(365)
+  const earnings = earningsPerDay.times(days)
   return {
     earningAfterFees: earnings,
     netValue: earnings.plus(amount),

--- a/features/earn/aave/open/services/getSthEthSimulationMachine.ts
+++ b/features/earn/aave/open/services/getSthEthSimulationMachine.ts
@@ -27,6 +27,7 @@ export function getSthEthSimulationMachine(
                 token: context.token!,
                 yields: context.yieldsMin!, // previously it was 'yields' and they were calculated using minimum risk ratio so i'll leave it like that
                 riskRatio: context.riskRatio!,
+                fees: context.fee!,
               })
             },
             getYields: async (context) => {


### PR DESCRIPTION
# [NET Value of Position](https://app.shortcut.com/oazo-apps/story/6377/update-the-earnings-net-value-to-use-the-actual-earnings-over-the-timeperiod)

