### PR TITLE
🧭 Discover mixpanel analytics

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -1,6 +1,7 @@
 import { ConnectionKind } from '@oasisdex/web3-context'
 import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
+import { getDiscoverMixpanelPage } from 'features/discover/helpers'
 import { DiscoverPages } from 'features/discover/types'
 import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { formatPrecision } from 'helpers/formatters/format'
@@ -65,6 +66,11 @@ export enum Pages {
   CloseVault = 'CloseVault',
   OpenEarnSTETH = 'OpenEarnSTETH',
   ManageSTETH = 'ManageSTETH',
+  DiscoverOasis = 'DiscoverOasis',
+  DiscoverHighRiskPositions = 'DiscoverHighRiskPositions',
+  DiscoverHighestMultiplyPnl = 'DiscoverHighestMultiplyPnl',
+  DiscoverMostYieldEarned = 'DiscoverMostYieldEarned',
+  DiscoverLargestDebt = 'DiscoverLargestDebt',
 }
 
 export enum EventTypes {
@@ -886,12 +892,18 @@ export const trackingEvents = {
   discover: {
     selectedInNavigation: (userContext: MixpanelUserContext) => {
       mixpanelInternalAPI(EventTypes.ButtonClick, {
+        product: Pages.DiscoverOasis,
+        page: Pages.LandingPage,
+        section: 'Header/tabs',
         id: 'Discover',
         ...userContext,
       })
     },
     selectedCategory: (kind: DiscoverPages, userContext: MixpanelUserContext) => {
       mixpanelInternalAPI(EventTypes.ButtonClick, {
+        product: Pages.DiscoverOasis,
+        page: Pages.DiscoverOasis,
+        section: 'Categories',
         id: upperFirst(camelCase(kind)),
         ...userContext,
       })
@@ -903,22 +915,29 @@ export const trackingEvents = {
       userContext: MixpanelUserContext,
     ) => {
       mixpanelInternalAPI(EventTypes.InputChange, {
+        product: Pages.DiscoverOasis,
+        page: getDiscoverMixpanelPage(kind),
+        section: 'Filters',
         id: `${upperFirst(camelCase(label))}Filter`,
-        table: kind,
         [label]: value,
         ...userContext,
       })
     },
     clickedTableBanner: (kind: DiscoverPages, link: string, userContext: MixpanelUserContext) => {
       mixpanelInternalAPI(EventTypes.ButtonClick, {
+        product: Pages.DiscoverOasis,
+        page: getDiscoverMixpanelPage(kind),
+        section: 'Table',
         id: 'TableBanner',
-        table: kind,
         link,
         ...userContext,
       })
     },
-    viewPosition: (vaultId: string | number) => {
+    viewPosition: (kind: DiscoverPages, vaultId: string | number) => {
       mixpanelInternalAPI(EventTypes.ButtonClick, {
+        product: Pages.DiscoverOasis,
+        page: getDiscoverMixpanelPage(kind),
+        section: 'Table',
         id: 'ViewPosition',
         vaultId,
       })

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -885,13 +885,13 @@ export const trackingEvents = {
 
   discover: {
     selectedInNavigation: (userContext: MixpanelUserContext) => {
-      mixpanelInternalAPI('btn-click', {
+      mixpanelInternalAPI(EventTypes.ButtonClick, {
         id: 'Discover',
         ...userContext,
       })
     },
     selectedCategory: (kind: DiscoverPages, userContext: MixpanelUserContext) => {
-      mixpanelInternalAPI('btn-click', {
+      mixpanelInternalAPI(EventTypes.ButtonClick, {
         id: upperFirst(camelCase(kind)),
         ...userContext,
       })
@@ -902,7 +902,7 @@ export const trackingEvents = {
       value: string,
       userContext: MixpanelUserContext,
     ) => {
-      mixpanelInternalAPI('input-change', {
+      mixpanelInternalAPI(EventTypes.InputChange, {
         id: `${upperFirst(camelCase(label))}Filter`,
         table: kind,
         [label]: value,
@@ -910,7 +910,7 @@ export const trackingEvents = {
       })
     },
     clickedTableBanner: (kind: DiscoverPages, link: string, userContext: MixpanelUserContext) => {
-      mixpanelInternalAPI('btn-click', {
+      mixpanelInternalAPI(EventTypes.ButtonClick, {
         id: 'TableBanner',
         table: kind,
         link,
@@ -918,7 +918,7 @@ export const trackingEvents = {
       })
     },
     viewPosition: (vaultId: string | number) => {
-      mixpanelInternalAPI('btn-click', {
+      mixpanelInternalAPI(EventTypes.ButtonClick, {
         id: 'ViewPosition',
         vaultId,
       })

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 import { Global } from '@emotion/core'
 import { Icon } from '@makerdao/dai-ui-icons'
-import { trackingEvents } from 'analytics/analytics'
+import { getMixpanelUserContext, trackingEvents } from 'analytics/analytics'
 import { ContextConnected } from 'blockchain/network'
 import { AppLink } from 'components/Links'
 import { LANDING_PILLS } from 'content/landing'
@@ -525,7 +525,12 @@ function ConnectedHeader() {
   )
 }
 
-function HeaderLink({ label, link, children }: { label: string; link?: string } & WithChildren) {
+function HeaderLink({
+  label,
+  link,
+  children,
+  onClick,
+}: { label: string; link?: string; onClick?: () => void } & WithChildren) {
   const { asPath } = useRouter()
   const [isMouseOver, setIsMouseOver] = useState<boolean>(false)
   const isActive = link ? asPath.includes(link) : false
@@ -552,7 +557,7 @@ function HeaderLink({ label, link, children }: { label: string; link?: string } 
       }}
     >
       {link ? (
-        <AppLink href={link} sx={itemSx}>
+        <AppLink href={link} sx={itemSx} onClick={onClick}>
           {label}
         </AppLink>
       ) : (
@@ -925,10 +930,13 @@ function DisconnectedHeader() {
 }
 
 function MainNavigation() {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
+  const { context$ } = useAppContext()
+  const [context] = useObservable(context$)
+  const { pathname } = useRouter()
 
   const discoverOasisEnabled = useFeatureToggle('DiscoverOasis')
-  const { pathname } = useRouter()
+  const userContext = getMixpanelUserContext(i18n.language, context)
 
   return (
     <Flex
@@ -990,7 +998,13 @@ function MainNavigation() {
           <HeaderLink label={t('nav.assets')}>
             <HeaderList links={LANDING_PILLS} columns={2} />
           </HeaderLink>
-          <HeaderLink label={t('nav.discover')} link={LINKS.discover} />
+          <HeaderLink
+            label={t('nav.discover')}
+            link={LINKS.discover}
+            onClick={() => {
+              trackingEvents.discover.selectedInNavigation(userContext)
+            }}
+          />
         </Grid>
       )}
     </Flex>

--- a/features/discover/common/DiscoverCards.tsx
+++ b/features/discover/common/DiscoverCards.tsx
@@ -1,3 +1,4 @@
+import { MixpanelUserContext } from 'analytics/analytics'
 import { DiscoverTableBanner } from 'features/discover/common/DiscoverTableBanner'
 import { DiscoverTableDataCellContent } from 'features/discover/common/DiscoverTableDataCellContent'
 import { getRowKey } from 'features/discover/helpers'
@@ -15,11 +16,13 @@ export function DiscoverCards({
   isLoading,
   kind,
   rows = [],
+  userContext,
 }: {
   banner?: DiscoverBanner
   isLoading: boolean
   kind: DiscoverPages
   rows: DiscoverTableRowData[]
+  userContext: MixpanelUserContext
 }) {
   return (
     <Box
@@ -52,7 +55,7 @@ export function DiscoverCards({
             <DiscoverCard row={row} />
             {banner && i === Math.floor((rows.length - 1) / 2) && (
               <Box as="li">
-                <DiscoverTableBanner kind={kind} {...banner} />
+                <DiscoverTableBanner kind={kind} userContext={userContext} {...banner} />
               </Box>
             )}
           </Fragment>

--- a/features/discover/common/DiscoverCards.tsx
+++ b/features/discover/common/DiscoverCards.tsx
@@ -52,7 +52,7 @@ export function DiscoverCards({
       >
         {rows.map((row, i) => (
           <Fragment key={getRowKey(i, row)}>
-            <DiscoverCard row={row} />
+            <DiscoverCard kind={kind} row={row} />
             {banner && i === Math.floor((rows.length - 1) / 2) && (
               <Box as="li">
                 <DiscoverTableBanner kind={kind} userContext={userContext} {...banner} />
@@ -65,7 +65,7 @@ export function DiscoverCards({
   )
 }
 
-export function DiscoverCard({ row }: { row: DiscoverTableRowData }) {
+export function DiscoverCard({ kind, row }: { kind: DiscoverPages; row: DiscoverTableRowData }) {
   const { t } = useTranslation()
 
   return (
@@ -97,7 +97,7 @@ export function DiscoverCard({ row }: { row: DiscoverTableRowData }) {
                 {t(`discover.table.header.${kebabCase(label)}`)}
               </Box>
             )}
-            <DiscoverTableDataCellContent label={label} row={row} />
+            <DiscoverTableDataCellContent kind={kind} label={label} row={row} />
           </Box>
         ))}
       </Grid>

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -1,3 +1,4 @@
+import { MixpanelUserContext } from 'analytics/analytics'
 import { DiscoverDataResponse } from 'features/discover/api'
 import { DiscoverCards } from 'features/discover/common/DiscoverCards'
 import { DiscoverError } from 'features/discover/common/DiscoverError'
@@ -15,9 +16,16 @@ interface DiscoverDataProps {
   response?: DiscoverDataResponse
   isLoading: boolean
   kind: DiscoverPages
+  userContext: MixpanelUserContext
 }
 
-export function DiscoverData({ banner, response, isLoading, kind }: DiscoverDataProps) {
+export function DiscoverData({
+  banner,
+  isLoading,
+  kind,
+  response,
+  userContext,
+}: DiscoverDataProps) {
   const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
 
   return (
@@ -31,6 +39,7 @@ export function DiscoverData({ banner, response, isLoading, kind }: DiscoverData
               isLoading={isLoading}
               kind={kind}
               rows={response.data.rows}
+              userContext={userContext}
             />
           ) : (
             <DiscoverTable
@@ -38,6 +47,7 @@ export function DiscoverData({ banner, response, isLoading, kind }: DiscoverData
               isLoading={isLoading}
               kind={kind}
               rows={response.data.rows}
+              userContext={userContext}
             />
           )}
         </>

--- a/features/discover/common/DiscoverNavigation.tsx
+++ b/features/discover/common/DiscoverNavigation.tsx
@@ -1,3 +1,4 @@
+import { MixpanelUserContext, trackingEvents } from 'analytics/analytics'
 import { GenericSelect } from 'components/GenericSelect'
 import { AppLink } from 'components/Links'
 import { DISCOVER_URL } from 'features/discover/helpers'
@@ -12,9 +13,10 @@ import { useOnMobile } from 'theme/useBreakpointIndex'
 
 interface DiscoverNavigationProps {
   kind: DiscoverPages
+  userContext: MixpanelUserContext
 }
 
-export function DiscoverNavigation({ kind }: DiscoverNavigationProps) {
+export function DiscoverNavigation({ kind, userContext }: DiscoverNavigationProps) {
   const { t } = useTranslation()
   const { push } = useRedirect()
   const onMobile = useOnMobile()
@@ -33,6 +35,7 @@ export function DiscoverNavigation({ kind }: DiscoverNavigationProps) {
           options={mobileLinks}
           defaultValue={selectedLink}
           onChange={(currentValue) => {
+            trackingEvents.discover.selectedCategory(kind, userContext)
             push(currentValue.value)
           }}
           wrapperSx={{ mb: 3 }}
@@ -49,7 +52,12 @@ export function DiscoverNavigation({ kind }: DiscoverNavigationProps) {
           }}
         >
           {discoverPagesMeta.map((item, i) => (
-            <DiscoverNavigationItem key={i} isActive={kind === item.kind} {...item} />
+            <DiscoverNavigationItem
+              key={i}
+              isActive={kind === item.kind}
+              userContext={userContext}
+              {...item}
+            />
           ))}
         </Flex>
       )}
@@ -62,7 +70,8 @@ export function DiscoverNavigationItem({
   kind,
   iconColor,
   iconContent,
-}: { isActive: boolean } & DiscoverPageMeta) {
+  userContext,
+}: { isActive: boolean; userContext: MixpanelUserContext } & DiscoverPageMeta) {
   const { t } = useTranslation()
   const [isMouseOver, setIsMouseOver] = useState<boolean>(false)
 
@@ -86,6 +95,9 @@ export function DiscoverNavigationItem({
           fontSize: 3,
           color: isActive || isMouseOver ? 'primary100' : 'neutral80',
           transition: '200ms color',
+        }}
+        onClick={() => {
+          trackingEvents.discover.selectedCategory(kind, userContext)
         }}
       >
         <svg

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -1,3 +1,4 @@
+import { MixpanelUserContext } from 'analytics/analytics'
 import { DiscoverTableBanner } from 'features/discover/common/DiscoverTableBanner'
 import { DiscoverTableDataCellContent } from 'features/discover/common/DiscoverTableDataCellContent'
 import { getRowKey } from 'features/discover/helpers'
@@ -12,12 +13,14 @@ export function DiscoverTable({
   banner,
   isLoading,
   kind,
-  rows = [],
+  rows,
+  userContext,
 }: {
   banner?: DiscoverBanner
   isLoading: boolean
   kind: DiscoverPages
   rows: DiscoverTableRowData[]
+  userContext: MixpanelUserContext
 }) {
   return (
     <Box
@@ -67,7 +70,7 @@ export function DiscoverTable({
               {banner && i === Math.floor((rows.length - 1) / 2) && (
                 <tr>
                   <td colSpan={Object.keys(row).length}>
-                    <DiscoverTableBanner kind={kind} {...banner} />
+                    <DiscoverTableBanner kind={kind} userContext={userContext} {...banner} />
                   </td>
                 </tr>
               )}

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -66,7 +66,7 @@ export function DiscoverTable({
         >
           {rows.map((row, i) => (
             <Fragment key={getRowKey(i, row)}>
-              <DiscoverTableDataRow row={row} />
+              <DiscoverTableDataRow kind={kind} row={row} />
               {banner && i === Math.floor((rows.length - 1) / 2) && (
                 <tr>
                   <td colSpan={Object.keys(row).length}>
@@ -107,7 +107,13 @@ export function DiscoverTableHeaderCell({ label }: { label: string }) {
   )
 }
 
-export function DiscoverTableDataRow({ row }: { row: DiscoverTableRowData }) {
+export function DiscoverTableDataRow({
+  kind,
+  row,
+}: {
+  kind: DiscoverPages
+  row: DiscoverTableRowData
+}) {
   return (
     <Box
       as="tr"
@@ -120,16 +126,18 @@ export function DiscoverTableDataRow({ row }: { row: DiscoverTableRowData }) {
       }}
     >
       {Object.keys(row).map((label, i) => (
-        <DiscoverTableDataCell key={getRowKey(i, row)} label={label} row={row} />
+        <DiscoverTableDataCell key={getRowKey(i, row)} kind={kind} label={label} row={row} />
       ))}
     </Box>
   )
 }
 
 export function DiscoverTableDataCell({
+  kind,
   label,
   row,
 }: {
+  kind: DiscoverPages
   label: string
   row: DiscoverTableRowData
 }) {
@@ -145,7 +153,7 @@ export function DiscoverTableDataCell({
         },
       }}
     >
-      <DiscoverTableDataCellContent label={label} row={row} />
+      <DiscoverTableDataCellContent kind={kind} label={label} row={row} />
     </Box>
   )
 }

--- a/features/discover/common/DiscoverTableBanner.tsx
+++ b/features/discover/common/DiscoverTableBanner.tsx
@@ -36,9 +36,12 @@ export function DiscoverTableBanner({
         </Text>
       </Box>
       <Box sx={{ flexShrink: 0, width: ['100%', null, 'auto'] }}>
-        <AppLink href={link} onClick={() => {
-          trackingEvents.discover.clickedTableBanner(kind, link, userContext)
-        }}>
+        <AppLink
+          href={link}
+          onClick={() => {
+            trackingEvents.discover.clickedTableBanner(kind, link, userContext)
+          }}
+        >
           <Button variant="action">{t(`discover.table.banner.${kind}.cta`)}</Button>
         </AppLink>
       </Box>

--- a/features/discover/common/DiscoverTableBanner.tsx
+++ b/features/discover/common/DiscoverTableBanner.tsx
@@ -1,3 +1,4 @@
+import { MixpanelUserContext, trackingEvents } from 'analytics/analytics'
 import { AppLink } from 'components/Links'
 import { DiscoverBanner } from 'features/discover/meta'
 import { DiscoverPages } from 'features/discover/types'
@@ -9,7 +10,8 @@ export function DiscoverTableBanner({
   kind,
   icon,
   link,
-}: { kind: DiscoverPages } & DiscoverBanner) {
+  userContext,
+}: { kind: DiscoverPages; userContext: MixpanelUserContext } & DiscoverBanner) {
   const { t } = useTranslation()
 
   return (
@@ -34,7 +36,9 @@ export function DiscoverTableBanner({
         </Text>
       </Box>
       <Box sx={{ flexShrink: 0, width: ['100%', null, 'auto'] }}>
-        <AppLink href={link}>
+        <AppLink href={link} onClick={() => {
+          trackingEvents.discover.clickedTableBanner(kind, link, userContext)
+        }}>
           <Button variant="action">{t(`discover.table.banner.${kind}.cta`)}</Button>
         </AppLink>
       </Box>

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
 import { AppLink } from 'components/Links'
 import {
+  DiscoverPages,
   DiscoverTableRowData,
   DiscoverTableVaultActivity,
   DiscoverTableVaultStatus,
@@ -38,9 +39,11 @@ const statusColors: { [key in DiscoverTableVaultStatus]: SxStyleProp } = {
 }
 
 export function DiscoverTableDataCellContent({
+  kind,
   label,
   row,
 }: {
+  kind: DiscoverPages
   label: string
   row: DiscoverTableRowData
 }) {
@@ -86,7 +89,7 @@ export function DiscoverTableDataCellContent({
         <AppLink
           href={`/${row?.cdpId}`}
           onClick={() => {
-            trackingEvents.discover.viewPosition(row?.cdpId)
+            trackingEvents.discover.viewPosition(kind, row?.cdpId)
           }}
         >
           <Button variant="tertiary">{t('discover.table.view-position')}</Button>

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import { trackingEvents } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
 import { AppLink } from 'components/Links'
@@ -82,7 +83,9 @@ export function DiscoverTableDataCellContent({
       )
     case 'cdpId':
       return (
-        <AppLink href={`/${row?.cdpId}`}>
+        <AppLink href={`/${row?.cdpId}`} onClick={() => {
+          trackingEvents.discover.viewPosition(row?.cdpId)
+        }}>
           <Button variant="tertiary">{t('discover.table.view-position')}</Button>
         </AppLink>
       )

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -83,9 +83,12 @@ export function DiscoverTableDataCellContent({
       )
     case 'cdpId':
       return (
-        <AppLink href={`/${row?.cdpId}`} onClick={() => {
-          trackingEvents.discover.viewPosition(row?.cdpId)
-        }}>
+        <AppLink
+          href={`/${row?.cdpId}`}
+          onClick={() => {
+            trackingEvents.discover.viewPosition(row?.cdpId)
+          }}
+        >
           <Button variant="tertiary">{t('discover.table.view-position')}</Button>
         </AppLink>
       )

--- a/features/discover/controllers/DiscoverControl.tsx
+++ b/features/discover/controllers/DiscoverControl.tsx
@@ -1,3 +1,4 @@
+import { MixpanelUserContext, trackingEvents } from 'analytics/analytics'
 import { getDiscoverData } from 'features/discover/api'
 import { DiscoverData } from 'features/discover/common/DiscoverData'
 import { DiscoverFilters } from 'features/discover/common/DiscoverFilters'
@@ -10,9 +11,10 @@ import { Box } from 'theme-ui'
 
 interface DiscoverControlProps {
   kind: DiscoverPages
+  userContext: MixpanelUserContext
 }
 
-export function DiscoverControl({ kind }: DiscoverControlProps) {
+export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
   const { banner, endpoint, filters } = keyBy(discoverPagesMeta, 'kind')[kind]
   const [settings, setSettings] = useState<DiscoverFiltersSettings>(
     getDefaultSettingsState({ filters, kind }),
@@ -37,6 +39,7 @@ export function DiscoverControl({ kind }: DiscoverControlProps) {
       <DiscoverFilters
         filters={filters}
         onChange={(key, currentValue) => {
+          trackingEvents.discover.selectedFilter(kind, key, currentValue.label, userContext)
           setIsLoading(true)
           setSettings({
             ...settings,
@@ -44,7 +47,13 @@ export function DiscoverControl({ kind }: DiscoverControlProps) {
           })
         }}
       />
-      <DiscoverData banner={banner} response={response} isLoading={isLoading} kind={kind} />
+      <DiscoverData
+        banner={banner}
+        isLoading={isLoading}
+        kind={kind}
+        response={response}
+        userContext={userContext}
+      />
     </Box>
   )
 }

--- a/features/discover/helpers.ts
+++ b/features/discover/helpers.ts
@@ -1,7 +1,23 @@
+import { Pages } from 'analytics/analytics'
 import { DiscoverFiltersList } from 'features/discover/meta'
 import { DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
 
 export const DISCOVER_URL = '/discover'
+
+export function getDiscoverMixpanelPage(kind: DiscoverPages): Pages {
+  switch (kind) {
+    case DiscoverPages.HIGH_RISK_POSITIONS:
+      return Pages.DiscoverHighRiskPositions
+    case DiscoverPages.HIGHEST_MULTIPLY_PNL:
+      return Pages.DiscoverHighestMultiplyPnl
+    case DiscoverPages.MOST_YIELD_EARNED:
+      return Pages.DiscoverMostYieldEarned
+    case DiscoverPages.LARGEST_DEBT:
+      return Pages.DiscoverLargestDebt
+    default:
+      return Pages.DiscoverOasis
+  }
+}
 
 export function getDefaultSettingsState({
   filters,

--- a/features/discover/views/DiscoverView.tsx
+++ b/features/discover/views/DiscoverView.tsx
@@ -1,14 +1,24 @@
+import { getMixpanelUserContext } from 'analytics/analytics'
+import { useAppContext } from 'components/AppContextProvider'
 import { DiscoverNavigation } from 'features/discover/common/DiscoverNavigation'
 import { DiscoverWrapperWithIntro } from 'features/discover/common/DiscoverWrapperWithIntro'
 import { DiscoverControl } from 'features/discover/controllers/DiscoverControl'
 import { DiscoverPages } from 'features/discover/types'
+import { useObservable } from 'helpers/observableHook'
+import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 export function DiscoverView({ kind }: { kind: DiscoverPages }) {
+  const { i18n } = useTranslation()
+  const { context$ } = useAppContext()
+  const [context] = useObservable(context$)
+
+  const userContext = getMixpanelUserContext(i18n.language, context)
+
   return (
     <DiscoverWrapperWithIntro key={kind}>
-      <DiscoverNavigation kind={kind} />
-      <DiscoverControl kind={kind} />
+      <DiscoverNavigation kind={kind} userContext={userContext} />
+      <DiscoverControl kind={kind} userContext={userContext} />
     </DiscoverWrapperWithIntro>
   )
 }


### PR DESCRIPTION
# [🧭 Discover mixpanel analytics](https://app.shortcut.com/oazo-apps/story/6185/discover-oasis-analytics)

All events are based on this sheet https://docs.google.com/spreadsheets/d/1Jie1SX_5i4-jDZLMKnCUkq4lhchkPKonIOVPNNJtsA8/edit#gid=308180383 with an exception of `ScrollTable` event which will be implemented differently, as a separated story.
  
## Changes 👷‍♀️

- Added dedicated events for tracking user behavior on Discover Oasis pages.
  
## How to test 🧪

- Try to trigger all trackable actions on Discover page UI, then look for request to `/api/t` and compare sent parameters with those required by Google sheet,
- please note that all parameters in `eventBody` were intentioanlly changed to camelCase and all event names to kebabCase.