### PR TITLE
Reverted to use yields instead of simulation in earn AAVE product card

### DIFF
--- a/components/productCards/ProductCardEarnAave.tsx
+++ b/components/productCards/ProductCardEarnAave.tsx
@@ -6,7 +6,7 @@ import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatHugeNumbersToShortHuman, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
-import { useSimulation } from 'helpers/useSimulation'
+import { useSimulationYields } from 'helpers/useSimulationYields'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -32,7 +32,7 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
   const maximumMultiple =
     aaveReserveState?.ltv && new RiskRatio(aaveReserveState.ltv, RiskRatio.TYPE.LTV)
 
-  const simulations = useSimulation({
+  const simulationYields = useSimulationYields({
     amount: aaveCalcValueBasis.amount,
     riskRatio: maximumMultiple,
     fields: ['7Days', '90Days'],
@@ -63,9 +63,9 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
             labels={[
               {
                 title: '7 day net APY',
-                value: simulations?.previous7Days ? (
+                value: simulationYields?.yields?.annualisedYield7days ? (
                   // this takes a while, so we show a spinner until it's ready
-                  formatPercent(simulations?.previous7Days.earningAfterFees, {
+                  formatPercent(simulationYields.yields.annualisedYield7days, {
                     precision: 2,
                   })
                 ) : (
@@ -74,8 +74,8 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
               },
               {
                 title: '90 day net APY',
-                value: simulations?.previous90Days ? (
-                  formatPercent(simulations?.previous90Days.earningAfterFees, {
+                value: simulationYields?.yields?.annualisedYield90days ? (
+                  formatPercent(simulationYields.yields.annualisedYield90days, {
                     precision: 2,
                   })
                 ) : (

--- a/features/earn/aave/manage/components/ManageSectionComponent.tsx
+++ b/features/earn/aave/manage/components/ManageSectionComponent.tsx
@@ -12,7 +12,7 @@ import {
 import { AppLink } from 'components/Links'
 import { AppSpinner } from 'helpers/AppSpinner'
 import { formatAmount, formatBigNumber, formatPercent } from 'helpers/formatters/format'
-import { useSimulation } from 'helpers/useSimulation'
+import { useSimulationYields } from 'helpers/useSimulationYields'
 import { zero } from 'helpers/zero'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
@@ -51,7 +51,7 @@ export function ManageSectionComponent({
     position,
   } = state.context.protocolData || {}
 
-  const simulations = useSimulation({
+  const simulations = useSimulationYields({
     amount: accountData?.totalCollateralETH,
     riskRatio: position?.riskRatio,
     fields: ['7Days'],

--- a/helpers/useSimulationYields.ts
+++ b/helpers/useSimulationYields.ts
@@ -1,30 +1,38 @@
 import { IRiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { useAppContext } from 'components/AppContextProvider'
-import { calculateSimulation, FilterYieldFieldsType } from 'features/earn/aave/open/services'
+import {
+  AaveStEthYieldsResponse,
+  calculateSimulation,
+  FilterYieldFieldsType,
+} from 'features/earn/aave/open/services'
 import { useEffect, useState } from 'react'
 
-type useSimulationParams = {
+type useSimulationYieldsParams = {
   amount?: BigNumber
   riskRatio?: IRiskRatio
   fields: FilterYieldFieldsType[]
 }
 
-export function useSimulation({ amount, riskRatio, fields }: useSimulationParams) {
-  const [simulations, setSimulations] = useState<ReturnType<typeof calculateSimulation>>()
+export function useSimulationYields({ amount, riskRatio, fields }: useSimulationYieldsParams) {
+  const [simulations, setSimulations] = useState<
+    ReturnType<typeof calculateSimulation> & { yields: AaveStEthYieldsResponse }
+  >()
   const { aaveSthEthYieldsQuery } = useAppContext()
 
   useEffect(() => {
     if (riskRatio && amount && !simulations) {
       void (async () => {
-        setSimulations(
-          calculateSimulation({
+        const yields = await aaveSthEthYieldsQuery(riskRatio, fields)
+        setSimulations({
+          ...calculateSimulation({
             amount,
             token: 'ETH',
-            yields: await aaveSthEthYieldsQuery(riskRatio, fields),
+            yields,
             riskRatio,
           }),
-        )
+          yields,
+        })
       })()
     }
   }, [amount, riskRatio])


### PR DESCRIPTION
# Reverted to use yields instead of simulation in earn AAVE product card

## Changes 👷‍♀️
- after changes in calculateSimulation the numbers weren't correct so I changed it to use raw yield numbers
  
## How to test 🧪
 - `/earn`
 - should display proper 7/90 day net APY
