### PR TITLE
convert gwei to ETH, and add to entry fees

### DIFF
--- a/blockchain/utils.test.ts
+++ b/blockchain/utils.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { RAD } from 'components/constants'
 import { one } from 'helpers/zero'
 
-import { amountFromRad, amountFromRay } from './utils'
+import { amountFromGwei, amountFromRad, amountFromRay } from './utils'
 
 describe('utils$', () => {
   it('should not reconfigure global precision for bignumber', () => {
@@ -27,5 +27,9 @@ describe('utils$', () => {
 
     expect(halfRadValueUnits.toFixed()).to.eq('0.500000000000000000000000000000000000000000001')
     expect(radValueUnits.div(2).toFixed()).to.eq(halfRadValueUnits.toFixed())
+  })
+
+  it('should convert from gwei correctly', () => {
+    expect(amountFromGwei(new BigNumber('1')).toString()).to.eq('0.000000001')
   })
 })

--- a/blockchain/utils.ts
+++ b/blockchain/utils.ts
@@ -52,3 +52,7 @@ export function amountToWeiRoundDown(amount: BigNumber, token: string): BigNumbe
   const { precision } = getToken(token)
   return amount.times(new BigNumber(10).pow(precision)).decimalPlaces(0, BigNumber.ROUND_DOWN)
 }
+
+export function amountFromGwei(amount: BigNumber): BigNumber {
+  return amount.div(new BigNumber(10).pow(9))
+}

--- a/features/earn/aave/open/state/openAaveStateMachine.ts
+++ b/features/earn/aave/open/state/openAaveStateMachine.ts
@@ -6,6 +6,7 @@ import { cancel } from 'xstate/lib/actions'
 import { MachineOptionsFrom } from 'xstate/lib/types'
 
 import { OperationExecutorTxMeta } from '../../../../../blockchain/calls/operationExecutor'
+import { amountFromGwei } from '../../../../../blockchain/utils'
 import { allDefined } from '../../../../../helpers/allDefined'
 import { HasGasEstimation } from '../../../../../helpers/form'
 import { zero } from '../../../../../helpers/zero'
@@ -325,7 +326,11 @@ export const createOpenAaveStateMachine = createMachine(
           const sourceTokenFee = event.parameters.simulation.swap.sourceTokenFee || zero
           const targetTokenFee = event.parameters.simulation.swap.targetTokenFee || zero
 
-          const gasFee = event.estimatedGasPrice?.gasEstimationEth || zero
+          const gasFee =
+            (event.estimatedGasPrice?.gasEstimation &&
+              amountFromGwei(new BigNumber(event.estimatedGasPrice.gasEstimation))) ||
+            zero
+
           return {
             type: 'FEE_CHANGED',
             fee: sourceTokenFee.plus(targetTokenFee).plus(gasFee),


### PR DESCRIPTION
# [Est. entry fees isn't taking into account the gas fees](https://app.shortcut.com/oazo-apps/story/6464/est-entry-fees-isn-t-taking-into-account-the-gas-fees)
  
Check that entry fees includes estimated gas fees.