### PR TITLE
Fixed updating liquidation price ratio in the sidebar when adjusting AAVE position

### DIFF
--- a/features/earn/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/earn/aave/common/components/SidebarAdjustRiskView.tsx
@@ -37,21 +37,24 @@ export function AdjustRiskView({
 }: AdjustRiskViewProps) {
   const { t } = useTranslation()
 
+  const transactionParametersSimulation = state.context.transactionParameters?.simulation
+
   const position = state.context.protocolData
     ? state.context.protocolData.position
-    : state.context.transactionParameters?.simulation.position
+    : transactionParametersSimulation?.position
 
   const maxRisk = position?.category.maxLoanToValue
 
   const minRisk =
-    (state.context.transactionParameters?.simulation.minConfigurableRiskRatio &&
+    (transactionParametersSimulation?.minConfigurableRiskRatio &&
       BigNumber.max(
-        state.context.transactionParameters?.simulation.minConfigurableRiskRatio.loanToValue,
+        transactionParametersSimulation?.minConfigurableRiskRatio.loanToValue,
         aaveStETHMinimumRiskRatio.loanToValue,
       )) ||
     aaveStETHMinimumRiskRatio.loanToValue
 
-  const liquidationPrice = position?.liquidationPrice || zero
+  const liquidationPrice =
+    transactionParametersSimulation?.position.liquidationPrice || position?.liquidationPrice || zero
 
   const oracleAssetPrice = state.context.strategyInfo?.oracleAssetPrice || zero
 


### PR DESCRIPTION
# [Fixed updating liquidation price ratio in the sidebar when adjusting AAVE position](https://app.shortcut.com/oazo-apps/story/6412/liquidation-price-does-not-update-when-adjusting-from-manage-page)

## Changes 👷‍♀️
 - moved some stuff around
  
## How to test 🧪
 - go and manage your position
 - liquidation price should update when you move the slider
