### PR TITLE
Added redirection to current position if user has any 

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -169,6 +169,7 @@ import {
 import { createOpenVault$ } from 'features/borrow/open/pipes/openVault'
 import { createCollateralPrices$ } from 'features/collateralPrices/collateralPrices'
 import { currentContent } from 'features/content'
+import { hasActiveAavePosition } from 'features/earn/aave/helpers/hasActiveAavePosition'
 import { getAaveStEthYield } from 'features/earn/aave/open/services'
 import {
   getTotalSupply,
@@ -1117,6 +1118,8 @@ export function setupAppContext() {
     ),
   )
 
+  const hasActiveAavePosition$ = hasActiveAavePosition(web3Context$, hasAave$)
+
   return {
     web3Context$,
     web3ContextConnected$,
@@ -1175,6 +1178,7 @@ export function setupAppContext() {
     aaveSthEthYieldsQuery,
     aaveAvailableLiquidityETH$,
     aaveUserAccountData$,
+    hasActiveAavePosition$,
   }
 }
 

--- a/components/productCards/ProductCardEarnAave.tsx
+++ b/components/productCards/ProductCardEarnAave.tsx
@@ -41,8 +41,6 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
     fields: ['7Days', '90Days'],
   })
 
-  console.log('aaveActivePosition', aaveActivePosition)
-
   return (
     <WithErrorHandler error={[aaveReserveStateError, aaveAvailableLiquidityETHError]}>
       <WithLoadingIndicator

--- a/components/productCards/ProductCardEarnAave.tsx
+++ b/components/productCards/ProductCardEarnAave.tsx
@@ -1,6 +1,7 @@
 import { RiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { TokenMetadataType } from 'blockchain/tokensMetadata'
+import { useAppContext } from 'components/AppContextProvider'
 import { useEarnContext } from 'features/earn/EarnContextProvider'
 import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
@@ -25,6 +26,8 @@ const aaveCalcValueBasis = {
 export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
   const { t } = useTranslation()
   const { aaveSTETHReserveConfigurationData, aaveAvailableLiquidityETH$ } = useEarnContext()
+  const { hasActiveAavePosition$ } = useAppContext()
+  const [aaveActivePosition] = useObservable(hasActiveAavePosition$)
   const [aaveReserveState, aaveReserveStateError] = useObservable(aaveSTETHReserveConfigurationData)
   const [aaveAvailableLiquidityETH, aaveAvailableLiquidityETHError] = useObservable(
     aaveAvailableLiquidityETH$,
@@ -38,13 +41,15 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
     fields: ['7Days', '90Days'],
   })
 
+  console.log('aaveActivePosition', aaveActivePosition)
+
   return (
     <WithErrorHandler error={[aaveReserveStateError, aaveAvailableLiquidityETHError]}>
       <WithLoadingIndicator
-        value={[aaveReserveState, aaveAvailableLiquidityETH, maximumMultiple]}
+        value={[aaveReserveState, aaveAvailableLiquidityETH, maximumMultiple, aaveActivePosition]}
         customLoader={<ProductCardsLoader />}
       >
-        {([_aaveReserveState, _availableLiquidity, _maximumMultiple]) => (
+        {([_aaveReserveState, _availableLiquidity, _maximumMultiple, _aaveActivePosition]) => (
           <ProductCard
             tokenImage={cardData.bannerIcon}
             tokenGif={cardData.bannerGif}
@@ -92,7 +97,9 @@ export function ProductCardEarnAave({ cardData }: ProductCardEarnAaveProps) {
               },
             ]}
             button={{
-              link: `/earn/aave/open/${cardData.symbol}`,
+              link: _aaveActivePosition
+                ? `/aave/${_aaveActivePosition}`
+                : `/earn/aave/open/${cardData.symbol}`,
               text: t('nav.earn'),
             }}
             background={cardData.background}

--- a/features/earn/aave/helpers/hasActiveAavePosition.ts
+++ b/features/earn/aave/helpers/hasActiveAavePosition.ts
@@ -1,0 +1,20 @@
+import { Web3Context } from '@oasisdex/web3-context'
+import { ContextConnected } from 'blockchain/network'
+import { startWithDefault } from 'helpers/operators'
+import { combineLatest, Observable } from 'rxjs'
+import { map, switchMap } from 'rxjs/operators'
+
+type hasActiveAavePositionProps = boolean | string
+
+export function hasActiveAavePosition(
+  context$: Observable<Web3Context>,
+  hasAavePosition$: (address: string) => Observable<boolean>,
+): Observable<hasActiveAavePositionProps> {
+  return context$.pipe(
+    switchMap((context: ContextConnected) =>
+      combineLatest(startWithDefault(hasAavePosition$(context.account), false)).pipe(
+        map(([hasAavePosition]) => hasAavePosition && context.account),
+      ),
+    ),
+  )
+}

--- a/features/earn/aave/helpers/useAaveRedirect.ts
+++ b/features/earn/aave/helpers/useAaveRedirect.ts
@@ -1,0 +1,12 @@
+import { useAppContext } from 'components/AppContextProvider'
+import { useObservable } from 'helpers/observableHook'
+import { useRedirect } from 'helpers/useRedirect'
+
+export function useAaveRedirect() {
+  const { hasActiveAavePosition$ } = useAppContext()
+  const router = useRedirect()
+  const [aaveActivePosition = false] = useObservable(hasActiveAavePosition$)
+  if (aaveActivePosition) {
+    void router.replace(`/aave/${aaveActivePosition}`)
+  }
+}

--- a/features/earn/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/earn/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -14,6 +14,7 @@ import { ProxyView } from '../../../../proxyNew'
 import { StrategyInformationContainer } from '../../common/components/informationContainer'
 import { AdjustRiskView } from '../../common/components/SidebarAdjustRiskView'
 import { aaveStETHMinimumRiskRatio } from '../../constants'
+import { useAaveRedirect } from '../../helpers/useAaveRedirect'
 import { useOpenAaveStateMachineContext } from '../containers/AaveOpenStateMachineContext'
 import { OpenAaveEvent, OpenAaveStateMachine, OpenAaveStateMachineState } from '../state/'
 import { SidebarOpenAaveVaultEditingState } from './SidebarOpenAaveVaultEditingState'
@@ -95,6 +96,7 @@ function OpenAaveFailureStateView({ state, send }: OpenAaveStateProps) {
 
 function OpenAaveEditingStateView({ state, send }: OpenAaveStateProps) {
   const { t } = useTranslation()
+  useAaveRedirect() // redirects to active position if user has one
 
   const hasProxy = state.context.proxyAddress !== undefined
   const isProxyCreationDisabled = useFeatureToggle('ProxyCreationDisabled')


### PR DESCRIPTION
# [Added redirection to current position if user has any ](https://app.shortcut.com/oazo-apps/story/6384/earn-card-goes-to-open-earn-position-when-user-already-has-a-position-should-go-to-already-existing-position)
  
## Changes 👷‍♀️
 - added check on open aave position page
 - added check on aave product card  

## How to test 🧪
 - if you dont have the aave position nothing changes
 - if you do have an aave position you should be redirected to it when clicking the product card on `/earn`
 - if you do have an aave position you should be redirected to it when going to the open position page by hand (ie. typing the address in the browser by hand)
