### PR TITLE
🧭 Discover asset cell validation

### DIFF
--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import BigNumber from 'bignumber.js'
-import { getToken } from 'blockchain/tokensMetadata'
 import { AppLink } from 'components/Links'
+import { discoverFiltersAssetItems } from 'features/discover/filters'
 import {
   DiscoverTableRowData,
   DiscoverTableVaultActivity,
@@ -47,12 +47,16 @@ export function DiscoverTableDataCellContent({
 
   switch (label) {
     case 'asset':
+      const asset = Object.values(discoverFiltersAssetItems).filter(
+        (item) => item.value === row.asset,
+      )[0]
+
       return (
         <Flex sx={{ alignItems: 'center' }}>
-          <Icon size={44} name={getToken(row.asset as string).iconCircle} />
+          {asset && asset.icon && <Icon size={44} name={asset.icon} />}
           <Flex sx={{ flexDirection: 'column', ml: '10px' }}>
             <Text as="span" sx={{ fontSize: 4, fontWeight: 'semiBold' }}>
-              {row.asset}
+              {asset ? asset.label : row.asset}
             </Text>
             {row.cdpId && (
               <Text as="span" sx={{ fontSize: 2, color: 'neutral80', whiteSpace: 'pre' }}>
@@ -111,6 +115,6 @@ export function DiscoverTableDataCellContent({
         </>
       )
     default:
-      return <>${row[label]}</>
+      return <>{row[label]}</>
   }
 }

--- a/features/discover/filters.ts
+++ b/features/discover/filters.ts
@@ -1,22 +1,22 @@
 import { getToken } from 'blockchain/tokensMetadata'
 import { DiscoverFiltersListItem } from 'features/discover/meta'
 
-export const discoverFiltersAssetItems = {
+export const discoverFiltersAssetItems: {[key: string]: DiscoverFiltersListItem} = {
   all: { value: 'all', label: 'All assets' },
   // TODO: update with nicer cuvre icon when available
-  curve: { value: 'curve', label: 'CURVE', icon: getToken('CRVV1ETHSTETH').iconCircle },
-  eth: { value: 'eth', label: 'ETH', icon: getToken('ETH').iconCircle },
-  gusd: { value: 'gusd', label: 'GUSD', icon: getToken('GUSD').iconCircle },
-  link: { value: 'link', label: 'LINK', icon: getToken('LINK').iconCircle },
-  mana: { value: 'mana', label: 'MANA', icon: getToken('MANA').iconCircle },
-  matic: { value: 'matic', label: 'MATIC', icon: getToken('MATIC').iconCircle },
+  curve: { value: 'CURVE_LP', label: 'CURVE', icon: getToken('CRVV1ETHSTETH').iconCircle },
+  eth: { value: 'ETH', label: 'ETH', icon: getToken('ETH').iconCircle },
+  gusd: { value: 'GUSD', label: 'GUSD', icon: getToken('GUSD').iconCircle },
+  link: { value: 'LINK', label: 'LINK', icon: getToken('LINK').iconCircle },
+  mana: { value: 'MANA', label: 'MANA', icon: getToken('MANA').iconCircle },
+  matic: { value: 'MATIC', label: 'MATIC', icon: getToken('MATIC').iconCircle },
   // TODO: update with dedicated icon when it's decided what to display here
-  stetheth: { value: 'stetheth', label: 'STETH/ETH', icon: getToken('ETH').iconCircle },
-  uni: { value: 'uni', label: 'UNI LP', icon: getToken('UNI').iconCircle },
+  stetheth: { value: 'STETHETH', label: 'STETH/ETH', icon: getToken('ETH').iconCircle },
+  uni: { value: 'UNI_LP', label: 'UNI LP', icon: getToken('UNI').iconCircle },
   // TODO: update with dedicated icon when it's decided what to display here
-  univ3daiusdc: { value: 'univ3daiusdc', label: 'UNIV3DAI/USDC', icon: getToken('ETH').iconCircle },
-  wbtc: { value: 'wbtc', label: 'WBTC', icon: getToken('WBTC').iconCircle },
-  yfi: { value: 'yfi', label: 'YFI', icon: getToken('YFI').iconCircle },
+  univ3daiusdc: { value: 'UNIV3DAIUSDC', label: 'UNIV3DAI/USDC', icon: getToken('ETH').iconCircle },
+  wbtc: { value: 'WBTC', label: 'WBTC', icon: getToken('WBTC').iconCircle },
+  yfi: { value: 'YFI', label: 'YFI', icon: getToken('YFI').iconCircle },
 }
 
 export const discoverSizeFilter: DiscoverFiltersListItem[] = [

--- a/features/discover/filters.ts
+++ b/features/discover/filters.ts
@@ -1,7 +1,7 @@
 import { getToken } from 'blockchain/tokensMetadata'
 import { DiscoverFiltersListItem } from 'features/discover/meta'
 
-export const discoverFiltersAssetItems: {[key: string]: DiscoverFiltersListItem} = {
+export const discoverFiltersAssetItems: { [key: string]: DiscoverFiltersListItem } = {
   all: { value: 'all', label: 'All assets' },
   // TODO: update with nicer cuvre icon when available
   curve: { value: 'CURVE_LP', label: 'CURVE', icon: getToken('CRVV1ETHSTETH').iconCircle },


### PR DESCRIPTION
# 🧭 Discover asset cell validation

If for any reason database would return asset name for which we don't have metadata, table would thrown an error. This PR fixes that issue.
  
## Changes 👷‍♀️

- Added validation for asset returned from database.
