### PR TITLE
stop flicker positions over page with aave positions

### DIFF
--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -116,9 +116,9 @@ export function createAavePosition$(
             ownerAddress: address,
           }
         }),
-        startWith(undefined),
       )
     }),
+    startWith(undefined),
   )
 }
 


### PR DESCRIPTION
# [Position flickering in and out of the page on owner page](https://app.shortcut.com/oazo-apps/story/6468/position-flickering-in-and-out-of-the-page-on-owner-page)
  
## How to test 🧪
- have an aave position
- load positions overview page
- observe that the positions list does not flicker in and out every 10 seconds
