### PR TITLE
Temporary allow to set Take profit trigger at $0

### DIFF
--- a/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
+++ b/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
@@ -14,6 +14,7 @@ import {
   prepareAutoTakeProfitResetData,
 } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { createTokenAth } from 'features/tokenAth/tokenAth'
+import { zero } from 'helpers/zero'
 
 import {
   AUTO_TAKE_PROFIT_FORM_CHANGE,
@@ -41,7 +42,7 @@ interface AutoTakeProfitStatus {
   resetData: AutoTakeProfitResetData
 }
 
-const MIN_MULTIPLIER = 1.05
+// const MIN_MULTIPLIER = 1.05
 const MAX_MULTIPLIER_WITH_ATH = 2
 const MAX_MULTIPLIER_WITH_PRICE = 10
 
@@ -85,7 +86,9 @@ export function getAutoTakeProfitStatus({
     collateralTokenIconCircle: getToken(vault.token).iconCircle,
   }
   const tokenAth = createTokenAth(vault.token)
-  const min = tokenMarketPrice.times(MIN_MULTIPLIER)
+  // TODO: bring back proper min slider value after testing
+  // const min = tokenMarketPrice.times(MIN_MULTIPLIER)
+  const min = zero
   const max = tokenAth
     ? tokenAth.times(MAX_MULTIPLIER_WITH_ATH)
     : tokenMarketPrice.times(MAX_MULTIPLIER_WITH_PRICE)

--- a/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
+++ b/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
@@ -14,7 +14,7 @@ import {
   prepareAutoTakeProfitResetData,
 } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { createTokenAth } from 'features/tokenAth/tokenAth'
-import { zero } from 'helpers/zero'
+import { one } from 'helpers/zero'
 
 import {
   AUTO_TAKE_PROFIT_FORM_CHANGE,
@@ -88,7 +88,7 @@ export function getAutoTakeProfitStatus({
   const tokenAth = createTokenAth(vault.token)
   // TODO: bring back proper min slider value after testing
   // const min = tokenMarketPrice.times(MIN_MULTIPLIER)
-  const min = zero
+  const min = one
   const max = tokenAth
     ? tokenAth.times(MAX_MULTIPLIER_WITH_ATH)
     : tokenMarketPrice.times(MAX_MULTIPLIER_WITH_PRICE)

--- a/features/automation/optimization/autoTakeProfit/validators.test.ts
+++ b/features/automation/optimization/autoTakeProfit/validators.test.ts
@@ -110,12 +110,13 @@ describe('auto take profit errors', () => {
 
     expect(errors).to.be.deep.eq([])
   })
-  it('should show error saying that auto-take profit trigger will be executed immediately', () => {
-    const errors = errorsAutoTakeProfitValidation({
-      ...autoTakeProfitErrorsValidationBaseData,
-      nextCollateralPrice: new BigNumber(1900),
-    })
+  // TODO: bring back test case after testing
+  // it('should show error saying that auto-take profit trigger will be executed immediately', () => {
+  //   const errors = errorsAutoTakeProfitValidation({
+  //     ...autoTakeProfitErrorsValidationBaseData,
+  //     nextCollateralPrice: new BigNumber(1900),
+  //   })
 
-    expect(errors).to.be.deep.eq(['autoTakeProfitTriggeredImmediately'])
-  })
+  //   expect(errors).to.be.deep.eq(['autoTakeProfitTriggeredImmediately'])
+  // })
 })

--- a/features/automation/optimization/autoTakeProfit/validators.ts
+++ b/features/automation/optimization/autoTakeProfit/validators.ts
@@ -46,8 +46,8 @@ export function warningsAutoTakeProfitValidation({
 }
 
 export function errorsAutoTakeProfitValidation({
-  nextCollateralPrice,
-  executionPrice,
+  // nextCollateralPrice,
+  // executionPrice,
   txError,
 }: {
   nextCollateralPrice: BigNumber
@@ -58,7 +58,9 @@ export function errorsAutoTakeProfitValidation({
     txError,
   })
 
-  const autoTakeProfitTriggeredImmediately = executionPrice.lte(nextCollateralPrice)
+  // TODO: bring back proper validation after testing
+  // const autoTakeProfitTriggeredImmediately = executionPrice.lte(nextCollateralPrice)
+  const autoTakeProfitTriggeredImmediately = false
 
   return errorMessagesHandler({ autoTakeProfitTriggeredImmediately, insufficientEthFundsForTx })
 }


### PR DESCRIPTION
# Temporary allow to set Take profit trigger at $0

Just for testing purposes, to be changed back later.
  
## Changes 👷‍♀️

- Set min on TP slider to `1`,
- turned off `autoTakeProfitTriggeredImmediately` validation.
