### PR TITLE
Informational message is always visible -> should only be visible on changes in the slider

### DIFF
--- a/features/earn/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/earn/aave/common/components/SidebarAdjustRiskView.tsx
@@ -1,5 +1,6 @@
 import { IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
 import { BigNumber } from 'bignumber.js'
+import { isEmpty } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Flex, Grid, Link, Text } from 'theme-ui'
@@ -143,13 +144,14 @@ export function AdjustRiskView({
           <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.increase-risk')}</Text>
         </Flex>
         <StrategyInformationContainer state={state} />
-        {viewLocked ? (
+        {viewLocked && (
           <MessageCard
             messages={[t('manage-earn-vault.has-asset-already')]}
             type="error"
             withBullet={false}
           />
-        ) : (
+        )}
+        {!isEmpty(state.context.userInput) && !viewLocked && (
           <MessageCard
             messages={[
               isWarning


### PR DESCRIPTION
# [Informational message is always visible -> should only be visible on changes in the slider](https://app.shortcut.com/oazo-apps/story/6489/informational-message-is-always-visible-should-only-be-visible-on-changes-in-the-slider)

## Changes 👷‍♀️
- the vault message on manage is visible only if user has changed the slider value
  
## How to test 🧪
