### PR TITLE
Added baseYieldsMin to the AaveStEthSimulateStateMachine to use it in the header

### DIFF
--- a/features/earn/aave/components/AavePositionHeader.tsx
+++ b/features/earn/aave/components/AavePositionHeader.tsx
@@ -46,12 +46,12 @@ export function AavePositionHeader({
   const { context: simulationContext } = simulationState
 
   const headlineDetails = []
-  if (simulationContext.yieldsMin && simulationContext.yieldsMax) {
+  if (simulationContext.baseYieldsMin && simulationContext.yieldsMax) {
     const formatYield = (yieldVal: BigNumber) =>
       formatPercent(yieldVal, {
         precision: 2,
       })
-    const yield7DaysMin = simulationContext.yieldsMin.annualisedYield7days!
+    const yield7DaysMin = simulationContext.baseYieldsMin.annualisedYield7days!
     const yield7DaysMax = simulationContext.yieldsMax.annualisedYield7days!
 
     const yield7DaysDiff = simulationContext.yieldsMax.annualisedYield7days!.minus(
@@ -100,7 +100,7 @@ export function AavePositionHeader({
       header={tokenPairList[strategyName].name}
       token={tokenPairList[strategyName].tokenList}
       details={headlineDetails}
-      loading={!aaveTVL?.totalValueLocked || simulationState.value === 'loading'}
+      loading={!aaveTVL?.totalValueLocked}
     />
   )
 }

--- a/features/earn/aave/open/state/aaveStEthSimulateStateMachine.ts
+++ b/features/earn/aave/open/state/aaveStEthSimulateStateMachine.ts
@@ -8,6 +8,7 @@ import { MachineOptionsFrom } from 'xstate/lib/types'
 import { AaveStEthYieldsResponse, CalculateSimulationResult } from '../services'
 
 interface AaveStEthSimulateStateMachineContext {
+  baseYieldsMin?: AaveStEthYieldsResponse
   yieldsMin?: AaveStEthYieldsResponse
   yieldsMax?: AaveStEthYieldsResponse
   token?: string
@@ -99,6 +100,7 @@ export const aaveStEthSimulateStateMachine = createMachine(
   {
     actions: {
       assignYields: assign((context, event) => ({
+        baseYieldsMin: context.baseYieldsMin ? context.baseYieldsMin : event.data.yieldsMin,
         yieldsMin: event.data.yieldsMin,
         yieldsMax: event.data.yieldsMax,
       })),


### PR DESCRIPTION
# [I expect the current yield in the header to remain the same - always - no matter the user input.](https://app.shortcut.com/oazo-apps/story/6491/i-expect-the-current-yield-in-the-header-to-remain-the-same-always-no-matter-the-user-input)

## Changes 👷‍♀️
 - Added `baseYieldsMin` to the AaveStEthSimulateStateMachine to use it in the header
 - Its the same thing as `yieldsMin` on the first simulation, but `yieldsMin` changes as the user is changing the slider value
  
## How to test 🧪
 - go to aave steth open page (without active position)
 - provide some ETH in the first step
 - on second step change the slider value
 - the header should stay the same
