### PR TITLE
Lucian feedback on opening

### DIFF
--- a/features/earn/aave/constants/index.ts
+++ b/features/earn/aave/constants/index.ts
@@ -2,4 +2,4 @@ import { RiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 
 export const aaveStrategiesList = ['stETHeth']
-export const aaveStETHMinimumRiskRatio = new RiskRatio(new BigNumber(1.1), RiskRatio.TYPE.MULITPLE)
+export const aaveStETHMinimumRiskRatio = new RiskRatio(new BigNumber(2.01), RiskRatio.TYPE.MULITPLE)

--- a/features/earn/aave/constants/index.ts
+++ b/features/earn/aave/constants/index.ts
@@ -2,4 +2,5 @@ import { RiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 
 export const aaveStrategiesList = ['stETHeth']
-export const aaveStETHMinimumRiskRatio = new RiskRatio(new BigNumber(2.01), RiskRatio.TYPE.MULITPLE)
+export const aaveStETHMinimumRiskRatio = new RiskRatio(new BigNumber(1.1), RiskRatio.TYPE.MULITPLE)
+export const aaveStETHDefaultRiskRatio = new RiskRatio(new BigNumber(2.01), RiskRatio.TYPE.MULITPLE)

--- a/features/earn/aave/open/components/SimulateSectionComponent.tsx
+++ b/features/earn/aave/open/components/SimulateSectionComponent.tsx
@@ -48,7 +48,6 @@ function SimulationSection({ actor }: { actor: ActorRefFrom<AaveStEthSimulateSta
                 [t('earn-vault.simulate.rowlabel1'), ...mapSimulation(simulation?.previous30Days)],
                 [t('earn-vault.simulate.rowlabel2'), ...mapSimulation(simulation?.previous90Days)],
                 [t('earn-vault.simulate.rowlabel3'), ...mapSimulation(simulation?.previous1Year)],
-                [t('earn-vault.simulate.rowlabel4'), ...mapSimulation(simulation?.sinceInception)],
               ]}
               footnote={<>{t('earn-vault.simulate.footnote1')}</>}
             />

--- a/features/earn/aave/open/services/getSthEthSimulationMachine.ts
+++ b/features/earn/aave/open/services/getSthEthSimulationMachine.ts
@@ -51,7 +51,7 @@ export function getSthEthSimulationMachine(
           },
         })
         .withContext({
-          amount: new BigNumber(100000),
+          amount: new BigNumber(100),
           token: 'ETH',
           riskRatio: aaveStETHMinimumRiskRatio,
           riskRatioMax: new RiskRatio(aaveReserveStEthData.ltv, RiskRatio.TYPE.LTV),

--- a/features/earn/aave/open/state/openAaveStateMachine.ts
+++ b/features/earn/aave/open/state/openAaveStateMachine.ts
@@ -12,7 +12,7 @@ import { zero } from '../../../../../helpers/zero'
 import { ProxyStateMachine } from '../../../../proxyNew/state'
 import { TransactionStateMachine } from '../../../../stateMachines/transaction'
 import { BaseAaveContext, BaseAaveEvent, IStrategyInfo } from '../../common/BaseAaveContext'
-import { aaveStETHMinimumRiskRatio } from '../../constants'
+import { aaveStETHDefaultRiskRatio, aaveStETHMinimumRiskRatio } from '../../constants'
 import {
   AaveStEthSimulateStateMachine,
   AaveStEthSimulateStateMachineEvents,
@@ -259,7 +259,7 @@ export const createOpenAaveStateMachine = createMachine(
           return {
             type: 'VARIABLES_RECEIVED',
             amount: context.userInput?.amount!,
-            riskRatio: context.userInput.riskRatio || aaveStETHMinimumRiskRatio,
+            riskRatio: context.userInput.riskRatio || aaveStETHDefaultRiskRatio,
             token: context.token,
             proxyAddress: context.proxyAddress,
           }


### PR DESCRIPTION
# [Lucian feedback on opening](https://app.shortcut.com/oazo-apps/story/6495/lucian-feedback-on-opening)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
 - Lowered the default simulation amount to 100 ETH (from 100000)
 - Set the default multiple for the simulation on open to 2x
 - Hidden the since inception for now
  
## How to test 🧪
 - go to `earn/aave/open/stETHeth`
 - it should show 100 ETH as base for calculations (before user input)
 - it should show 2x multiply as default (before moving slider and after deposit input)
 - it _shoudn't_ display `Since inception` simulation
