### PR TITLE
Marketing the product

### DIFF
--- a/components/HomePageBanner.tsx
+++ b/components/HomePageBanner.tsx
@@ -5,12 +5,12 @@ import { Flex, Text } from 'theme-ui'
 import { AppLink } from './Links'
 import { Notice } from './Notice'
 
-interface ReferralBannerProps {
+interface HomePageBannerProps {
   heading: string
   link: string
 }
 const handleClose = () => null
-export function ReferralBanner({ heading, link }: ReferralBannerProps) {
+export function HomePageBanner({ heading, link }: HomePageBannerProps) {
   return (
     <Notice
       close={() => {
@@ -20,7 +20,7 @@ export function ReferralBanner({ heading, link }: ReferralBannerProps) {
         marginBottom: 0,
         overflow: 'hidden',
         borderRadius: '50px',
-        maxWidth: ['230px', '335px'],
+        maxWidth: ['400px', '520px'],
         p: '3px 8px 3px 4px',
         '&:hover': {
           opacity: '80%',
@@ -34,8 +34,8 @@ export function ReferralBanner({ heading, link }: ReferralBannerProps) {
           sx={{
             justifySelf: 'center',
             alignItems: 'center',
-            textAlign: 'center',
-            flexDirection: 'row',
+            textAlign: 'left',
+            flexDirection: ['row'],
             justifyContent: ['start', 'space-between', 'space-between', 'space-between'],
             minHeight: '44px',
             '&:hover svg': {
@@ -45,27 +45,25 @@ export function ReferralBanner({ heading, link }: ReferralBannerProps) {
         >
           <Flex
             sx={{
-              background: '#fee9bf',
+              background: '#D3F3F5',
               borderRadius: '50px',
               flexDirection: 'row',
               justifySelf: 'center',
               alignItems: 'center',
-              textAlign: 'center',
+              textAlign: 'left',
               minHeight: '42px',
+              minWidth: '44px',
               px: '8px',
               mr: '8px',
             }}
           >
             <Icon
-              name="dai_circle_color"
+              name="steth_circle_color"
               size="30px"
               sx={{
                 transform: 'none !important',
               }}
             />
-            <Text color="#5a4e3b" mx="4px" sx={{ fontSize: '14px', fontWeight: 'semiBold' }}>
-              5%
-            </Text>
           </Flex>
           <Flex
             sx={{

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -23,14 +23,21 @@ interface TabBarProps {
   useDropdownOnMobile?: boolean
   variant: TabVariant
   switchEvent?: { value: string }
+  defaultTab?: string
 }
 
-export function TabBar({ sections, variant, useDropdownOnMobile, switchEvent }: TabBarProps) {
+export function TabBar({
+  sections,
+  variant,
+  useDropdownOnMobile,
+  switchEvent,
+  defaultTab,
+}: TabBarProps) {
   const [hash, setHash] = useHash<string>()
 
   useEffect(() => {
-    if (!hash) {
-      setHash(sections[0]?.value)
+    if (!hash || !!defaultTab) {
+      setHash(defaultTab || sections[0]?.value)
     }
   }, [])
 

--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -229,6 +229,7 @@ export function HomepageView() {
         <TabBar
           variant="large"
           useDropdownOnMobile
+          defaultTab="earn"
           sections={[
             {
               label: t('landing.tabs.multiply.tabLabel'),

--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import BigNumber from 'bignumber.js'
 import { useAppContext } from 'components/AppContextProvider'
+import { HomePageBanner } from 'components/HomePageBanner'
 import { InfoCard } from 'components/InfoCard'
 import { AppLink } from 'components/Links'
 import {
@@ -8,7 +9,6 @@ import {
   EarnProductCardsContainer,
   MultiplyProductCardsContainer,
 } from 'components/productCards/ProductCardsContainer'
-import { ReferralBanner } from 'components/ReferralBanner'
 import { TabBar } from 'components/TabBar'
 import { LANDING_PILLS } from 'content/landing'
 import { NewReferralModal } from 'features/referralOverview/NewReferralModal'
@@ -174,20 +174,15 @@ export function HomepageView() {
         flex: 1,
       }}
     >
-      {referralsEnabled && (
-        <Flex
-          sx={{
-            justifyContent: 'center',
-            mt: '80px',
-            mb: 0,
-          }}
-        >
-          <ReferralBanner
-            heading={t('ref.banner')}
-            link={userReferral?.user ? `/referrals/${userReferral.user.address}` : '/referrals'}
-          ></ReferralBanner>
-        </Flex>
-      )}
+      <Flex
+        sx={{
+          justifyContent: 'center',
+          mt: '80px',
+          mb: 0,
+        }}
+      >
+        <HomePageBanner heading={t('ref.banner')} link="/earn/aave/open/stETHeth" />
+      </Flex>
       {referralsEnabled && landedWithRef && context?.status === 'connectedReadonly' && (
         <NewReferralModal />
       )}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1797,7 +1797,7 @@
     "closed-vault-existing-trigger-description": "You can cancel your existing Constant Multiple here or deposit into your vault in overview tab"
   },
   "ref": {
-    "banner": "Refer a Friend. Earn DAI today",
+    "banner": "Earn on ETH with our new stETH product. Check it out today",
     "ref-a-friend": "Refer a Friend",
     "intro-1": "Refer someone to us and you both get rewarded with 5% of all fees they generate on Oasis.app... forever! Read more about ",
     "intro-link": "Oasis Refer a Friend",


### PR DESCRIPTION
# [Marketing the product](https://app.shortcut.com/oazo-apps/story/6543/marketing-the-product)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
 - updated the referral banner copy (changed it to more generic "HomepageBanner") + change the logo to stETH + remove the 5% and link this to the opening aave steth position
 - updated the homepage to default to #earn instead of #multiply.
  
## How to test 🧪
 - check the above changes on the home page, should look like this: (note the banner above headline and selected tab on the bottom):
 
 
![image](https://user-images.githubusercontent.com/5095527/197565449-b05db816-919a-4537-90c1-00a98d091eb1.png)

