### PR TITLE
No spinner before user has the proxy

### DIFF
--- a/features/earn/aave/open/state/openAaveStateMachine.ts
+++ b/features/earn/aave/open/state/openAaveStateMachine.ts
@@ -281,7 +281,10 @@ export const createOpenAaveStateMachine = createMachine(
           id: 'update-parameters-machine',
         },
       ),
-      setIsLoadingTrue: assign((_) => ({ loading: true })),
+      setIsLoadingTrue: assign((context) =>
+        // no spinner before user has the proxy (otherwise it will be stuck there forever)
+        context.proxyAddress ? { loading: true } : { loading: false },
+      ),
       setIsLoadingFalse: assign((_) => ({ loading: false })),
       setRiskRatio: assign((context, event) => {
         return {


### PR DESCRIPTION
# [No spinner before user has the proxy](https://app.shortcut.com/oazo-apps/story/6553/this-spinner-starts-when-the-user-hasn-t-clicked-the-button-yet-so-it-seems-a-bit-like-the-user-cannot-click-create-proxy)
  
## Changes 👷‍♀️
 - added a guard to _not_ show the spinner on AAVE steth open page before the user has created a proxy
  
## How to test 🧪
 - go to aave steth open page using a wallet with no proxy 
 - there should be no spinner spinning forever when you input the deposit amount