### PR TITLE
Revert "Temporary allow to set Take profit trigger at $0 (#1609)"

### DIFF
--- a/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
+++ b/features/automation/optimization/autoTakeProfit/state/autoTakeProfitStatus.ts
@@ -21,7 +21,6 @@ import {
 } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitTriggerData'
 import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { createTokenAth } from 'features/tokenAth/tokenAth'
-import { one } from 'helpers/zero'
 
 import {
   AUTO_TAKE_PROFIT_FORM_CHANGE,
@@ -49,7 +48,7 @@ interface AutoTakeProfitStatus {
   resetData: AutoTakeProfitResetData
 }
 
-// const MIN_MULTIPLIER = 1.05
+const MIN_MULTIPLIER = 1.05
 const MAX_MULTIPLIER_WITH_ATH = 2
 const MAX_MULTIPLIER_WITH_PRICE = 10
 
@@ -104,9 +103,7 @@ export function getAutoTakeProfitStatus({
     collateralTokenIconCircle: getToken(vault.token).iconCircle,
   }
   const tokenAth = createTokenAth(vault.token)
-  // TODO: bring back proper min slider value after testing
-  // const min = tokenMarketPrice.times(MIN_MULTIPLIER)
-  const min = one
+  const min = tokenMarketPrice.times(MIN_MULTIPLIER)
   const max = tokenAth
     ? tokenAth.times(MAX_MULTIPLIER_WITH_ATH)
     : tokenMarketPrice.times(MAX_MULTIPLIER_WITH_PRICE)

--- a/features/automation/optimization/autoTakeProfit/validators.test.ts
+++ b/features/automation/optimization/autoTakeProfit/validators.test.ts
@@ -110,13 +110,12 @@ describe('auto take profit errors', () => {
 
     expect(errors).to.be.deep.eq([])
   })
-  // TODO: bring back test case after testing
-  // it('should show error saying that auto-take profit trigger will be executed immediately', () => {
-  //   const errors = errorsAutoTakeProfitValidation({
-  //     ...autoTakeProfitErrorsValidationBaseData,
-  //     nextCollateralPrice: new BigNumber(1900),
-  //   })
+  it('should show error saying that auto-take profit trigger will be executed immediately', () => {
+    const errors = errorsAutoTakeProfitValidation({
+      ...autoTakeProfitErrorsValidationBaseData,
+      nextCollateralPrice: new BigNumber(1900),
+    })
 
-  //   expect(errors).to.be.deep.eq(['autoTakeProfitTriggeredImmediately'])
-  // })
+    expect(errors).to.be.deep.eq(['autoTakeProfitTriggeredImmediately'])
+  })
 })

--- a/features/automation/optimization/autoTakeProfit/validators.ts
+++ b/features/automation/optimization/autoTakeProfit/validators.ts
@@ -46,8 +46,8 @@ export function warningsAutoTakeProfitValidation({
 }
 
 export function errorsAutoTakeProfitValidation({
-  // nextCollateralPrice,
-  // executionPrice,
+  nextCollateralPrice,
+  executionPrice,
   txError,
 }: {
   nextCollateralPrice: BigNumber
@@ -58,9 +58,7 @@ export function errorsAutoTakeProfitValidation({
     txError,
   })
 
-  // TODO: bring back proper validation after testing
-  // const autoTakeProfitTriggeredImmediately = executionPrice.lte(nextCollateralPrice)
-  const autoTakeProfitTriggeredImmediately = false
+  const autoTakeProfitTriggeredImmediately = executionPrice.lte(nextCollateralPrice)
 
   return errorMessagesHandler({ autoTakeProfitTriggeredImmediately, insufficientEthFundsForTx })
 }


### PR DESCRIPTION
This reverts commit 8086b9495906bda7da7571fde5ed6731bff77288.

# [Revert "Temporary allow to set Take profit trigger at $0 (#1609)"](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- reverted changes that were created to suppress FE validation of ATP
  
## How to test 🧪
  <Please explain how to test your changes>

- slider min value should be set to token market price
- validations should be in place
- tests should pass
