### PR TITLE
🧭 Support translations on Discover pages

### DIFF
--- a/pages/discover/[slug].tsx
+++ b/pages/discover/[slug].tsx
@@ -28,7 +28,7 @@ export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
 
   return {
     paths,
-    fallback: true,
+    fallback: false,
   }
 }
 

--- a/pages/discover/[slug].tsx
+++ b/pages/discover/[slug].tsx
@@ -20,12 +20,15 @@ DiscoverPage.seoTags = discoverPageSeoTags
 
 export default DiscoverPage
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = discoverPagesMeta.map(({ kind }) => ({ params: { slug: kind } }))
+export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
+  const paths =
+    locales
+      ?.map((locale) => discoverPagesMeta.map(({ kind }) => ({ params: { slug: kind }, locale })))
+      .flat() || []
 
   return {
     paths,
-    fallback: false,
+    fallback: true,
   }
 }
 


### PR DESCRIPTION
# 🧭 Support translations on Discover pages

Due to dynamic links in Discover, any language other than default English was returning `404` error.
  
## Changes 👷‍♀️

- Added `locale` to static path generation.
  
## How to test 🧪

Try accessing other languages on any Discover page.
