### PR TITLE
🧭 Discover API errors handling and loader tweaks

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -175,7 +175,7 @@ export function Footer() {
   const { t } = useTranslation()
 
   return (
-    <Box as="footer" sx={{ position: 'relative', zIndex: 'footer' }}>
+    <Box as="footer" sx={{ position: 'relative' }}>
       <Container sx={{ maxWidth: '1200px', mb: 5, pb: 0, pt: 2 }}>
         <Grid
           sx={{

--- a/features/discover/api.ts
+++ b/features/discover/api.ts
@@ -11,14 +11,13 @@ import { Observable } from 'rxjs'
 import { ajax } from 'rxjs/ajax'
 import { catchError, map } from 'rxjs/operators'
 
+export interface DiscoverDataResponseError {
+  code: DiscoverApiErrors
+  reason?: string
+}
 export interface DiscoverDataResponse {
-  data?: {
-    rows: DiscoverTableRowData[]
-  }
-  error?: {
-    code: DiscoverApiErrors
-    reason?: string
-  }
+  rows: DiscoverTableRowData[]
+  error?: DiscoverDataResponseError
 }
 
 function getDiscoverData$(endpoint: string, query: string): Observable<DiscoverDataResponse> {
@@ -26,7 +25,7 @@ function getDiscoverData$(endpoint: string, query: string): Observable<DiscoverD
     url: `${endpoint}?${query}`,
     method: 'GET',
   }).pipe(
-    map(({ response }) => ({ data: response })),
+    map(({ response }) => response),
     catchError(() => of({ error: { code: DiscoverApiErrors.UNKNOWN_ERROR } })),
   )
 }

--- a/features/discover/common/DiscoverCards.tsx
+++ b/features/discover/common/DiscoverCards.tsx
@@ -27,12 +27,9 @@ export function DiscoverCards({
   return (
     <Box
       sx={{
-        mt: '12px',
         px: ['24px', null, null, 4],
         pt: 4,
         pb: '24px',
-        borderTop: '1px solid',
-        borderTopColor: 'neutral20',
       }}
     >
       <Flex

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -29,8 +29,8 @@ export function DiscoverData({
   const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
 
   return (
-    <Box sx={{ position: 'relative' }}>
-      {response?.data?.rows && response?.data?.rows.length > 0 ? (
+    <Box sx={{ position: 'relative', borderTop: '1px solid', borderTopColor: 'neutral20' }}>
+      {response?.rows ? (
         <>
           {isLoading && <DiscoverPreloader isContentLoaded={true} />}
           {isSmallerScreen ? (
@@ -38,7 +38,7 @@ export function DiscoverData({
               banner={banner}
               isLoading={isLoading}
               kind={kind}
-              rows={response.data.rows}
+              rows={response.rows}
               userContext={userContext}
             />
           ) : (
@@ -46,7 +46,7 @@ export function DiscoverData({
               banner={banner}
               isLoading={isLoading}
               kind={kind}
-              rows={response.data.rows}
+              rows={response.rows}
               userContext={userContext}
             />
           )}
@@ -54,7 +54,7 @@ export function DiscoverData({
       ) : isLoading ? (
         <DiscoverPreloader isContentLoaded={false} />
       ) : (
-        <DiscoverError />
+        <DiscoverError error={response?.error} />
       )}
     </Box>
   )

--- a/features/discover/common/DiscoverError.tsx
+++ b/features/discover/common/DiscoverError.tsx
@@ -1,8 +1,9 @@
+import { DiscoverDataResponseError } from 'features/discover/api'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Text } from 'theme-ui'
 
-export function DiscoverError() {
+export function DiscoverError({ error }: { error?: DiscoverDataResponseError }) {
   const { t } = useTranslation()
 
   return (
@@ -12,11 +13,9 @@ export function DiscoverError() {
       sx={{
         px: ['24px', null, null, 4],
         py: 4,
-        borderTop: '1px solid',
-        borderTopColor: 'neutral20',
       }}
     >
-      {t('discover.table.no-entries')}
+      {t(`discover.api-error.${error?.code}`)}
     </Text>
   )
 }

--- a/features/discover/common/DiscoverPreloader.tsx
+++ b/features/discover/common/DiscoverPreloader.tsx
@@ -15,7 +15,7 @@ export function DiscoverPreloader({ isContentLoaded }: { isContentLoaded: boolea
               my: 'auto',
             }
           : {
-              mb: ['24px', null, null, 4],
+              my: ['24px', null, null, 4],
             }),
       }}
       variant="extraLarge"

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -28,12 +28,10 @@ export function DiscoverTable({
         position: 'relative',
         px: ['24px', null, null, 4],
         pb: 1,
-        borderTop: '1px solid',
-        borderTopColor: 'neutral20',
         '&::before': {
           content: '""',
           position: 'absolute',
-          top: '52px',
+          top: '51px',
           left: 0,
           right: 0,
           height: '1px',

--- a/features/discover/common/DiscoverWrapperWithIntro.tsx
+++ b/features/discover/common/DiscoverWrapperWithIntro.tsx
@@ -9,7 +9,7 @@ export function DiscoverWrapperWithIntro({ children }: WithChildren) {
   const { t } = useTranslation()
 
   return (
-    <Box sx={{ width: '100%', mt: [0, 5], zIndex: 3 }}>
+    <Box sx={{ width: '100%', mt: [0, 5] }}>
       <Box sx={{ mb: ['48px', 5], textAlign: 'center' }}>
         <Heading variant="header2" sx={{ mb: 2 }}>
           {t('discover.heading')}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -151,6 +151,10 @@
       "most-yield-earned": "Most Yield Earned",
       "largest-debt": "Largest Debt"
     },
+    "api-error": {
+      "1": "Unknown error occurred, please try again later.",
+      "2": "There are no entries available for selected filters."
+    },
     "table": {
       "no-entries": "There are no entries available for selected filters.",
       "vault-number": "Vault #{{cdpId}}",


### PR DESCRIPTION
# [🧭 Discover API errors handling and loader tweaks](https://app.shortcut.com/oazo-apps/story/6576/loading-and-error-states-handling)

![image](https://user-images.githubusercontent.com/16230404/198009851-55c8b100-6857-41a5-a042-7d1191fadbec.png)
![image](https://user-images.githubusercontent.com/16230404/198009896-e6e428bf-999a-4924-bb7c-ae23b989fbca.png)

## Changes 👷‍♀️

- Removed `zIndex` from the footer, since it was overlapping filters options in Discover (and probably some other places in edge cases that we missed),
- errors are now displayed based on message returned from API,
- tiny tweaks in Discover layout.
  
## How to test 🧪

- To receive `UNKNOWN_ERROR` error, in `/features/discover/meta.tsx` file change `endpoint` to some gibberish,
- to receive `NO_ENTRIES` error, in one of the json files in `/public/mocks/discover` remove all data and leave empty `rows` array,
- this is already handling actual API response, so if you have seeded `discovery` table in database, you can test it changing one of meta endpoints to `/api/discover`,
- I removed `zIndex` from footer, so it would be good to do some quick smoke tests and check random pages if there isn't something funny happening there.
