### PR TITLE
Stop loss with attached xstate events

### DIFF
--- a/components/AutomationContextProvider.tsx
+++ b/components/AutomationContextProvider.tsx
@@ -26,7 +26,7 @@ import { useObservable } from 'helpers/observableHook'
 import { WithChildren } from 'helpers/types'
 import React, { useContext, useEffect, useState } from 'react'
 
-interface AutomationContext {
+export interface AutomationContext {
   autoSellTriggerData: AutoBSTriggerData
   autoBuyTriggerData: AutoBSTriggerData
   stopLossTriggerData: StopLossTriggerData

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -5,7 +5,9 @@ import { useAutomationContext } from 'components/AutomationContextProvider'
 import { useAutoBSstateInitialization } from 'features/automation/common/state/useAutoBSStateInitializator'
 import { useAutoTakeProfitStateInitializator } from 'features/automation/optimization/autoTakeProfit/state/useAutoTakeProfitStateInitializator'
 import { useConstantMultipleStateInitialization } from 'features/automation/optimization/constantMultiple/state/useConstantMultipleStateInitialization'
+import { stopLossStateMachine } from 'features/automation/protection/stopLoss/state/stopLossStateMachine'
 import { useStopLossStateInitializator } from 'features/automation/protection/stopLoss/state/useStopLossStateInitializator'
+import { StopLossContextProvider } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { guniFaq } from 'features/content/faqs/guni'
 import { GuniVaultHeader } from 'features/earn/guni/common/GuniVaultHeader'
 import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
@@ -83,16 +85,18 @@ export function GeneralManageLayout({ generalManageVault }: GeneralManageLayoutP
     generalManageVault.type === VaultType.Earn ? <Card variant="faq">{guniFaq}</Card> : undefined
 
   return (
-    <Grid gap={0} sx={{ width: '100%' }}>
-      <VaultNoticesView id={vault.id} />
-      <Box sx={{ zIndex: 0, mt: 4 }}>{headlineElement}</Box>
-      <GeneralManageTabBar
-        positionInfo={positionInfo}
-        generalManageVault={generalManageVault}
-        showAutomationTabs={showAutomationTabs}
-        protectionEnabled={protectionEnabled}
-        optimizationEnabled={optimizationEnabled}
-      />
-    </Grid>
+    <StopLossContextProvider machine={stopLossStateMachine}>
+      <Grid gap={0} sx={{ width: '100%' }}>
+        <VaultNoticesView id={vault.id} />
+        <Box sx={{ zIndex: 0, mt: 4 }}>{headlineElement}</Box>
+        <GeneralManageTabBar
+          positionInfo={positionInfo}
+          generalManageVault={generalManageVault}
+          showAutomationTabs={showAutomationTabs}
+          protectionEnabled={protectionEnabled}
+          optimizationEnabled={optimizationEnabled}
+        />
+      </Grid>
+    </StopLossContextProvider>
   )
 }

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -85,7 +85,7 @@ export function GeneralManageLayout({ generalManageVault }: GeneralManageLayoutP
     generalManageVault.type === VaultType.Earn ? <Card variant="faq">{guniFaq}</Card> : undefined
 
   return (
-    <StopLossContextProvider machine={stopLossStateMachine}>
+    <StopLossContextProvider machine={stopLossStateMachine} commonData={{ debt: vault.debt }}>
       <Grid gap={0} sx={{ width: '100%' }}>
         <VaultNoticesView id={vault.id} />
         <Box sx={{ zIndex: 0, mt: 4 }}>{headlineElement}</Box>

--- a/components/vault/GeneralManageTabBar.tsx
+++ b/components/vault/GeneralManageTabBar.tsx
@@ -1,3 +1,4 @@
+import { useActor } from '@xstate/react'
 import {
   AutomationEventIds,
   CommonAnalyticsSections,
@@ -5,7 +6,9 @@ import {
   trackingEvents,
 } from 'analytics/analytics'
 import { useAppContext } from 'components/AppContextProvider'
+import { useAutomationContext } from 'components/AutomationContextProvider'
 import { TabBar } from 'components/TabBar'
+import { useStopLossContext } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
 import { GeneralManageVaultViewAutomation } from 'features/generalManageVault/GeneralManageVaultView'
 import { TAB_CHANGE_SUBJECT, TabChange } from 'features/generalManageVault/TabChange'
@@ -52,6 +55,9 @@ export function GeneralManageTabBar({
   const { uiChanges } = useAppContext()
   const { t } = useTranslation()
   const autoBSEnabled = useFeatureToggle('BasicBS')
+  const { stateMachine } = useStopLossContext()
+  const [, send] = useActor(stateMachine)
+  const automationContext = useAutomationContext()
 
   useEffect(() => {
     const uiChanges$ = uiChanges.subscribe<TabChange>(TAB_CHANGE_SUBJECT)
@@ -67,6 +73,14 @@ export function GeneralManageTabBar({
     vaultId: vault.id.toString(),
     ilk: vault.ilk,
   }
+
+  // PUSH AUTOMATION DATA TO STOP LOSS STATE MACHINE
+  const debt = generalManageVault.state.vault.debt
+  useEffect(() => {
+    console.log('HEEREEE')
+    send({ type: 'loadAutomationData', data: automationContext })
+    send({ type: 'loadCommonData', data: { debt } })
+  }, [automationContext, debt.toString()])
 
   return (
     <TabBar

--- a/components/vault/GeneralManageTabBar.tsx
+++ b/components/vault/GeneralManageTabBar.tsx
@@ -1,4 +1,3 @@
-import { useActor } from '@xstate/react'
 import {
   AutomationEventIds,
   CommonAnalyticsSections,
@@ -6,9 +5,7 @@ import {
   trackingEvents,
 } from 'analytics/analytics'
 import { useAppContext } from 'components/AppContextProvider'
-import { useAutomationContext } from 'components/AutomationContextProvider'
 import { TabBar } from 'components/TabBar'
-import { useStopLossContext } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
 import { GeneralManageVaultViewAutomation } from 'features/generalManageVault/GeneralManageVaultView'
 import { TAB_CHANGE_SUBJECT, TabChange } from 'features/generalManageVault/TabChange'
@@ -55,9 +52,6 @@ export function GeneralManageTabBar({
   const { uiChanges } = useAppContext()
   const { t } = useTranslation()
   const autoBSEnabled = useFeatureToggle('BasicBS')
-  const { stateMachine } = useStopLossContext()
-  const [, send] = useActor(stateMachine)
-  const automationContext = useAutomationContext()
 
   useEffect(() => {
     const uiChanges$ = uiChanges.subscribe<TabChange>(TAB_CHANGE_SUBJECT)
@@ -73,14 +67,6 @@ export function GeneralManageTabBar({
     vaultId: vault.id.toString(),
     ilk: vault.ilk,
   }
-
-  // PUSH AUTOMATION DATA TO STOP LOSS STATE MACHINE
-  const debt = generalManageVault.state.vault.debt
-  useEffect(() => {
-    console.log('HEEREEE')
-    send({ type: 'loadAutomationData', data: automationContext })
-    send({ type: 'loadCommonData', data: { debt } })
-  }, [automationContext, debt.toString()])
 
   return (
     <TabBar

--- a/features/automation/common/controls/AddAndRemoveTriggerControl.tsx
+++ b/features/automation/common/controls/AddAndRemoveTriggerControl.tsx
@@ -15,6 +15,7 @@ import {
 import { AutomationPublishType, SidebarAutomationStages } from 'features/automation/common/types'
 import { AutoTakeProfitResetData } from 'features/automation/optimization/autoTakeProfit/state/autoTakeProfitFormChange'
 import { StopLossResetData } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
+import { TxDetails } from 'features/automation/protection/stopLoss/state/stopLossStateMachine'
 import { addTransactionMap, TX_DATA_CHANGE } from 'helpers/gasEstimate'
 import { ReactElement, useEffect } from 'react'
 
@@ -42,6 +43,7 @@ interface AddAndRemoveTriggerControlProps {
   ) => ReactElement
   vault: Vault
   analytics: AutomationTxHandlerAnalytics
+  xstateSend?: (txDetails: TxDetails) => void
 }
 
 export function AddAndRemoveTriggerControl({
@@ -61,6 +63,7 @@ export function AddAndRemoveTriggerControl({
   txHelpers,
   vault,
   analytics,
+  xstateSend,
 }: AddAndRemoveTriggerControlProps) {
   const { uiChanges } = useAppContext()
 
@@ -81,6 +84,7 @@ export function AddAndRemoveTriggerControl({
     ilk: vault.ilk,
     collateralizationRatio: vault.collateralizationRatio,
     analytics,
+    xstateSend,
   })
 
   useEffect(() => {

--- a/features/automation/common/state/automationFeatureTxHandlers.ts
+++ b/features/automation/common/state/automationFeatureTxHandlers.ts
@@ -18,6 +18,7 @@ import {
   removeAutomationTrigger,
 } from 'features/automation/api/automationTxHandlers'
 import { AutomationPublishType, SidebarAutomationStages } from 'features/automation/common/types'
+import { TxDetails } from 'features/automation/protection/stopLoss/state/stopLossStateMachine'
 import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { useMemo } from 'react'
 
@@ -57,6 +58,7 @@ interface GetAutomationFeatureTxHandlersParams {
   ilk: string
   analytics: AutomationTxHandlerAnalytics
   txHelpers?: TxHelpers
+  xstateSend?: (txDetails: TxDetails) => void
 }
 
 interface AutomationFeatureTxHandlers {
@@ -82,8 +84,10 @@ export function getAutomationFeatureTxHandlers({
   ilk,
   collateralizationRatio,
   analytics,
+  xstateSend,
 }: GetAutomationFeatureTxHandlersParams): AutomationFeatureTxHandlers {
   const { uiChanges } = useAppContext()
+
   const triggerEnabled = !!triggersId.filter((item) => item).length
 
   const analyticsAdditionalParams = {
@@ -123,7 +127,14 @@ export function getAutomationFeatureTxHandlers({
         options?.callOnSuccess && options.callOnSuccess()
       } else {
         if (isAddForm) {
-          addAutomationTrigger(txHelpers, addTxData, uiChanges, ethMarketPrice, publishType)
+          addAutomationTrigger(
+            txHelpers,
+            addTxData,
+            uiChanges,
+            ethMarketPrice,
+            publishType,
+            xstateSend,
+          )
 
           trackingEvents.automation.buttonClick(
             triggerEnabled ? analytics.id.edit : analytics.id.add,
@@ -133,7 +144,14 @@ export function getAutomationFeatureTxHandlers({
           )
         }
         if (isRemoveForm) {
-          removeAutomationTrigger(txHelpers, removeTxData, uiChanges, ethMarketPrice, publishType)
+          removeAutomationTrigger(
+            txHelpers,
+            removeTxData,
+            uiChanges,
+            ethMarketPrice,
+            publishType,
+            xstateSend,
+          )
 
           trackingEvents.automation.buttonClick(
             analytics.id.remove,

--- a/features/automation/protection/stopLoss/StopLossContextProvider.tsx
+++ b/features/automation/protection/stopLoss/StopLossContextProvider.tsx
@@ -1,0 +1,33 @@
+import { useInterpret } from '@xstate/react'
+import { StopLossStateMachine } from 'features/automation/protection/stopLoss/state/stopLossStateMachine'
+import { WithChildren } from 'helpers/types'
+import { env } from 'process'
+import React, { createContext, useContext } from 'react'
+
+export const stopLossContext = createContext<StopLossStateMachineContext | undefined>(undefined)
+
+function setupStopLossStateContext({ machine }: { machine: StopLossStateMachine }) {
+  const stateMachine = useInterpret(machine, { devTools: env.NODE_ENV !== 'production' }).start()
+  return {
+    stateMachine,
+  }
+}
+
+export type StopLossStateMachineContext = ReturnType<typeof setupStopLossStateContext>
+
+export function useStopLossContext(): StopLossStateMachineContext {
+  const context = useContext(stopLossContext)
+  if (!context) {
+    throw new Error('useStopLossContext must be used within a StopLossContextProvider')
+  }
+  return context
+}
+
+export function StopLossContextProvider({
+  children,
+  machine,
+}: WithChildren & { machine: StopLossStateMachine }) {
+  const stateMachine = useInterpret(machine, { devTools: env.NODE_ENV !== 'production' }).start()
+
+  return <stopLossContext.Provider value={{ stateMachine }}>{children}</stopLossContext.Provider>
+}

--- a/features/automation/protection/stopLoss/StopLossContextProvider.tsx
+++ b/features/automation/protection/stopLoss/StopLossContextProvider.tsx
@@ -35,10 +35,12 @@ export function StopLossContextProvider({
   const [, send] = useActor(stateMachine)
 
   // PUSH DEPENDENCIES TO MACHINE
+  // MOST LIKELY SHOULD BE CONVERTED TO ACTORS AND SPAWN IN STOP LOSS MACHINE WITH THEIR CONTEXT
   useEffect(() => {
     send({ type: 'loadAutomationData', data: automationContext })
     send({ type: 'loadCommonData', data: { debt: commonData.debt } })
   }, [automationContext, commonData.debt.toString()])
 
+  // GIVEN EXAMPLE DOES NOT INCLUDE HANDLING FOR DEFAULT FORM STATE WHEN TRIGGER IS NOT CREATED YET
   return <stopLossContext.Provider value={{ stateMachine }}>{children}</stopLossContext.Provider>
 }

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -6,7 +6,11 @@ import { IlkData } from 'blockchain/ilks'
 import { Context } from 'blockchain/network'
 import { Vault } from 'blockchain/vaults'
 import { TxHelpers } from 'components/AppContext'
-import { CloseVaultToEnum, MAX_DEBT_FOR_SETTING_STOP_LOSS } from 'features/automation/common/consts'
+import {
+  CloseVaultToEnum,
+  failedStatuses,
+  MAX_DEBT_FOR_SETTING_STOP_LOSS,
+} from 'features/automation/common/consts'
 import { AddAndRemoveTriggerControl } from 'features/automation/common/controls/AddAndRemoveTriggerControl'
 import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
 import { getAutomationFeatureStatus } from 'features/automation/common/state/automationFeatureStatus'
@@ -135,6 +139,9 @@ export function StopLossFormControl({
         send({ type: 'updateTxDetails', value: txDetails })
         if (txDetails.txStatus === TxStatus.Success) {
           send({ type: 'success' })
+        }
+        if (failedStatuses.includes(txDetails.txStatus!)) {
+          send({ type: 'txError' })
         }
       }}
     >

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -1,3 +1,5 @@
+import { TxStatus } from '@oasisdex/transactions'
+import { useActor } from '@xstate/react'
 import { AutomationEventIds, Pages } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
 import { IlkData } from 'blockchain/ilks'
@@ -18,6 +20,7 @@ import {
 import { getStopLossStatus } from 'features/automation/protection/stopLoss/state/stopLossStatus'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { getStopLossTxHandlers } from 'features/automation/protection/stopLoss/state/stopLossTxHandlers'
+import { useStopLossContext } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { VaultType } from 'features/generalManageVault/vaultType'
 import { BalanceInfo } from 'features/shared/balanceInfo'
 import { PriceInfo } from 'features/shared/priceInfo'
@@ -58,6 +61,8 @@ export function StopLossFormControl({
   vaultType,
 }: StopLossFormControlProps) {
   const [stopLossState] = useUIChanges<StopLossFormChange>(STOP_LOSS_FORM_CHANGE)
+  const { stateMachine } = useStopLossContext()
+  const [, send] = useActor(stateMachine)
 
   const feature = AutomationFeatures.STOP_LOSS
   const {
@@ -125,6 +130,12 @@ export function StopLossFormControl({
             ? CloseVaultToEnum.COLLATERAL
             : CloseVaultToEnum.DAI,
         },
+      }}
+      xstateSend={(txDetails) => {
+        send({ type: 'updateTxDetails', value: txDetails })
+        if (txDetails.txStatus === TxStatus.Success) {
+          send({ type: 'success' })
+        }
       }}
     >
       {(textButtonHandler, txHandler) => (

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@theme-ui/components'
+import { useActor } from '@xstate/react'
 import {
   AutomationEventIds,
   CommonAnalyticsSections,
@@ -31,6 +32,7 @@ import {
   StopLossFormChange,
 } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { useStopLossContext } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { formatAmount, formatFiatBalance } from 'helpers/formatters/format'
@@ -158,6 +160,8 @@ export function SidebarAdjustStopLossEditingStage({
 }: SidebarAdjustStopLossEditingStageProps) {
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
+  const { stateMachine } = useStopLossContext()
+  const [, send] = useActor(stateMachine)
 
   useDebouncedCallback(
     (value) =>
@@ -231,6 +235,7 @@ export function SidebarAdjustStopLossEditingStage({
                   type: 'stop-loss-level',
                   stopLossLevel: initialSlRatioWhenTriggerDoesntExist,
                 })
+                send({ type: 'reset' })
               }}
             />
           )}

--- a/features/automation/protection/stopLoss/state/stopLossStateMachine.ts
+++ b/features/automation/protection/stopLoss/state/stopLossStateMachine.ts
@@ -101,15 +101,15 @@ export const stopLossStateMachine =
             txError: {
               target: 'formStage',
             },
-            updateTxDetails: {
-              actions: 'assignTxDetails',
-            },
             success: {
               target: 'txSuccess',
               cond: 'txSucceed',
             },
             loadAutomationData: {
               actions: 'assignAutomationContext',
+            },
+            updateTxDetails: {
+              actions: 'assignTxDetails',
             },
           },
         },

--- a/features/automation/protection/stopLoss/state/stopLossStateMachine.ts
+++ b/features/automation/protection/stopLoss/state/stopLossStateMachine.ts
@@ -1,0 +1,166 @@
+import { TxStatus } from '@oasisdex/transactions'
+import BigNumber from 'bignumber.js'
+import { AutomationContext } from 'components/AutomationContextProvider'
+import { AutomationFormType } from 'features/automation/common/state/automationFeatureChange'
+import { errorsStopLossValidation } from 'features/automation/protection/stopLoss/validators'
+import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
+import { TxError } from 'helpers/types'
+import { assign, createMachine } from 'xstate'
+
+function canSubmit(context: StopLossStateMachineContext) {
+  const errors = errorsStopLossValidation({
+    txError: context.txDetails?.txError,
+    debt: context.commonData.debt,
+    stopLossLevel: context.triggerLevel,
+    autoBuyTriggerData: context.automationContext.autoBuyTriggerData,
+  })
+  return errors.length === 0
+}
+
+function txSucceed(context: StopLossStateMachineContext) {
+  return context.txDetails?.txStatus === TxStatus.Success
+}
+
+export type TxDetails = {
+  txStatus?: TxStatus
+  txError?: TxError
+  txHash?: string
+  txCost?: BigNumber
+}
+interface CommonData {
+  debt: BigNumber
+}
+
+export interface StopLossStateMachineContext {
+  // automationContext & commonData most likely should be injected somehow
+  automationContext: AutomationContext
+  commonData: CommonData
+  triggerLevel: BigNumber
+  closeTo: CloseVaultTo
+  currentForm: AutomationFormType
+  txDetails: TxDetails
+}
+
+export const stopLossStateMachine =
+  /** @xstate-layout N4IgpgJg5mDOIC5QGUAuB7ADgGXbWAdAGboBOAtmgIYwDEANulRAIICuG5VqAlugHYARblQDaABgC6iUJjw9eAmSAAeiAMwAmcQQCc63boDs+owFYjAFksA2ADQgAnojOX1BAIzHxxzbo82AWYAvsEOaFi4+MRklKg0YLSwbABG5AoS0kggcrAKfPzKagg2AByanqVGVR5mFn6lHg7OCJpGHgSlNuIe7YZlHqXqoeEYOHiEJBTUdADGjLBgACroAMIAFlT8MJnKuflK2cVaZgSWHoPWZppePpbNiAC0HuqnuuXqXUPiZuLiNiMQBFxtEpnEErRSHAwKhdtl9opCkcNJpTppSo0bK8jOJNJYzPYnE9LKU9B50SSXqj9KVdIDgVFJrEZolYPQeBAwKQNlsdlI9vJEUUUUYziYbJZxEZNHjzA8EJ8CCY7mUjJ9zrZ6WNGTFpvE6LAAO4KWbrABisThskFBWFCs0Nk8+NxXXUrwltXl5MsSq0OJJll0FnU4mGYSB2omuvBdEYzFW6HI5AEwniVpyNsOoGOmnclnM0tKFhJ1LM8vxaMDMrqeLK4ksWsiUdQKgAkvwAAqkdBQKH4WgtgCipG7pHTCNtyIQRnMYtsDqDHnEpXxXrMeaGZSLNmqEqMAPDDObbc73d7cFgtDYmAg3GWKkEMKoPHosHHmaR2cQS-xBHR9fUHddDaLwjHLGVPA8Cshi6G590bEFCBbdsux7PtL2SWZZgvd88iFKcLiGAhAPKADgJ3UN5RAzpunJQtzi8F4EJ1ZDTzQi8GCYVgOETbgClTMR+XhD87XeH1bHaGwQMCf5dHlMwLgIGwsTcExrnrVwD1GJtohbZA2CwjiUioWYAGsVgtChcIOT9VEQLpHSxXRbCDco1Wc+Vnl-IZXD+dRAwMXxQnDfh0E5eBsiPUFmX1MABTwycvwQFzPDMFd-gUtV1Cgqj2k6fNyX+AqXn85jjxQs90Pimy7SXZcCFDF43ClKTJTkolWjyld2m0PcLjdBtD0jXSVH0wz8Gq-CkqgwD8tcINgxlMpco6brCr6krBu0xDJsSuzOoqfRDBMdQC2sQkWkeXMfRMWlenKXNzGC4IgA */
+  createMachine(
+    {
+      tsTypes: {} as import('./stopLossStateMachine.typegen').Typegen0,
+      schema: {
+        context: {} as StopLossStateMachineContext,
+        services: {} as {
+          getTriggerData: {
+            data: AutomationContext
+          }
+        },
+        events: {} as
+          | { type: 'submit' }
+          | { type: 'sliderChange'; value: BigNumber }
+          | { type: 'closeToChange'; value: CloseVaultTo }
+          | { type: 'switchForm'; value: 'add' | 'remove' }
+          | { type: 'reset' }
+          | { type: 'backToForm' }
+          | { type: 'success' }
+          | { type: 'retry' }
+          | { type: 'txError' }
+          | { type: 'loadAutomationData'; data: AutomationContext }
+          | { type: 'loadCommonData'; data: CommonData }
+          | { type: 'updateTxDetails'; value: TxDetails },
+      },
+      predictableActionArguments: true,
+      initial: 'formStage',
+      states: {
+        formStage: {
+          on: {
+            loadAutomationData: {
+              actions: 'assignAutomationContext',
+            },
+            submit: {
+              target: 'txInProgress',
+              cond: 'canSubmit',
+            },
+            closeToChange: {
+              actions: 'assignCloseTo',
+            },
+            reset: {
+              actions: 'assignDefaults',
+            },
+            sliderChange: {
+              actions: 'assignTriggerLevel',
+            },
+            switchForm: {
+              actions: 'assignCurrentForm',
+            },
+            loadCommonData: {
+              actions: 'assignCommonData',
+            },
+          },
+        },
+        txInProgress: {
+          on: {
+            txError: {
+              target: 'formStage',
+            },
+            updateTxDetails: {
+              actions: 'assignTxDetails',
+            },
+            success: {
+              target: 'txSuccess',
+              cond: 'txSucceed',
+            },
+            loadAutomationData: {
+              actions: 'assignAutomationContext',
+            },
+          },
+        },
+        txSuccess: {
+          on: {
+            backToForm: {
+              target: 'formStage',
+            },
+          },
+        },
+      },
+      id: 'StopLoss',
+    },
+    {
+      actions: {
+        assignAutomationContext: assign((_, event) => ({
+          automationContext: event.data,
+          triggerLevel: event.data.stopLossTriggerData.stopLossLevel,
+          closeTo: (event.data.stopLossTriggerData.isToCollateral
+            ? 'collateral'
+            : 'dai') as CloseVaultTo,
+          currentForm: 'add' as AutomationFormType,
+        })),
+        assignCommonData: assign((_, event) => ({
+          commonData: event.data,
+        })),
+        assignCloseTo: assign((_, event) => ({
+          closeTo: event.value,
+        })),
+        assignTriggerLevel: assign((_, event) => ({
+          triggerLevel: event.value,
+        })),
+        assignDefaults: assign((context) => ({
+          triggerLevel: context.automationContext.stopLossTriggerData.stopLossLevel,
+          closeTo: (context.automationContext.stopLossTriggerData.isToCollateral
+            ? 'collateral'
+            : 'dai') as CloseVaultTo,
+          currentForm: 'add' as AutomationFormType,
+        })),
+        assignCurrentForm: assign((_, event) => ({
+          currentForm: event.value,
+        })),
+        assignTxDetails: assign((_, event) => ({
+          txDetails: event.value,
+        })),
+      },
+      guards: {
+        canSubmit,
+        txSucceed,
+      },
+    },
+  )
+
+export type StopLossStateMachine = typeof stopLossStateMachine

--- a/features/automation/protection/stopLoss/state/stopLossStatus.ts
+++ b/features/automation/protection/stopLoss/state/stopLossStatus.ts
@@ -1,3 +1,4 @@
+import { useActor } from '@xstate/react'
 import {
   AutomationEventIds,
   CommonAnalyticsSections,
@@ -28,6 +29,7 @@ import {
   StopLossResetData,
 } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { useStopLossContext } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
 
 interface GetStopLossStatusParams {
@@ -64,6 +66,8 @@ export function getStopLossStatus({
   ilkData,
 }: GetStopLossStatusParams): StopLossStatus {
   const { uiChanges } = useAppContext()
+  const { stateMachine } = useStopLossContext()
+  const [, send] = useActor(stateMachine)
 
   const isEditing = checkIfIsEditingStopLoss({
     isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
@@ -111,6 +115,7 @@ export function getStopLossStatus({
         type: 'close-type',
         toCollateral: optionName === closeVaultOptions[0],
       })
+      send({ type: 'closeToChange', value: optionName as CloseVaultTo })
       trackingEvents.automation.buttonClick(
         AutomationEventIds.CloseToX,
         Pages.StopLoss,

--- a/features/automation/protection/stopLoss/state/stopLossTxHandlers.ts
+++ b/features/automation/protection/stopLoss/state/stopLossTxHandlers.ts
@@ -1,4 +1,5 @@
 import { TxStatus } from '@oasisdex/transactions'
+import { useActor } from '@xstate/react'
 import { AutomationBotAddTriggerData } from 'blockchain/calls/automationBot'
 import { Vault } from 'blockchain/vaults'
 import { useAppContext } from 'components/AppContextProvider'
@@ -10,6 +11,7 @@ import {
   prepareAddStopLossTriggerData,
   StopLossTriggerData,
 } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
+import { useStopLossContext } from 'features/automation/protection/stopLoss/StopLossContextProvider'
 import { zero } from 'helpers/zero'
 import { useMemo } from 'react'
 
@@ -33,6 +35,8 @@ export function getStopLossTxHandlers({
   isAddForm,
 }: GetStopLossTxHandlersParams): StopLossTxHandlers {
   const { uiChanges } = useAppContext()
+  const { stateMachine } = useStopLossContext()
+  const [, send] = useActor(stateMachine)
 
   const addTxData = useMemo(
     () =>
@@ -56,6 +60,7 @@ export function getStopLossTxHandlers({
         stopLossLevel: zero,
       })
     }
+    send({ type: 'switchForm', value: isAddForm ? 'remove' : 'add' })
   }
 
   return {


### PR DESCRIPTION
# [Stop loss with attached xstate events](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- created stop loss state machine and attached events to ui changes publish events to monitor how state machine changes over time
  
## How to test 🧪
  <Please explain how to test your changes>

- run it locally and do action within stop loss form (given example is based on trigger that already exists and user perform updates, testing it in different scenarios wont work because default form state (mapping) have not been implemented)

## State machine
![image](https://user-images.githubusercontent.com/39706811/198053891-b9d1eddf-0a42-41f1-a538-face9ffe513a.png)

- `loadCommonData` and `loadAutomationData` events most likely should be converted to separate state machines (actors) and spawned with their context in `stop loss state machine`. Still I'm not sure how for example `loadAutomationData` would maintain refresh of data when triggers is updated without `send`ing specific event to update its context (as I did in `stop loss machine` with events described above). I tried using services to invoke some asynchronous code but because of that state machine was changing constantly with resulted in warnings in console - `react_devtools_backend.js:4026 Machine given to 'useMachine' has changed between renders. This is not supported and might lead to unexpected results.`. 
