### PR TITLE
🧭 Support timeAgo in Discovery liquidation status

### DIFF
--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -4,12 +4,12 @@ import BigNumber from 'bignumber.js'
 import { AppLink } from 'components/Links'
 import { DiscoverTableDataCellPill } from 'features/discover/common/DiscoverTableDataCellPill'
 import { discoverFiltersAssetItems } from 'features/discover/filters'
+import { parsePillAdditionalData } from 'features/discover/helpers'
 import { DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Button, Flex, Text } from 'theme-ui'
-import { timeAgo } from 'utils'
 
 export function DiscoverTableDataCellContent({
   kind,
@@ -46,23 +46,17 @@ export function DiscoverTableDataCellContent({
     case 'status':
       return (
         <DiscoverTableDataCellPill status={row.status?.kind}>
-          {t(`discover.table.status.${row.status?.kind}`, { ...row.status?.additionalData })}
+          {t(`discover.table.status.${row.status?.kind}`, {
+            ...parsePillAdditionalData(i18n.language, row.status),
+          })}
         </DiscoverTableDataCellPill>
       )
     case 'activity':
-      const additionalData = {
-        ...row.activity?.additionalData,
-        ...(row.activity?.additionalData?.timestamp && {
-          timeAgo: timeAgo({
-            lang: i18n.language,
-            to: new Date(row.activity?.additionalData?.timestamp),
-          }),
-        }),
-      }
-
       return (
         <DiscoverTableDataCellPill activity={row.activity?.kind}>
-          {t(`discover.table.activity.${row.activity?.kind}`, { ...additionalData })}
+          {t(`discover.table.activity.${row.activity?.kind}`, {
+            ...parsePillAdditionalData(i18n.language, row.activity),
+          })}
         </DiscoverTableDataCellPill>
       )
     case 'cdpId':

--- a/features/discover/helpers.ts
+++ b/features/discover/helpers.ts
@@ -1,6 +1,12 @@
 import { Pages } from 'analytics/analytics'
 import { DiscoverFiltersList } from 'features/discover/meta'
-import { DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
+import {
+  DiscoverPages,
+  DiscoverTableActivityRowData,
+  DiscoverTableRowData,
+  DiscoverTableStatusRowData,
+} from 'features/discover/types'
+import { timeAgo } from 'utils'
 
 export const DISCOVER_URL = '/discover'
 
@@ -34,4 +40,19 @@ export function getDefaultSettingsState({
 
 export function getRowKey(i: number, row: DiscoverTableRowData) {
   return [...(row.asset ? [row.asset] : []), ...(row.cdpId ? [row.cdpId] : []), i].join('-')
+}
+
+export function parsePillAdditionalData(
+  lang: string,
+  content?: DiscoverTableActivityRowData | DiscoverTableStatusRowData,
+) {
+  return {
+    ...content?.additionalData,
+    ...(content?.additionalData?.timestamp && {
+      timeAgo: timeAgo({
+        lang,
+        to: new Date(Number(content.additionalData?.timestamp)),
+      }),
+    }),
+  }
 }

--- a/features/discover/types.ts
+++ b/features/discover/types.ts
@@ -31,27 +31,34 @@ export interface DiscoverFiltersSettings {
   [key: string]: string
 }
 
+export type DiscoverTableColRatioRowData = {
+  level: number
+  isAtRiskDanger: boolean
+  isAtRiskWarning: boolean
+}
+
+export type DiscoverTableActivityRowData = {
+  kind: DiscoverTableVaultActivity
+  additionalData?: {
+    timestamp?: number
+  }
+}
+
+export type DiscoverTableStatusRowData = {
+  kind: DiscoverTableVaultStatus
+  additionalData?: {
+    timestamp?: number
+    tillLiquidation?: number
+    toStopLoss?: number
+  }
+}
+
 export type DiscoverTableRowData = {
   [key: string]: string | number
 } & {
-  colRatio?: {
-    level: number
-    isAtRiskDanger: boolean
-    isAtRiskWarning: boolean
-  }
+  colRatio?: DiscoverTableColRatioRowData
 } & {
-  activity?: {
-    kind: DiscoverTableVaultActivity
-    additionalData?: {
-      timestamp?: number
-    }
-  }
+  activity?: DiscoverTableActivityRowData
 } & {
-  status?: {
-    kind: DiscoverTableVaultStatus
-    additionalData?: {
-      tillLiquidation?: number
-      toStopLoss?: number
-    }
-  }
+  status?: DiscoverTableStatusRowData
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -177,7 +177,7 @@
         "vault-debt": "Vault debt"
       },
       "status": {
-        "1": "Liquidated",
+        "1": "Liquidated {{timeAgo}}",
         "2": "Being liquidated",
         "3": "{{tillLiquidation}}% till liquidation",
         "4": "{{toStopLoss}}% to Stop-loss",

--- a/public/mocks/discover/highest-risk-positions.json
+++ b/public/mocks/discover/highest-risk-positions.json
@@ -6,7 +6,10 @@
       "nextOsmPrice": 1326.9,
       "maxLiquidationAmount": 353422.43,
       "status": {
-        "kind": 1
+        "kind": 1,
+        "additionalData": {
+          "timestamp": 1666876948181
+        }
       },
       "cdpId": 18604
     },

--- a/public/mocks/discover/largest-debt.json
+++ b/public/mocks/discover/largest-debt.json
@@ -60,7 +60,7 @@
       "activity": {
         "kind": 6,
         "additionalData": {
-          "timestamp": 1666579801018
+          "timestamp": 1666876905464
         }
       },
       "cdpId": 24985


### PR DESCRIPTION
# 🧭 Support `timeAgo` in Discover liquidation status

![image](https://user-images.githubusercontent.com/16230404/198297655-8fe7a624-1059-4fa5-a70e-ceee1e620c2a.png)
  
## Changes 👷‍♀️

- Liquidated vault are displayed with pill explaining when it was liquidated.
  
## How to test 🧪

- See for `/discover/highest-risk-positions` if liquidated row contains time ago in its pill.
