### PR TITLE
🧭 Discover sticky filters

### DIFF
--- a/components/GenericSelect.tsx
+++ b/components/GenericSelect.tsx
@@ -117,6 +117,7 @@ export function GenericSelect({
     menuList: () => ({
       paddingTop: '12px',
       paddingBottom: '12px',
+      maxHeight: '340px',
     }),
     option: ({ isSelected }) => ({
       display: 'flex',

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -37,7 +37,7 @@ export function TableContainer({
       as="table"
     >
       <Box sx={{ display: ['none', 'table-header-group'] }} as="thead">
-        <Box as="tr">{header}</Box>
+        <tr>{header}</tr>
       </Box>
       <Box sx={{ width: '100%' }} as="tbody">
         {children}

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -29,7 +29,7 @@ export function DiscoverData({
   const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
 
   return (
-    <Box sx={{ position: 'relative', borderTop: '1px solid', borderTopColor: 'neutral20' }}>
+    <Box sx={{ position: 'relative' }}>
       {response?.rows ? (
         <>
           {isLoading && <DiscoverPreloader isContentLoaded={true} />}

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -11,10 +11,10 @@ import { Box } from 'theme-ui'
 
 interface DiscoverDataProps {
   banner?: DiscoverBanner
-  response?: DiscoverDataResponse
   isLoading: boolean
   isSmallerScreen: boolean
   kind: DiscoverPages
+  response?: DiscoverDataResponse
   userContext: MixpanelUserContext
 }
 

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -7,14 +7,13 @@ import { DiscoverTable } from 'features/discover/common/DiscoverTable'
 import { DiscoverBanner } from 'features/discover/meta'
 import { DiscoverPages } from 'features/discover/types'
 import React from 'react'
-import { theme } from 'theme'
 import { Box } from 'theme-ui'
-import { useMediaQuery } from 'usehooks-ts'
 
 interface DiscoverDataProps {
   banner?: DiscoverBanner
   response?: DiscoverDataResponse
   isLoading: boolean
+  isSmallerScreen: boolean
   kind: DiscoverPages
   userContext: MixpanelUserContext
 }
@@ -22,12 +21,11 @@ interface DiscoverDataProps {
 export function DiscoverData({
   banner,
   isLoading,
+  isSmallerScreen,
   kind,
   response,
   userContext,
 }: DiscoverDataProps) {
-  const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
-
   return (
     <Box sx={{ position: 'relative' }}>
       {response?.rows ? (

--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -11,7 +11,19 @@ export function DiscoverFilters({
   onChange: (key: string, currentValue: DiscoverFiltersListItem) => void
 }) {
   return (
-    <Box sx={{ p: ['24px', null, null, 4] }}>
+    <Box
+      sx={{
+        position: 'sticky',
+        top: 0,
+        p: ['24px', null, null, 4],
+        backgroundColor: 'neutral10',
+        borderBottom: '1px solid',
+        borderBottomColor: 'neutral20',
+        borderTopLeftRadius: 'large',
+        borderTopRightRadius: 'large',
+        zIndex: 2,
+      }}
+    >
       <Grid
         gap="12px"
         sx={{

--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -5,16 +5,20 @@ import { Box, Grid } from 'theme-ui'
 
 export function DiscoverFilters({
   filters,
+  isSmallerScreen,
   onChange,
 }: {
   filters: DiscoverFiltersList
+  isSmallerScreen: boolean
   onChange: (key: string, currentValue: DiscoverFiltersListItem) => void
 }) {
   return (
     <Box
       sx={{
-        position: 'sticky',
-        top: 0,
+        ...(!isSmallerScreen && {
+          position: 'sticky',
+          top: 0,
+        }),
         p: ['24px', null, null, 4],
         backgroundColor: 'neutral10',
         borderBottom: '1px solid',

--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -4,10 +4,12 @@ import React from 'react'
 import { Box, Grid } from 'theme-ui'
 
 export function DiscoverFilters({
+  amountOfRows,
   filters,
   isSmallerScreen,
   onChange,
 }: {
+  amountOfRows: number
   filters: DiscoverFiltersList
   isSmallerScreen: boolean
   onChange: (key: string, currentValue: DiscoverFiltersListItem) => void
@@ -16,7 +18,7 @@ export function DiscoverFilters({
     <Box
       sx={{
         ...(!isSmallerScreen && {
-          position: 'sticky',
+          position: amountOfRows > 2 ? 'sticky' : 'relative',
           top: 0,
         }),
         p: ['24px', null, null, 4],

--- a/features/discover/common/DiscoverPreloader.tsx
+++ b/features/discover/common/DiscoverPreloader.tsx
@@ -1,24 +1,27 @@
 import { AppSpinner } from 'helpers/AppSpinner'
 import React from 'react'
+import { Box } from 'theme-ui'
 
 export function DiscoverPreloader({ isContentLoaded }: { isContentLoaded: boolean }) {
   return (
-    <AppSpinner
-      sx={{
-        mx: 'auto',
-        ...(isContentLoaded
-          ? {
-              position: 'absolute',
-              top: '80px',
-              right: 0,
-              left: 0,
-              my: 'auto',
-            }
-          : {
-              my: ['24px', null, null, 4],
-            }),
-      }}
-      variant="extraLarge"
-    />
+    <Box sx={{ position: 'sticky', top: '120px', zIndex: 1 }}>
+      <AppSpinner
+        sx={{
+          mx: 'auto',
+          ...(isContentLoaded
+            ? {
+                position: 'absolute',
+                top: '80px',
+                right: 0,
+                left: 0,
+                my: 'auto',
+              }
+            : {
+                my: ['24px', null, null, 4],
+              }),
+        }}
+        variant="extraLarge"
+      />
+    </Box>
   )
 }

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -44,26 +44,11 @@ export function DiscoverTable({
             position: 'sticky',
             zIndex: 1,
             top: '120px',
-            '&::before, &::after': {
-              content: '""',
-              position: 'absolute',
-              left: -4,
-              right: -4,
-              bottom: 0,
-            },
-            '&::before': {
-              top: 0,
-              backgroundColor: 'neutral10',
-            },
-            '&::after': {
-              height: '1px',
-              backgroundColor: 'neutral20',
-            },
           }}
         >
-          <Box as="tr" sx={{ position: 'relative', zIndex: 2 }}>
+          <Box as="tr">
             {Object.keys(rows[0]).map((label, i) => (
-              <DiscoverTableHeaderCell key={getRowKey(i, rows[0])} label={label} />
+              <DiscoverTableHeaderCell key={getRowKey(i, rows[0])} first={i === 0} label={label} />
             ))}
           </Box>
         </Box>
@@ -93,7 +78,7 @@ export function DiscoverTable({
   )
 }
 
-export function DiscoverTableHeaderCell({ label }: { label: string }) {
+export function DiscoverTableHeaderCell({ first, label }: { first: boolean; label: string }) {
   const { t } = useTranslation()
 
   return (
@@ -101,6 +86,7 @@ export function DiscoverTableHeaderCell({ label }: { label: string }) {
       as="th"
       sx={{
         px: '12px',
+        py: '20px',
         fontSize: 1,
         fontWeight: 'semiBold',
         color: 'neutral80',
@@ -112,7 +98,30 @@ export function DiscoverTableHeaderCell({ label }: { label: string }) {
         },
       }}
     >
-      {t(`discover.table.header.${kebabCase(label)}`)}
+      {first && (
+        <Box
+          sx={{
+            '&::before, &::after': {
+              content: '""',
+              position: 'absolute',
+              left: -4,
+              right: -4,
+              bottom: 0,
+            },
+            '&::before': {
+              top: 0,
+              backgroundColor: 'neutral10',
+            },
+            '&::after': {
+              height: '1px',
+              backgroundColor: 'neutral20',
+            },
+          }}
+        />
+      )}
+      <Box as="span" sx={{ position: 'relative' }}>
+        {t(`discover.table.header.${kebabCase(label)}`)}
+      </Box>
     </Box>
   )
 }

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -122,7 +122,7 @@ export function DiscoverTableHeaderCell({
             bottom: 0,
           },
           '&::before': {
-            top: 0,
+            top: -20,
             backgroundColor: 'neutral10',
           },
           '&::after': {

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -48,7 +48,7 @@ export function DiscoverTable({
             }),
           }}
         >
-          <Box as="tr">
+          <tr>
             {Object.keys(rows[0]).map((label, i) => (
               <DiscoverTableHeaderCell
                 key={getRowKey(i, rows[0])}
@@ -57,7 +57,7 @@ export function DiscoverTable({
                 label={label}
               />
             ))}
-          </Box>
+          </tr>
         </Box>
         <Box
           as="tbody"

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -41,9 +41,11 @@ export function DiscoverTable({
         <Box
           as="thead"
           sx={{
-            position: 'sticky',
-            zIndex: 1,
-            top: '120px',
+            ...(rows.length > 2 && {
+              position: 'sticky',
+              zIndex: 1,
+              top: '120px',
+            }),
           }}
         >
           <Box as="tr">

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -122,7 +122,7 @@ export function DiscoverTableHeaderCell({
             bottom: 0,
           },
           '&::before': {
-            top: -20,
+            top: '-20px',
             backgroundColor: 'neutral10',
           },
           '&::after': {

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -48,7 +48,12 @@ export function DiscoverTable({
         >
           <Box as="tr">
             {Object.keys(rows[0]).map((label, i) => (
-              <DiscoverTableHeaderCell key={getRowKey(i, rows[0])} first={i === 0} label={label} />
+              <DiscoverTableHeaderCell
+                key={getRowKey(i, rows[0])}
+                first={i === 0}
+                last={i + 1 === Object.keys(rows[0]).length}
+                label={label}
+              />
             ))}
           </Box>
         </Box>
@@ -78,13 +83,22 @@ export function DiscoverTable({
   )
 }
 
-export function DiscoverTableHeaderCell({ first, label }: { first: boolean; label: string }) {
+export function DiscoverTableHeaderCell({
+  first,
+  last,
+  label,
+}: {
+  first: boolean
+  last: boolean
+  label: string
+}) {
   const { t } = useTranslation()
 
   return (
     <Box
       as="th"
       sx={{
+        position: 'relative',
         px: '12px',
         py: '20px',
         fontSize: 1,
@@ -98,27 +112,25 @@ export function DiscoverTableHeaderCell({ first, label }: { first: boolean; labe
         },
       }}
     >
-      {first && (
-        <Box
-          sx={{
-            '&::before, &::after': {
-              content: '""',
-              position: 'absolute',
-              left: -4,
-              right: -4,
-              bottom: 0,
-            },
-            '&::before': {
-              top: 0,
-              backgroundColor: 'neutral10',
-            },
-            '&::after': {
-              height: '1px',
-              backgroundColor: 'neutral20',
-            },
-          }}
-        />
-      )}
+      <Box
+        sx={{
+          '&::before, &::after': {
+            content: '""',
+            position: 'absolute',
+            left: first ? -4 : 0,
+            right: last ? -4 : 0,
+            bottom: 0,
+          },
+          '&::before': {
+            top: 0,
+            backgroundColor: 'neutral10',
+          },
+          '&::after': {
+            height: '1px',
+            backgroundColor: 'neutral20',
+          },
+        }}
+      />
       <Box as="span" sx={{ position: 'relative' }}>
         {t(`discover.table.header.${kebabCase(label)}`)}
       </Box>

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -28,15 +28,7 @@ export function DiscoverTable({
         position: 'relative',
         px: ['24px', null, null, 4],
         pb: 1,
-        '&::before': {
-          content: '""',
-          position: 'absolute',
-          top: '51px',
-          left: 0,
-          right: 0,
-          height: '1px',
-          backgroundColor: 'neutral20',
-        },
+        mt: '-20px',
       }}
     >
       <Box
@@ -46,17 +38,38 @@ export function DiscoverTable({
           borderSpacing: '0 20px',
         }}
       >
-        <Box as="thead">
-          <tr>
+        <Box
+          as="thead"
+          sx={{
+            position: 'sticky',
+            zIndex: 1,
+            top: '120px',
+            '&::before, &::after': {
+              content: '""',
+              position: 'absolute',
+              left: -4,
+              right: -4,
+              bottom: 0,
+            },
+            '&::before': {
+              top: 0,
+              backgroundColor: 'neutral10',
+            },
+            '&::after': {
+              height: '1px',
+              backgroundColor: 'neutral20',
+            },
+          }}
+        >
+          <Box as="tr" sx={{ position: 'relative', zIndex: 2 }}>
             {Object.keys(rows[0]).map((label, i) => (
               <DiscoverTableHeaderCell key={getRowKey(i, rows[0])} label={label} />
             ))}
-          </tr>
+          </Box>
         </Box>
         <Box
           as="tbody"
           sx={{
-            borderSpacing: '12px 0',
             opacity: isLoading ? 0.5 : 1,
             pointerEvents: isLoading ? 'none' : 'auto',
             transition: '200ms opacity',
@@ -88,7 +101,6 @@ export function DiscoverTableHeaderCell({ label }: { label: string }) {
       as="th"
       sx={{
         px: '12px',
-        pb: '20px',
         fontSize: 1,
         fontWeight: 'semiBold',
         color: 'neutral80',

--- a/features/discover/controllers/DiscoverControl.tsx
+++ b/features/discover/controllers/DiscoverControl.tsx
@@ -6,7 +6,7 @@ import { getDefaultSettingsState } from 'features/discover/helpers'
 import { discoverPagesMeta } from 'features/discover/meta'
 import { DiscoverFiltersSettings, DiscoverPages } from 'features/discover/types'
 import { keyBy } from 'lodash'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { theme } from 'theme'
 import { Box } from 'theme-ui'
 import { useMediaQuery } from 'usehooks-ts'
@@ -18,6 +18,7 @@ interface DiscoverControlProps {
 
 export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
   const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
+  const anchor = useRef<HTMLDivElement>(null)
   const { banner, endpoint, filters } = keyBy(discoverPagesMeta, 'kind')[kind]
   const [settings, setSettings] = useState<DiscoverFiltersSettings>(
     getDefaultSettingsState({ filters, kind }),
@@ -26,12 +27,33 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
 
   const response = getDiscoverData(endpoint, settings)
 
+  const onChangeHandler = useCallback(
+    (key, currentValue) => {
+      if (!isSmallerScreen) {
+        const currentPosition = document.querySelector('body')?.scrollTop || 0
+        const destinatedPosition = anchor.current ? anchor.current.offsetTop + 1 : 0
+
+        if (currentPosition > destinatedPosition) {
+          document.querySelector('body')?.scrollTo({ top: destinatedPosition, behavior: 'smooth' })
+        }
+      }
+      trackingEvents.discover.selectedFilter(kind, key, currentValue.label, userContext)
+      setIsLoading(true)
+      setSettings({
+        ...settings,
+        [key]: currentValue.value,
+      })
+    },
+    [settings],
+  )
+
   useEffect(() => {
     if (response) setIsLoading(false)
   }, [response])
 
   return (
     <Box
+      ref={anchor}
       sx={{
         backgroundColor: 'neutral10',
         border: '1px solid',
@@ -42,14 +64,7 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
       <DiscoverFilters
         filters={filters}
         isSmallerScreen={isSmallerScreen}
-        onChange={(key, currentValue) => {
-          trackingEvents.discover.selectedFilter(kind, key, currentValue.label, userContext)
-          setIsLoading(true)
-          setSettings({
-            ...settings,
-            [key]: currentValue.value,
-          })
-        }}
+        onChange={onChangeHandler}
       />
       <DiscoverData
         banner={banner}

--- a/features/discover/controllers/DiscoverControl.tsx
+++ b/features/discover/controllers/DiscoverControl.tsx
@@ -62,6 +62,7 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
       }}
     >
       <DiscoverFilters
+        amountOfRows={response?.rows.length || 0}
         filters={filters}
         isSmallerScreen={isSmallerScreen}
         onChange={onChangeHandler}

--- a/features/discover/controllers/DiscoverControl.tsx
+++ b/features/discover/controllers/DiscoverControl.tsx
@@ -7,7 +7,9 @@ import { discoverPagesMeta } from 'features/discover/meta'
 import { DiscoverFiltersSettings, DiscoverPages } from 'features/discover/types'
 import { keyBy } from 'lodash'
 import React, { useEffect, useState } from 'react'
+import { theme } from 'theme'
 import { Box } from 'theme-ui'
+import { useMediaQuery } from 'usehooks-ts'
 
 interface DiscoverControlProps {
   kind: DiscoverPages
@@ -15,6 +17,7 @@ interface DiscoverControlProps {
 }
 
 export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
+  const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
   const { banner, endpoint, filters } = keyBy(discoverPagesMeta, 'kind')[kind]
   const [settings, setSettings] = useState<DiscoverFiltersSettings>(
     getDefaultSettingsState({ filters, kind }),
@@ -38,6 +41,7 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
     >
       <DiscoverFilters
         filters={filters}
+        isSmallerScreen={isSmallerScreen}
         onChange={(key, currentValue) => {
           trackingEvents.discover.selectedFilter(kind, key, currentValue.label, userContext)
           setIsLoading(true)
@@ -50,6 +54,7 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
       <DiscoverData
         banner={banner}
         isLoading={isLoading}
+        isSmallerScreen={isSmallerScreen}
         kind={kind}
         response={response}
         userContext={userContext}

--- a/handlers/discover/getDiscoveryData.tsx
+++ b/handlers/discover/getDiscoveryData.tsx
@@ -4,7 +4,7 @@ import { NextApiRequest } from 'next'
 import { prisma } from 'server/prisma'
 import * as z from 'zod'
 
-const AMOUNT_OF_ROWS = 10
+const AMOUNT_OF_ROWS = 20
 
 const querySchema = z.object({
   asset: z.string().optional(),


### PR DESCRIPTION
# 🧭 Discover sticky filters

Filters follow user while they are scrolling through table.
Works only on desktop, on mobile it was taking too much of a space.
Does not sticky when there are less than two rows in the table.

[Tab-1666960119062.webm](https://user-images.githubusercontent.com/16230404/198587020-c78d0ae6-d9cc-47fc-83e2-c7ca170e5296.webm)

## Changes 👷‍♀️

- Added sticky filters,
- added auto scroll to the top of table after each filtering.
  
## How to test 🧪

- Scroll like a madman 😵
