### PR TITLE
Feedback from Chris/Barron

### DIFF
--- a/components/dumb/SliderValuePicker.tsx
+++ b/components/dumb/SliderValuePicker.tsx
@@ -6,9 +6,9 @@ import { Flex, SxStyleProp, useThemeUI } from 'theme-ui'
 export interface SliderValuePickerProps {
   sliderPercentageFill: BigNumber
   leftBoundry: BigNumber
-  leftBoundryFormatter: (input: BigNumber) => string
+  leftBoundryFormatter: (input: BigNumber) => string | JSX.Element
   rightBoundry: BigNumber
-  rightBoundryFormatter: (input: BigNumber) => string
+  rightBoundryFormatter: (input: BigNumber) => string | JSX.Element
   onChange: (input: BigNumber) => void
   minBoundry: BigNumber
   maxBoundry: BigNumber

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -1,5 +1,6 @@
 import { IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
 import { BigNumber } from 'bignumber.js'
+import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Flex, Grid, Link, Text } from 'theme-ui'
@@ -87,48 +88,63 @@ export function AdjustRiskView({
     onChainPosition?.riskRatio.loanToValue ||
     aaveStETHDefaultRiskRatio.loanToValue
 
+  const isSliderMoved = allDefined(onChainPosition)
+    ? allDefined(state.context.userInput.riskRatio?.loanToValue) &&
+      !onChainPosition?.riskRatio.loanToValue.isEqualTo(
+        state.context.userInput.riskRatio!.loanToValue,
+      )
+    : allDefined(state.context.userInput.riskRatio?.loanToValue) &&
+      !aaveStETHDefaultRiskRatio.loanToValue.isEqualTo(
+        state.context.userInput.riskRatio!.loanToValue,
+      )
+
+  const tokensRatioText = (
+    <Text as="span" variant="paragraph4" color="neutral80">
+      {collateralToken}/{debtToken}
+    </Text>
+  )
+
   const sidebarSectionProps: SidebarSectionProps = {
     title: t('open-earn.aave.vault-form.title'),
     content: (
       <Grid gap={3}>
         <SliderValuePicker
-          sliderPercentageFill={new BigNumber(0)}
           leftBoundry={liquidationPrice}
           leftBoundryFormatter={(value) => {
             if (state.context.loading) {
               return '...'
             } else {
-              return formatBigNumber(value, 2)
+              return (
+                <>
+                  {formatBigNumber(value, 2)} {tokensRatioText}
+                </>
+              )
             }
           }}
           rightBoundry={oracleAssetPrice}
-          rightBoundryFormatter={(value) => `Current: ${formatBigNumber(value, 2)}`}
-          rightBoundryStyling={{
-            color: riskTrafficLight === RiskLevel.OK ? 'success100' : 'warning100',
-          }}
+          rightBoundryFormatter={(value) => (
+            <>
+              {formatBigNumber(value, 2)} {tokensRatioText}
+            </>
+          )}
           onChange={(ltv) => {
             send({ type: 'SET_RISK_RATIO', riskRatio: new RiskRatio(ltv, RiskRatio.TYPE.LTV) })
+          }}
+          leftBoundryStyling={{
+            color: riskTrafficLight !== RiskLevel.OK ? 'warning100' : 'neutral100',
           }}
           minBoundry={minRisk}
           maxBoundry={maxRisk || zero}
           lastValue={sliderValue}
           disabled={viewLocked}
           step={0.01}
-          leftLabel={t('open-earn.aave.vault-form.configure-multiple.liquidation-price', {
-            collateralToken,
-            debtToken,
-          })}
-          rightLabel={
-            <Link target="_blank" href="https://dune.com/dataalways/stETH-De-Peg">
-              <Text variant="paragraph4" color="interactive100">
-                {t('open-earn.aave.vault-form.configure-multiple.historical-ratio', {
-                  collateralToken,
-                  debtToken,
-                })}{' '}
-                &gt;
-              </Text>
-            </Link>
+          sliderPercentageFill={
+            maxRisk && isSliderMoved
+              ? sliderValue.minus(minRisk).times(100).dividedBy(maxRisk.minus(minRisk))
+              : new BigNumber(0)
           }
+          leftLabel={t('open-earn.aave.vault-form.configure-multiple.liquidation-price')}
+          rightLabel={t('open-earn.aave.vault-form.configure-multiple.current-price')}
         />
         <Flex
           sx={{
@@ -140,6 +156,17 @@ export function AdjustRiskView({
           <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.decrease-risk')}</Text>
           <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.increase-risk')}</Text>
         </Flex>
+        {collateralToken && debtToken && (
+          <Link target="_blank" href="https://dune.com/dataalways/stETH-De-Peg">
+            <Text variant="paragraph4" color="interactive100">
+              {t('open-earn.aave.vault-form.configure-multiple.historical-ratio', {
+                collateralToken,
+                debtToken,
+              })}{' '}
+              &gt;
+            </Text>
+          </Link>
+        )}
         <StrategyInformationContainer state={state} />
         {viewLocked ? (
           <MessageCard

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -1,5 +1,6 @@
 import { IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
 import { BigNumber } from 'bignumber.js'
+import { WithArrow } from 'components/WithArrow'
 import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -158,16 +159,14 @@ export function AdjustRiskView({
         </Flex>
         {collateralToken && debtToken && (
           <Link target="_blank" href="https://dune.com/dataalways/stETH-De-Peg">
-            <Text variant="paragraph4" color="interactive100">
+            <WithArrow variant="paragraph4" sx={{ color: 'interactive100' }}>
               {t('open-earn.aave.vault-form.configure-multiple.historical-ratio', {
                 collateralToken,
                 debtToken,
-              })}{' '}
-              &gt;
-            </Text>
+              })}
+            </WithArrow>
           </Link>
         )}
-        <StrategyInformationContainer state={state} />
         {viewLocked ? (
           <MessageCard
             messages={[t('manage-earn-vault.has-asset-already')]}
@@ -192,10 +191,12 @@ export function AdjustRiskView({
                       liquidationPenalty,
                     }),
               ]}
+              withBullet={false}
               type={isWarning ? 'warning' : 'ok'}
             />
           )
         )}
+        <StrategyInformationContainer state={state} />
 
         <SidebarResetButton
           clear={() => {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1935,7 +1935,8 @@
         "back-to-editing": "Back to editing",
         "configure-multiple": {
           "title": "Set your risk level",
-          "liquidation-price": "{{collateralToken}}/{{debtToken}} Liquidation Price",
+          "liquidation-price": "Liquidation Price",
+          "current-price": "Current Price",
           "historical-ratio": "{{collateralToken}} / {{debtToken}} Historical Ratio",
           "back-to-enter-eth": "Back to enter ETH",
           "increase-risk": "Increase risk",


### PR DESCRIPTION
# [Feedback from Chris/Barron](https://app.shortcut.com/oazo-apps/story/6611/feedback-from-chris-barron)
  
## Changes 👷‍♀️ (opening and managing AAVE StETH/ETH position)
 - Adding the units on both sides
 - Moving the big word "Current" to be Current Price
 - Moving the historical ratio link
 - Having the color of the Liquidation price change in stead of the current Price
 - slider changes color (filled from left side)
 - (mine) moved the message up so the user can see it without scrolling and removed the bullet)
  
## How to test 🧪
 - see attached pictures for changes
 
Before:
![image](https://user-images.githubusercontent.com/5095527/198612144-a6f36b3b-92c7-4bbc-802e-70bdf734d002.png)

After:
![image](https://user-images.githubusercontent.com/5095527/198611993-c6c6ed03-2e6e-47b5-b871-99fac0f7424e.png)

