### PR TITLE
Non owner view for AAVE position.

### DIFF
--- a/blockchain/calls/aave/aaveLendingPool.ts
+++ b/blockchain/calls/aave/aaveLendingPool.ts
@@ -16,11 +16,11 @@ export interface AaveUserAccountData {
 }
 
 export interface AaveUserAccountDataParameters {
-  proxyAddress: string
+  address: string
 }
 
 export type AaveUserConfigurationsParameters = {
-  proxyAddress: string
+  address: string
 }
 export type AaveConfigurationData = string[]
 
@@ -28,8 +28,8 @@ export const getAaveUserAccountData: CallDef<AaveUserAccountDataParameters, Aave
   call: (args, { contract, aaveLendingPool }) => {
     return contract<AaveLendingPool>(aaveLendingPool).methods.getUserAccountData
   },
-  prepareArgs: ({ proxyAddress }) => {
-    return [proxyAddress]
+  prepareArgs: ({ address }) => {
+    return [address]
   },
   postprocess: (result) => {
     return {
@@ -53,8 +53,8 @@ export const getAaveUserConfiguration: CallDef<
   call: (args, { contract, aaveLendingPool }) => {
     return contract<AaveLendingPool>(aaveLendingPool).methods.getUserConfiguration
   },
-  prepareArgs: ({ proxyAddress }) => {
-    return [proxyAddress]
+  prepareArgs: ({ address }) => {
+    return [address]
   },
 }
 

--- a/blockchain/calls/aave/aaveProtocolDataProvider.ts
+++ b/blockchain/calls/aave/aaveProtocolDataProvider.ts
@@ -6,7 +6,7 @@ import { CallDef } from '../callsHelpers'
 
 export interface AaveUserReserveDataParameters {
   token: string
-  proxyAddress: string
+  address: string
 }
 
 export interface AaveReserveDataParameters {
@@ -41,8 +41,8 @@ export const getAaveUserReserveData: CallDef<AaveUserReserveDataParameters, Aave
   call: (args, { contract, aaveProtocolDataProvider }) => {
     return contract<AaveProtocolDataProvider>(aaveProtocolDataProvider).methods.getUserReserveData
   },
-  prepareArgs: ({ token, proxyAddress }, context) => {
-    return [context.tokens[token].address, proxyAddress]
+  prepareArgs: ({ token, address }, context) => {
+    return [context.tokens[token].address, address]
   },
   postprocess: (result, args) => {
     return {

--- a/features/aave/helpers/hasAavePosition.ts
+++ b/features/aave/helpers/hasAavePosition.ts
@@ -15,7 +15,7 @@ export function hasAavePosition$(
 ): Observable<boolean> {
   return getProxyAddress$(address).pipe(
     filter((proxyAddress) => proxyAddress !== undefined),
-    switchMap((proxyAddress) => getAaveUserAccountData$({ proxyAddress: proxyAddress! })),
+    switchMap((proxyAddress) => getAaveUserAccountData$({ address: proxyAddress! })),
     map((accountData) => {
       // cheap hack to determine if the user has the relevant aave position here
       // todo: check collateral/debt for current address against strategy token config to determine if this account already has a position here

--- a/features/aave/manage/services/getAaveProtocolData.ts
+++ b/features/aave/manage/services/getAaveProtocolData.ts
@@ -19,9 +19,9 @@ import { AaveProtocolData } from '../state'
 export type AaveOracleAssetPriceDataType = ({ token }: { token: string }) => Observable<BigNumber>
 
 export type AaveUserConfigurationType = ({
-  proxyAddress,
+  address,
 }: {
-  proxyAddress: string
+  address: string
 }) => Observable<AaveConfigurationData>
 
 export type AaveReserveConfigurationDataType = ({
@@ -38,14 +38,14 @@ export function getAaveProtocolData$(
   aaveReservesList$: () => Observable<AaveConfigurationData>,
   aaveReserveConfigurationData$: AaveReserveConfigurationDataType,
   token: string,
-  proxyAddress: string,
+  address: string,
 ): Observable<AaveProtocolData> {
   return combineLatest(
-    aaveUserReserveData$({ token, proxyAddress }),
-    aaveUserAccountData$({ proxyAddress }),
+    aaveUserReserveData$({ token, address }),
+    aaveUserAccountData$({ address }),
     aaveOracleAssetPriceData$({ token }),
     aaveReserveConfigurationData$({ token }),
-    aaveUserConfiguration$({ proxyAddress }),
+    aaveUserConfiguration$({ address }),
     aaveReservesList$(),
   ).pipe(
     map(

--- a/features/aave/open/services/getOpenAaveStateMachine.ts
+++ b/features/aave/open/services/getOpenAaveStateMachine.ts
@@ -40,11 +40,7 @@ export function getOpenAavePositionStateMachineServices(
   }: {
     token: string
   }) => Observable<AaveReserveConfigurationData>,
-  aaveUserConfiguration$: ({
-    proxyAddress,
-  }: {
-    proxyAddress: string
-  }) => Observable<AaveConfigurationData>,
+  aaveUserConfiguration$: ({ address }: { address: string }) => Observable<AaveConfigurationData>,
   aaveReservesList$: () => Observable<AaveConfigurationData>,
 ): OpenAaveStateMachineServices {
   return {
@@ -85,7 +81,7 @@ export function getOpenAavePositionStateMachineServices(
     },
     getHasOtherAssets: ({ proxyAddress }) => {
       return combineLatest(
-        aaveUserConfiguration$({ proxyAddress: proxyAddress! }),
+        aaveUserConfiguration$({ address: proxyAddress! }),
         aaveReservesList$(),
       ).pipe(
         map(([aaveUserConfiguration, aaveReservesList]) => {

--- a/features/aave/view/containers/AavePositionView.tsx
+++ b/features/aave/view/containers/AavePositionView.tsx
@@ -21,6 +21,7 @@ import { SidebarViewPositionAaveVault } from '../sidebars/SidebarViewPositionAav
 
 interface AaveManageViewPositionViewProps {
   address: string
+  proxyAddress?: string
 }
 
 function AavePositionContainer({
@@ -88,7 +89,7 @@ function AavePositionContainer({
   )
 }
 
-export function AavePositionView({ address }: AaveManageViewPositionViewProps) {
+export function AavePositionView({ address, proxyAddress }: AaveManageViewPositionViewProps) {
   const { connectedContext$ } = useAppContext()
   const { aaveProtocolData$ } = useAaveContext()
   const { aaveSTETHReserveConfigurationData, aavePreparedReserveDataETH$ } = useEarnContext()
@@ -97,7 +98,7 @@ export function AavePositionView({ address }: AaveManageViewPositionViewProps) {
   const [aaveReserveState, aaveReserveStateError] = useObservable(aaveSTETHReserveConfigurationData)
   const [aaveStrategy, aaveStrategyError] = useObservable(getAaveStrategy$(address))
   const [aaveProtocolData, aaveProtocolDataError] = useObservable(
-    aaveProtocolData$('STETH', address),
+    aaveProtocolData$('STETH', proxyAddress ?? address),
   )
 
   return (

--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -99,7 +99,7 @@ export function createAavePosition$(
   return combineLatest(getUserProxyAddress$(address), aaveAvailableLiquidityETH$, ethPrice$).pipe(
     switchMap(([proxyAddress, liquidity, ethPrice]) => {
       if (!proxyAddress) return EMPTY
-      return userAaveAccountData$({ proxyAddress }).pipe(
+      return userAaveAccountData$({ address: proxyAddress }).pipe(
         filter((accountData) => accountData.totalCollateralETH.gt(MINIMAL_COLLATERAL)),
         map((accountData) => {
           const netValue = accountData.totalCollateralETH

--- a/pages/aave/[address].tsx
+++ b/pages/aave/[address].tsx
@@ -27,9 +27,10 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 }
 
 function Position({ address }: { address: string }) {
-  const { web3Context$, connectedContext$ } = useAppContext()
+  const { web3Context$, connectedContext$, proxyAddress$ } = useAppContext()
   const [web3Context, web3ContextError] = useObservable(web3Context$)
   const [connectedContext, connectedContextError] = useObservable(connectedContext$)
+  const [proxyAddress, proxyAddressError] = useObservable(proxyAddress$(address))
 
   return (
     <AaveContextProvider>
@@ -39,15 +40,18 @@ function Position({ address }: { address: string }) {
             <WithTermsOfService>
               <Grid gap={0} sx={{ width: '100%' }}>
                 <BackgroundLight />
-                <WithErrorHandler error={[web3ContextError, connectedContextError]}>
+                <WithErrorHandler
+                  error={[web3ContextError, connectedContextError, proxyAddressError]}
+                >
                   <WithLoadingIndicator
                     value={[
                       web3Context,
                       ['connectedReadonly', 'connected'].includes(web3Context?.status || ''),
+                      proxyAddress,
                     ]}
                     customLoader={<VaultContainerSpinner />}
                   >
-                    {([_web3Context, _]) => {
+                    {([_web3Context, _, _proxyAddress]) => {
                       if (
                         _web3Context.status === 'connected' &&
                         connectedContext?.account === address
@@ -55,7 +59,7 @@ function Position({ address }: { address: string }) {
                         return <AaveManagePositionView address={address} />
                       }
                       if (['connectedReadonly', 'connected'].includes(_web3Context.status)) {
-                        return <AavePositionView address={address} />
+                        return <AavePositionView address={address} proxyAddress={proxyAddress} />
                       }
                       // theoretically should never happen (unless web3Context fails)
                       return <div />


### PR DESCRIPTION
# [Non owner view](https://app.shortcut.com/oazo-apps/story/6632/bug-non-owner-view-is-broken-for-steth)

  
## Changes 👷‍♀️
- Before without a connected wallet, the page displayed aave for the address, not for the proxy account connected to the address. 
- Now, if a proxy exists, the page will display the position for the proxy. If it doesn't exist, the page will display the position for the address from the URL. 
## How to test 🧪
- Go to the position page without connected wallet. 