### PR TITLE
Send without gas estimation

### DIFF
--- a/features/stateMachines/transaction/transactionStateMachine.ts
+++ b/features/stateMachines/transaction/transactionStateMachine.ts
@@ -113,12 +113,12 @@ export function startTransactionService<T extends TxMeta>(
   return (context) => {
     return combineLatest(context$, txHelpers$).pipe(
       first(),
-      switchMap(([{ safeConfirmations }, { sendWithGasEstimation }]) => {
+      switchMap(([{ safeConfirmations }, { send }]) => {
         if (context.transactionParameters === undefined) {
           throw new Error('transactionParameters not set')
         }
 
-        return sendWithGasEstimation(context.transactionDef, context.transactionParameters).pipe(
+        return send(context.transactionDef, context.transactionParameters).pipe(
           transactionToX<TransactionStateMachineEvents<T>, T>(
             {
               type: 'WAITING_FOR_APPROVAL',


### PR DESCRIPTION
# [Cannot create a position](https://app.shortcut.com/oazo-apps/story/6634/bug-cannot-enter-positions-tx-reverts)

  
## Changes 👷‍♀️
- Transaction (related to AAVE) is performed without gas estimation 
  
## How to test 🧪
- Try to open a new position.
