### PR TITLE
Split commonData into environmentData and positionData

### DIFF
--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -118,12 +118,10 @@ interface OptimizationControlProps {
 
 export function OptimizationControl({ vaultHistory }: OptimizationControlProps) {
   const {
-    constantMultipleTriggerData,
-    autoTakeProfitTriggerData,
     autoBuyTriggerData,
-    commonData: {
-      positionInfo: { debt },
-    },
+    autoTakeProfitTriggerData,
+    constantMultipleTriggerData,
+    positionData: { debt },
   } = useAutomationContext()
   const { txHelpers$ } = useAppContext()
   const [txHelpersData] = useObservable(txHelpers$)

--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -103,11 +103,9 @@ function getZeroDebtProtectionBannerProps({
 export function ProtectionControl() {
   const { txHelpers$ } = useAppContext()
   const {
-    stopLossTriggerData,
     autoSellTriggerData,
-    commonData: {
-      positionInfo: { debt, debtFloor },
-    },
+    stopLossTriggerData,
+    positionData: { debt, debtFloor },
   } = useAutomationContext()
   const [txHelpersData] = useObservable(txHelpers$)
   const [stopLossState] = useUIChanges<StopLossFormChange>(STOP_LOSS_FORM_CHANGE)

--- a/features/automation/common/controls/AddAndRemoveTriggerControl.tsx
+++ b/features/automation/common/controls/AddAndRemoveTriggerControl.tsx
@@ -59,10 +59,8 @@ export function AddAndRemoveTriggerControl({
 }: AddAndRemoveTriggerControlProps) {
   const { uiChanges } = useAppContext()
   const {
-    commonData: {
-      positionInfo: { id, ilk, owner, collateralizationRatio },
-      environmentInfo: { ethMarketPrice },
-    },
+    environmentData: { ethMarketPrice },
+    positionData: { id, ilk, owner, collateralizationRatio },
   } = useAutomationContext()
 
   const { removeTxData, textButtonHandler, txHandler } = getAutomationFeatureTxHandlers({

--- a/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
@@ -17,9 +17,7 @@ export function AutoBuyDetailsControl() {
   const {
     constantMultipleTriggerData,
     autoBuyTriggerData,
-    commonData: {
-      positionInfo: { ilk, id, token, debt, lockedCollateral },
-    },
+    positionData: { ilk, id, token, debt, lockedCollateral },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
@@ -30,10 +30,8 @@ export function AutoBuyFormControl({
   const [autoBuyState] = useUIChanges<AutoBSFormChange>(AUTO_BUY_FORM_CHANGE)
   const {
     autoBuyTriggerData,
-    commonData: {
-      positionInfo: { id, debt, lockedCollateral, collateralizationRatio, owner },
-      environmentInfo: { canInteract },
-    },
+    environmentData: { canInteract },
+    positionData: { id, debt, lockedCollateral, collateralizationRatio, owner },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.AUTO_BUY

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -61,9 +61,7 @@ export function SidebarAutoBuyEditingStage({
   const {
     autoBuyTriggerData,
     stopLossTriggerData,
-    commonData: {
-      positionInfo: { id, ilk, token, debt, debtFloor, lockedCollateral, collateralizationRatio },
-    },
+    positionData: { id, ilk, token, debt, debtFloor, lockedCollateral, collateralizationRatio },
   } = useAutomationContext()
   const { uiChanges } = useAppContext()
   const [, setHash] = useHash()
@@ -339,9 +337,7 @@ function AutoBuyInfoSectionControl({
   collateralDelta,
 }: AutoBuyInfoSectionControlProps) {
   const {
-    commonData: {
-      positionInfo: { debt, lockedCollateral, token },
-    },
+    positionData: { debt, lockedCollateral, token },
   } = useAutomationContext()
 
   const deviationPercent = autoBuyState.deviation.div(100)

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
@@ -21,9 +21,7 @@ export function SidebarAutoBuyRemovalEditingStage({
   autoBuyState,
 }: SidebarAutoBuyRemovalEditingStageProps) {
   const {
-    commonData: {
-      positionInfo: { debtFloor, token },
-    },
+    positionData: { debtFloor, token },
   } = useAutomationContext()
 
   return (
@@ -45,9 +43,7 @@ interface AutoBuyInfoSectionControlProps {
 function AutoBuyInfoSectionControl({ autoBuyState }: AutoBuyInfoSectionControlProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { collateralizationRatio, liquidationPrice, debt },
-    },
+    positionData: { collateralizationRatio, liquidationPrice, debt },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
@@ -65,14 +65,12 @@ export function SidebarSetupAutoBuy({
   const gasEstimation = useGasEstimationContext()
   const {
     autoBuyTriggerData,
-    constantMultipleTriggerData,
-    autoTakeProfitTriggerData,
-    stopLossTriggerData,
     autoSellTriggerData,
-    commonData: {
-      positionInfo: { collateralizationRatioAtNextPrice, token, liquidationRatio, vaultType },
-      environmentInfo: { ethBalance, ethMarketPrice, etherscanUrl },
-    },
+    autoTakeProfitTriggerData,
+    constantMultipleTriggerData,
+    stopLossTriggerData,
+    environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
+    positionData: { collateralizationRatioAtNextPrice, token, liquidationRatio, vaultType },
   } = useAutomationContext()
 
   const flow = getAutomationFormFlow({ isFirstSetup, isRemoveForm, feature })

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -17,10 +17,8 @@ export function AutoTakeProfitDetailsControl() {
   const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
   const {
     autoTakeProfitTriggerData,
-    commonData: {
-      positionInfo: { id, ilk, debt, debtOffset, collateralizationRatio, lockedCollateral, token },
-      environmentInfo: { ethMarketPrice },
-    },
+    environmentData: { ethMarketPrice },
+    positionData: { id, ilk, debt, debtOffset, collateralizationRatio, lockedCollateral, token },
   } = useAutomationContext()
 
   const { isTriggerEnabled, executionPrice } = autoTakeProfitTriggerData

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -29,10 +29,8 @@ export function AutoTakeProfitFormControl({
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
   const {
     autoTakeProfitTriggerData,
-    commonData: {
-      positionInfo: { ilk, id, token, owner },
-      environmentInfo: { canInteract, tokenMarketPrice },
-    },
+    environmentData: { canInteract, tokenMarketPrice },
+    positionData: { ilk, id, token, owner },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -52,9 +52,7 @@ export function SidebarAutoTakeProfitEditingStage({
 
   const {
     autoTakeProfitTriggerData,
-    commonData: {
-      positionInfo: { ilk, id, collateralizationRatio, debt, debtFloor, token },
-    },
+    positionData: { ilk, id, collateralizationRatio, debt, debtFloor, token },
   } = useAutomationContext()
 
   useDebouncedCallback(
@@ -148,10 +146,8 @@ function AutoTakeProfitInfoSectionControl({
   triggerColRatio,
 }: AutoTakeProfitInfoSectionControlProps) {
   const {
-    commonData: {
-      positionInfo: { debt, debtOffset, token, lockedCollateral },
-      environmentInfo: { ethMarketPrice },
-    },
+    environmentData: { ethMarketPrice },
+    positionData: { debt, debtOffset, token, lockedCollateral },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
@@ -19,9 +19,7 @@ export function SidebarAutoTakeProfitRemovalEditingStage({
 }: SidebarAutoTakeProfitRemovalEditingStageProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { debtFloor, token },
-    },
+    positionData: { debtFloor, token },
   } = useAutomationContext()
 
   return (
@@ -39,9 +37,7 @@ export function SidebarAutoTakeProfitRemovalEditingStage({
 function AutoTakeProfitInfoSectionControl() {
   const {
     autoTakeProfitTriggerData,
-    commonData: {
-      positionInfo: { token, debt, collateralizationRatio },
-    },
+    positionData: { token, debt, collateralizationRatio },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -77,10 +77,8 @@ export function SidebarSetupAutoTakeProfit({
     autoBuyTriggerData,
     autoTakeProfitTriggerData,
     constantMultipleTriggerData,
-    commonData: {
-      positionInfo: { debt, debtOffset, token, vaultType, lockedCollateral },
-      environmentInfo: { ethMarketPrice, etherscanUrl, nextCollateralPrice, ethBalance },
-    },
+    environmentData: { ethMarketPrice, etherscanUrl, nextCollateralPrice, ethBalance },
+    positionData: { debt, debtOffset, token, vaultType, lockedCollateral },
   } = useAutomationContext()
 
   const flow = getAutomationFormFlow({ isFirstSetup, isRemoveForm, feature })

--- a/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
+++ b/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
@@ -9,9 +9,7 @@ export function CancelConstantMultipleInfoSection() {
   const { t } = useTranslation()
   const {
     constantMultipleTriggerData,
-    commonData: {
-      positionInfo: { collateralizationRatio, debt, liquidationPrice },
-    },
+    positionData: { collateralizationRatio, debt, liquidationPrice },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsControl.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsControl.tsx
@@ -31,10 +31,8 @@ export function ConstantMultipleDetailsControl({
 
   const {
     constantMultipleTriggerData,
-    commonData: {
-      positionInfo: { ilk, id, token, debt, lockedCollateral },
-      environmentInfo: { tokenMarketPrice },
-    },
+    environmentData: { tokenMarketPrice },
+    positionData: { ilk, id, token, debt, lockedCollateral },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsLayout.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsLayout.tsx
@@ -64,9 +64,7 @@ export function ConstantMultipleDetailsLayout({
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
   const {
-    commonData: {
-      positionInfo: { vaultType },
-    },
+    positionData: { vaultType },
   } = useAutomationContext()
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
   const isMultiplyVault = vaultType === VaultType.Multiply

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
@@ -38,10 +38,8 @@ export function ConstantMultipleFormControl({
     autoBuyTriggerData,
     autoSellTriggerData,
     constantMultipleTriggerData,
-    commonData: {
-      positionInfo: { id, owner, debt, collateralizationRatio, lockedCollateral },
-      environmentInfo: { canInteract, ethMarketPrice },
-    },
+    environmentData: { canInteract, ethMarketPrice },
+    positionData: { id, owner, debt, collateralizationRatio, lockedCollateral },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.CONSTANT_MULTIPLE

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -85,12 +85,10 @@ export function SidebarConstantMultipleEditingStage({
   const [, setHash] = useHash()
   const {
     autoBuyTriggerData,
+    autoSellTriggerData,
     constantMultipleTriggerData,
     stopLossTriggerData,
-    autoSellTriggerData,
-    commonData: {
-      positionInfo: { ilk, id, collateralizationRatio, debt, debtFloor, token },
-    },
+    positionData: { ilk, id, collateralizationRatio, debt, debtFloor, token },
   } = useAutomationContext()
 
   automationMultipleRangeSliderAnalytics({

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleRemovalEditingStage.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleRemovalEditingStage.tsx
@@ -19,9 +19,7 @@ export function SidebarConstantMultipleRemovalEditingStage({
 }: SidebarConstantMultipleRemovalEditingStageProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { debtFloor, token },
-    },
+    positionData: { debtFloor, token },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
@@ -73,14 +73,12 @@ export function SidebarSetupConstantMultiple({
   const gasEstimation = useGasEstimationContext()
   const {
     autoBuyTriggerData,
-    constantMultipleTriggerData,
-    autoTakeProfitTriggerData,
-    stopLossTriggerData,
     autoSellTriggerData,
-    commonData: {
-      positionInfo: { debt, debtFloor, collateralizationRatioAtNextPrice, token, vaultType },
-      environmentInfo: { ethBalance, ethMarketPrice, etherscanUrl },
-    },
+    autoTakeProfitTriggerData,
+    constantMultipleTriggerData,
+    stopLossTriggerData,
+    environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
+    positionData: { debt, debtFloor, collateralizationRatioAtNextPrice, token, vaultType },
   } = useAutomationContext()
 
   const flow = getAutomationFormFlow({ isFirstSetup, isRemoveForm, feature })

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
@@ -14,9 +14,7 @@ export function AutoSellDetailsControl() {
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const {
     autoSellTriggerData,
-    commonData: {
-      positionInfo: { debt, lockedCollateral },
-    },
+    positionData: { debt, lockedCollateral },
   } = useAutomationContext()
 
   const [autoSellState] = useUIChanges<AutoBSFormChange>(AUTO_SELL_FORM_CHANGE)

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsLayout.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsLayout.tsx
@@ -45,9 +45,7 @@ export function AutoSellDetailsLayout({
   const {
     autoSellTriggerData,
     constantMultipleTriggerData: { isTriggerEnabled },
-    commonData: {
-      positionInfo: { id, ilk, token },
-    },
+    positionData: { id, ilk, token },
   } = useAutomationContext()
 
   const isConstantMultipleEnabled = isTriggerEnabled

--- a/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
@@ -31,10 +31,8 @@ export function AutoSellFormControl({
 
   const {
     autoSellTriggerData,
-    commonData: {
-      positionInfo: { id, debt, lockedCollateral, collateralizationRatio, owner },
-      environmentInfo: { canInteract },
-    },
+    environmentData: { canInteract },
+    positionData: { id, debt, lockedCollateral, collateralizationRatio, owner },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.AUTO_SELL

--- a/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
@@ -16,9 +16,7 @@ interface AutoSellInfoSectionControlProps {
 function AutoSellInfoSectionControl({ autoSellState }: AutoSellInfoSectionControlProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { debt, collateralizationRatio, liquidationPrice },
-    },
+    positionData: { debt, collateralizationRatio, liquidationPrice },
   } = useAutomationContext()
 
   return (
@@ -47,9 +45,7 @@ export function SidebarAutoSellCancelEditingStage({
 }: SidebarAutoSellCancelEditingStageProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { debtFloor, token },
-    },
+    positionData: { debtFloor, token },
   } = useAutomationContext()
 
   return (

--- a/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
@@ -51,9 +51,7 @@ function AutoSellInfoSectionControl({
   executionPrice,
 }: AutoSellInfoSectionControlProps) {
   const {
-    commonData: {
-      positionInfo: { debt, lockedCollateral, token },
-    },
+    positionData: { debt, lockedCollateral, token },
   } = useAutomationContext()
   const deviationPercent = autoSellState.deviation.div(100)
 
@@ -109,11 +107,9 @@ export function SidebarAutoSellAddEditingStage({
 }: SidebarAutoSellAddEditingStageProps) {
   const { uiChanges } = useAppContext()
   const {
-    stopLossTriggerData,
     autoSellTriggerData,
-    commonData: {
-      positionInfo: { id, ilk, debt, debtFloor, lockedCollateral, collateralizationRatio, token },
-    },
+    stopLossTriggerData,
+    positionData: { id, ilk, debt, debtFloor, lockedCollateral, collateralizationRatio, token },
   } = useAutomationContext()
   const { t } = useTranslation()
   const [, setHash] = useHash()

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -68,20 +68,18 @@ export function SidebarSetupAutoSell({
   const gasEstimation = useGasEstimationContext()
 
   const {
-    stopLossTriggerData,
     autoBuyTriggerData,
-    constantMultipleTriggerData,
     autoSellTriggerData,
-    commonData: {
-      positionInfo: {
-        debt,
-        collateralizationRatioAtNextPrice,
-        token,
-        debtFloor,
-        liquidationRatio,
-        vaultType,
-      },
-      environmentInfo: { ethBalance, ethMarketPrice, etherscanUrl },
+    constantMultipleTriggerData,
+    stopLossTriggerData,
+    environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
+    positionData: {
+      collateralizationRatioAtNextPrice,
+      debt,
+      debtFloor,
+      liquidationRatio,
+      token,
+      vaultType,
     },
   } = useAutomationContext()
 

--- a/features/automation/protection/stopLoss/controls/StopLossCompleteInformation.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossCompleteInformation.tsx
@@ -26,9 +26,7 @@ export function StopLossCompleteInformation({
 }: StopLossCompleteInformationProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { token, debt, lockedCollateral, liquidationPrice, liquidationRatio },
-    },
+    positionData: { token, debt, lockedCollateral, liquidationPrice, liquidationRatio },
   } = useAutomationContext()
 
   const dynamicStopLossPrice = liquidationPrice

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
@@ -28,18 +28,16 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
   const { t } = useTranslation()
   const {
     stopLossTriggerData,
-    commonData: {
-      positionInfo: {
-        id,
-        ilk,
-        debt,
-        token,
-        lockedCollateral,
-        collateralizationRatio,
-        liquidationRatio,
-        liquidationPenalty,
-        collateralizationRatioAtNextPrice,
-      },
+    positionData: {
+      collateralizationRatio,
+      collateralizationRatioAtNextPrice,
+      debt,
+      id,
+      ilk,
+      liquidationPenalty,
+      liquidationRatio,
+      lockedCollateral,
+      token,
     },
   } = useAutomationContext()
   const { uiChanges } = useAppContext()

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -29,10 +29,8 @@ export function StopLossFormControl({
   const [stopLossState] = useUIChanges<StopLossFormChange>(STOP_LOSS_FORM_CHANGE)
   const {
     stopLossTriggerData,
-    commonData: {
-      positionInfo: { id, ilk, debt, token, lockedCollateral, liquidationRatio, owner },
-      environmentInfo: { canInteract },
-    },
+    environmentData: { canInteract },
+    positionData: { id, ilk, debt, token, lockedCollateral, liquidationRatio, owner },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.STOP_LOSS

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -55,15 +55,13 @@ export function SetDownsideProtectionInformation({
 }: SetDownsideProtectionInformationProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: {
-        debt,
-        token,
-        lockedCollateral,
-        liquidationRatio,
-        liquidationPenalty,
-        liquidationPrice,
-      },
+    positionData: {
+      debt,
+      liquidationPenalty,
+      liquidationPrice,
+      liquidationRatio,
+      lockedCollateral,
+      token,
     },
   } = useAutomationContext()
 
@@ -158,10 +156,8 @@ export function SidebarAdjustStopLossEditingStage({
   const { uiChanges } = useAppContext()
   const {
     stopLossTriggerData,
-    commonData: {
-      positionInfo: { id, ilk, token, debt, liquidationRatio, collateralizationRatio, debtFloor },
-      environmentInfo: { ethMarketPrice },
-    },
+    environmentData: { ethMarketPrice },
+    positionData: { id, ilk, token, debt, liquidationRatio, collateralizationRatio, debtFloor },
   } = useAutomationContext()
 
   useDebouncedCallback(

--- a/features/automation/protection/stopLoss/sidebars/SidebarCancelStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarCancelStopLossEditingStage.tsx
@@ -66,9 +66,7 @@ export function SidebarCancelStopLossEditingStage({
 }: SidebarCancelStopLossEditingStageProps) {
   const { t } = useTranslation()
   const {
-    commonData: {
-      positionInfo: { token, debtFloor, liquidationPrice },
-    },
+    positionData: { token, debtFloor, liquidationPrice },
   } = useAutomationContext()
   return (
     <Grid>

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -83,14 +83,12 @@ export function SidebarSetupStopLoss({
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
   const {
-    stopLossTriggerData,
-    autoSellTriggerData,
     autoBuyTriggerData,
+    autoSellTriggerData,
     constantMultipleTriggerData,
-    commonData: {
-      positionInfo: { debt, token, liquidationRatio, collateralizationRatioAtNextPrice, vaultType },
-      environmentInfo: { nextCollateralPrice, ethBalance, ethMarketPrice, etherscanUrl },
-    },
+    stopLossTriggerData,
+    environmentData: { nextCollateralPrice, ethBalance, ethMarketPrice, etherscanUrl },
+    positionData: { debt, token, liquidationRatio, collateralizationRatioAtNextPrice, vaultType },
   } = useAutomationContext()
 
   const gasEstimationContext = useGasEstimationContext()


### PR DESCRIPTION
# Split `commonData` into `environmentData` and `positionData`

From structural point of view, I think that works better for several reasons:

- Marks clear separation between things that are app specific (`environmentData`) and protocol specific (`positionData`),
- shortens `useMemo` list of dependencies for each part,
- more in-line with rest of the interface,
- shorten getting data by destructuring while using `useAutomationContext` since in most places `environmentData` wasn't needed.
