### PR TITLE
Separated methods for position and environment data extraction

### DIFF
--- a/features/automation/common/context/getAutomationAavePositionData.ts
+++ b/features/automation/common/context/getAutomationAavePositionData.ts
@@ -1,0 +1,29 @@
+import { AutomationPositionData } from 'components/AutomationContextProvider'
+import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
+import { zero } from 'helpers/zero'
+
+interface getAutomationAavePositionDataParams {
+  generalManageVault: GeneralManageVaultState
+}
+
+export function getAutomationAavePositionData({
+  generalManageVault,
+}: getAutomationAavePositionDataParams): AutomationPositionData {
+  //TODO: fill with actual AAVE data
+  return {
+    collateralizationRatio: zero,
+    collateralizationRatioAtNextPrice: zero,
+    debt: zero,
+    debtFloor: zero,
+    debtOffset: zero,
+    id: zero,
+    ilk: '',
+    liquidationPenalty: zero,
+    liquidationPrice: zero,
+    liquidationRatio: zero,
+    lockedCollateral: zero,
+    owner: '',
+    token: '',
+    vaultType: generalManageVault.type,
+  }
+}

--- a/features/automation/common/context/getAutomationEnvironment.ts
+++ b/features/automation/common/context/getAutomationEnvironment.ts
@@ -1,0 +1,47 @@
+import BigNumber from 'bignumber.js'
+import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
+import { UnreachableCaseError } from 'helpers/UnreachableCaseError'
+import { zero } from 'helpers/zero'
+
+interface getAutomationEnvironmentParams {
+  generalManageVault: GeneralManageVaultState
+  vaultProtocol: VaultProtocol
+}
+
+interface AutomationEnvironment {
+  controller?: string
+  ethBalance: BigNumber
+  nextCollateralPrice: BigNumber
+  token: string
+}
+
+export function getAutomationEnvironment({
+  generalManageVault,
+  vaultProtocol,
+}: getAutomationEnvironmentParams): AutomationEnvironment {
+  switch (vaultProtocol) {
+    case VaultProtocol.Maker:
+      const {
+        balanceInfo: { ethBalance },
+        vault: { token, controller },
+        priceInfo: { nextCollateralPrice },
+      } = generalManageVault.state
+
+      return {
+        controller,
+        ethBalance,
+        nextCollateralPrice,
+        token,
+      }
+    case VaultProtocol.Aave:
+      return {
+        controller: '',
+        ethBalance: zero,
+        nextCollateralPrice: zero,
+        token: '',
+      }
+    default:
+      throw new UnreachableCaseError(vaultProtocol)
+  }
+}

--- a/features/automation/common/context/getAutomationMakerPositionData.ts
+++ b/features/automation/common/context/getAutomationMakerPositionData.ts
@@ -1,0 +1,43 @@
+import { AutomationPositionData } from 'components/AutomationContextProvider'
+import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
+
+interface getAutomationMakerPositionDataParams {
+  generalManageVault: GeneralManageVaultState
+}
+
+export function getAutomationMakerPositionData({
+  generalManageVault,
+}: getAutomationMakerPositionDataParams): AutomationPositionData {
+  const {
+    vault: {
+      collateralizationRatio,
+      collateralizationRatioAtNextPrice,
+      debt,
+      debtOffset,
+      id,
+      ilk,
+      liquidationPrice,
+      lockedCollateral,
+      owner,
+      token,
+    },
+    ilkData: { liquidationRatio, debtFloor, liquidationPenalty },
+  } = generalManageVault.state
+
+  return {
+    collateralizationRatio,
+    collateralizationRatioAtNextPrice,
+    debt,
+    debtFloor,
+    debtOffset,
+    id,
+    ilk,
+    liquidationPenalty,
+    liquidationPrice,
+    liquidationRatio,
+    lockedCollateral,
+    owner,
+    token,
+    vaultType: generalManageVault.type,
+  }
+}

--- a/features/automation/common/context/getAutomationPositionData.ts
+++ b/features/automation/common/context/getAutomationPositionData.ts
@@ -1,0 +1,25 @@
+import { AutomationPositionData } from 'components/AutomationContextProvider'
+import { getAutomationAavePositionData } from 'features/automation/common/context/getAutomationAavePositionData'
+import { getAutomationMakerPositionData } from 'features/automation/common/context/getAutomationMakerPositionData'
+import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
+import { UnreachableCaseError } from 'helpers/UnreachableCaseError'
+
+interface GetAutomationPositionDataParams {
+  generalManageVault: GeneralManageVaultState
+  vaultProtocol: VaultProtocol
+}
+
+export function getAutomationPositionData({
+  generalManageVault,
+  vaultProtocol,
+}: GetAutomationPositionDataParams): AutomationPositionData {
+  switch (vaultProtocol) {
+    case VaultProtocol.Maker:
+      return getAutomationMakerPositionData({ generalManageVault })
+    case VaultProtocol.Aave:
+      return getAutomationAavePositionData({ generalManageVault })
+    default:
+      throw new UnreachableCaseError(vaultProtocol)
+  }
+}

--- a/helpers/getVaultProtocol.ts
+++ b/helpers/getVaultProtocol.ts
@@ -1,0 +1,11 @@
+export enum VaultProtocol {
+  Maker,
+  Aave,
+}
+
+// TODO: decide what parameters are needed to check vault protocol and write function body
+// is this going to be just based on url? or GeneralManageVaultState?
+
+export function getVaultProtocol() {
+  return VaultProtocol.Maker
+}


### PR DESCRIPTION
# Separated methods for position and environment data extraction

Assuming that different protocols may need different data sources that just `generalManageVault`, I prepared dedicated methods for data extractions.

`getAutomationPositionData` doesn't have any assumptions, just simply returns entire `positionData` object.
`getAutomationEnvironment` returns only part of the data, since some of environmental information are shared between protocols (ETH market price), so `environmentData` is later merged using those partial data.