### PR TITLE
🧭 Auto generate "all" option in assets filter in Discover

### DIFF
--- a/features/discover/controllers/DiscoverControl.tsx
+++ b/features/discover/controllers/DiscoverControl.tsx
@@ -62,7 +62,7 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
       }}
     >
       <DiscoverFilters
-        amountOfRows={response?.rows.length || 0}
+        amountOfRows={response?.rows?.length || 0}
         filters={filters}
         isSmallerScreen={isSmallerScreen}
         onChange={onChangeHandler}

--- a/features/discover/filters.ts
+++ b/features/discover/filters.ts
@@ -2,7 +2,6 @@ import { getToken } from 'blockchain/tokensMetadata'
 import { DiscoverFiltersListItem } from 'features/discover/meta'
 
 export const discoverFiltersAssetItems: { [key: string]: DiscoverFiltersListItem } = {
-  all: { value: 'all', label: 'All assets' },
   // TODO: update with nicer cuvre icon when available
   curve: { value: 'CURVE_LP', label: 'CURVE', icon: getToken('CRVV1ETHSTETH').iconCircle },
   eth: { value: 'ETH', label: 'ETH', icon: getToken('ETH').iconCircle },
@@ -40,3 +39,9 @@ export const discoverTimeFilter: DiscoverFiltersListItem[] = [
   { value: '30d', label: '30 days' },
   { value: '1y', label: '1 year' },
 ]
+
+export function getAssetOptions(options: DiscoverFiltersListItem[]): DiscoverFiltersListItem[] {
+  const all = { value: options.map((item) => item.value).join(','), label: 'All assets' }
+
+  return [all, ...options]
+}

--- a/features/discover/meta.tsx
+++ b/features/discover/meta.tsx
@@ -3,6 +3,7 @@ import {
   discoverMultipleFilter,
   discoverSizeFilter,
   discoverTimeFilter,
+  getAssetOptions,
 } from 'features/discover/filters'
 import { discoverBannerIcons, discoverNavigationIconContent } from 'features/discover/icons'
 import { DiscoverPages } from 'features/discover/types'
@@ -35,8 +36,7 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
     iconColor: '#FE665C',
     iconContent: discoverNavigationIconContent[DiscoverPages.HIGHEST_RISK_POSITIONS],
     filters: {
-      asset: [
-        discoverFiltersAssetItems.all,
+      asset: getAssetOptions([
         discoverFiltersAssetItems.eth,
         discoverFiltersAssetItems.wbtc,
         discoverFiltersAssetItems.uni,
@@ -46,7 +46,7 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
         discoverFiltersAssetItems.gusd,
         discoverFiltersAssetItems.curve,
         discoverFiltersAssetItems.yfi,
-      ],
+      ]),
       size: discoverSizeFilter,
     },
     banner: {
@@ -60,15 +60,14 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
     iconColor: '#FFC700',
     iconContent: discoverNavigationIconContent[DiscoverPages.HIGHEST_MULTIPLY_PNL],
     filters: {
-      asset: [
-        discoverFiltersAssetItems.all,
+      asset: getAssetOptions([
         discoverFiltersAssetItems.eth,
         discoverFiltersAssetItems.wbtc,
         discoverFiltersAssetItems.link,
         discoverFiltersAssetItems.mana,
         discoverFiltersAssetItems.matic,
         discoverFiltersAssetItems.yfi,
-      ],
+      ]),
       multiple: discoverMultipleFilter,
       size: discoverSizeFilter,
       time: discoverTimeFilter,
@@ -84,11 +83,10 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
     iconColor: '#00E2BA',
     iconContent: discoverNavigationIconContent[DiscoverPages.MOST_YIELD_EARNED],
     filters: {
-      asset: [
-        discoverFiltersAssetItems.all,
+      asset: getAssetOptions([
         discoverFiltersAssetItems.univ3daiusdc,
         discoverFiltersAssetItems.stetheth,
-      ],
+      ]),
       size: discoverSizeFilter,
       time: discoverTimeFilter,
     },
@@ -103,8 +101,7 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
     iconColor: '#FF4DB8',
     iconContent: discoverNavigationIconContent[DiscoverPages.LARGEST_DEBT],
     filters: {
-      asset: [
-        discoverFiltersAssetItems.all,
+      asset: getAssetOptions([
         discoverFiltersAssetItems.eth,
         discoverFiltersAssetItems.wbtc,
         discoverFiltersAssetItems.uni,
@@ -114,7 +111,7 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
         discoverFiltersAssetItems.gusd,
         discoverFiltersAssetItems.curve,
         discoverFiltersAssetItems.yfi,
-      ],
+      ]),
       size: discoverSizeFilter,
     },
     banner: {

--- a/handlers/discover/getDiscoveryData.tsx
+++ b/handlers/discover/getDiscoveryData.tsx
@@ -1,5 +1,9 @@
 import { DiscoverApiErrors, DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
-import { getAssetFilter, getGenericRangeFilter, getTimeSignature } from 'handlers/discover/helpers'
+import {
+  getGenericArrayFilter,
+  getGenericRangeFilter,
+  getTimeSignature,
+} from 'handlers/discover/helpers'
 import { NextApiRequest } from 'next'
 import { prisma } from 'server/prisma'
 import * as z from 'zod'
@@ -25,7 +29,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
             await prisma.highestRiskPositions.findMany({
               take: AMOUNT_OF_ROWS,
               where: {
-                collateral_type: getAssetFilter(asset),
+                collateral_type: getGenericArrayFilter(asset),
                 collateral_value: getGenericRangeFilter(size),
               },
             })
@@ -46,7 +50,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
             await prisma.highestMultiplyPnl.findMany({
               take: AMOUNT_OF_ROWS,
               where: {
-                collateral_type: getAssetFilter(asset),
+                collateral_type: getGenericArrayFilter(asset),
                 collateral_value: getGenericRangeFilter(size),
                 vault_multiple: getGenericRangeFilter(multiple),
               },
@@ -70,7 +74,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
             await prisma.mostYieldEarned.findMany({
               take: AMOUNT_OF_ROWS,
               where: {
-                collateral_type: getAssetFilter(asset),
+                collateral_type: getGenericArrayFilter(asset),
                 collateral_value: getGenericRangeFilter(size),
               },
               orderBy: { [timeSignature]: 'desc' },
@@ -91,7 +95,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
             await prisma.largestDebt.findMany({
               take: AMOUNT_OF_ROWS,
               where: {
-                collateral_type: getAssetFilter(asset),
+                collateral_type: getGenericArrayFilter(asset),
                 collateral_value: getGenericRangeFilter(size),
               },
             })

--- a/handlers/discover/helpers.ts
+++ b/handlers/discover/helpers.ts
@@ -1,6 +1,4 @@
 import { HighestMultiplyPnl, MostYieldEarned, Prisma } from '@prisma/client'
-import { discoverFiltersAssetItems } from 'features/discover/filters'
-import { values } from 'lodash'
 
 type OmitNonDecimal<T> = { [K in keyof T]: T[K] extends Prisma.Decimal ? K : never }[keyof T]
 type DiscoverLite = OmitNonDecimal<HighestMultiplyPnl | MostYieldEarned>
@@ -18,14 +16,10 @@ export function getGenericRangeFilter(filter?: string): Prisma.StringFilter {
   } else return { gte: '0' }
 }
 
-export function getAssetFilter(asset?: string): Prisma.StringFilter {
-  return !asset || asset === 'all'
-    ? {
-        in: values(discoverFiltersAssetItems)
-          .map((item) => item.value)
-          .filter((item) => item !== 'all'),
-      }
-    : { equals: asset }
+export function getGenericArrayFilter(filter?: string): Prisma.StringFilter {
+  return {
+    in: filter?.split(','),
+  }
 }
 
 export function getTimeSignature(prefix: string, time?: string): DiscoverLite {


### PR DESCRIPTION
# 🧭 Auto generate "all" option in assets filter in Discover

"All" option used to display all available tokens, no matter what was available in dropdown. From now it will only merge those that were in options list.
  
## Changes 👷‍♀️

- Removed generic "all" option from assets filter,
- created `getGenericArrayFilter` method for API filtering,
- removed `getAssetFilter` method as dedicated one for assets is no longer needed.
  
## How to test 🧪

- Try using all options combinations in assets filter.
