### PR TITLE
🧭 Discover table uses `isSticky` prop

### DIFF
--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -12,6 +12,7 @@ import { Box } from 'theme-ui'
 interface DiscoverDataProps {
   banner?: DiscoverBanner
   isLoading: boolean
+  isSticky: boolean
   isSmallerScreen: boolean
   kind: DiscoverPages
   response?: DiscoverDataResponse
@@ -21,6 +22,7 @@ interface DiscoverDataProps {
 export function DiscoverData({
   banner,
   isLoading,
+  isSticky,
   isSmallerScreen,
   kind,
   response,
@@ -43,6 +45,7 @@ export function DiscoverData({
             <DiscoverTable
               banner={banner}
               isLoading={isLoading}
+              isSticky={isSticky}
               kind={kind}
               rows={response.rows}
               userContext={userContext}

--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -4,21 +4,21 @@ import React from 'react'
 import { Box, Grid } from 'theme-ui'
 
 export function DiscoverFilters({
-  amountOfRows,
   filters,
   isSmallerScreen,
+  isSticky,
   onChange,
 }: {
-  amountOfRows: number
   filters: DiscoverFiltersList
   isSmallerScreen: boolean
+  isSticky: boolean
   onChange: (key: string, currentValue: DiscoverFiltersListItem) => void
 }) {
   return (
     <Box
       sx={{
         ...(!isSmallerScreen && {
-          position: amountOfRows > 2 ? 'sticky' : 'relative',
+          position: isSticky ? 'sticky' : 'relative',
           top: 0,
         }),
         p: ['24px', null, null, 4],

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -12,12 +12,14 @@ import { Box } from 'theme-ui'
 export function DiscoverTable({
   banner,
   isLoading,
+  isSticky,
   kind,
   rows,
   userContext,
 }: {
   banner?: DiscoverBanner
   isLoading: boolean
+  isSticky: boolean
   kind: DiscoverPages
   rows: DiscoverTableRowData[]
   userContext: MixpanelUserContext
@@ -43,7 +45,7 @@ export function DiscoverTable({
         <Box
           as="thead"
           sx={{
-            ...(rows.length > 2 && {
+            ...(isSticky && {
               position: 'sticky',
               zIndex: 1,
               top: '120px',

--- a/features/discover/controllers/DiscoverControl.tsx
+++ b/features/discover/controllers/DiscoverControl.tsx
@@ -26,6 +26,7 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
   const [isLoading, setIsLoading] = useState<boolean>(true)
 
   const response = getDiscoverData(endpoint, settings)
+  const isSticky = (response && response?.rows?.length > 2) || false
 
   const onChangeHandler = useCallback(
     (key, currentValue) => {
@@ -62,14 +63,15 @@ export function DiscoverControl({ kind, userContext }: DiscoverControlProps) {
       }}
     >
       <DiscoverFilters
-        amountOfRows={response?.rows?.length || 0}
         filters={filters}
         isSmallerScreen={isSmallerScreen}
+        isSticky={isSticky}
         onChange={onChangeHandler}
       />
       <DiscoverData
         banner={banner}
         isLoading={isLoading}
+        isSticky={isSticky}
         isSmallerScreen={isSmallerScreen}
         kind={kind}
         response={response}


### PR DESCRIPTION
# 🧭 Discover table uses `isSticky` prop
  
## Changes 👷‍♀️

- Added `isSticky` props instead of checking amount of rows.
