### PR TITLE
Added Modular Proxy Actions Security Audit link to Security page

### DIFF
--- a/pages/security.tsx
+++ b/pages/security.tsx
@@ -43,6 +43,10 @@ function SecurityPage() {
             'https://chainsecurity.com/security-audit/oasis-automation-consultancy-smart-contracts/',
           label: t('security.category.audit.link-automation'),
         },
+        {
+          url: 'https://chainsecurity.com/security-audit/oasis-app-modular-proxy-actions/',
+          label: t('security.category.audit.link-modular-proxy-actions'),
+        },
       ],
     },
     {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2000,8 +2000,9 @@
         "header": "Independently audited",
         "description": "Our stringent security procedures didn’t occur by luck. It came about with a rigorous process of both internal and external audits.",
         "link-multiply": "Multiply Audit Report",
-        "link-multiply-fmm": "Multiply FMM extension audit report",
-        "link-automation": "Automation Audit Report"
+        "link-multiply-fmm": "Multiply FMM extension Audit Report",
+        "link-automation": "Automation Audit Report",
+        "link-modular-proxy-actions": "Modular Proxy Actions Audit Report"
       },
       "bug": {
         "header": "Bug bounty",


### PR DESCRIPTION
# [Added Modular Proxy Actions Security Audit link to Security page](https://app.shortcut.com/oazo-apps/story/6675/add-steth-audit-to-security-page)

  
## Changes 👷‍♀️
- Added link to newest audit on the `/security`
- Fixed other labels so they read `Audit Report` everywhere
  
## How to test 🧪
- go to `/security`
- there should be a new link `Modular Proxy Actions Audit Report`