### PR TITLE
created users_who_follow_vaults table

### DIFF
--- a/server/database/migrations/013-add-users-who-follow-vaults.sql
+++ b/server/database/migrations/013-add-users-who-follow-vaults.sql
@@ -7,12 +7,12 @@ CREATE TABLE
     );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "vault_vault_id_chain_id_key" ON "vault" ("vault_id", "chain_id");
+CREATE UNIQUE INDEX "tos_approval_address_chain_id_key" ON "tos_approval" ("address", "chain_id");
+
+-- AddForeignKey
+ALTER TABLE
+    "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_user_address_vault_chain_id_fkey" FOREIGN KEY ("user_address", "vault_chain_id") REFERENCES "tos_approval" ("address", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE
     "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_chain_id_fkey" FOREIGN KEY ("vault_id", "vault_chain_id") REFERENCES "vault" ("vault_id", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE
-    "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_user_address_fkey" FOREIGN KEY ("user_address") REFERENCES "user" ("address") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/database/migrations/013-add-users-who-follow-vaults.sql
+++ b/server/database/migrations/013-add-users-who-follow-vaults.sql
@@ -2,12 +2,17 @@ CREATE TABLE "users_who_follow_vaults" (
     "user_address" TEXT NOT NULL,
     "vault_id" INTEGER NOT NULL,
     "vault_type" "vault_type" NOT NULL,
+    "vault_chain_id" INTEGER NOT NULL,
 
-    CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY ("user_address","vault_id","vault_type")
+    CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY ("user_address","vault_id","vault_type","vault_chain_id")
 );
 -- CreateIndex
 CREATE UNIQUE INDEX "vault_vault_id_key" ON "vault"("vault_id");
-CREATE UNIQUE INDEX "vault_vault_id_type_key" ON "vault"("vault_id", "type");
+-- CreateIndex
+CREATE UNIQUE INDEX "vault_vault_id_chain_id_key" ON "vault"("vault_id", "chain_id");
+-- CreateIndex
+CREATE UNIQUE INDEX "vault_vault_id_type_chain_id_key" ON "vault"("vault_id", "type", "chain_id");
 -- AddForeignKey
-ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_type_fkey" FOREIGN KEY ("vault_id", "vault_type") REFERENCES "vault"("vault_id", "type") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_type_vault_chain_id_fkey" FOREIGN KEY ("vault_id", "vault_type", "vault_chain_id") REFERENCES "vault"("vault_id", "type", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+-- AddForeignKey
 ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_user_address_fkey" FOREIGN KEY ("user_address") REFERENCES "user"("address") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/database/migrations/013-add-users-who-follow-vaults.sql
+++ b/server/database/migrations/013-add-users-who-follow-vaults.sql
@@ -2,25 +2,16 @@ CREATE TABLE
     "users_who_follow_vaults" (
         "user_address" TEXT NOT NULL,
         "vault_id" INTEGER NOT NULL,
-        "vault_type" "vault_type" NOT NULL,
         "vault_chain_id" INTEGER NOT NULL,
-        CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY (
-            "user_address",
-            "vault_id",
-            "vault_type",
-            "vault_chain_id"
-        )
+        CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY ("user_address", "vault_id", "vault_chain_id")
     );
 
 -- CreateIndex
 CREATE UNIQUE INDEX "vault_vault_id_chain_id_key" ON "vault" ("vault_id", "chain_id");
 
--- CreateIndex
-CREATE UNIQUE INDEX "vault_vault_id_type_chain_id_key" ON "vault" ("vault_id", "type", "chain_id");
-
 -- AddForeignKey
 ALTER TABLE
-    "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_type_vault_chain_id_fkey" FOREIGN KEY ("vault_id", "vault_type", "vault_chain_id") REFERENCES "vault" ("vault_id", "type", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_chain_id_fkey" FOREIGN KEY ("vault_id", "vault_chain_id") REFERENCES "vault" ("vault_id", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE

--- a/server/database/migrations/013-add-users-who-follow-vaults.sql
+++ b/server/database/migrations/013-add-users-who-follow-vaults.sql
@@ -1,18 +1,27 @@
-CREATE TABLE "users_who_follow_vaults" (
-    "user_address" TEXT NOT NULL,
-    "vault_id" INTEGER NOT NULL,
-    "vault_type" "vault_type" NOT NULL,
-    "vault_chain_id" INTEGER NOT NULL,
+CREATE TABLE
+    "users_who_follow_vaults" (
+        "user_address" TEXT NOT NULL,
+        "vault_id" INTEGER NOT NULL,
+        "vault_type" "vault_type" NOT NULL,
+        "vault_chain_id" INTEGER NOT NULL,
+        CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY (
+            "user_address",
+            "vault_id",
+            "vault_type",
+            "vault_chain_id"
+        )
+    );
 
-    CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY ("user_address","vault_id","vault_type","vault_chain_id")
-);
 -- CreateIndex
-CREATE UNIQUE INDEX "vault_vault_id_key" ON "vault"("vault_id");
+CREATE UNIQUE INDEX "vault_vault_id_chain_id_key" ON "vault" ("vault_id", "chain_id");
+
 -- CreateIndex
-CREATE UNIQUE INDEX "vault_vault_id_chain_id_key" ON "vault"("vault_id", "chain_id");
--- CreateIndex
-CREATE UNIQUE INDEX "vault_vault_id_type_chain_id_key" ON "vault"("vault_id", "type", "chain_id");
+CREATE UNIQUE INDEX "vault_vault_id_type_chain_id_key" ON "vault" ("vault_id", "type", "chain_id");
+
 -- AddForeignKey
-ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_type_vault_chain_id_fkey" FOREIGN KEY ("vault_id", "vault_type", "vault_chain_id") REFERENCES "vault"("vault_id", "type", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE
+    "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_type_vault_chain_id_fkey" FOREIGN KEY ("vault_id", "vault_type", "vault_chain_id") REFERENCES "vault" ("vault_id", "type", "chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
 -- AddForeignKey
-ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_user_address_fkey" FOREIGN KEY ("user_address") REFERENCES "user"("address") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE
+    "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_user_address_fkey" FOREIGN KEY ("user_address") REFERENCES "user" ("address") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/database/migrations/013-add-users-who-follow-vaults.sql
+++ b/server/database/migrations/013-add-users-who-follow-vaults.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "users_who_follow_vaults" (
+    "user_address" TEXT NOT NULL,
+    "vault_id" INTEGER NOT NULL,
+    "vault_type" "vault_type" NOT NULL,
+
+    CONSTRAINT "users_who_follow_vaults_pkey" PRIMARY KEY ("user_address","vault_id","vault_type")
+);
+-- CreateIndex
+CREATE UNIQUE INDEX "vault_vault_id_key" ON "vault"("vault_id");
+CREATE UNIQUE INDEX "vault_vault_id_type_key" ON "vault"("vault_id", "type");
+-- AddForeignKey
+ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_vault_id_vault_type_fkey" FOREIGN KEY ("vault_id", "vault_type") REFERENCES "vault"("vault_id", "type") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "users_who_follow_vaults" ADD CONSTRAINT "users_who_follow_vaults_user_address_fkey" FOREIGN KEY ("user_address") REFERENCES "user"("address") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -28,12 +28,14 @@ model TosApproval {
 }
 
 model Vault {
-    vault_id      Int       @unique
+    vault_id      Int                    @unique
     type          VaultType
     owner_address String
     chain_id      Int?
+    users         UsersWhoFollowVaults[]
 
     @@unique([vault_id, chain_id], name: "vault_vault_id_chain_id_unique_constraint")
+    @@unique([vault_id, type])
     @@map("vault")
 }
 
@@ -45,13 +47,14 @@ enum VaultType {
 }
 
 model User {
-    address                    String        @unique
-    timestamp                  DateTime      @default(now())
+    address                    String                 @unique
+    timestamp                  DateTime               @default(now())
     user_that_referred_address String?
-    user_that_referred         User?         @relation("UserToUser", fields: [user_that_referred_address], references: [address])
-    referred_users             User[]        @relation("UserToUser")
+    user_that_referred         User?                  @relation("UserToUser", fields: [user_that_referred_address], references: [address])
+    referred_users             User[]                 @relation("UserToUser")
     weekly_claims              WeeklyClaim[]
     accepted                   Boolean
+    vaults                     UsersWhoFollowVaults[]
 
     @@map("user")
 }
@@ -199,4 +202,14 @@ model LargestDebt {
 
     @@unique([protocol_id, position_id], name: "protocol_id_position_id")
     @@map("largest_debt")
+}
+
+model UsersWhoFollowVaults {
+    user         User      @relation(fields: [user_address], references: [address])
+    user_address String // relation scalar field (used in the `@relation` attribute above)
+    vault        Vault     @relation(fields: [vault_id, vault_type], references: [vault_id, type])
+    vault_id     Int // relation scalar field (used in the `@relation` attribute above)
+    vault_type   VaultType // relation scalar field (used in the `@relation` attribute above)
+
+    @@id([user_address, vault_id, vault_type])
 }

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -15,15 +15,17 @@ model migrations {
 }
 
 model TosApproval {
-    id          Int      @id @default(autoincrement())
+    id          Int                       @id @default(autoincrement())
     address     String
     signature   String
     message     String
     chain_id    Int
     doc_version String
     sign_date   DateTime
+    vaults      users_who_follow_vaults[]
 
     @@unique([address, doc_version], name: "tos_approval_unique_signature")
+    @@unique([address, chain_id], name: "tos_approval_unique_addres_per_chain")
     @@map("tos_approval")
 }
 
@@ -46,14 +48,13 @@ enum VaultType {
 }
 
 model User {
-    address                    String                    @unique
-    timestamp                  DateTime                  @default(now())
+    address                    String        @unique
+    timestamp                  DateTime      @default(now())
     user_that_referred_address String?
-    user_that_referred         User?                     @relation("UserToUser", fields: [user_that_referred_address], references: [address])
-    referred_users             User[]                    @relation("UserToUser")
+    user_that_referred         User?         @relation("UserToUser", fields: [user_that_referred_address], references: [address])
+    referred_users             User[]        @relation("UserToUser")
     weekly_claims              WeeklyClaim[]
     accepted                   Boolean
-    vaults                     users_who_follow_vaults[]
 
     @@map("user")
 }
@@ -204,9 +205,9 @@ model LargestDebt {
 }
 
 model users_who_follow_vaults {
-    user           User   @relation(fields: [user_address], references: [address])
+    user           TosApproval @relation(fields: [user_address, vault_chain_id], references: [address, chain_id])
     user_address   String // relation scalar field (used in the `@relation` attribute above)
-    vault          Vault  @relation(fields: [vault_id, vault_chain_id], references: [vault_id, chain_id])
+    vault          Vault       @relation(fields: [vault_id, vault_chain_id], references: [vault_id, chain_id])
     vault_id       Int // relation scalar field (used in the `@relation` attribute above)
     vault_chain_id Int
 

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -28,14 +28,13 @@ model TosApproval {
 }
 
 model Vault {
-    vault_id      Int                    @unique
+    vault_id      Int                       @unique
     type          VaultType
     owner_address String
     chain_id      Int?
     users         users_who_follow_vaults[]
 
     @@unique([vault_id, chain_id], name: "vault_vault_id_chain_id_unique_constraint")
-    @@unique([vault_id, type, chain_id])
     @@map("vault")
 }
 
@@ -47,11 +46,11 @@ enum VaultType {
 }
 
 model User {
-    address                    String                 @unique
-    timestamp                  DateTime               @default(now())
+    address                    String                    @unique
+    timestamp                  DateTime                  @default(now())
     user_that_referred_address String?
-    user_that_referred         User?                  @relation("UserToUser", fields: [user_that_referred_address], references: [address])
-    referred_users             User[]                 @relation("UserToUser")
+    user_that_referred         User?                     @relation("UserToUser", fields: [user_that_referred_address], references: [address])
+    referred_users             User[]                    @relation("UserToUser")
     weekly_claims              WeeklyClaim[]
     accepted                   Boolean
     vaults                     users_who_follow_vaults[]
@@ -205,12 +204,11 @@ model LargestDebt {
 }
 
 model users_who_follow_vaults {
-    user         User      @relation(fields: [user_address], references: [address])
-    user_address String // relation scalar field (used in the `@relation` attribute above)
-    vault        Vault     @relation(fields: [vault_id, vault_type, vault_chain_id], references: [vault_id, type, chain_id])
-    vault_id     Int // relation scalar field (used in the `@relation` attribute above)
-    vault_type   VaultType // relation scalar field (used in the `@relation` attribute above)
-    vault_chain_id     Int
+    user           User   @relation(fields: [user_address], references: [address])
+    user_address   String // relation scalar field (used in the `@relation` attribute above)
+    vault          Vault  @relation(fields: [vault_id, vault_chain_id], references: [vault_id, chain_id])
+    vault_id       Int // relation scalar field (used in the `@relation` attribute above)
+    vault_chain_id Int
 
-    @@id([user_address, vault_id, vault_type, vault_chain_id])
+    @@id([user_address, vault_id, vault_chain_id])
 }

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -32,10 +32,10 @@ model Vault {
     type          VaultType
     owner_address String
     chain_id      Int?
-    users         UsersWhoFollowVaults[]
+    users         users_who_follow_vaults[]
 
     @@unique([vault_id, chain_id], name: "vault_vault_id_chain_id_unique_constraint")
-    @@unique([vault_id, type])
+    @@unique([vault_id, type, chain_id])
     @@map("vault")
 }
 
@@ -54,7 +54,7 @@ model User {
     referred_users             User[]                 @relation("UserToUser")
     weekly_claims              WeeklyClaim[]
     accepted                   Boolean
-    vaults                     UsersWhoFollowVaults[]
+    vaults                     users_who_follow_vaults[]
 
     @@map("user")
 }
@@ -204,12 +204,13 @@ model LargestDebt {
     @@map("largest_debt")
 }
 
-model UsersWhoFollowVaults {
+model users_who_follow_vaults {
     user         User      @relation(fields: [user_address], references: [address])
     user_address String // relation scalar field (used in the `@relation` attribute above)
-    vault        Vault     @relation(fields: [vault_id, vault_type], references: [vault_id, type])
+    vault        Vault     @relation(fields: [vault_id, vault_type, vault_chain_id], references: [vault_id, type, chain_id])
     vault_id     Int // relation scalar field (used in the `@relation` attribute above)
     vault_type   VaultType // relation scalar field (used in the `@relation` attribute above)
+    vault_chain_id     Int
 
-    @@id([user_address, vault_id, vault_type])
+    @@id([user_address, vault_id, vault_type, vault_chain_id])
 }


### PR DESCRIPTION
# [Store users who follow vaults in db](https://app.shortcut.com/oazo-apps/story/5897/store-followed-vaults-in-database-relation-1-address-to-many-cdpids)

  
## Changes 👷‍♀️
- added junction table which specifies which addresses follow which vaults of what type on given chainid
  
## How to test 🧪
- Run dev.sh
- see if migration works
- try to manually add in db records that define user following vault
- Check for edge cases like multiple users can follow the same vault of the same type
- One user can follow multiple vaults
- One user can follow vaults with the same ids on different chains

![image](https://user-images.githubusercontent.com/6871923/201703039-99dd6521-dfbf-4a7b-bc78-b683bdb6ab45.png)

