### PR TITLE
Added next price timer to maker vaults

### DIFF
--- a/components/vault/DefaultVaultHeadline.tsx
+++ b/components/vault/DefaultVaultHeadline.tsx
@@ -1,7 +1,9 @@
 import { PriceInfo } from 'features/shared/priceInfo'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { moreMinutes } from 'helpers/time'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { timeAgo } from 'utils'
 
 import { getPriceChangeColor } from './VaultDetails'
 import { VaultHeadline, VaultHeadlineProps } from './VaultHeadline'
@@ -18,13 +20,24 @@ export function DefaultVaultHeadline({
   colRatio: string
 }) {
   const { t } = useTranslation()
-  const { currentCollateralPrice, nextCollateralPrice, collateralPricePercentageChange } = priceInfo
+  const {
+    currentCollateralPrice,
+    nextCollateralPrice,
+    collateralPricePercentageChange,
+    dateNextCollateralPrice,
+  } = priceInfo
   const currentPrice = formatAmount(currentCollateralPrice, 'USD')
   const nextPrice = formatAmount(nextCollateralPrice, 'USD')
-  const priceChange = formatPercent(collateralPricePercentageChange.times(100), {
+  const priceChange = `(${formatPercent(collateralPricePercentageChange.times(100), {
     precision: 2,
-  })
+  })})`
   const priceChangeColor = getPriceChangeColor({ collateralPricePercentageChange })
+  const nextCollateralPriceTimeInMinutes = dateNextCollateralPrice
+    ? timeAgo({ from: new Date(), to: dateNextCollateralPrice, style: 'short' })
+    : ''
+  const isNextPriceLessThanTwoMinutes = dateNextCollateralPrice
+    ? dateNextCollateralPrice < moreMinutes(3)
+    : false
 
   return (
     <VaultHeadline
@@ -38,8 +51,13 @@ export function DefaultVaultHeadline({
         {
           label: t('manage-vault.next-price', { token }),
           value: `$${nextPrice}`,
-          sub: priceChange,
-          subColor: priceChangeColor,
+          sub: [
+            isNextPriceLessThanTwoMinutes
+              ? t('manage-vault.next-price-any-time')
+              : nextCollateralPriceTimeInMinutes,
+            priceChange,
+          ],
+          subColor: ['neutral80', priceChangeColor],
         },
         {
           label: t('system.collateral-ratio'),

--- a/components/vault/VaultHeadlineDetails.tsx
+++ b/components/vault/VaultHeadlineDetails.tsx
@@ -4,8 +4,8 @@ import { Box, Text } from 'theme-ui'
 export interface HeadlineDetailsProp {
   label: string
   value: string | number
-  sub?: string
-  subColor?: string
+  sub?: string | string[]
+  subColor?: string | string[]
 }
 
 export function VaultHeadlineDetails({ label, value, sub, subColor }: HeadlineDetailsProp) {
@@ -43,11 +43,22 @@ export function VaultHeadlineDetails({ label, value, sub, subColor }: HeadlineDe
       <Text as="span" sx={{ ml: 1, fontWeight: 'semiBold', color: 'primary100' }}>
         {value}
       </Text>
-      {sub && subColor && (
+      {typeof sub === 'string' && subColor && (
         <Text as="span" sx={{ ml: 1, fontSize: 2, fontWeight: 'semiBold', color: subColor }}>
           {sub}
         </Text>
       )}
+      {Array.isArray(sub) &&
+        Array.isArray(subColor) &&
+        sub.map((arrSub, arrSubIndex) => (
+          <Text
+            key={arrSub}
+            as="span"
+            sx={{ ml: 1, fontSize: 2, fontWeight: 'semiBold', color: subColor[arrSubIndex] }}
+          >
+            {arrSub}
+          </Text>
+        ))}
     </Box>
   )
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -475,6 +475,7 @@
     "action": "Manage Vault",
     "current-price": "Current {{token}} Price",
     "next-price": "Next {{token}} Price",
+    "next-price-any-time": "< 2 minutes",
     "card": {
       "collateralization-ratio-calculated": "Your collateralization ratio is calculated by: value of your collateral / Dai debt.",
       "collateralization-ratio-header2": "Current Collateralization ratio:",
@@ -944,8 +945,6 @@
     "header": "{{ilk}} Vault {{id}}",
     "insti-header": "Institutional {{ilk}} Vault {{id}}",
     "next-price": "Next price in {{count}} minute",
-    "next-price-any-time": "Next price in <2 minutes",
-    "next-price_plural": "Next price in {{count}} minutes",
     "open-vault": "Open {{ilk}} Vault",
     "vault-details": "Vault Details",
     "token-uds-price": "{{token}}/USD price"


### PR DESCRIPTION
# [Add next price timer back to the UI](https://app.shortcut.com/oazo-apps/story/5924/add-next-price-timer-back-to-the-ui)

## Changes 👷‍♀️
- added the time to next oracle price update in the maker vaults header
  
## How to test 🧪
- go to any maker vault
- the `Next (token) Price` should have next update time specified
- if the time is less than 3 minutes it should show `> 2 minutes`
(it's rounding down to full minutes, so it goes from `in 3 mins` to `> 2 minutes`)