### PR TITLE
Proxy for API testing

### DIFF
--- a/pages/api/proxy/index.tsx
+++ b/pages/api/proxy/index.tsx
@@ -1,0 +1,19 @@
+import { withSentry } from '@sentry/nextjs'
+import { NextApiHandler } from 'next'
+
+const handler: NextApiHandler = async (req, res) => {
+  switch (req.method) {
+    case 'GET':
+      if (req.url && req.query.url) {
+        const response = await fetch(req.url.replace('/api/proxy?url=', ''))
+
+        return res.status(response.status).json(await response.json())
+      } else {
+        return res.status(500).end()
+      }
+    default:
+      return res.status(405).end()
+  }
+}
+
+export default withSentry(handler)

--- a/pages/api/proxy/index.tsx
+++ b/pages/api/proxy/index.tsx
@@ -8,9 +8,7 @@ const handler: NextApiHandler = async (req, res) => {
         const response = await fetch(req.url.replace('/api/proxy?url=', ''))
 
         return res.status(response.status).json(await response.json())
-      } else {
-        return res.status(500).end()
-      }
+      } else return res.status(500).end()
     default:
       return res.status(405).end()
   }


### PR DESCRIPTION
# Proxy for API testing

Extremely simple internal proxy for local testing API that doesn't allow for request directly from the browser.
  
## Changes 👷‍♀️

- Created `api/proxy` endpoint.
  
## How to test 🧪

- For example, try requesting `/api/proxy?url=https://staging.oasis.app/api/discover?asset=ETH%2CWBTC%2CMANA%2CLINK%2CGUSD%2CYFI%2CUNI%2CMATIC%2CWSTETH%2CCRVV1ETHSTETH&size=&table=highest-risk-positions`.
