### PR TITLE
Incorporated stop loss to aave (just UI)

### DIFF
--- a/components/AutomationContextProvider.tsx
+++ b/components/AutomationContextProvider.tsx
@@ -49,8 +49,8 @@ export interface AutomationCommonData {
 }
 
 export interface AutomationPositionData {
-  collateralizationRatio: BigNumber
-  collateralizationRatioAtNextPrice: BigNumber
+  positionRatio: BigNumber
+  nextPositionRatio: BigNumber
   debt: BigNumber
   debtFloor: BigNumber
   debtOffset: BigNumber
@@ -159,21 +159,21 @@ export function AutomationContextProvider({
 
   useStopLossStateInitializator({
     liquidationRatio: positionData.liquidationRatio,
-    collateralizationRatio: positionData.collateralizationRatio,
+    positionRatio: positionData.positionRatio,
     stopLossTriggerData: autoContext.stopLossTriggerData,
   })
 
   useAutoBSstateInitialization({
     autoTriggersData: autoContext.autoSellTriggerData,
     stopLossTriggerData: autoContext.stopLossTriggerData,
-    collateralizationRatio: positionData.collateralizationRatio,
+    positionRatio: positionData.positionRatio,
     type: TriggerType.BasicSell,
   })
 
   useAutoBSstateInitialization({
     autoTriggersData: autoContext.autoBuyTriggerData,
     stopLossTriggerData: autoContext.stopLossTriggerData,
-    collateralizationRatio: positionData.collateralizationRatio,
+    positionRatio: positionData.positionRatio,
     type: TriggerType.BasicBuy,
   })
 
@@ -182,7 +182,7 @@ export function AutomationContextProvider({
     debt: positionData.debt,
     debtFloor: positionData.debtFloor,
     liquidationRatio: positionData.liquidationRatio,
-    collateralizationRatio: positionData.collateralizationRatio,
+    positionRatio: positionData.positionRatio,
     lockedCollateral: positionData.lockedCollateral,
     stopLossTriggerData: autoContext.stopLossTriggerData,
     autoSellTriggerData: autoContext.autoSellTriggerData,
@@ -193,7 +193,7 @@ export function AutomationContextProvider({
   useAutoTakeProfitStateInitializator({
     debt: positionData.debt,
     lockedCollateral: positionData.lockedCollateral,
-    collateralizationRatio: positionData.collateralizationRatio,
+    positionRatio: positionData.positionRatio,
     autoTakeProfitTriggerData: autoContext.autoTakeProfitTriggerData,
   })
 

--- a/components/vault/SidebarFormInfo.tsx
+++ b/components/vault/SidebarFormInfo.tsx
@@ -15,6 +15,7 @@ export function SidebarFormInfo({ title, description }: SidebarFormInfoProps) {
         sx={{
           fontSize: 3,
           fontWeight: 600,
+          lineHeight: '22px',
         }}
       >
         {title}

--- a/components/vault/detailsSection/ContentCardCollateralizationRatio.tsx
+++ b/components/vault/detailsSection/ContentCardCollateralizationRatio.tsx
@@ -10,19 +10,19 @@ import React from 'react'
 import { Card, Grid, Heading, Text } from 'theme-ui'
 
 interface ContentCardCollateralizationRatioModalProps {
-  collateralizationRatioFormatted: string
-  collateralizationRatioAtNextPriceFormated?: string
+  positionRatioFormatted: string
+  nextPositionRatioFormated?: string
 }
 interface ContentCardCollateralizationRatioProps {
-  collateralizationRatio: BigNumber
-  collateralizationRatioAtNextPrice?: BigNumber
-  afterCollateralizationRatio?: BigNumber
+  positionRatio: BigNumber
+  nextPositionRatio?: BigNumber
+  afterPositionRatio?: BigNumber
   changeVariant?: ChangeVariantType
 }
 
 function ContentCardCollateralizationRatioModal({
-  collateralizationRatioFormatted,
-  collateralizationRatioAtNextPriceFormated,
+  positionRatioFormatted,
+  nextPositionRatioFormated,
 }: ContentCardCollateralizationRatioModalProps) {
   const { t } = useTranslation()
 
@@ -34,16 +34,16 @@ function ContentCardCollateralizationRatioModal({
       </Text>
       <Heading variant="header3">{t('manage-vault.card.collateralization-ratio-header2')}</Heading>
       <Card variant="vaultDetailsCardModal" sx={{ my: 2 }}>
-        {collateralizationRatioFormatted}
+        {positionRatioFormatted}
       </Card>
       <Text variant="paragraph2">{t('manage-vault.card.collateralization-ratio-description')}</Text>
-      {collateralizationRatioAtNextPriceFormated && (
+      {nextPositionRatioFormated && (
         <>
           <Heading variant="header3" sx={{ mt: 2 }}>
             {t('manage-vault.card.collateralization-ratio-next-price')}
           </Heading>
           <Card variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
-            {collateralizationRatioAtNextPriceFormated}
+            {nextPositionRatioFormated}
           </Card>
         </>
       )}
@@ -52,54 +52,53 @@ function ContentCardCollateralizationRatioModal({
 }
 
 export function ContentCardCollateralizationRatio({
-  collateralizationRatio,
-  collateralizationRatioAtNextPrice,
-  afterCollateralizationRatio,
+  positionRatio,
+  nextPositionRatio,
+  afterPositionRatio,
   changeVariant,
 }: ContentCardCollateralizationRatioProps) {
   const { t } = useTranslation()
 
   const formatted = {
-    collateralizationRatio: formatPercent(collateralizationRatio.times(100), {
+    positionRatio: formatPercent(positionRatio.times(100), {
       precision: 2,
       roundMode: BigNumber.ROUND_DOWN,
     }),
-    collateralizationRatioAtNextPrice:
-      collateralizationRatioAtNextPrice &&
-      formatPercent(collateralizationRatioAtNextPrice.times(100), {
+    nextPositionRatio:
+      nextPositionRatio &&
+      formatPercent(nextPositionRatio.times(100), {
         precision: 2,
         roundMode: BigNumber.ROUND_DOWN,
       }),
-    afterCollateralizationRatio:
-      afterCollateralizationRatio &&
-      formatPercent(afterCollateralizationRatio.times(100), {
+    afterPostionRatio:
+      afterPositionRatio &&
+      formatPercent(afterPositionRatio.times(100), {
         precision: 2,
         roundMode: BigNumber.ROUND_DOWN,
       }),
   }
 
   const contentCardModalSettings: ContentCardCollateralizationRatioModalProps = {
-    collateralizationRatioFormatted: formatted.collateralizationRatio,
+    positionRatioFormatted: formatted.positionRatio,
   }
 
-  if (collateralizationRatioAtNextPrice)
-    contentCardModalSettings.collateralizationRatioAtNextPriceFormated =
-      formatted.collateralizationRatioAtNextPrice
+  if (nextPositionRatio)
+    contentCardModalSettings.nextPositionRatioFormated = formatted.nextPositionRatio
 
   const contentCardSettings: ContentCardProps = {
     title: t('system.collateralization-ratio'),
-    value: formatted.collateralizationRatio,
+    value: formatted.positionRatio,
     modal: <ContentCardCollateralizationRatioModal {...contentCardModalSettings} />,
   }
 
-  if (afterCollateralizationRatio && changeVariant)
+  if (afterPositionRatio && changeVariant)
     contentCardSettings.change = {
-      value: `${formatted.afterCollateralizationRatio} ${t('system.cards.common.after')}`,
+      value: `${formatted.afterPostionRatio} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     }
-  if (collateralizationRatioAtNextPrice)
+  if (nextPositionRatio)
     contentCardSettings.footnote = t('system.cards.collateralization-ratio.footnote', {
-      amount: formatted.collateralizationRatioAtNextPrice,
+      amount: formatted.nextPositionRatio,
     })
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/components/vault/detailsSection/ContentCardStopLossCollateralRatio.tsx
+++ b/components/vault/detailsSection/ContentCardStopLossCollateralRatio.tsx
@@ -14,7 +14,7 @@ interface ContentCardStopLossCollateralRatioProps {
   isStopLossEnabled: boolean
   isEditing: boolean
   slRatio: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   afterSlRatio: BigNumber
 }
 
@@ -45,7 +45,7 @@ export function ContentCardStopLossCollateralRatio({
   isEditing,
   slRatio,
   afterSlRatio,
-  collateralizationRatio,
+  positionRatio,
 }: ContentCardStopLossCollateralRatioProps) {
   const { t } = useTranslation()
 
@@ -53,7 +53,7 @@ export function ContentCardStopLossCollateralRatio({
     slRatio: formatPercent(slRatio.times(100), {
       precision: 2,
     }),
-    belowCurrentCollRatio: formatPercent(collateralizationRatio.minus(slRatio).times(100), {
+    belowCurrentCollRatio: formatPercent(positionRatio.minus(slRatio).times(100), {
       precision: 2,
     }),
     afterSlRatio: formatPercent(afterSlRatio.times(100), {

--- a/features/aave/manage/containers/AaveManageView.tsx
+++ b/features/aave/manage/containers/AaveManageView.tsx
@@ -2,6 +2,7 @@ import { useActor } from '@xstate/react'
 import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
 import { useAppContext } from 'components/AppContextProvider'
 import { TabBar } from 'components/TabBar'
+import { ProtectionControl } from 'components/vault/ProtectionControl'
 import { AaveAutomationContext } from 'features/automation/contexts/AaveAutomationContext'
 import { AaveFaq } from 'features/content/faqs/aave'
 import { useEarnContext } from 'features/earn/EarnContextProvider'
@@ -10,6 +11,7 @@ import { Survey } from 'features/survey'
 import { VaultContainerSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from 'helpers/observableHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Card, Container, Grid } from 'theme-ui'
@@ -44,6 +46,7 @@ function AaveManageContainer({
   const VaultDetails = strategyConfig.viewComponents.vaultDetailsManage
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state] = useActor(stateMachine)
+  const aaveProtection = useFeatureToggle('AaveProtection')
 
   if (!state.context.protocolData) {
     return null
@@ -90,6 +93,16 @@ function AaveManageContainer({
                 </Card>
               ),
             },
+            ...(aaveProtection
+              ? [
+                  {
+                    label: t('system.protection'),
+                    value: 'protection',
+                    tag: { include: true, active: false },
+                    content: <ProtectionControl />,
+                  },
+                ]
+              : []),
           ]}
         />
         <Survey for="earn" />

--- a/features/aave/view/containers/AavePositionView.tsx
+++ b/features/aave/view/containers/AavePositionView.tsx
@@ -1,6 +1,7 @@
 import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
 import { useAppContext } from 'components/AppContextProvider'
 import { TabBar } from 'components/TabBar'
+import { ProtectionControl } from 'components/vault/ProtectionControl'
 import { useAaveContext } from 'features/aave/AaveContextProvider'
 import { AaveProtocolData } from 'features/aave/manage/state'
 import { AaveAutomationContext } from 'features/automation/contexts/AaveAutomationContext'
@@ -11,6 +12,7 @@ import { Survey } from 'features/survey'
 import { VaultContainerSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from 'helpers/observableHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Card, Container, Grid } from 'theme-ui'
@@ -42,6 +44,8 @@ function AavePositionContainer({
   const { t } = useTranslation()
   const Header = strategyConfig.viewComponents.headerView
   const VaultDetails = strategyConfig.viewComponents.vaultDetailsView
+  const aaveProtection = useFeatureToggle('AaveProtection')
+
   return (
     <AaveAutomationContext
       aaveManageVault={{
@@ -94,6 +98,16 @@ function AavePositionContainer({
                 </Card>
               ),
             },
+            ...(aaveProtection
+              ? [
+                  {
+                    label: t('system.protection'),
+                    value: 'protection',
+                    tag: { include: true, active: false },
+                    content: <ProtectionControl />,
+                  },
+                ]
+              : []),
           ]}
         />
         <Survey for="earn" />

--- a/features/automation/common/consts.ts
+++ b/features/automation/common/consts.ts
@@ -1,6 +1,7 @@
 import { TxStatus } from '@oasisdex/transactions'
 import BigNumber from 'bignumber.js'
 import { AutomationFeatures, AutomationKinds } from 'features/automation/common/types'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { FixedSizeArray } from 'helpers/types'
 import { one } from 'helpers/zero'
 
@@ -59,4 +60,15 @@ export const autoKindToCopyMap = {
 export enum CloseVaultToEnum {
   DAI = 'dai',
   COLLATERAL = 'collateral',
+}
+
+export const protocolAutomations = {
+  [VaultProtocol.Maker]: [
+    AutomationFeatures.STOP_LOSS,
+    AutomationFeatures.AUTO_SELL,
+    AutomationFeatures.AUTO_BUY,
+    AutomationFeatures.CONSTANT_MULTIPLE,
+    AutomationFeatures.AUTO_TAKE_PROFIT,
+  ],
+  [VaultProtocol.Aave]: [AutomationFeatures.STOP_LOSS],
 }

--- a/features/automation/common/context/getAutomationAavePositionData.ts
+++ b/features/automation/common/context/getAutomationAavePositionData.ts
@@ -26,8 +26,8 @@ export function getAutomationAavePositionData({
   const ilkOrToken = strategyConfig.tokens?.collateral!
 
   return {
-    collateralizationRatio: one.div(ltv.div(10000)),
-    collateralizationRatioAtNextPrice: one.div(ltv.div(10000)),
+    positionRatio: one.div(ltv.div(10000)),
+    nextPositionRatio: one.div(ltv.div(10000)),
     debt: totalDebtETH,
     debtFloor: position.category.dustLimit,
     debtOffset: zero,

--- a/features/automation/common/context/getAutomationMakerPositionData.ts
+++ b/features/automation/common/context/getAutomationMakerPositionData.ts
@@ -25,8 +25,8 @@ export function getAutomationMakerPositionData({
   } = generalManageVault.state
 
   return {
-    collateralizationRatio,
-    collateralizationRatioAtNextPrice,
+    positionRatio: collateralizationRatio,
+    nextPositionRatio: collateralizationRatioAtNextPrice,
     debt,
     debtFloor,
     debtOffset,

--- a/features/automation/common/controls/AddAndRemoveTriggerControl.tsx
+++ b/features/automation/common/controls/AddAndRemoveTriggerControl.tsx
@@ -60,7 +60,7 @@ export function AddAndRemoveTriggerControl({
   const { uiChanges } = useAppContext()
   const {
     environmentData: { ethMarketPrice },
-    positionData: { id, ilk, owner, collateralizationRatio },
+    positionData: { id, ilk, owner, positionRatio },
   } = useAutomationContext()
 
   const { removeTxData, textButtonHandler, txHandler } = getAutomationFeatureTxHandlers({
@@ -78,7 +78,7 @@ export function AddAndRemoveTriggerControl({
     txHelpers,
     vaultId: id,
     ilk,
-    collateralizationRatio,
+    positionRatio,
     analytics,
   })
 

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -75,32 +75,32 @@ export function resolveWithThreshold({
 export function prepareAutoBSSliderDefaults({
   execCollRatio,
   targetCollRatio,
-  collateralizationRatio,
+  positionRatio,
   publishKey,
 }: {
   execCollRatio: BigNumber
   targetCollRatio: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   publishKey: 'AUTO_SELL_FORM_CHANGE' | 'AUTO_BUY_FORM_CHANGE'
 }) {
-  const defaultTargetCollRatio = new BigNumber(collateralizationRatio)
+  const defaultTargetCollRatio = new BigNumber(positionRatio)
 
   const defaultTriggerForSell = new BigNumber(
-    collateralizationRatio.minus(DEFAULT_DISTANCE_FROM_TRIGGER_TO_TARGET),
+    positionRatio.minus(DEFAULT_DISTANCE_FROM_TRIGGER_TO_TARGET),
   )
   const defaultTriggerForBuy = new BigNumber(
-    collateralizationRatio.plus(DEFAULT_DISTANCE_FROM_TRIGGER_TO_TARGET),
+    positionRatio.plus(DEFAULT_DISTANCE_FROM_TRIGGER_TO_TARGET),
   )
 
   return {
     execCollRatio:
-      execCollRatio.isZero() && collateralizationRatio.gt(zero)
+      execCollRatio.isZero() && positionRatio.gt(zero)
         ? publishKey === 'AUTO_SELL_FORM_CHANGE'
           ? defaultTriggerForSell.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
           : defaultTriggerForBuy.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
         : execCollRatio,
     targetCollRatio:
-      targetCollRatio.isZero() && collateralizationRatio.gt(zero)
+      targetCollRatio.isZero() && positionRatio.gt(zero)
         ? defaultTargetCollRatio.times(100).decimalPlaces(0, BigNumber.ROUND_DOWN)
         : targetCollRatio,
   }
@@ -108,13 +108,13 @@ export function prepareAutoBSSliderDefaults({
 
 export function prepareAutoBSResetData(
   autoBSTriggersData: AutoBSTriggerData,
-  collateralizationRatio: BigNumber,
+  positionRatio: BigNumber,
   publishKey: 'AUTO_SELL_FORM_CHANGE' | 'AUTO_BUY_FORM_CHANGE',
 ) {
   const defaultSliderValues = prepareAutoBSSliderDefaults({
     execCollRatio: autoBSTriggersData.execCollRatio,
     targetCollRatio: autoBSTriggersData.targetCollRatio,
-    collateralizationRatio,
+    positionRatio,
     publishKey,
   })
   return {
@@ -288,7 +288,7 @@ export function automationMultipleRangeSliderAnalytics({
   leftValue,
   rightValue,
   vaultId,
-  collateralizationRatio,
+  positionRatio,
   ilk,
   type,
   targetMultiple,
@@ -296,7 +296,7 @@ export function automationMultipleRangeSliderAnalytics({
   leftValue: BigNumber
   rightValue: BigNumber
   vaultId: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   ilk: string
   type:
     | AutomationFeatures.AUTO_SELL
@@ -307,7 +307,7 @@ export function automationMultipleRangeSliderAnalytics({
   const analyticsAdditionalParams = {
     vaultId: vaultId.toString(),
     ilk: ilk,
-    collateralRatio: collateralizationRatio.times(100).decimalPlaces(2).toString(),
+    collateralRatio: positionRatio.times(100).decimalPlaces(2).toString(),
     ...(targetMultiple && { targetMultiple: targetMultiple.toString() }),
   }
 
@@ -368,7 +368,7 @@ export function automationInputsAnalytics({
   type,
   vaultId,
   ilk,
-  collateralizationRatio,
+  positionRatio,
 }: {
   minSellPrice?: BigNumber
   withMinSellPriceThreshold?: boolean
@@ -379,7 +379,7 @@ export function automationInputsAnalytics({
     | AutomationFeatures.AUTO_BUY
     | AutomationFeatures.CONSTANT_MULTIPLE
   vaultId: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   ilk: string
 }) {
   const shouldTrackMinSellInput =
@@ -390,7 +390,7 @@ export function automationInputsAnalytics({
   const analyticsAdditionalParams = {
     vaultId: vaultId.toString(),
     ilk: ilk,
-    collateralRatio: collateralizationRatio.times(100).decimalPlaces(2).toString(),
+    collateralRatio: positionRatio.times(100).decimalPlaces(2).toString(),
   }
 
   const resolvedMinSellPrice = resolveMinSellPriceAnalytics({

--- a/features/automation/common/helpers.ts
+++ b/features/automation/common/helpers.ts
@@ -13,6 +13,7 @@ import { TriggerRecord, TriggersData } from 'features/automation/api/automationT
 import {
   DEFAULT_DISTANCE_FROM_TRIGGER_TO_TARGET,
   maxUint256,
+  protocolAutomations,
 } from 'features/automation/common/consts'
 import {
   AUTO_BUY_FORM_CHANGE,
@@ -28,6 +29,7 @@ import {
 import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
 import { getVaultChange } from 'features/multiply/manage/pipes/manageMultiplyVaultCalculations'
 import { SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { LOAN_FEE, OAZO_FEE } from 'helpers/multiply/calculations'
 import { useDebouncedCallback } from 'helpers/useDebouncedCallback'
 import { one, zero } from 'helpers/zero'
@@ -456,4 +458,18 @@ export function openVaultWithStopLossAnalytics({
       collateralRatio: afterCollateralizationRatio.times(100).decimalPlaces(2).toString(),
     },
   )
+}
+
+export function getAvailableAutomation(protocol: VaultProtocol) {
+  return {
+    isStopLossAvailable: protocolAutomations[protocol].includes(AutomationFeatures.STOP_LOSS),
+    isAutoSellAvailable: protocolAutomations[protocol].includes(AutomationFeatures.AUTO_SELL),
+    isAutoBuyAvailable: protocolAutomations[protocol].includes(AutomationFeatures.AUTO_BUY),
+    isConstantMultipleAvailable: protocolAutomations[protocol].includes(
+      AutomationFeatures.CONSTANT_MULTIPLE,
+    ),
+    isTakeProfitAvailable: protocolAutomations[protocol].includes(
+      AutomationFeatures.AUTO_TAKE_PROFIT,
+    ),
+  }
 }

--- a/features/automation/common/sidebars/CancelAutoBSInfoSection.tsx
+++ b/features/automation/common/sidebars/CancelAutoBSInfoSection.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 interface CancelAutoBSInfoSectionProps {
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   liquidationPrice: BigNumber
   debt: BigNumber
   title: string
@@ -18,7 +18,7 @@ interface CancelAutoBSInfoSectionProps {
 }
 
 export function CancelAutoBSInfoSection({
-  collateralizationRatio,
+  positionRatio,
   liquidationPrice,
   debt,
   title,
@@ -31,7 +31,7 @@ export function CancelAutoBSInfoSection({
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
 
   const liquidationPriceFormatted = formatAmount(liquidationPrice, 'USD')
-  const collateralizationRatioFormatted = formatPercent(collateralizationRatio.times(100), {
+  const positionRatioFormatted = formatPercent(positionRatio.times(100), {
     precision: 2,
   })
   const execCollRatioFormatted = formatPercent(autoBSState.execCollRatio, { precision: 2 })
@@ -57,7 +57,7 @@ export function CancelAutoBSInfoSection({
           : [
               {
                 label: t('system.collateral-ratio'),
-                value: collateralizationRatioFormatted,
+                value: positionRatioFormatted,
               },
               {
                 label: t('system.liquidation-price'),

--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -1,6 +1,7 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { SidebarSectionHeaderDropdown } from 'components/sidebar/SidebarSectionHeader'
 import { SidebarSectionHeaderSelectItem } from 'components/sidebar/SidebarSectionHeaderSelect'
+import { getAvailableAutomation } from 'features/automation/common/helpers'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationOptimizationFeatures,
@@ -106,20 +107,28 @@ export function getAutoFeaturesSidebarDropdown({
     isFeatureEnabled: isAutoTakeProfitEnabled,
   })
 
+  const {
+    isStopLossAvailable,
+    isAutoSellAvailable,
+    isAutoBuyAvailable,
+    isConstantMultipleAvailable,
+    isTakeProfitAvailable,
+  } = getAvailableAutomation(protocol)
+
   const items = [
     ...(type === 'Protection'
       ? [
-          stopLossDropdownItem,
-          ...(!isAutoConstantMultipleEnabled && protocol === VaultProtocol.Maker
-            ? [autoSellDropdownItem]
-            : []),
+          ...(isStopLossAvailable ? [stopLossDropdownItem] : []),
+          ...(!isAutoConstantMultipleEnabled && isAutoSellAvailable ? [autoSellDropdownItem] : []),
         ]
       : []),
     ...(type === 'Optimization'
       ? [
-          ...(!isAutoConstantMultipleEnabled ? [basicBuyDropdownItem] : []),
-          ...(vaultType === VaultType.Multiply ? [constantMultipleDropdownItem] : []),
-          ...(autoTakeProfitEnabled ? [autoTakeProfitDropdownItem] : []),
+          ...(!isAutoConstantMultipleEnabled && isAutoBuyAvailable ? [basicBuyDropdownItem] : []),
+          ...(vaultType === VaultType.Multiply && isConstantMultipleAvailable
+            ? [constantMultipleDropdownItem]
+            : []),
+          ...(autoTakeProfitEnabled && isTakeProfitAvailable ? [autoTakeProfitDropdownItem] : []),
         ]
       : []),
   ]

--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -9,6 +9,7 @@ import {
 } from 'features/automation/common/state/automationFeatureChange'
 import { AutomationFeatures } from 'features/automation/common/types'
 import { VaultType } from 'features/generalManageVault/vaultType'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 
@@ -16,6 +17,7 @@ interface GetAutoFeaturesSidebarDropdownProps {
   type: AutomationTypes
   forcePanel: AutomationProtectionFeatures | AutomationOptimizationFeatures
   vaultType: VaultType
+  protocol: VaultProtocol
   disabled?: boolean
   isStopLossEnabled?: boolean
   isAutoSellEnabled?: boolean
@@ -69,6 +71,7 @@ export function getAutoFeaturesSidebarDropdown({
   isAutoConstantMultipleEnabled,
   isAutoTakeProfitEnabled,
   vaultType,
+  protocol,
 }: GetAutoFeaturesSidebarDropdownProps): SidebarSectionHeaderDropdown | undefined {
   const autoTakeProfitEnabled = useFeatureToggle('AutoTakeProfit')
 
@@ -105,7 +108,12 @@ export function getAutoFeaturesSidebarDropdown({
 
   const items = [
     ...(type === 'Protection'
-      ? [stopLossDropdownItem, ...(!isAutoConstantMultipleEnabled ? [autoSellDropdownItem] : [])]
+      ? [
+          stopLossDropdownItem,
+          ...(!isAutoConstantMultipleEnabled && protocol === VaultProtocol.Maker
+            ? [autoSellDropdownItem]
+            : []),
+        ]
       : []),
     ...(type === 'Optimization'
       ? [

--- a/features/automation/common/state/autoBSStatus.ts
+++ b/features/automation/common/state/autoBSStatus.ts
@@ -21,7 +21,7 @@ interface GetAutoBSStatusParams {
   stage: SidebarAutomationStages
   lockedCollateral: BigNumber
   debt: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
 }
 
 interface AutoBSStatus {
@@ -46,7 +46,7 @@ export function getAutoBSStatus({
   stage,
   debt,
   lockedCollateral,
-  collateralizationRatio,
+  positionRatio,
 }: GetAutoBSStatusParams): AutoBSStatus {
   const isEditing = checkIfIsEditingAutoBS({
     autoBSTriggerData,
@@ -67,7 +67,7 @@ export function getAutoBSStatus({
     vaultDebt: debt,
   })
   const executionPriceAtCurrentCollRatio = collateralPriceAtRatio({
-    colRatio: collateralizationRatio,
+    colRatio: positionRatio,
     collateral: lockedCollateral,
     vaultDebt: debt,
   })
@@ -81,13 +81,13 @@ export function getAutoBSStatus({
   })
   const { debtDelta: debtDeltaAtCurrentCollRatio } = getAutoBSVaultChange({
     targetCollRatio: autoBSState.targetCollRatio,
-    execCollRatio: collateralizationRatio.times(100),
+    execCollRatio: positionRatio.times(100),
     deviation: autoBSState.deviation,
     executionPrice: executionPriceAtCurrentCollRatio,
     lockedCollateral: lockedCollateral,
     debt: debt,
   })
-  const resetData = prepareAutoBSResetData(autoBSTriggerData, collateralizationRatio, publishType)
+  const resetData = prepareAutoBSResetData(autoBSTriggerData, positionRatio, publishType)
 
   return {
     collateralDelta,

--- a/features/automation/common/state/autoBSTxHandlers.ts
+++ b/features/automation/common/state/autoBSTxHandlers.ts
@@ -13,7 +13,7 @@ interface GetAutoBSTxHandlersParams {
   isAddForm: boolean
   publishType: AutomationBSPublishType
   triggerType: AutoBSTriggerTypes
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   id: BigNumber
   owner: string
 }
@@ -29,7 +29,7 @@ export function getAutoBSTxHandlers({
   isAddForm,
   publishType,
   triggerType,
-  collateralizationRatio,
+  positionRatio,
   id,
   owner,
 }: GetAutoBSTxHandlersParams): AutoBSTxHandlers {
@@ -57,7 +57,7 @@ export function getAutoBSTxHandlers({
       autoBSState.maxBuyOrMinSellPrice?.toNumber(),
       autoBSState.triggerId.toNumber(),
       autoBSState.maxBaseFeeInGwei.toNumber(),
-      collateralizationRatio.toNumber(),
+      positionRatio.toNumber(),
     ],
   )
 

--- a/features/automation/common/state/automationFeatureTxHandlers.ts
+++ b/features/automation/common/state/automationFeatureTxHandlers.ts
@@ -53,7 +53,7 @@ interface GetAutomationFeatureTxHandlersParams {
   textButtonHandlerExtension?: () => void
   triggersId: number[]
   vaultId: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   ilk: string
   analytics: AutomationTxHandlerAnalytics
   txHelpers?: TxHelpers
@@ -80,7 +80,7 @@ export function getAutomationFeatureTxHandlers({
   txHelpers,
   vaultId,
   ilk,
-  collateralizationRatio,
+  positionRatio,
   analytics,
 }: GetAutomationFeatureTxHandlersParams): AutomationFeatureTxHandlers {
   const { uiChanges } = useAppContext()
@@ -89,10 +89,7 @@ export function getAutomationFeatureTxHandlers({
   const analyticsAdditionalParams = {
     vaultId: vaultId.toString(),
     ilk,
-    collateralRatio: collateralizationRatio
-      .times(100)
-      .decimalPlaces(2, BigNumber.ROUND_DOWN)
-      .toString(),
+    collateralRatio: positionRatio.times(100).decimalPlaces(2, BigNumber.ROUND_DOWN).toString(),
   }
 
   const removeTxData: AutomationBotRemoveTriggersData = useMemo(

--- a/features/automation/common/state/useAutoBSStateInitializator.ts
+++ b/features/automation/common/state/useAutoBSStateInitializator.ts
@@ -18,9 +18,9 @@ export function useAutoBSstateInitialization({
   autoTriggersData,
   stopLossTriggerData,
   type,
-  collateralizationRatio,
+  positionRatio,
 }: {
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   autoTriggersData: AutoBSTriggerData
   stopLossTriggerData: StopLossTriggerData
   type: TriggerType
@@ -44,7 +44,7 @@ export function useAutoBSstateInitialization({
   const sliderDefaults = prepareAutoBSSliderDefaults({
     execCollRatio,
     targetCollRatio,
-    collateralizationRatio,
+    positionRatio,
     publishKey,
   })
 
@@ -97,11 +97,7 @@ export function useAutoBSstateInitialization({
       type: 'is-awaiting-confirmation',
       isAwaitingConfirmation: false,
     })
-  }, [
-    triggerId.toNumber(),
-    collateralizationRatio.toNumber(),
-    stopLossTriggerData.triggerId.toNumber(),
-  ])
+  }, [triggerId.toNumber(), positionRatio.toNumber(), stopLossTriggerData.triggerId.toNumber()])
 
   useEffect(() => {
     uiChanges.publish(publishKey, {
@@ -112,7 +108,7 @@ export function useAutoBSstateInitialization({
       type: 'current-form',
       currentForm: 'add',
     })
-  }, [collateralizationRatio.toNumber()])
+  }, [positionRatio.toNumber()])
 
   return isTriggerEnabled
 }

--- a/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
@@ -31,7 +31,7 @@ export function AutoBuyFormControl({
   const {
     autoBuyTriggerData,
     environmentData: { canInteract },
-    positionData: { id, debt, lockedCollateral, collateralizationRatio, owner },
+    positionData: { id, debt, lockedCollateral, positionRatio, owner },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.AUTO_BUY
@@ -66,7 +66,7 @@ export function AutoBuyFormControl({
     stage,
     debt,
     lockedCollateral,
-    collateralizationRatio,
+    positionRatio,
   })
   const { addTxData, textButtonHandlerExtension } = getAutoBSTxHandlers({
     autoBSState: autoBuyState,
@@ -75,7 +75,7 @@ export function AutoBuyFormControl({
     triggerType: TriggerType.BasicBuy,
     id,
     owner,
-    collateralizationRatio,
+    positionRatio,
   })
 
   return (

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -11,7 +11,11 @@ import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
-import { maxUint256, MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/common/consts'
+import {
+  maxUint256,
+  MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
+  sidebarAutomationFeatureCopyMap,
+} from 'features/automation/common/consts'
 import {
   adjustDefaultValuesIfOutsideSlider,
   automationInputsAnalytics,
@@ -62,7 +66,7 @@ export function SidebarAutoBuyEditingStage({
   const {
     autoBuyTriggerData,
     stopLossTriggerData,
-    positionData: { id, ilk, token, debt, debtFloor, lockedCollateral, collateralizationRatio },
+    positionData: { id, ilk, token, debt, debtFloor, lockedCollateral, positionRatio },
   } = useAutomationContext()
   const { uiChanges } = useAppContext()
   const [, setHash] = useHash()
@@ -85,7 +89,7 @@ export function SidebarAutoBuyEditingStage({
       uiChanges,
       publishType: AUTO_BUY_FORM_CHANGE,
     })
-  }, [collateralizationRatio.toNumber()])
+  }, [positionRatio.toNumber()])
 
   automationMultipleRangeSliderAnalytics({
     leftValue: autoBuyState.targetCollRatio,
@@ -93,7 +97,7 @@ export function SidebarAutoBuyEditingStage({
     type: AutomationFeatures.AUTO_BUY,
     ilk,
     vaultId: id,
-    collateralizationRatio,
+    positionRatio,
   })
 
   automationInputsAnalytics({
@@ -102,10 +106,10 @@ export function SidebarAutoBuyEditingStage({
     type: AutomationFeatures.AUTO_BUY,
     vaultId: id,
     ilk,
-    collateralizationRatio,
+    positionRatio,
   })
 
-  const isCurrentCollRatioHigherThanSliderMax = collateralizationRatio.times(100).gt(sliderMax)
+  const isCurrentCollRatioHigherThanSliderMax = positionRatio.times(100).gt(sliderMax)
 
   if (
     isStopLossEnabled &&
@@ -171,11 +175,22 @@ export function SidebarAutoBuyEditingStage({
     )
   }
 
+  const feature = t(sidebarAutomationFeatureCopyMap[AutomationFeatures.AUTO_BUY])
+
   if (isVaultEmpty && autoBuyTriggerData.isTriggerEnabled) {
     return (
       <SidebarFormInfo
-        title={t('auto-buy.closed-vault-existing-trigger-header')}
-        description={t('auto-buy.closed-vault-existing-trigger-description')}
+        title={t('automation.closed-vault-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-existing-trigger-description', { feature })}
+      />
+    )
+  }
+
+  if (isVaultEmpty) {
+    return (
+      <SidebarFormInfo
+        title={t('automation.closed-vault-not-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-not-existing-trigger-description', { feature })}
       />
     )
   }
@@ -308,7 +323,7 @@ export function SidebarAutoBuyEditingStage({
                 type: 'reset',
                 resetData: prepareAutoBSResetData(
                   autoBuyTriggerData,
-                  collateralizationRatio,
+                  positionRatio,
                   AUTO_BUY_FORM_CHANGE,
                 ),
               })

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
@@ -43,12 +43,12 @@ interface AutoBuyInfoSectionControlProps {
 function AutoBuyInfoSectionControl({ autoBuyState }: AutoBuyInfoSectionControlProps) {
   const { t } = useTranslation()
   const {
-    positionData: { collateralizationRatio, liquidationPrice, debt },
+    positionData: { positionRatio, liquidationPrice, debt },
   } = useAutomationContext()
 
   return (
     <CancelAutoBSInfoSection
-      collateralizationRatio={collateralizationRatio}
+      positionRatio={positionRatio}
       liquidationPrice={liquidationPrice}
       title={t('auto-buy.cancel-summary-title')}
       targetLabel={t('auto-buy.target-col-ratio-each-buy')}

--- a/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
@@ -78,7 +78,8 @@ export function SidebarSetupAutoBuy({
     constantMultipleTriggerData,
     stopLossTriggerData,
     environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
-    positionData: { collateralizationRatioAtNextPrice, token, liquidationRatio, vaultType },
+    positionData: { nextPositionRatio, token, liquidationRatio, vaultType },
+    protocol,
   } = useAutomationContext()
 
   const { isAwaitingConfirmation } = autoBuyState
@@ -97,6 +98,7 @@ export function SidebarSetupAutoBuy({
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     isAutoTakeProfitEnabled: autoTakeProfitTriggerData.isTriggerEnabled,
     vaultType,
+    protocol,
   })
 
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
@@ -135,7 +137,7 @@ export function SidebarSetupAutoBuy({
     executionPrice,
     autoTakeProfitExecutionPrice: autoTakeProfitTriggerData.executionPrice,
     token,
-    collateralizationRatioAtNextPrice,
+    nextPositionRatio,
   })
   const errors = errorsAutoBuyValidation({
     autoBuyState,

--- a/features/automation/optimization/autoBuy/validators.ts
+++ b/features/automation/optimization/autoBuy/validators.ts
@@ -21,7 +21,7 @@ export function warningsAutoBuyValidation({
   executionPrice,
   autoTakeProfitExecutionPrice,
   token,
-  collateralizationRatioAtNextPrice,
+  nextPositionRatio,
 }: {
   ethBalance: BigNumber
   ethPrice: BigNumber
@@ -36,7 +36,7 @@ export function warningsAutoBuyValidation({
   executionPrice: BigNumber
   autoTakeProfitExecutionPrice: BigNumber
   token: string
-  collateralizationRatioAtNextPrice: BigNumber
+  nextPositionRatio: BigNumber
 }) {
   const potentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({
     token,
@@ -53,9 +53,7 @@ export function warningsAutoBuyValidation({
 
   const settingAutoBuyTriggerWithNoThreshold = !withThreshold
 
-  const autoBuyTriggeredImmediately = autoBuyState.execCollRatio
-    .div(100)
-    .lte(collateralizationRatioAtNextPrice)
+  const autoBuyTriggeredImmediately = autoBuyState.execCollRatio.div(100).lte(nextPositionRatio)
 
   const autoBuyTriggerGreaterThanAutoTakeProfit =
     isAutoTakeProfitEnabled && executionPrice.gt(autoTakeProfitExecutionPrice)

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -18,7 +18,7 @@ export function AutoTakeProfitDetailsControl() {
   const {
     autoTakeProfitTriggerData,
     environmentData: { ethMarketPrice },
-    positionData: { id, ilk, debt, debtOffset, collateralizationRatio, lockedCollateral, token },
+    positionData: { id, ilk, debt, debtOffset, positionRatio, lockedCollateral, token },
   } = useAutomationContext()
 
   const { isTriggerEnabled, executionPrice } = autoTakeProfitTriggerData
@@ -53,7 +53,7 @@ export function AutoTakeProfitDetailsControl() {
       afterTriggerColPrice: autoTakeProfitState.executionPrice,
       afterTriggerColRatio: autoTakeProfitState.executionCollRatio,
     }),
-    currentColRatio: collateralizationRatio.times(100),
+    currentColRatio: positionRatio.times(100),
   }
 
   if (readOnlyAutoTakeProfitEnabled || isDebtZero) return null

--- a/features/automation/optimization/autoTakeProfit/controls/CancelAutoTakeProfitInfoSection.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/CancelAutoTakeProfitInfoSection.tsx
@@ -7,14 +7,14 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 interface CancelAutoTakeProfitInfoSectionProps {
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   token: string
   triggerColPrice: BigNumber
   debt: BigNumber
 }
 
 export function CancelAutoTakeProfitInfoSection({
-  collateralizationRatio,
+  positionRatio,
   token,
   triggerColPrice,
   debt,
@@ -44,7 +44,7 @@ export function CancelAutoTakeProfitInfoSection({
               },
               {
                 label: t('system.collateral-ratio'),
-                value: formatPercent(collateralizationRatio, {
+                value: formatPercent(positionRatio, {
                   precision: 2,
                   roundMode: BigNumber.ROUND_DOWN,
                 }),

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -13,6 +13,8 @@ import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
+import { AutomationFeatures } from 'features/automation/common/types'
 import {
   AUTO_TAKE_PROFIT_FORM_CHANGE,
   AutoTakeProfitFormChange,
@@ -51,7 +53,7 @@ export function SidebarAutoTakeProfitEditingStage({
 
   const {
     autoTakeProfitTriggerData,
-    positionData: { ilk, id, collateralizationRatio, debt, debtFloor, token },
+    positionData: { ilk, id, positionRatio, debt, debtFloor, token },
   } = useAutomationContext()
 
   useDebouncedCallback(
@@ -63,7 +65,7 @@ export function SidebarAutoTakeProfitEditingStage({
         {
           vaultId: id.toString(),
           ilk: ilk,
-          collateralRatio: collateralizationRatio.times(100).decimalPlaces(2).toString(),
+          collateralRatio: positionRatio.times(100).decimalPlaces(2).toString(),
           triggerValue: value,
         },
       ),
@@ -81,11 +83,22 @@ export function SidebarAutoTakeProfitEditingStage({
     )
   }
 
+  const feature = t(sidebarAutomationFeatureCopyMap[AutomationFeatures.AUTO_TAKE_PROFIT])
+
   if (isVaultEmpty && autoTakeProfitTriggerData.isTriggerEnabled) {
     return (
       <SidebarFormInfo
-        title={t('auto-take-profit.closed-vault-existing-trigger-header')}
-        description={t('auto-take-profit.closed-vault-existing-trigger-description')}
+        title={t('automation.closed-vault-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-existing-trigger-description', { feature })}
+      />
+    )
+  }
+
+  if (isVaultEmpty) {
+    return (
+      <SidebarFormInfo
+        title={t('automation.closed-vault-not-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-not-existing-trigger-description', { feature })}
       />
     )
   }

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
@@ -37,12 +37,12 @@ export function SidebarAutoTakeProfitRemovalEditingStage({
 function AutoTakeProfitInfoSectionControl() {
   const {
     autoTakeProfitTriggerData,
-    positionData: { token, debt, collateralizationRatio },
+    positionData: { token, debt, positionRatio },
   } = useAutomationContext()
 
   return (
     <CancelAutoTakeProfitInfoSection
-      collateralizationRatio={collateralizationRatio.times(100)}
+      positionRatio={positionRatio.times(100)}
       token={token}
       debt={debt}
       triggerColPrice={autoTakeProfitTriggerData.executionPrice}

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -82,6 +82,7 @@ export function SidebarSetupAutoTakeProfit({
     constantMultipleTriggerData,
     environmentData: { ethMarketPrice, etherscanUrl, nextCollateralPrice, ethBalance },
     positionData: { debt, debtOffset, token, vaultType, lockedCollateral },
+    protocol,
   } = useAutomationContext()
 
   const { isAwaitingConfirmation } = autoTakeProfitState
@@ -100,6 +101,7 @@ export function SidebarSetupAutoTakeProfit({
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     isAutoTakeProfitEnabled: autoTakeProfitTriggerData.isTriggerEnabled,
     vaultType,
+    protocol,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,
@@ -230,7 +232,7 @@ export function SidebarSetupAutoTakeProfit({
                 <SidebarAwaitingConfirmation
                   feature={
                     <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-                      {t('automation.auto-take-profit-confirmation-text', {
+                      {t('auto-take-profit.auto-take-profit-confirmation-text', {
                         price: ethMarketPrice.toString(),
                         profit: estimatedProfitOnClose.toFixed(2).toString(),
                       })}

--- a/features/automation/optimization/autoTakeProfit/state/useAutoTakeProfitStateInitializator.ts
+++ b/features/automation/optimization/autoTakeProfit/state/useAutoTakeProfitStateInitializator.ts
@@ -11,12 +11,12 @@ const INITIAL_SELECTED_PRICE_MULTIPLIER = 1.2
 export function useAutoTakeProfitStateInitializator({
   debt,
   lockedCollateral,
-  collateralizationRatio,
+  positionRatio,
   autoTakeProfitTriggerData,
 }: {
   debt: BigNumber
   lockedCollateral: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   autoTakeProfitTriggerData: AutoTakeProfitTriggerData
 }) {
   const { uiChanges } = useAppContext()
@@ -25,7 +25,7 @@ export function useAutoTakeProfitStateInitializator({
   const initialSelectedPrice = isTriggerEnabled
     ? executionPrice
     : collateralPriceAtRatio({
-        colRatio: collateralizationRatio.times(INITIAL_SELECTED_PRICE_MULTIPLIER),
+        colRatio: positionRatio.times(INITIAL_SELECTED_PRICE_MULTIPLIER),
         collateral: lockedCollateral,
         vaultDebt: debt,
       })
@@ -51,7 +51,7 @@ export function useAutoTakeProfitStateInitializator({
       type: 'close-type',
       toCollateral: isToCollateral,
     })
-  }, [triggerId.toNumber(), collateralizationRatio.toNumber()])
+  }, [triggerId.toNumber(), positionRatio.toNumber()])
 
   useEffect(() => {
     uiChanges.publish(AUTO_TAKE_PROFIT_FORM_CHANGE, {
@@ -62,7 +62,7 @@ export function useAutoTakeProfitStateInitializator({
       type: 'tx-details',
       txDetails: {},
     })
-  }, [collateralizationRatio.toNumber()])
+  }, [positionRatio.toNumber()])
 
   return isTriggerEnabled
 }

--- a/features/automation/optimization/common/controls/OptimizationDetailsControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationDetailsControl.tsx
@@ -1,3 +1,5 @@
+import { useAutomationContext } from 'components/AutomationContextProvider'
+import { getAvailableAutomation } from 'features/automation/common/helpers'
 import { AutoBuyDetailsControl } from 'features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl'
 import { AutoTakeProfitDetailsControl } from 'features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl'
 import { ConstantMultipleDetailsControl } from 'features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsControl'
@@ -9,11 +11,21 @@ interface OptimizationDetailsControlProps {
 }
 
 export function OptimizationDetailsControl({ vaultHistory }: OptimizationDetailsControlProps) {
+  const { protocol } = useAutomationContext()
+
+  const {
+    isAutoBuyAvailable,
+    isConstantMultipleAvailable,
+    isTakeProfitAvailable,
+  } = getAvailableAutomation(protocol)
+
   return (
     <>
-      <AutoBuyDetailsControl />
-      <ConstantMultipleDetailsControl vaultHistory={vaultHistory} />
-      <AutoTakeProfitDetailsControl />
+      {isAutoBuyAvailable && <AutoBuyDetailsControl />}
+      {isConstantMultipleAvailable && (
+        <ConstantMultipleDetailsControl vaultHistory={vaultHistory} />
+      )}
+      {isTakeProfitAvailable && <AutoTakeProfitDetailsControl />}
     </>
   )
 }

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -1,7 +1,10 @@
 import { TxHelpers } from 'components/AppContext'
 import { useAppContext } from 'components/AppContextProvider'
 import { useAutomationContext } from 'components/AutomationContextProvider'
-import { getShouldRemoveAllowance } from 'features/automation/common/helpers'
+import {
+  getAvailableAutomation,
+  getShouldRemoveAllowance,
+} from 'features/automation/common/helpers'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
@@ -24,6 +27,7 @@ export function OptimizationFormControl({ txHelpers }: OptimizationFormControlPr
     automationTriggersData,
     constantMultipleTriggerData,
     autoTakeProfitTriggerData,
+    protocol,
   } = useAutomationContext()
 
   const { uiChanges } = useAppContext()
@@ -69,23 +73,35 @@ export function OptimizationFormControl({ txHelpers }: OptimizationFormControlPr
     autoBuyTriggerData.isTriggerEnabled,
   ])
 
+  const {
+    isAutoBuyAvailable,
+    isConstantMultipleAvailable,
+    isTakeProfitAvailable,
+  } = getAvailableAutomation(protocol)
+
   return (
     <>
-      <AutoBuyFormControl
-        isAutoBuyActive={isAutoBuyActive}
-        shouldRemoveAllowance={shouldRemoveAllowance}
-        txHelpers={txHelpers}
-      />
-      <ConstantMultipleFormControl
-        isConstantMultipleActive={isConstantMultipleActive}
-        shouldRemoveAllowance={shouldRemoveAllowance}
-        txHelpers={txHelpers}
-      />
-      <AutoTakeProfitFormControl
-        isAutoTakeProfitActive={isAutoTakeProfitActive}
-        shouldRemoveAllowance={shouldRemoveAllowance}
-        txHelpers={txHelpers}
-      />
+      {isAutoBuyAvailable && (
+        <AutoBuyFormControl
+          isAutoBuyActive={isAutoBuyActive}
+          shouldRemoveAllowance={shouldRemoveAllowance}
+          txHelpers={txHelpers}
+        />
+      )}
+      {isConstantMultipleAvailable && (
+        <ConstantMultipleFormControl
+          isConstantMultipleActive={isConstantMultipleActive}
+          shouldRemoveAllowance={shouldRemoveAllowance}
+          txHelpers={txHelpers}
+        />
+      )}
+      {isTakeProfitAvailable && (
+        <AutoTakeProfitFormControl
+          isAutoTakeProfitActive={isAutoTakeProfitActive}
+          shouldRemoveAllowance={shouldRemoveAllowance}
+          txHelpers={txHelpers}
+        />
+      )}
     </>
   )
 }

--- a/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
+++ b/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
@@ -9,7 +9,7 @@ export function CancelConstantMultipleInfoSection() {
   const { t } = useTranslation()
   const {
     constantMultipleTriggerData,
-    positionData: { collateralizationRatio, debt, liquidationPrice },
+    positionData: { positionRatio, debt, liquidationPrice },
   } = useAutomationContext()
 
   return (
@@ -37,7 +37,7 @@ export function CancelConstantMultipleInfoSection() {
           : [
               {
                 label: t('system.collateral-ratio'),
-                value: formatPercent(collateralizationRatio.times(100), {
+                value: formatPercent(positionRatio.times(100), {
                   precision: 2,
                 }),
               },

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
@@ -39,7 +39,7 @@ export function ConstantMultipleFormControl({
     autoSellTriggerData,
     constantMultipleTriggerData,
     environmentData: { canInteract, ethMarketPrice },
-    positionData: { id, owner, debt, collateralizationRatio, lockedCollateral },
+    positionData: { id, owner, debt, positionRatio, lockedCollateral },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.CONSTANT_MULTIPLE
@@ -78,7 +78,7 @@ export function ConstantMultipleFormControl({
     isRemoveForm,
     stage,
     debt,
-    collateralizationRatio,
+    positionRatio,
     lockedCollateral,
   })
   const { addTxData, textButtonHandlerExtension } = getConstantMultipleTxHandlers({
@@ -89,7 +89,7 @@ export function ConstantMultipleFormControl({
     isAddForm,
     id,
     owner,
-    collateralizationRatio,
+    positionRatio,
   })
 
   return (

--- a/features/automation/optimization/constantMultiple/helpers.ts
+++ b/features/automation/optimization/constantMultiple/helpers.ts
@@ -64,7 +64,7 @@ export function checkIfIsEditingConstantMultiple({
 
 export function getEligibleMultipliers({
   multipliers,
-  collateralizationRatio,
+  positionRatio,
   lockedCollateral,
   debt,
   debtFloor,
@@ -73,7 +73,7 @@ export function getEligibleMultipliers({
   maxTargetRatio,
 }: {
   multipliers: number[]
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   lockedCollateral: BigNumber
   debt: BigNumber
   debtFloor: BigNumber
@@ -121,14 +121,14 @@ export function getEligibleMultipliers({
       const deduplicatedVerifiedSellExtremes = [...new Set(verifiedSellExtremes)]
 
       const executionPriceAtCurrentCollRatio = collateralPriceAtRatio({
-        colRatio: collateralizationRatio,
+        colRatio: positionRatio,
         collateral: lockedCollateral,
         vaultDebt: debt,
       })
 
       const { debtDelta: debtDeltaAtCurrentCollRatio } = getAutoBSVaultChange({
         targetCollRatio,
-        execCollRatio: collateralizationRatio.times(100),
+        execCollRatio: positionRatio.times(100),
         deviation,
         executionPrice: executionPriceAtCurrentCollRatio,
         lockedCollateral,

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -16,7 +16,10 @@ import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
-import { MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/common/consts'
+import {
+  MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
+  sidebarAutomationFeatureCopyMap,
+} from 'features/automation/common/consts'
 import {
   automationInputsAnalytics,
   automationMultipleRangeSliderAnalytics,
@@ -85,7 +88,7 @@ export function SidebarConstantMultipleEditingStage({
     autoSellTriggerData,
     constantMultipleTriggerData,
     stopLossTriggerData,
-    positionData: { ilk, id, collateralizationRatio, debt, debtFloor, token },
+    positionData: { ilk, id, positionRatio, debt, debtFloor, token },
   } = useAutomationContext()
 
   automationMultipleRangeSliderAnalytics({
@@ -97,7 +100,7 @@ export function SidebarConstantMultipleEditingStage({
     ).decimalPlaces(2),
     ilk,
     vaultId: id,
-    collateralizationRatio,
+    positionRatio,
   })
 
   automationInputsAnalytics({
@@ -108,7 +111,7 @@ export function SidebarConstantMultipleEditingStage({
     type: AutomationFeatures.CONSTANT_MULTIPLE,
     ilk,
     vaultId: id,
-    collateralizationRatio,
+    positionRatio,
   })
 
   const isVaultEmpty = debt.isZero()
@@ -123,11 +126,22 @@ export function SidebarConstantMultipleEditingStage({
     )
   }
 
+  const feature = t(sidebarAutomationFeatureCopyMap[AutomationFeatures.CONSTANT_MULTIPLE])
+
   if (isVaultEmpty && constantMultipleTriggerData.isTriggerEnabled) {
     return (
       <SidebarFormInfo
-        title={t('constant-multiple.closed-vault-existing-trigger-header')}
-        description={t('constant-multiple.closed-vault-existing-trigger-description')}
+        title={t('automation.closed-vault-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-existing-trigger-description', { feature })}
+      />
+    )
+  }
+
+  if (isVaultEmpty) {
+    return (
+      <SidebarFormInfo
+        title={t('automation.closed-vault-not-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-not-existing-trigger-description', { feature })}
       />
     )
   }

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
@@ -86,7 +86,8 @@ export function SidebarSetupConstantMultiple({
     constantMultipleTriggerData,
     stopLossTriggerData,
     environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
-    positionData: { debt, debtFloor, collateralizationRatioAtNextPrice, token, vaultType },
+    positionData: { debt, debtFloor, nextPositionRatio, token, vaultType },
+    protocol,
   } = useAutomationContext()
 
   const { isAwaitingConfirmation } = constantMultipleState
@@ -105,6 +106,7 @@ export function SidebarSetupConstantMultiple({
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     isAutoTakeProfitEnabled: autoTakeProfitTriggerData.isTriggerEnabled,
     vaultType,
+    protocol,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,
@@ -148,7 +150,7 @@ export function SidebarSetupConstantMultiple({
     autoTakeProfitExecutionPrice: autoTakeProfitTriggerData.executionPrice,
     debt,
     token,
-    collateralizationRatioAtNextPrice,
+    nextPositionRatio,
   })
   const cancelConstantMultipleErrors = extractCancelAutomationErrors(errors)
   const cancelConstantMultipleWarnings = extractCancelAutomationWarnings(warnings)

--- a/features/automation/optimization/constantMultiple/state/constantMultipleStatus.ts
+++ b/features/automation/optimization/constantMultiple/state/constantMultipleStatus.ts
@@ -27,7 +27,7 @@ interface GetConstantMultipleStatusParams {
   stage: SidebarAutomationStages
   lockedCollateral: BigNumber
   debt: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
 }
 
 interface ConstantMultipleStatus {
@@ -58,7 +58,7 @@ export function getConstantMultipleStatus({
   stage,
   debt,
   lockedCollateral,
-  collateralizationRatio,
+  positionRatio,
 }: GetConstantMultipleStatusParams): ConstantMultipleStatus {
   const { gasPrice$ } = useAppContext()
   const [gasPrice] = useObservable(gasPrice$)
@@ -87,7 +87,7 @@ export function getConstantMultipleStatus({
     vaultDebt: debt,
   })
   const sellPriceAtCurrentCollRatio = collateralPriceAtRatio({
-    colRatio: collateralizationRatio,
+    colRatio: positionRatio,
     collateral: lockedCollateral,
     vaultDebt: debt,
   })
@@ -116,7 +116,7 @@ export function getConstantMultipleStatus({
   })
   const { debtDelta: debtDeltaWhenSellAtCurrentCollRatio } = getAutoBSVaultChange({
     targetCollRatio: constantMultipleState.targetCollRatio,
-    execCollRatio: collateralizationRatio.times(100),
+    execCollRatio: positionRatio.times(100),
     deviation: constantMultipleState.deviation,
     executionPrice: sellPriceAtCurrentCollRatio,
     lockedCollateral,

--- a/features/automation/optimization/constantMultiple/state/constantMultipleTxHandlers.ts
+++ b/features/automation/optimization/constantMultiple/state/constantMultipleTxHandlers.ts
@@ -19,7 +19,7 @@ interface GetConstantMultipleTxHandlersParams {
   constantMultipleState: ConstantMultipleFormChange
   constantMultipleTriggerData: ConstantMultipleTriggerData
   isAddForm: boolean
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   id: BigNumber
   owner: string
 }
@@ -36,7 +36,7 @@ export function getConstantMultipleTxHandlers({
   constantMultipleState,
   constantMultipleTriggerData,
   isAddForm,
-  collateralizationRatio,
+  positionRatio,
   id,
   owner,
 }: GetConstantMultipleTxHandlersParams): ConstantMultipleTxHandlers {
@@ -65,7 +65,7 @@ export function getConstantMultipleTxHandlers({
       }),
     [
       constantMultipleTriggerData.triggersId,
-      collateralizationRatio.toNumber(),
+      positionRatio.toNumber(),
       constantMultipleState.maxBuyPrice?.toNumber(),
       constantMultipleState.minSellPrice?.toNumber(),
       constantMultipleState.buyExecutionCollRatio?.toNumber(),

--- a/features/automation/optimization/constantMultiple/state/useConstantMultipleStateInitialization.ts
+++ b/features/automation/optimization/constantMultiple/state/useConstantMultipleStateInitialization.ts
@@ -28,14 +28,14 @@ export function useConstantMultipleStateInitialization({
   debtFloor,
   liquidationRatio,
   lockedCollateral,
-  collateralizationRatio,
+  positionRatio,
   constantMultipleTriggerData,
   autoSellTriggerData,
   stopLossTriggerData,
   autoBuyTriggerData,
 }: {
   ilk: string
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   liquidationRatio: BigNumber
   lockedCollateral: BigNumber
   debtFloor: BigNumber
@@ -61,7 +61,7 @@ export function useConstantMultipleStateInitialization({
 
   const eligibleMultipliers = getEligibleMultipliers({
     multipliers,
-    collateralizationRatio: collateralizationRatio,
+    positionRatio,
     lockedCollateral: lockedCollateral,
     debt: debt,
     debtFloor: debtFloor,
@@ -118,7 +118,7 @@ export function useConstantMultipleStateInitialization({
       currentForm: 'add',
     })
   }, [
-    collateralizationRatio.toNumber(),
+    positionRatio.toNumber(),
     stopLossTriggerData.triggerId.toNumber(),
     autoBuyTriggerData.triggerId.toNumber(),
     autoSellTriggerData.triggerId.toNumber(),

--- a/features/automation/optimization/constantMultiple/validators.ts
+++ b/features/automation/optimization/constantMultiple/validators.ts
@@ -21,7 +21,7 @@ export function warningsConstantMultipleValidation({
   constantMultipleBuyExecutionPrice,
   debt,
   token,
-  collateralizationRatioAtNextPrice,
+  nextPositionRatio,
 }: {
   token: string
   ethBalance: BigNumber
@@ -38,7 +38,7 @@ export function warningsConstantMultipleValidation({
   constantMultipleState: ConstantMultipleFormChange
   autoTakeProfitExecutionPrice: BigNumber
   constantMultipleBuyExecutionPrice: BigNumber
-  collateralizationRatioAtNextPrice: BigNumber
+  nextPositionRatio: BigNumber
 }) {
   const {
     sellExecutionCollRatio,
@@ -60,12 +60,12 @@ export function warningsConstantMultipleValidation({
   const addingConstantMultipleWhenAutoSellOrBuyEnabled = isAutoBuyEnabled || isAutoSellEnabled
 
   const constantMultipleAutoSellTriggeredImmediately =
-    sellExecutionCollRatio.div(100).gte(collateralizationRatioAtNextPrice) &&
+    sellExecutionCollRatio.div(100).gte(nextPositionRatio) &&
     !debtFloor.gt(debt.plus(debtDeltaWhenSellAtCurrentCollRatio))
 
   const constantMultipleAutoBuyTriggeredImmediately = buyExecutionCollRatio
     .div(100)
-    .lte(collateralizationRatioAtNextPrice)
+    .lte(nextPositionRatio)
 
   const noMinSellPriceWhenStopLossEnabled = !sellWithThreshold && isStopLossEnabled
 

--- a/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
@@ -32,7 +32,7 @@ export function AutoSellFormControl({
   const {
     autoSellTriggerData,
     environmentData: { canInteract },
-    positionData: { id, debt, lockedCollateral, collateralizationRatio, owner },
+    positionData: { id, debt, lockedCollateral, positionRatio, owner },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.AUTO_SELL
@@ -68,12 +68,12 @@ export function AutoSellFormControl({
     stage,
     debt,
     lockedCollateral,
-    collateralizationRatio,
+    positionRatio,
   })
   const { addTxData, textButtonHandlerExtension } = getAutoBSTxHandlers({
     id,
     owner,
-    collateralizationRatio,
+    positionRatio,
     autoBSState: autoSellState,
     isAddForm,
     publishType,

--- a/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
@@ -16,12 +16,12 @@ interface AutoSellInfoSectionControlProps {
 function AutoSellInfoSectionControl({ autoSellState }: AutoSellInfoSectionControlProps) {
   const { t } = useTranslation()
   const {
-    positionData: { debt, collateralizationRatio, liquidationPrice },
+    positionData: { debt, positionRatio, liquidationPrice },
   } = useAutomationContext()
 
   return (
     <CancelAutoBSInfoSection
-      collateralizationRatio={collateralizationRatio}
+      positionRatio={positionRatio}
       liquidationPrice={liquidationPrice}
       debt={debt}
       title={t('auto-sell.cancel-summary-title')}

--- a/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
@@ -11,7 +11,10 @@ import { SidebarFormInfo } from 'components/vault/SidebarFormInfo'
 import { VaultActionInput } from 'components/vault/VaultActionInput'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
-import { MIX_MAX_COL_RATIO_TRIGGER_OFFSET } from 'features/automation/common/consts'
+import {
+  MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
+  sidebarAutomationFeatureCopyMap,
+} from 'features/automation/common/consts'
 import {
   adjustDefaultValuesIfOutsideSlider,
   automationInputsAnalytics,
@@ -62,7 +65,7 @@ export function SidebarAutoSellAddEditingStage({
   const {
     autoSellTriggerData,
     stopLossTriggerData,
-    positionData: { id, ilk, debt, debtFloor, lockedCollateral, collateralizationRatio, token },
+    positionData: { id, ilk, debt, debtFloor, lockedCollateral, positionRatio, token },
   } = useAutomationContext()
   const { t } = useTranslation()
   const [, setHash] = useHash()
@@ -84,13 +87,13 @@ export function SidebarAutoSellAddEditingStage({
       uiChanges,
       publishType: AUTO_SELL_FORM_CHANGE,
     })
-  }, [collateralizationRatio.toNumber()])
+  }, [positionRatio.toNumber()])
 
   automationMultipleRangeSliderAnalytics({
     leftValue: autoSellState.execCollRatio,
     rightValue: autoSellState.targetCollRatio,
     vaultId: id,
-    collateralizationRatio,
+    positionRatio,
     ilk,
     type: AutomationFeatures.AUTO_SELL,
   })
@@ -99,12 +102,12 @@ export function SidebarAutoSellAddEditingStage({
     minSellPrice: autoSellState.maxBuyOrMinSellPrice,
     withMinSellPriceThreshold: autoSellState.withThreshold,
     vaultId: id,
-    collateralizationRatio,
+    positionRatio,
     ilk,
     type: AutomationFeatures.AUTO_SELL,
   })
 
-  const isCurrentCollRatioHigherThanSliderMax = collateralizationRatio.times(100).gt(sliderMax)
+  const isCurrentCollRatioHigherThanSliderMax = positionRatio.times(100).gt(sliderMax)
 
   if (
     isStopLossEnabled &&
@@ -170,11 +173,13 @@ export function SidebarAutoSellAddEditingStage({
     )
   }
 
+  const feature = t(sidebarAutomationFeatureCopyMap[AutomationFeatures.AUTO_SELL])
+
   if (isVaultEmpty && autoSellTriggerData.isTriggerEnabled) {
     return (
       <SidebarFormInfo
-        title={t('auto-sell.closed-vault-existing-trigger-header')}
-        description={t('auto-sell.closed-vault-existing-trigger-description')}
+        title={t('automation.closed-vault-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-existing-trigger-description', { feature })}
       />
     )
   }
@@ -182,8 +187,8 @@ export function SidebarAutoSellAddEditingStage({
   if (isVaultEmpty) {
     return (
       <SidebarFormInfo
-        title={t('auto-sell.closed-vault-not-existing-trigger-header')}
-        description={t('auto-sell.closed-vault-not-existing-trigger-description')}
+        title={t('automation.closed-vault-not-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-not-existing-trigger-description', { feature })}
       />
     )
   }
@@ -312,7 +317,7 @@ export function SidebarAutoSellAddEditingStage({
                 type: 'reset',
                 resetData: prepareAutoBSResetData(
                   autoSellTriggerData,
-                  collateralizationRatio,
+                  positionRatio,
                   AUTO_SELL_FORM_CHANGE,
                 ),
               })

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -80,14 +80,8 @@ export function SidebarSetupAutoSell({
     constantMultipleTriggerData,
     stopLossTriggerData,
     environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
-    positionData: {
-      collateralizationRatioAtNextPrice,
-      debt,
-      debtFloor,
-      liquidationRatio,
-      token,
-      vaultType,
-    },
+    positionData: { nextPositionRatio, debt, debtFloor, liquidationRatio, token, vaultType },
+    protocol,
   } = useAutomationContext()
 
   const { isAwaitingConfirmation } = autoSellState
@@ -106,6 +100,7 @@ export function SidebarSetupAutoSell({
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     vaultType,
+    protocol,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,
@@ -131,7 +126,7 @@ export function SidebarSetupAutoSell({
 
   const warnings = warningsAutoSellValidation({
     debt,
-    collateralizationRatioAtNextPrice,
+    nextPositionRatio,
     token,
     gasEstimationUsd: gasEstimation?.usdValue,
     ethBalance: ethBalance,

--- a/features/automation/protection/autoSell/validators.ts
+++ b/features/automation/protection/autoSell/validators.ts
@@ -21,13 +21,13 @@ export function warningsAutoSellValidation({
   debtDeltaAtCurrentCollRatio,
   debtFloor,
   debt,
-  collateralizationRatioAtNextPrice,
+  nextPositionRatio,
   token,
 }: {
   token: string
   ethBalance: BigNumber
   debt: BigNumber
-  collateralizationRatioAtNextPrice: BigNumber
+  nextPositionRatio: BigNumber
   ethPrice: BigNumber
   sliderMin: BigNumber
   sliderMax: BigNumber
@@ -54,7 +54,7 @@ export function warningsAutoSellValidation({
     isAutoBuyEnabled && autoSellState.targetCollRatio.isEqualTo(sliderMax)
 
   const autoSellTriggeredImmediately =
-    autoSellState.execCollRatio.div(100).gte(collateralizationRatioAtNextPrice) &&
+    autoSellState.execCollRatio.div(100).gte(nextPositionRatio) &&
     !debtFloor.gt(debt.plus(debtDeltaAtCurrentCollRatio))
 
   return warningMessagesHandler({

--- a/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
@@ -6,11 +6,12 @@ import {
 import { AutoSellDetailsControl } from 'features/automation/protection/autoSell/controls/AutoSellDetailsControl'
 import { getActiveProtectionFeature } from 'features/automation/protection/common/helpers'
 import { StopLossDetailsControl } from 'features/automation/protection/stopLoss/controls/StopLossDetailsControl'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React from 'react'
 
 export function ProtectionDetailsControl() {
-  const { stopLossTriggerData, autoSellTriggerData } = useAutomationContext()
+  const { stopLossTriggerData, autoSellTriggerData, protocol } = useAutomationContext()
 
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
 
@@ -21,10 +22,17 @@ export function ProtectionDetailsControl() {
     section: 'details',
   })
 
-  return (
-    <>
-      <StopLossDetailsControl isStopLossActive={isStopLossActive} />
-      <AutoSellDetailsControl />
-    </>
-  )
+  switch (protocol) {
+    case VaultProtocol.Maker:
+      return (
+        <>
+          <StopLossDetailsControl isStopLossActive={isStopLossActive} />
+          <AutoSellDetailsControl />
+        </>
+      )
+    case VaultProtocol.Aave:
+      return <StopLossDetailsControl isStopLossActive={isStopLossActive} />
+    default:
+      return null
+  }
 }

--- a/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
@@ -1,4 +1,5 @@
 import { useAutomationContext } from 'components/AutomationContextProvider'
+import { getAvailableAutomation } from 'features/automation/common/helpers'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
@@ -6,7 +7,6 @@ import {
 import { AutoSellDetailsControl } from 'features/automation/protection/autoSell/controls/AutoSellDetailsControl'
 import { getActiveProtectionFeature } from 'features/automation/protection/common/helpers'
 import { StopLossDetailsControl } from 'features/automation/protection/stopLoss/controls/StopLossDetailsControl'
-import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React from 'react'
 
@@ -22,17 +22,12 @@ export function ProtectionDetailsControl() {
     section: 'details',
   })
 
-  switch (protocol) {
-    case VaultProtocol.Maker:
-      return (
-        <>
-          <StopLossDetailsControl isStopLossActive={isStopLossActive} />
-          <AutoSellDetailsControl />
-        </>
-      )
-    case VaultProtocol.Aave:
-      return <StopLossDetailsControl isStopLossActive={isStopLossActive} />
-    default:
-      return null
-  }
+  const { isStopLossAvailable, isAutoSellAvailable } = getAvailableAutomation(protocol)
+
+  return (
+    <>
+      {isStopLossAvailable && <StopLossDetailsControl isStopLossActive={isStopLossActive} />}
+      {isAutoSellAvailable && <AutoSellDetailsControl />}
+    </>
+  )
 }

--- a/features/automation/protection/common/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionFormControl.tsx
@@ -1,7 +1,10 @@
 import { TxHelpers } from 'components/AppContext'
 import { useAppContext } from 'components/AppContextProvider'
 import { useAutomationContext } from 'components/AutomationContextProvider'
-import { getShouldRemoveAllowance } from 'features/automation/common/helpers'
+import {
+  getAvailableAutomation,
+  getShouldRemoveAllowance,
+} from 'features/automation/common/helpers'
 import {
   AUTOMATION_CHANGE_FEATURE,
   AutomationChangeFeature,
@@ -10,7 +13,6 @@ import { AutomationFeatures } from 'features/automation/common/types'
 import { AutoSellFormControl } from 'features/automation/protection/autoSell/controls/AutoSellFormControl'
 import { getActiveProtectionFeature } from 'features/automation/protection/common/helpers'
 import { StopLossFormControl } from 'features/automation/protection/stopLoss/controls/StopLossFormControl'
-import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React, { useEffect } from 'react'
 
@@ -53,31 +55,24 @@ export function ProtectionFormControl({ txHelpers }: ProtectionFormControlProps)
     }
   }, [autoSellTriggerData.isTriggerEnabled, stopLossTriggerData.isStopLossEnabled])
 
-  switch (protocol) {
-    case VaultProtocol.Maker:
-      return (
-        <>
-          <StopLossFormControl
-            isStopLossActive={isStopLossActive}
-            txHelpers={txHelpers}
-            shouldRemoveAllowance={shouldRemoveAllowance}
-          />
-          <AutoSellFormControl
-            isAutoSellActive={isAutoSellActive}
-            txHelpers={txHelpers}
-            shouldRemoveAllowance={shouldRemoveAllowance}
-          />
-        </>
-      )
-    case VaultProtocol.Aave:
-      return (
+  const { isStopLossAvailable, isAutoSellAvailable } = getAvailableAutomation(protocol)
+
+  return (
+    <>
+      {isStopLossAvailable && (
         <StopLossFormControl
           isStopLossActive={isStopLossActive}
           txHelpers={txHelpers}
           shouldRemoveAllowance={shouldRemoveAllowance}
         />
-      )
-    default:
-      return null
-  }
+      )}
+      {isAutoSellAvailable && (
+        <AutoSellFormControl
+          isAutoSellActive={isAutoSellActive}
+          txHelpers={txHelpers}
+          shouldRemoveAllowance={shouldRemoveAllowance}
+        />
+      )}
+    </>
+  )
 }

--- a/features/automation/protection/common/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionFormControl.tsx
@@ -10,6 +10,7 @@ import { AutomationFeatures } from 'features/automation/common/types'
 import { AutoSellFormControl } from 'features/automation/protection/autoSell/controls/AutoSellFormControl'
 import { getActiveProtectionFeature } from 'features/automation/protection/common/helpers'
 import { StopLossFormControl } from 'features/automation/protection/stopLoss/controls/StopLossFormControl'
+import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import React, { useEffect } from 'react'
 
@@ -22,6 +23,7 @@ export function ProtectionFormControl({ txHelpers }: ProtectionFormControlProps)
     stopLossTriggerData,
     autoSellTriggerData,
     automationTriggersData,
+    protocol,
   } = useAutomationContext()
 
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
@@ -51,18 +53,31 @@ export function ProtectionFormControl({ txHelpers }: ProtectionFormControlProps)
     }
   }, [autoSellTriggerData.isTriggerEnabled, stopLossTriggerData.isStopLossEnabled])
 
-  return (
-    <>
-      <StopLossFormControl
-        isStopLossActive={isStopLossActive}
-        txHelpers={txHelpers}
-        shouldRemoveAllowance={shouldRemoveAllowance}
-      />
-      <AutoSellFormControl
-        isAutoSellActive={isAutoSellActive}
-        txHelpers={txHelpers}
-        shouldRemoveAllowance={shouldRemoveAllowance}
-      />
-    </>
-  )
+  switch (protocol) {
+    case VaultProtocol.Maker:
+      return (
+        <>
+          <StopLossFormControl
+            isStopLossActive={isStopLossActive}
+            txHelpers={txHelpers}
+            shouldRemoveAllowance={shouldRemoveAllowance}
+          />
+          <AutoSellFormControl
+            isAutoSellActive={isAutoSellActive}
+            txHelpers={txHelpers}
+            shouldRemoveAllowance={shouldRemoveAllowance}
+          />
+        </>
+      )
+    case VaultProtocol.Aave:
+      return (
+        <StopLossFormControl
+          isStopLossActive={isStopLossActive}
+          txHelpers={txHelpers}
+          shouldRemoveAllowance={shouldRemoveAllowance}
+        />
+      )
+    default:
+      return null
+  }
 }

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
@@ -29,8 +29,8 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
   const {
     stopLossTriggerData,
     positionData: {
-      collateralizationRatio,
-      collateralizationRatioAtNextPrice,
+      positionRatio,
+      nextPositionRatio,
       debt,
       id,
       ilk,
@@ -55,7 +55,7 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
           token={token}
           liquidationRatio={liquidationRatio}
           liquidationPenalty={liquidationPenalty}
-          collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
+          nextPositionRatio={nextPositionRatio}
           isCollateralActive={!!stopLossState?.collateralActive}
           isEditing={checkIfIsEditingStopLoss({
             isStopLossEnabled: stopLossTriggerData.isStopLossEnabled,
@@ -65,7 +65,7 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
             isToCollateral: stopLossTriggerData.isToCollateral,
             isRemoveForm: stopLossState.currentForm === 'remove',
           })}
-          collateralizationRatio={collateralizationRatio}
+          positionRatio={positionRatio}
         />
       ) : (
         <Banner

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsLayout.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsLayout.tsx
@@ -19,8 +19,8 @@ export interface StopLossDetailsLayoutProps {
   afterSlRatio: BigNumber
   isCollateralActive: boolean
   isEditing: boolean
-  collateralizationRatioAtNextPrice: BigNumber
-  collateralizationRatio: BigNumber
+  nextPositionRatio: BigNumber
+  positionRatio: BigNumber
 }
 
 export function StopLossDetailsLayout({
@@ -34,8 +34,8 @@ export function StopLossDetailsLayout({
   afterSlRatio,
   isCollateralActive,
   isEditing,
-  collateralizationRatioAtNextPrice,
-  collateralizationRatio,
+  nextPositionRatio,
+  positionRatio,
 }: StopLossDetailsLayoutProps) {
   const { t } = useTranslation()
 
@@ -52,12 +52,12 @@ export function StopLossDetailsLayout({
               isStopLossEnabled={isStopLossEnabled}
               isEditing={isEditing}
               slRatio={slRatio}
-              collateralizationRatio={collateralizationRatio}
+              positionRatio={positionRatio}
               afterSlRatio={afterSlRatio}
             />
             <ContentCardCollateralizationRatio
-              collateralizationRatio={collateralizationRatio}
-              collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
+              positionRatio={positionRatio}
+              nextPositionRatio={nextPositionRatio}
             />
             <ContentCardDynamicStopPrice
               isStopLossEnabled={isStopLossEnabled}

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -177,8 +177,8 @@ export function getDataForStopLoss(
     context: { status: 'connected', account: '0x0', etherscan: { url: '' } } as Context,
     ethAndTokenPricesData: { ETH: currentEthPrice, [token]: currentCollateralPrice } as Tickers,
     positionData: {
-      collateralizationRatio: afterCollateralizationRatio,
-      collateralizationRatioAtNextPrice: afterCollateralizationRatioAtNextPrice,
+      positionRatio: afterCollateralizationRatio,
+      nextPositionRatio: afterCollateralizationRatioAtNextPrice,
       debt,
       debtFloor,
       debtOffset: zero,

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -23,7 +23,9 @@ import { VaultWarnings } from 'components/vault/VaultWarnings'
 import {
   DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE,
   MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
+  sidebarAutomationFeatureCopyMap,
 } from 'features/automation/common/consts'
+import { AutomationFeatures } from 'features/automation/common/types'
 import { getStartingSlRatio } from 'features/automation/protection/stopLoss/helpers'
 import {
   STOP_LOSS_FORM_CHANGE,
@@ -157,7 +159,7 @@ export function SidebarAdjustStopLossEditingStage({
   const {
     stopLossTriggerData,
     environmentData: { ethMarketPrice },
-    positionData: { id, ilk, token, debt, liquidationRatio, collateralizationRatio, debtFloor },
+    positionData: { id, ilk, token, debt, liquidationRatio, positionRatio, debtFloor },
   } = useAutomationContext()
 
   useDebouncedCallback(
@@ -169,7 +171,7 @@ export function SidebarAdjustStopLossEditingStage({
         {
           vaultId: id ? id.toString() : 'n/a',
           ilk: ilk,
-          collateralRatio: collateralizationRatio.times(100).decimalPlaces(2).toString(),
+          collateralRatio: positionRatio.times(100).decimalPlaces(2).toString(),
           triggerValue: value,
         },
       ),
@@ -177,12 +179,22 @@ export function SidebarAdjustStopLossEditingStage({
   )
 
   const isVaultEmpty = debt.isZero()
+  const feature = t(sidebarAutomationFeatureCopyMap[AutomationFeatures.STOP_LOSS])
 
-  if (isVaultEmpty && !stopLossTriggerData.isStopLossEnabled) {
+  if (isVaultEmpty && stopLossTriggerData.isStopLossEnabled) {
     return (
       <SidebarFormInfo
-        title={t('protection.closed-vault-not-existing-trigger-header')}
-        description={t('protection.closed-vault-not-existing-trigger-description')}
+        title={t('automation.closed-vault-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-existing-trigger-description', { feature })}
+      />
+    )
+  }
+
+  if (isVaultEmpty) {
+    return (
+      <SidebarFormInfo
+        title={t('automation.closed-vault-not-existing-trigger-header', { feature })}
+        description={t('automation.closed-vault-not-existing-trigger-description', { feature })}
       />
     )
   }

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -92,7 +92,8 @@ export function SidebarSetupStopLoss({
     constantMultipleTriggerData,
     stopLossTriggerData,
     environmentData: { nextCollateralPrice, ethBalance, ethMarketPrice, etherscanUrl },
-    positionData: { debt, token, liquidationRatio, collateralizationRatioAtNextPrice, vaultType },
+    positionData: { debt, token, liquidationRatio, nextPositionRatio, vaultType },
+    protocol,
   } = useAutomationContext()
   const { isAwaitingConfirmation, stopLossLevel } = stopLossState
 
@@ -113,6 +114,7 @@ export function SidebarSetupStopLoss({
     isAutoSellEnabled: autoSellTriggerData.isTriggerEnabled,
     isAutoConstantMultipleEnabled: constantMultipleTriggerData.isTriggerEnabled,
     vaultType,
+    protocol,
   })
   const primaryButtonLabel = getAutomationPrimaryButtonLabel({
     flow,
@@ -139,7 +141,7 @@ export function SidebarSetupStopLoss({
     ? constantMultipleTriggerData.sellExecutionCollRatio
         .minus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET)
         .div(100)
-    : collateralizationRatioAtNextPrice.minus(NEXT_COLL_RATIO_OFFSET.div(100))
+    : nextPositionRatio.minus(NEXT_COLL_RATIO_OFFSET.div(100))
   const maxBoundry = new BigNumber(max.multipliedBy(100).toFixed(0, BigNumber.ROUND_DOWN))
   const liqRatio = liquidationRatio
 
@@ -152,7 +154,7 @@ export function SidebarSetupStopLoss({
   const afterNewLiquidationPrice = stopLossLevel
     .dividedBy(100)
     .multipliedBy(nextCollateralPrice)
-    .dividedBy(collateralizationRatioAtNextPrice)
+    .dividedBy(nextPositionRatio)
 
   const sliderConfig: SliderValuePickerProps = {
     ...stopLossSliderBasicConfig,

--- a/features/automation/protection/stopLoss/state/useStopLossStateInitializator.ts
+++ b/features/automation/protection/stopLoss/state/useStopLossStateInitializator.ts
@@ -12,18 +12,18 @@ import { useEffect } from 'react'
 
 export function useStopLossStateInitializator({
   liquidationRatio,
-  collateralizationRatio,
+  positionRatio,
   stopLossTriggerData,
 }: {
   liquidationRatio: BigNumber
-  collateralizationRatio: BigNumber
+  positionRatio: BigNumber
   stopLossTriggerData: StopLossTriggerData
 }) {
   const { uiChanges } = useAppContext()
   const { stopLossLevel, isStopLossEnabled, isToCollateral, triggerId } = stopLossTriggerData
 
   const sliderMin = liquidationRatio.plus(MIX_MAX_COL_RATIO_TRIGGER_OFFSET.div(100))
-  const selectedStopLossCollRatioIfTriggerDoesntExist = collateralizationRatio.isZero()
+  const selectedStopLossCollRatioIfTriggerDoesntExist = positionRatio.isZero()
     ? zero
     : sliderMin.plus(DEFAULT_THRESHOLD_FROM_LOWEST_POSSIBLE_SL_VALUE)
   const initialSelectedSlRatio = getStartingSlRatio({
@@ -41,7 +41,7 @@ export function useStopLossStateInitializator({
       type: 'stop-loss-level',
       stopLossLevel: initialSelectedSlRatio,
     })
-  }, [triggerId.toNumber(), collateralizationRatio.toNumber()])
+  }, [triggerId.toNumber(), positionRatio.toNumber()])
 
   useEffect(() => {
     uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
@@ -56,7 +56,7 @@ export function useStopLossStateInitializator({
       type: 'is-awaiting-confirmation',
       isAwaitingConfirmation: false,
     })
-  }, [collateralizationRatio.toNumber()])
+  }, [positionRatio.toNumber()])
 
   return isStopLossEnabled
 }

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -157,9 +157,9 @@ export function ManageVaultDetails(
               changeVariant={changeVariant}
             />
             <ContentCardCollateralizationRatio
-              collateralizationRatio={collateralizationRatio}
-              collateralizationRatioAtNextPrice={collateralizationRatioAtNextPrice}
-              afterCollateralizationRatio={afterCollateralizationRatio}
+              positionRatio={collateralizationRatio}
+              nextPositionRatio={collateralizationRatioAtNextPrice}
+              afterPositionRatio={afterCollateralizationRatio}
               changeVariant={changeVariant}
             />
             <ContentCardCollateralLocked

--- a/features/borrow/open/containers/OpenVaultDetails.tsx
+++ b/features/borrow/open/containers/OpenVaultDetails.tsx
@@ -54,8 +54,8 @@ export function OpenVaultDetails(props: OpenVaultState) {
               changeVariant={changeVariant}
             />
             <ContentCardCollateralizationRatio
-              collateralizationRatio={collateralizationRatio}
-              afterCollateralizationRatio={afterCollateralizationRatio}
+              positionRatio={collateralizationRatio}
+              afterPositionRatio={afterCollateralizationRatio}
               changeVariant={changeVariant}
             />
             <ContentCardCollateralLocked

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -22,6 +22,7 @@ export type Feature =
   | 'DiscoverOasis'
   | 'ShowAaveStETHETHProductCard'
   | 'FollowVaults'
+  | 'AaveProtection'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -42,6 +43,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   DiscoverOasis: false,
   ShowAaveStETHETHProductCard: true,
   FollowVaults: false,
+  AaveProtection: false,
   // your feature here....
 }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1324,8 +1324,6 @@
     "edit-order": "Edit Order",
     "confirm": "Confirm",
     "unable-to-access-protection": "Unable to access Protection",
-    "closed-vault-not-existing-trigger-header": "You need to generate Dai before you can set up Stop-Loss",
-    "closed-vault-not-existing-trigger-description": "To enable Stop-Loss you need to generate Dai in overview tab",
     "adding-new-triggers-disabled-description": "Due to extreme adversarial market conditions we have currently disabled setting up NEW Stop-Loss triggers, as they might not result in the expected outcome for our users. Please use the 'close vault' option if you want to close your vault right now."
   },
   "newsletter": {
@@ -1628,10 +1626,6 @@
     "set-min-sell-price": "Set Min Sell Price",
     "set-trigger-description": "You are creating a recurring sell action to trigger at a collateralization ratio of {{execCollRatio}}%, increasing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}, with a min sell price of ${{minSellPrice}}/{{token}}. Learn More ",
     "set-trigger-description-no-threshold": "You are creating a recurring sell action to trigger at a collateralization ratio of {{execCollRatio}}%, increasing it to your Target Ratio of {{targetCollRatio}}%. Initially it will execute with at ${{executionPrice}}/{{token}}. With no min sell price. Learn More ",
-    "closed-vault-existing-trigger-header": "Your vault is closed but Auto-Sell is still active",
-    "closed-vault-existing-trigger-description": "You can cancel your existing Auto-Sell here or deposit into your vault in overview tab",
-    "closed-vault-not-existing-trigger-header": "You need to generate Dai before you can set up Auto-Sell",
-    "closed-vault-not-existing-trigger-description": "To enable Auto-Sell you need to generate Dai in overview tab",
     "adding-new-triggers-disabled": "Creation of the new Auto-Sell trigger is currently disabled.",
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Auto-Sell triggers",
     "add-content": "Your vault is currently being updated to add your Auto-Sell. Auto-Sell will not be active until this completes.",
@@ -1679,8 +1673,6 @@
     "target-ratio-with-deviation": "Target ratio with deviation",
     "outstanding-debt-after-next-buy": "Outstanding Debt after next buy",
     "col-to-be-purchased": "{{token}} to be purchased at next buy",
-    "closed-vault-existing-trigger-header": "Your vault is closed but Auto-Buy is still active",
-    "closed-vault-existing-trigger-description": "You can cancel your existing Auto-Buy here or deposit into your vault in overview tab",
     "adding-new-triggers-disabled": "Creation of the new Auto-Buy trigger is currently disabled.",
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Auto-Buy triggers",
     "add-content": "Your vault is currently being updated to add your Auto-Buy. Auto-Buy will not be active until this completes.",
@@ -1734,10 +1726,8 @@
     "cancel-instructions": "To cancel the Take Profit you'll need to click the button below and confirm the transaction.",
     "adding-new-triggers-disabled": "Creation of the new Take Profit trigger is currently disabled.",
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Take Profit triggers",
-    "closed-vault-existing-trigger-header": "Your vault is closed but Take Profit is still active",
-    "closed-vault-existing-trigger-description": "You can cancel your existing Take Profit here or deposit into your vault in overview tab"
+    "auto-take-profit-confirmation-text": "You are setting an Auto-Take Profit order to trigger at an ETH price of ${{price}}. Your vault will be closed and your expected profit of ${{profit}} paid will be paid out in DAI."
   },
-
   "automation": {
     "setup": "{{feature}} Setup",
     "trigger-added": "{{feature}} Enabled",
@@ -1757,7 +1747,10 @@
     "trigger-executed": "Your {{feature}} was triggered",
     "estimated-col-ratio-at-trigger": "Estimated Coll. Ratio at Trigger",
     "confirmation-text": "Confirm your {{feature}} setup",
-    "auto-take-profit-confirmation-text": "You are setting an Auto-Take Profit order to trigger at an ETH price of ${{price}}. Your vault will be closed and your expected profit of ${{profit}} paid will be paid out in DAI."
+    "closed-vault-existing-trigger-header": "Your vault is closed but {{feature}} is still active",
+    "closed-vault-existing-trigger-description": "You can cancel your existing {{feature}} here or deposit into your vault in overview tab",
+    "closed-vault-not-existing-trigger-header": "You need to generate Dai before you can set up {{feature}}",
+    "closed-vault-not-existing-trigger-description": "To enable {{feature}} you need to generate Dai in overview tab"
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",
@@ -1809,9 +1802,7 @@
     "adding-new-triggers-disabled": "Creation of the new Constant Multiple trigger is currently disabled.",
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Constant Multiple triggers",
     "sl-too-high": "Constant Multiple is not available as your existing Stop-Loss Protection trigger is too high. Please <0>adjust your Stop-Loss Trigger</0> below {{maxStopLoss}}% before using Constant Multiple.",
-    "coll-ratio-too-close-to-dust-limit": "Constant Multiple is not available as your current Col. Ratio is close to dust limit. Please <0>adjust your Col. Ratio</0> before using Constant Multiple.",
-    "closed-vault-existing-trigger-header": "Your vault is closed but Constant Multiple is still active",
-    "closed-vault-existing-trigger-description": "You can cancel your existing Constant Multiple here or deposit into your vault in overview tab"
+    "coll-ratio-too-close-to-dust-limit": "Constant Multiple is not available as your current Col. Ratio is close to dust limit. Please <0>adjust your Col. Ratio</0> before using Constant Multiple."
   },
   "ref": {
     "banner": "Earn on ETH with our new stETH product. Check it out today",


### PR DESCRIPTION
# [Incorporated stop loss to Aave (just UI)](https://app.shortcut.com/oazo-apps/story/6716/incorporate-stop-loss-to-manage-aave-view)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added feature toggle `AaveProtection` 
- added protection tab with stoploss (behind feature toggle) to aave manage/view vault page
- adjusted automation context variable names to something more generic
- fixed minor issues with automation form states when vault is empty
  
## How to test 🧪
  <Please explain how to test your changes>

- create aave position (using hardhat), try to enable / disable `AaveProtection` feature toggle
- when feature toggle enable stop loss should be available under protection tab
- for now do not pay attention to stop loss UI content as values was not yet mapped and handled properly as it is in the scope of other task