### PR TITLE
🧭 Discover multiselect for "size" and "multiple" filters 

### DIFF
--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -1,7 +1,8 @@
 import { GenericSelect } from 'components/GenericSelect'
 import { DiscoverMultiselect } from 'features/discover/common/DiscoverMultiselect'
-import { DiscoverFiltersList } from 'features/discover/meta'
-import React, { Fragment } from 'react'
+import { DiscoverFiltersList, DiscoverFiltersListItem } from 'features/discover/meta'
+import { DiscoverFilterType } from 'features/discover/types'
+import React from 'react'
 import { Box, Grid } from 'theme-ui'
 
 export function DiscoverFilters({
@@ -38,26 +39,43 @@ export function DiscoverFilters({
         }}
       >
         {Object.keys(filters).map((key) => (
-          <Fragment key={key}>
-            {filters[key].multi ? (
-              <DiscoverMultiselect
-                {...filters[key]}
-                onChange={(value) => {
-                  onChange(key, value)
-                }}
-              />
-            ) : (
-              <GenericSelect
-                options={filters[key].options}
-                defaultValue={filters[key].options[0]}
-                onChange={(currentValue) => {
-                  onChange(key, currentValue.value)
-                }}
-              />
-            )}
-          </Fragment>
+          <DiscoverFilter filter={key} item={filters[key]} key={key} onChange={onChange} />
         ))}
       </Grid>
     </Box>
   )
+}
+
+export function DiscoverFilter({
+  filter,
+  item,
+  onChange,
+}: {
+  filter: string
+  item: DiscoverFiltersListItem
+  onChange: (key: string, currentValue: string) => void
+}) {
+  switch (item.type) {
+    case DiscoverFilterType.SINGLE:
+      return (
+        <GenericSelect
+          options={item.options}
+          defaultValue={item.options[0]}
+          onChange={(currentValue) => {
+            onChange(filter, currentValue.value)
+          }}
+        />
+      )
+    case DiscoverFilterType.MULTI:
+      return (
+        <DiscoverMultiselect
+          {...item}
+          onChange={(value) => {
+            onChange(filter, value)
+          }}
+        />
+      )
+    default:
+      return null
+  }
 }

--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -1,7 +1,7 @@
 import { GenericSelect } from 'components/GenericSelect'
 import { DiscoverMultiselect } from 'features/discover/common/DiscoverMultiselect'
 import { DiscoverFiltersList } from 'features/discover/meta'
-import React from 'react'
+import React, { Fragment } from 'react'
 import { Box, Grid } from 'theme-ui'
 
 export function DiscoverFilters({
@@ -38,10 +38,9 @@ export function DiscoverFilters({
         }}
       >
         {Object.keys(filters).map((key) => (
-          <>
+          <Fragment key={key}>
             {filters[key].multi ? (
               <DiscoverMultiselect
-                key={key}
                 {...filters[key]}
                 onChange={(value) => {
                   onChange(key, value)
@@ -49,7 +48,6 @@ export function DiscoverFilters({
               />
             ) : (
               <GenericSelect
-                key={key}
                 options={filters[key].options}
                 defaultValue={filters[key].options[0]}
                 onChange={(currentValue) => {
@@ -57,7 +55,7 @@ export function DiscoverFilters({
                 }}
               />
             )}
-          </>
+          </Fragment>
         ))}
       </Grid>
     </Box>

--- a/features/discover/common/DiscoverMultiselect.tsx
+++ b/features/discover/common/DiscoverMultiselect.tsx
@@ -40,7 +40,7 @@ export function DiscoverMultiselect({
             {selected.icon && (
               <Icon size={32} sx={{ flexShrink: 0, mr: '12px' }} name={selected.icon} />
             )}
-            {selected.value}
+            {selected.label}
           </>
         )
       default:
@@ -123,7 +123,10 @@ export function DiscoverMultiselect({
         <DiscoverMultiselectItem
           isDisabled={values.length === 0}
           label={t('clear-selection')}
-          onClick={() => setValues([])}
+          onClick={() => {
+            setValues([])
+            setIsOpen(false)
+          }}
           value=""
         />
         {options.map((option) => (

--- a/features/discover/common/DiscoverMultiselect.tsx
+++ b/features/discover/common/DiscoverMultiselect.tsx
@@ -180,27 +180,17 @@ export function DiscoverMultiselectItem({
         size={14}
         sx={{
           position: 'absolute',
-          top: 0,
-          bottom: 0,
+          top: '17px',
           left: '20px',
-          margin: 'auto',
           opacity: isSelected ? 1 : 0,
           transition: 'opacity 150ms',
+          fontWeight: 'bold'
         }}
         name="tick"
         color="neutral80"
       />
       {icon && <Icon size={32} sx={{ flexShrink: 0, mr: '12px' }} name={icon} />}
-      <Text
-        as="span"
-        sx={{
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-        }}
-      >
-        {label}
-      </Text>
+      {label}
     </Box>
   )
 }

--- a/features/discover/common/DiscoverMultiselect.tsx
+++ b/features/discover/common/DiscoverMultiselect.tsx
@@ -184,7 +184,6 @@ export function DiscoverMultiselectItem({
           left: '20px',
           opacity: isSelected ? 1 : 0,
           transition: 'opacity 150ms',
-          fontWeight: 'bold'
         }}
         name="tick"
         color="neutral80"

--- a/features/discover/filters.ts
+++ b/features/discover/filters.ts
@@ -28,9 +28,8 @@ export const discoverFiltersAssetItems: { [key: string]: DiscoverFiltersListOpti
 
 export const discoverSizeFilter: DiscoverFiltersListItem = {
   label: 'Sizes',
-  multi: false,
+  multi: true,
   options: [
-    { value: '', label: 'All sizes' },
     { value: '<100000', label: 'Under $100,000' },
     { value: '100000-250000', label: '$100,000 - $250,000' },
     { value: '250000-500000', label: '$250,000 - $500,000' },
@@ -41,9 +40,8 @@ export const discoverSizeFilter: DiscoverFiltersListItem = {
 
 export const discoverMultipleFilter: DiscoverFiltersListItem = {
   label: 'Multiples',
-  multi: false,
+  multi: true,
   options: [
-    { value: '', label: 'All multiples' },
     { value: '1-2', label: 'Multiple: 1-2x' },
     { value: '2-3', label: 'Multiple: 2-3x' },
     { value: '>3', label: 'Multiple: over 3x' },

--- a/features/discover/filters.ts
+++ b/features/discover/filters.ts
@@ -1,5 +1,6 @@
 import { getToken } from 'blockchain/tokensMetadata'
 import { DiscoverFiltersListItem, DiscoverFiltersListOptions } from 'features/discover/meta'
+import { DiscoverFilterType } from 'features/discover/types'
 
 export const discoverFiltersAssetItems: { [key: string]: DiscoverFiltersListOptions } = {
   crvv1ethsteth: {
@@ -28,7 +29,7 @@ export const discoverFiltersAssetItems: { [key: string]: DiscoverFiltersListOpti
 
 export const discoverSizeFilter: DiscoverFiltersListItem = {
   label: 'Sizes',
-  multi: true,
+  type: DiscoverFilterType.MULTI,
   options: [
     { value: '<100000', label: 'Under $100,000' },
     { value: '100000-250000', label: '$100,000 - $250,000' },
@@ -40,7 +41,7 @@ export const discoverSizeFilter: DiscoverFiltersListItem = {
 
 export const discoverMultipleFilter: DiscoverFiltersListItem = {
   label: 'Multiples',
-  multi: true,
+  type: DiscoverFilterType.MULTI,
   options: [
     { value: '1-2', label: 'Multiple: 1-2x' },
     { value: '2-3', label: 'Multiple: 2-3x' },
@@ -50,7 +51,7 @@ export const discoverMultipleFilter: DiscoverFiltersListItem = {
 
 export const discoverTimeFilter: DiscoverFiltersListItem = {
   label: 'Time',
-  multi: false,
+  type: DiscoverFilterType.SINGLE,
   options: [
     { value: 'all', label: 'All time' },
     { value: '1d', label: '1 day' },
@@ -60,10 +61,13 @@ export const discoverTimeFilter: DiscoverFiltersListItem = {
   ],
 }
 
-export function getAssetOptions(options: DiscoverFiltersListOptions[]): DiscoverFiltersListItem {
+export function getAssetOptions(
+  options: DiscoverFiltersListOptions[],
+  type: DiscoverFilterType = DiscoverFilterType.MULTI,
+): DiscoverFiltersListItem {
   return {
     label: 'Assets',
-    multi: true,
+    type,
     options,
   }
 }

--- a/features/discover/helpers.ts
+++ b/features/discover/helpers.ts
@@ -1,6 +1,7 @@
 import { Pages } from 'analytics/analytics'
 import { DiscoverFiltersList } from 'features/discover/meta'
 import {
+  DiscoverFilterType,
   DiscoverPages,
   DiscoverTableActivityRowData,
   DiscoverTableRowData,
@@ -36,9 +37,10 @@ export function getDefaultSettingsState({
     ...Object.keys(filters).reduce(
       (o, key) => ({
         ...o,
-        [key]: filters[key].multi
-          ? filters[key].options.map((item) => item.value).join(',')
-          : filters[key].options[0].value,
+        [key]:
+          filters[key].type === DiscoverFilterType.SINGLE
+            ? filters[key].options[0].value
+            : filters[key].options.map((item) => item.value).join(','),
       }),
       {},
     ),

--- a/features/discover/meta.tsx
+++ b/features/discover/meta.tsx
@@ -6,7 +6,7 @@ import {
   getAssetOptions,
 } from 'features/discover/filters'
 import { discoverBannerIcons, discoverNavigationIconContent } from 'features/discover/icons'
-import { DiscoverPages } from 'features/discover/types'
+import { DiscoverFilterType, DiscoverPages } from 'features/discover/types'
 
 export interface DiscoverFiltersListOptions {
   label: string
@@ -15,7 +15,7 @@ export interface DiscoverFiltersListOptions {
 }
 export interface DiscoverFiltersListItem {
   label: string
-  multi: boolean
+  type: DiscoverFilterType
   options: DiscoverFiltersListOptions[]
 }
 export interface DiscoverFiltersList {
@@ -88,10 +88,10 @@ export const discoverPagesMeta: DiscoverPageMeta[] = [
     iconColor: '#00E2BA',
     iconContent: discoverNavigationIconContent[DiscoverPages.MOST_YIELD_EARNED],
     filters: {
-      asset: getAssetOptions([
-        discoverFiltersAssetItems.guniv3daiusdc1,
-        discoverFiltersAssetItems.guniv3daiusdc2,
-      ]),
+      asset: getAssetOptions(
+        [discoverFiltersAssetItems.guniv3daiusdc1, discoverFiltersAssetItems.guniv3daiusdc2],
+        DiscoverFilterType.HIDDEN,
+      ),
       size: discoverSizeFilter,
       time: discoverTimeFilter,
     },

--- a/features/discover/types.ts
+++ b/features/discover/types.ts
@@ -26,6 +26,12 @@ export enum DiscoverTableVaultStatus {
   TO_STOP_LOSS = 4,
 }
 
+export enum DiscoverFilterType {
+  SINGLE,
+  MULTI,
+  HIDDEN,
+}
+
 export interface DiscoverFiltersSettings {
   [key: string]: string
 }

--- a/handlers/discover/getDiscoveryData.tsx
+++ b/handlers/discover/getDiscoveryData.tsx
@@ -5,6 +5,7 @@ import {
   getGenericRangeFilter,
   getStatus,
   getTimeSignature,
+  wrapFilterCombination,
 } from 'handlers/discover/helpers'
 import { NextApiRequest } from 'next'
 import { prisma } from 'server/prisma'
@@ -32,7 +33,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                collateral_value: getGenericRangeFilter(size),
+                OR: [...wrapFilterCombination('collateral_value', getGenericRangeFilter, size)],
               },
               orderBy: { liquidation_proximity: 'asc' },
             })
@@ -54,8 +55,10 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                collateral_value: getGenericRangeFilter(size),
-                vault_multiple: getGenericRangeFilter(multiple),
+                OR: [
+                  ...wrapFilterCombination('collateral_value', getGenericRangeFilter, size),
+                  ...wrapFilterCombination('vault_multiple', getGenericRangeFilter, multiple),
+                ],
                 type: 'multiply',
               },
               orderBy: { [timeSignature]: 'desc' },
@@ -79,7 +82,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                collateral_value: getGenericRangeFilter(size),
+                OR: [...wrapFilterCombination('collateral_value', getGenericRangeFilter, size)],
               },
               orderBy: { [timeSignature]: 'desc' },
             })
@@ -100,7 +103,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                collateral_value: getGenericRangeFilter(size),
+                OR: [...wrapFilterCombination('collateral_value', getGenericRangeFilter, size)],
               },
               orderBy: { vault_debt: 'desc' },
             })

--- a/handlers/discover/helpers.ts
+++ b/handlers/discover/helpers.ts
@@ -16,6 +16,14 @@ type DiscoverLite = OmitNonDecimal<HighestMultiplyPnl | MostYieldEarned>
 
 const ELIGIBLE_TIME_SIGNATURES = ['1d', '7d', '30d', '365d']
 
+export function wrapFilterCombination(
+  field: string,
+  fn: (filter?: string) => Prisma.StringFilter,
+  filter?: string,
+): { [k: string]: Prisma.StringFilter }[] {
+  return filter ? filter.split(',').map((item) => ({ [field]: fn(item) })) : []
+}
+
 export function getGenericRangeFilter(filter?: string): Prisma.StringFilter {
   const split = filter?.split('-')
 


### PR DESCRIPTION
# [🧭 Discover multiselect for "size" and "multiple" filters ](https://app.shortcut.com/oazo-apps/story/6797/discover-oasis-multi-select-filters)

![image](https://user-images.githubusercontent.com/16230404/202244866-003cc765-6ecc-4145-913f-62040fa7902b.png)

## Changes 👷‍♀️

- Added different types of filter types as enum: `single`, `multi`, `hidden`,
- set "size" and "multiple" as `multi`,
- set "asset" only for "Most Yield Earned" as `hidden`,
- refined API calls to accept more than one range as `where` filter.
  
## How to test 🧪

- Firstly, you need local Discover database to test it. Since API call were altered, proxy'ing request to staging won't work ,
- after getting yourself localdatabase or connection to staging one (only connection to staging, not API proxy), just test entire filters section.
