### PR TITLE
Adjusted risk handling

### DIFF
--- a/features/walletAssociatedRisk/WalletAssociatedRisk.tsx
+++ b/features/walletAssociatedRisk/WalletAssociatedRisk.tsx
@@ -1,9 +1,8 @@
+import { useAppContext } from 'components/AppContextProvider'
+import { disconnect } from 'components/connectWallet/ConnectWallet'
+import { useObservable } from 'helpers/observableHook'
 import getConfig from 'next/config'
 import React, { ReactNode, useEffect } from 'react'
-
-import { useAppContext } from '../../components/AppContextProvider'
-import { disconnect } from '../../components/connectWallet/ConnectWallet'
-import { useObservable } from '../../helpers/observableHook'
 
 interface WithWalletAssociatedRiskProps {
   children: ReactNode
@@ -16,11 +15,6 @@ export function WithWalletAssociatedRisk({ children }: WithWalletAssociatedRiskP
   const shouldUseTrm = getConfig()?.publicRuntimeConfig?.useTrmApi
 
   useEffect(() => {
-    if (walletAssociatedRisk?.error && shouldUseTrm) {
-      alert('We are temporarily unable to verify your address. Please try again in a moment.')
-      disconnect(web3Context)
-    }
-
     if (walletAssociatedRisk?.isRisky && shouldUseTrm) {
       alert(
         'Your wallet has been flagged by our automated risk tools, and as such your access to oasis.app restricted. If you believe this to be incorrect, please reach out to support@oasis.app',

--- a/handlers/risk/get.ts
+++ b/handlers/risk/get.ts
@@ -78,7 +78,13 @@ async function checkIfRisky(address: string) {
       console.log('TRM_LOG logging failed', ex)
     }
 
-    return !!trmData.addressRiskIndicators.length
+    if (!trmData.addressRiskIndicators.length) {
+      return false
+    }
+
+    return trmData.addressRiskIndicators
+      .map((indicator) => Number(indicator.totalVolumeUsd) > 0)
+      .includes(true)
   } catch (ex) {
     console.log(`TRM_LOG ${address} check failed`)
     throw ex


### PR DESCRIPTION
# [Adjusted risk handling](https://app.shortcut.com/oazo-apps/story/6816/trm-check-totalvolumeusd-0)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed alert and disconnect call when error occurs
- risky when risk indicator exists and totalVolumeUsd greater than zero
  
## How to test 🧪
  <Please explain how to test your changes>

- use risky and non risky wallet on mainnet, connect wallet on the owner page and check response from api about risk
- when error occurs user shouldn't be disconnected and alert shouldn't pop up