### PR TITLE
🧭 Nicer checkbox for Discover multiselect

### DIFF
--- a/features/discover/common/DiscoverMultiselect.tsx
+++ b/features/discover/common/DiscoverMultiselect.tsx
@@ -121,6 +121,7 @@ export function DiscoverMultiselect({
         }}
       >
         <DiscoverMultiselectItem
+          hasCheckbox={false}
           isDisabled={values.length === 0}
           label={t('clear-selection')}
           onClick={() => {
@@ -143,6 +144,7 @@ export function DiscoverMultiselect({
 }
 
 export function DiscoverMultiselectItem({
+  hasCheckbox = true,
   icon,
   isDisabled = false,
   isSelected = false,
@@ -150,6 +152,7 @@ export function DiscoverMultiselectItem({
   onClick,
   value,
 }: {
+  hasCheckbox?: boolean
   isDisabled?: boolean
   isSelected?: boolean
   onClick: (value: string) => void
@@ -163,7 +166,7 @@ export function DiscoverMultiselectItem({
         alignItems: 'center',
         py: '12px',
         pr: 3,
-        pl: '48px',
+        pl: hasCheckbox ? '48px' : '16px',
         fontSize: 3,
         color: isDisabled ? 'neutral80' : 'primary100',
         transition: 'color 200ms, background-color 200ms',
@@ -176,19 +179,40 @@ export function DiscoverMultiselectItem({
         if (!isDisabled) onClick(value)
       }}
     >
-      <Icon
-        size={14}
-        sx={{
-          position: 'absolute',
-          top: '17px',
-          left: '20px',
-          opacity: isSelected ? 1 : 0,
-          transition: 'opacity 150ms',
-        }}
-        name="tick"
-        color="neutral80"
-      />
-      {icon && <Icon size={32} sx={{ flexShrink: 0, mr: '12px' }} name={icon} />}
+      {hasCheckbox && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '14px',
+            left: '16px',
+            width: '20px',
+            height: '20px',
+            backgroundColor: isSelected ? 'success10' : 'neutral10',
+            border: '1px solid',
+            borderColor: isSelected ? 'success100' : 'neutral60',
+            borderRadius: 'small',
+            transition: 'background-color 100ms, border-color 100ms',
+          }}
+        >
+          <Icon
+            fill="none"
+            size={10}
+            sx={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              bottom: 0,
+              left: 0,
+              margin: 'auto',
+              opacity: isSelected ? 1 : 0,
+              transition: 'opacity 100ms',
+            }}
+            name="checkmark"
+            color="success100"
+          />
+        </Box>
+      )}
+      {icon && <Icon size={32} sx={{ flexShrink: 0, my: '-4px', mr: '12px' }} name={icon} />}
       {label}
     </Box>
   )

--- a/icons.d.ts
+++ b/icons.d.ts
@@ -6,6 +6,7 @@ declare module '@makerdao/dai-ui-icons' {
     name: string
     width?: string | number
     height?: string | number
+    fill?: string
     onClick?(): void
   }>
 
@@ -20,6 +21,7 @@ declare module '@makerdao/dai-ui-icons-branding' {
     name: string
     width?: string | number
     height?: string | number
+    fill?: string
     onClick?(): void
   }>
 

--- a/theme/icons.tsx
+++ b/theme/icons.tsx
@@ -2302,6 +2302,18 @@ const userWalletIcons = {
     ),
     viewBox: '0 0 14 12',
   },
+  checkmark: {
+    path: (
+      <path
+        d="M1.1543 5.76922L3.46199 8.07691L8.8466 1.92307"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    ),
+    viewBox: '0 0 10 10',
+  },
   circle_exchange: {
     path: (
       <>


### PR DESCRIPTION
# 🧭 Nicer checkbox for Discover multiselect

![image](https://user-images.githubusercontent.com/16230404/202440424-df2a216e-8bae-4b01-bf66-e13e62c349a1.png)
  
## Changes 👷‍♀️

- Changed item selection mark from standalone tick to two-state checkbox.
  
## How to test 🧪

Self explanatory.
