### PR TITLE
🧭 Fix OR filter for Highest Multiply P&L in Discover

### DIFF
--- a/handlers/discover/getDiscoveryData.tsx
+++ b/handlers/discover/getDiscoveryData.tsx
@@ -33,7 +33,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                OR: [...wrapFilterCombination('collateral_value', getGenericRangeFilter, size)],
+                OR: wrapFilterCombination('collateral_value', getGenericRangeFilter, size),
               },
               orderBy: { liquidation_proximity: 'asc' },
             })
@@ -55,9 +55,9 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                OR: [
-                  ...wrapFilterCombination('collateral_value', getGenericRangeFilter, size),
-                  ...wrapFilterCombination('vault_multiple', getGenericRangeFilter, multiple),
+                AND: [
+                  { OR: wrapFilterCombination('collateral_value', getGenericRangeFilter, size) },
+                  { OR: wrapFilterCombination('vault_multiple', getGenericRangeFilter, multiple) },
                 ],
                 type: 'multiply',
               },
@@ -82,7 +82,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                OR: [...wrapFilterCombination('collateral_value', getGenericRangeFilter, size)],
+                OR: wrapFilterCombination('collateral_value', getGenericRangeFilter, size),
               },
               orderBy: { [timeSignature]: 'desc' },
             })
@@ -103,7 +103,7 @@ export async function getDiscoveryData(query: NextApiRequest['query']) {
               take: AMOUNT_OF_ROWS,
               where: {
                 token: getGenericArrayFilter(asset),
-                OR: [...wrapFilterCombination('collateral_value', getGenericRangeFilter, size)],
+                OR: wrapFilterCombination('collateral_value', getGenericRangeFilter, size),
               },
               orderBy: { vault_debt: 'desc' },
             })


### PR DESCRIPTION
# 🧭 Fix OR filter for Highest Multiply P&L in Discover
  
## Changes 👷‍♀️

- Added `AND` between `OR` for "multiple" and "size" filters.
  
## How to test 🧪

See if selecting single option in "multiple" or "size" filter on "Highest Multiply P&L" page has any effect.