### PR TITLE
🧭 Remove checkbox icon

### DIFF
--- a/features/discover/common/DiscoverFilters.tsx
+++ b/features/discover/common/DiscoverFilters.tsx
@@ -35,7 +35,7 @@ export function DiscoverFilters({
       <Grid
         gap="12px"
         sx={{
-          gridTemplateColumns: ['100%', 'repeat(2, 1fr)', null, 'repeat(4, 234px)'],
+          gridTemplateColumns: ['100%', 'repeat(2, 1fr)', null, 'repeat(4, 1fr)'],
         }}
       >
         {Object.keys(filters).map((key) => (

--- a/features/discover/common/DiscoverMultiselect.tsx
+++ b/features/discover/common/DiscoverMultiselect.tsx
@@ -207,7 +207,7 @@ export function DiscoverMultiselectItem({
               opacity: isSelected ? 1 : 0,
               transition: 'opacity 100ms',
             }}
-            name="checkmark"
+            name="single_tick"
             color="success100"
           />
         </Box>

--- a/features/discover/common/DiscoverMultiselect.tsx
+++ b/features/discover/common/DiscoverMultiselect.tsx
@@ -195,7 +195,6 @@ export function DiscoverMultiselectItem({
           }}
         >
           <Icon
-            fill="none"
             size={10}
             sx={{
               position: 'absolute',
@@ -207,7 +206,7 @@ export function DiscoverMultiselectItem({
               opacity: isSelected ? 1 : 0,
               transition: 'opacity 100ms',
             }}
-            name="single_tick"
+            name="checkmark"
             color="success100"
           />
         </Box>

--- a/theme/icons.tsx
+++ b/theme/icons.tsx
@@ -2302,18 +2302,6 @@ const userWalletIcons = {
     ),
     viewBox: '0 0 14 12',
   },
-  single_tick: {
-    path: (
-      <path
-        d="M1.1543 5.76922L3.46199 8.07691L8.8466 1.92307"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    ),
-    viewBox: '0 0 10 10',
-  },
   circle_exchange: {
     path: (
       <>

--- a/theme/icons.tsx
+++ b/theme/icons.tsx
@@ -2302,7 +2302,7 @@ const userWalletIcons = {
     ),
     viewBox: '0 0 14 12',
   },
-  checkmark: {
+  single_tick: {
     path: (
       <path
         d="M1.1543 5.76922L3.46199 8.07691L8.8466 1.92307"


### PR DESCRIPTION
# 🧭 Remove checkbox icon

Turns out the icon I've add was already available in external library and keeping it in our repo was unnecesary. Also, it broke one of the places where it was used before 🤷
  
## Changes 👷‍♀️

- Removed local `checkmark` icon,
- sneaked tiny change in Discover UI - all filters are taking equally 1/4 of available space in width.
