### PR TITLE
Fix failing transaction for adjusting risk. 

### DIFF
--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -132,11 +132,11 @@ export async function getAdjustAaveParameters({
     },
   )
 
-  const operationName = riskRatio.loanToValue.gt(currentPosition.riskRatio.loanToValue)
-    ? OPERATION_NAMES.aave.DECREASE_POSITION
-    : OPERATION_NAMES.aave.INCREASE_POSITION
+  // const operationName = riskRatio.loanToValue.gt(currentPosition.riskRatio.loanToValue)
+  //   ? OPERATION_NAMES.common.CUSTOM_OPERATION
+  //   : OPERATION_NAMES.common.CUSTOM_OPERATION
 
-  return { strategy, operationName }
+  return { strategy, operationName: OPERATION_NAMES.common.CUSTOM_OPERATION }
 }
 
 export async function getCloseAaveParameters({

--- a/features/earn/aave/riskSliderConfig.tsx
+++ b/features/earn/aave/riskSliderConfig.tsx
@@ -14,7 +14,7 @@ export const adjustRiskSliderConfig: AdjustRiskViewConfig = {
   rightBoundary: {
     valueExtractor: (data) => data?.oracleAssetPrice,
     formatter: (qty) => {
-      return richFormattedBoundary({ value: formatBigNumber(qty, 2), unit: 'STETH/ETH' })
+      return richFormattedBoundary({ value: formatBigNumber(qty, 4), unit: 'STETH/ETH' })
     },
     translationKey: 'open-earn.aave.vault-form.configure-multiple.current-price',
   },


### PR DESCRIPTION
# [Fix failing transaction for adjusting risk](https://app.shortcut.com/oazo-apps/story/6835/staging-bug-adjusting-up-down-for-steth-eth-is-broken)
  
## Changes 👷‍♀️
- CUSTOM_OPERATION instead of INCREASE_POSITION and DECREASE_POSITION
- 4 digits for stETH/ETH price
  
## How to test 🧪
- Open position
- Try to decrease or increase risk