### PR TITLE
🧭 Set Discover feature flag `true` by default

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -40,7 +40,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   AutoTakeProfit: true,
   UpdatedPnL: false,
   ReadOnlyAutoTakeProfit: false,
-  DiscoverOasis: false,
+  DiscoverOasis: true,
   ShowAaveStETHETHProductCard: true,
   FollowVaults: false,
   AaveProtection: false,


### PR DESCRIPTION
# 🧭 Set Discover feature flag `true` by default

As in title.
  
## Changes 👷‍♀️

- Changed `DiscoverOasis` to `true`.
  
## How to test 🧪

Open Oasis.app in incognito mode and check if main navigation contains link to Discover by default.
