### PR TITLE
Fix summary when removing Auto-(Buy/Sell) trigger and vault is closed

### DIFF
--- a/features/automation/common/sidebars/CancelAutoBSInfoSection.tsx
+++ b/features/automation/common/sidebars/CancelAutoBSInfoSection.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
-import { AutoBSFormChange } from 'features/automation/common/state/autoBSFormChange'
+import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
@@ -14,7 +14,7 @@ interface CancelAutoBSInfoSectionProps {
   title: string
   targetLabel: string
   triggerLabel: string
-  autoBSState: AutoBSFormChange
+  autoBSTriggerData: AutoBSTriggerData
 }
 
 export function CancelAutoBSInfoSection({
@@ -24,7 +24,7 @@ export function CancelAutoBSInfoSection({
   title,
   targetLabel,
   triggerLabel,
-  autoBSState,
+  autoBSTriggerData,
 }: CancelAutoBSInfoSectionProps) {
   const { t } = useTranslation()
   const isDebtZero = debt.isZero()
@@ -34,8 +34,10 @@ export function CancelAutoBSInfoSection({
   const positionRatioFormatted = formatPercent(positionRatio.times(100), {
     precision: 2,
   })
-  const execCollRatioFormatted = formatPercent(autoBSState.execCollRatio, { precision: 2 })
-  const targetCollRatioFormatted = formatPercent(autoBSState.targetCollRatio, { precision: 2 })
+  const execCollRatioFormatted = formatPercent(autoBSTriggerData.execCollRatio, { precision: 2 })
+  const targetCollRatioFormatted = formatPercent(autoBSTriggerData.targetCollRatio, {
+    precision: 2,
+  })
 
   return (
     <InfoSection

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
@@ -1,8 +1,9 @@
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
 import { CancelAutoBSInfoSection } from 'features/automation/common/sidebars/CancelAutoBSInfoSection'
-import { AutoBSFormChange } from 'features/automation/common/state/autoBSFormChange'
+import { AutomationFeatures } from 'features/automation/common/types'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { useTranslation } from 'next-i18next'
@@ -12,38 +13,36 @@ import { Text } from 'theme-ui'
 interface SidebarAutoBuyRemovalEditingStageProps {
   errors: VaultErrorMessage[]
   warnings: VaultWarningMessage[]
-  autoBuyState: AutoBSFormChange
 }
 
 export function SidebarAutoBuyRemovalEditingStage({
   errors,
   warnings,
-  autoBuyState,
 }: SidebarAutoBuyRemovalEditingStageProps) {
   const {
     positionData: { debtFloor, token },
   } = useAutomationContext()
+  const { t } = useTranslation()
 
   return (
     <>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-        To cancel the Auto-Buy you’ll need to click the button below and confirm the transaction.
+        {t('automation.cancel-summary-description', {
+          feature: t(sidebarAutomationFeatureCopyMap[AutomationFeatures.AUTO_BUY]),
+        })}
       </Text>
       <VaultErrors errorMessages={errors} ilkData={{ debtFloor, token }} />
       <VaultWarnings warningMessages={warnings} ilkData={{ debtFloor }} />
-      <AutoBuyInfoSectionControl autoBuyState={autoBuyState} />
+      <AutoBuyInfoSectionControl />
     </>
   )
 }
 
-interface AutoBuyInfoSectionControlProps {
-  autoBuyState: AutoBSFormChange
-}
-
-function AutoBuyInfoSectionControl({ autoBuyState }: AutoBuyInfoSectionControlProps) {
+function AutoBuyInfoSectionControl() {
   const { t } = useTranslation()
   const {
     positionData: { positionRatio, liquidationPrice, debt },
+    autoBuyTriggerData,
   } = useAutomationContext()
 
   return (
@@ -53,7 +52,7 @@ function AutoBuyInfoSectionControl({ autoBuyState }: AutoBuyInfoSectionControlPr
       title={t('auto-buy.cancel-summary-title')}
       targetLabel={t('auto-buy.target-col-ratio-each-buy')}
       triggerLabel={t('auto-buy.trigger-col-ratio-to-perform-buy')}
-      autoBSState={autoBuyState}
+      autoBSTriggerData={autoBuyTriggerData}
       debt={debt}
     />
   )

--- a/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
@@ -187,7 +187,6 @@ export function SidebarSetupAutoBuy({
                 <SidebarAutoBuyRemovalEditingStage
                   errors={cancelAutoBuyErrors}
                   warnings={cancelAutoBuyWarnings}
-                  autoBuyState={autoBuyState}
                 />
               )}
             </>

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
@@ -1,6 +1,8 @@
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
+import { AutomationFeatures } from 'features/automation/common/types'
 import { CancelAutoTakeProfitInfoSection } from 'features/automation/optimization/autoTakeProfit/controls/CancelAutoTakeProfitInfoSection'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
@@ -25,7 +27,9 @@ export function SidebarAutoTakeProfitRemovalEditingStage({
   return (
     <>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-        {t('auto-take-profit.cancel-instructions')}
+        {t('automation.cancel-summary-description', {
+          feature: t(sidebarAutomationFeatureCopyMap[AutomationFeatures.AUTO_TAKE_PROFIT]),
+        })}
       </Text>
       <VaultErrors errorMessages={errors} ilkData={{ debtFloor, token }} />
       <VaultWarnings warningMessages={warnings} ilkData={{ debtFloor }} />

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleRemovalEditingStage.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleRemovalEditingStage.tsx
@@ -1,6 +1,8 @@
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
+import { AutomationFeatures } from 'features/automation/common/types'
 import { CancelConstantMultipleInfoSection } from 'features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
@@ -25,7 +27,9 @@ export function SidebarConstantMultipleRemovalEditingStage({
   return (
     <>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-        {t('constant-multiple.cancel-instructions')}
+        {t('automation.cancel-summary-description', {
+          feature: t(sidebarAutomationFeatureCopyMap[AutomationFeatures.CONSTANT_MULTIPLE]),
+        })}
       </Text>
       <VaultErrors errorMessages={errors} ilkData={{ debtFloor, token }} />
       <VaultWarnings warningMessages={warnings} ilkData={{ debtFloor }} />

--- a/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
@@ -1,22 +1,20 @@
 import { useAutomationContext } from 'components/AutomationContextProvider'
 import { VaultErrors } from 'components/vault/VaultErrors'
 import { VaultWarnings } from 'components/vault/VaultWarnings'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
 import { CancelAutoBSInfoSection } from 'features/automation/common/sidebars/CancelAutoBSInfoSection'
-import { AutoBSFormChange } from 'features/automation/common/state/autoBSFormChange'
+import { AutomationFeatures } from 'features/automation/common/types'
 import { VaultErrorMessage } from 'features/form/errorMessagesHandler'
 import { VaultWarningMessage } from 'features/form/warningMessagesHandler'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Text } from 'theme-ui'
 
-interface AutoSellInfoSectionControlProps {
-  autoSellState: AutoBSFormChange
-}
-
-function AutoSellInfoSectionControl({ autoSellState }: AutoSellInfoSectionControlProps) {
+function AutoSellInfoSectionControl() {
   const { t } = useTranslation()
   const {
     positionData: { debt, positionRatio, liquidationPrice },
+    autoSellTriggerData,
   } = useAutomationContext()
 
   return (
@@ -27,7 +25,7 @@ function AutoSellInfoSectionControl({ autoSellState }: AutoSellInfoSectionContro
       title={t('auto-sell.cancel-summary-title')}
       targetLabel={t('auto-sell.target-col-ratio-each-sell')}
       triggerLabel={t('auto-sell.trigger-col-ratio-to-perfrom-sell')}
-      autoBSState={autoSellState}
+      autoBSTriggerData={autoSellTriggerData}
     />
   )
 }
@@ -35,13 +33,11 @@ function AutoSellInfoSectionControl({ autoSellState }: AutoSellInfoSectionContro
 interface SidebarAutoSellCancelEditingStageProps {
   errors: VaultErrorMessage[]
   warnings: VaultWarningMessage[]
-  autoSellState: AutoBSFormChange
 }
 
 export function SidebarAutoSellCancelEditingStage({
   errors,
   warnings,
-  autoSellState,
 }: SidebarAutoSellCancelEditingStageProps) {
   const { t } = useTranslation()
   const {
@@ -51,11 +47,13 @@ export function SidebarAutoSellCancelEditingStage({
   return (
     <>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-        {t('auto-sell.cancel-summary-description')}
+        {t('automation.cancel-summary-description', {
+          feature: t(sidebarAutomationFeatureCopyMap[AutomationFeatures.AUTO_SELL]),
+        })}
       </Text>
       <VaultErrors errorMessages={errors} ilkData={{ debtFloor, token }} />
       <VaultWarnings warningMessages={warnings} ilkData={{ debtFloor }} />
-      <AutoSellInfoSectionControl autoSellState={autoSellState} />
+      <AutoSellInfoSectionControl />
     </>
   )
 }

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -193,7 +193,6 @@ export function SidebarSetupAutoSell({
                 <SidebarAutoSellCancelEditingStage
                   errors={cancelAutoSellErrors}
                   warnings={cancelAutoSellWarnings}
-                  autoSellState={autoSellState}
                 />
               )}
             </>

--- a/features/automation/protection/stopLoss/sidebars/SidebarCancelStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarCancelStopLossEditingStage.tsx
@@ -7,7 +7,9 @@ import {
   VaultChangesInformationContainer,
   VaultChangesInformationItem,
 } from 'components/vault/VaultChangesInformation'
+import { sidebarAutomationFeatureCopyMap } from 'features/automation/common/consts'
 import { AutomationValidationMessages } from 'features/automation/common/sidebars/AutomationValidationMessages'
+import { AutomationFeatures } from 'features/automation/common/types'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -68,7 +70,9 @@ export function SidebarCancelStopLossEditingStage({
   return (
     <Grid>
       <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-        {t('protection.cancel-downside-protection-desc')}
+        {t('automation.cancel-summary-description', {
+          feature: t(sidebarAutomationFeatureCopyMap[AutomationFeatures.STOP_LOSS]),
+        })}
       </Text>
       <AutomationValidationMessages messages={errors} type="error" />
       <AutomationValidationMessages messages={warnings} type="warning" />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1276,7 +1276,6 @@
     "set-downside-protection": "Set up Stop-Loss Protection",
     "set-downside-protection-desc": "Set the {{ratioParam}} trigger at the point which you want your Vault to be closed at automatically. Learn more about how Stop-Loss works",
     "cancel-downside-protection": "Cancellation confirmation",
-    "cancel-downside-protection-desc": "To cancel the Stop-Loss you’ll need to click the button below and confirm the transaction.",
     "setting-downside-protection": "Setting Stop-Loss Protection",
     "setting-auto-sell": "Setting up your Auto-Sell",
     "cancelling-auto-sell": "Cancelling your Auto-Sell",
@@ -1614,7 +1613,6 @@
     "sell-title": "Basic Auto-Sell Summary",
     "cancel-summary-title": "Cancel Auto-Sell order summary",
     "confirmation": "Confirm your auto-sell setup.",
-    "cancel-summary-description": "To cancel the Auto-Sell you'll need to click the button below and confirm the transaction.",
     "target-col-ratio-each-sell": "Target Col. Ratio after each sell",
     "target-multiple-each-sell": "Target Multiple after each sell",
     "trigger-col-ratio-to-perfrom-sell": "Trigger Col. Ratio to perfrom each automated sell",
@@ -1742,7 +1740,6 @@
       "estimated-gas-fee": "Estimated gas fee",
       "setup-transaction-cost": "Setup transaction cost"
     },
-    "cancel-instructions": "To cancel the Take Profit you'll need to click the button below and confirm the transaction.",
     "adding-new-triggers-disabled": "Creation of the new Take Profit trigger is currently disabled.",
     "adding-new-triggers-disabled-description": "To protect our users, due to extreme adversarial market conditions we have currently disabled setting up NEW Take Profit triggers",
     "auto-take-profit-confirmation-text": "You are setting an Auto-Take Profit order to trigger at an ETH price of ${{price}}. Your vault will be closed and your expected profit of ${{profit}} paid will be paid out in DAI."
@@ -1777,7 +1774,8 @@
       "is-stop-loss-trigger-close-to-auto-sell-trigger": "Setting a higher Trigger Ratio would trigger your existing Auto-Sell. If you want to use a higher trigger ratio, please adjust your Auto-Sell trigger first.",
       "is-stop-loss-trigger-close-to-constant-multiple-sell-trigger": "Setting a higher Trigger Ratio would trigger your existing Constant-Multiple. If you want to use a higher trigger ratio, please adjust your Constant-Multiple Sell trigger first.",
       "is-stop-loss-trigger-higher-than-auto-buy-target": "Setting your an Stop-Loss trigger at this level could result in it being executed by your Auto-Buy. Please adjust your Auto-Buy Target ratio first"
-    }
+    },
+    "cancel-summary-description": "To cancel the {{feature}} you'll need to click the button below and confirm the transaction."
   },
   "optimization": {
     "zero-debt-heading": "You need to Generate DAI before you can set up Optimization",
@@ -1803,7 +1801,6 @@
     "operating-cost": "Operating Cost",
     "operating-cost-desc": "The cost of setting up and running your Constant Multiple.\nSet up cost + execution costs = Operating Cost",
     "pnl-since-enabled": "P&L since enabled: {{amount}}",
-    "cancel-instructions": "To cancel the Constant Multiple you'll need to click the button below and confirm the transaction.",
     "banner": {
       "header": "Set and forget with Constant Multiple",
       "content": "Remove the day to day management of your Vault by taking advantage of volatility and staying at your target multiple. So when the market adjusts, so does your Vault. Find out more about how this works",


### PR DESCRIPTION
# [Fix summary when removing Auto-(Buy/Sell) trigger and vault is closed](https://app.shortcut.com/oazo-apps/story/6929/fix-summary-when-removing-auto-buy-sell-trigger-and-vault-is-closed)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed summary when removing Auto-(Buy/Sell) trigger and vault is closed
- prepared one copy for all automation features regarding trigger removal description
  
## How to test 🧪
  <Please explain how to test your changes>

- visit vault `29833` on mainnet, go to optimization tab and to remove auto-buy trigger step, summary should show correct data
