### PR TITLE
🧭 Discover - incorrect timestamp in Highest-Risk Positions

### DIFF
--- a/handlers/discover/helpers.ts
+++ b/handlers/discover/helpers.ts
@@ -57,10 +57,14 @@ export function getColRatio(item: LargestDebt): DiscoverTableColRatioRowData {
 
 export function getStatus(item: HighestRiskPositions) {
   const status = item.status as DiscoverTableStatusRowDataApi
+
   if (!status) {
     return
   }
   switch (status.kind) {
+    case DiscoverTableVaultStatus.LIQUIDATED:
+    case DiscoverTableVaultStatus.BEING_LIQUIDATED:
+      return status
     case DiscoverTableVaultStatus.TO_STOP_LOSS:
       return {
         ...status,
@@ -73,17 +77,6 @@ export function getStatus(item: HighestRiskPositions) {
             .floor()
             .div(100),
         },
-      }
-    case DiscoverTableVaultStatus.LIQUIDATED:
-      return {
-        ...status,
-        additionalData: {
-          timestamp: status.additionalData!.timestamp! * 1000,
-        },
-      }
-    case DiscoverTableVaultStatus.BEING_LIQUIDATED:
-      return {
-        ...status,
       }
     default:
       return {


### PR DESCRIPTION
# 🧭 Discover - incorrect timestamp in Highest-Risk Positions

Turns out timestamp in one place was mistakenly multiplied by 1000.
![image](https://user-images.githubusercontent.com/16230404/204300404-bc6ecdc5-a02f-46a1-b8cd-f05388cb53a7.png)
  
## Changes 👷‍♀️

- Removed timestamp multiplier for liquidated vaults API handlers,
- since `DiscoverTableVaultStatus.LIQUIDATED` and `DiscoverTableVaultStatus.BEING_LIQUIDATED` now returns exactly the same thing, I moved them to single case statement.
