### PR TITLE
Unified common interface structure for metadata

### DIFF
--- a/components/AutomationContextProvider.tsx
+++ b/components/AutomationContextProvider.tsx
@@ -79,11 +79,11 @@ export interface AutomationContext {
   automationTriggersData: TriggersData
   environmentData: AutomationEnvironmentData
   metadata: {
-    autoBuy: AutoBSMetadata
-    autoSell: AutoBSMetadata
-    autoTakeProfit: AutoTakeProfitMetadata
-    constantMultiple: ConstantMultipleMetadata
-    stopLoss: StopLossMetadata
+    autoBuyMetadata: AutoBSMetadata
+    autoSellMetadata: AutoBSMetadata
+    autoTakeProfitMetadata: AutoTakeProfitMetadata
+    constantMultipleMetadata: ConstantMultipleMetadata
+    stopLossMetadata: StopLossMetadata
   }
   positionData: AutomationPositionData
   protocol: VaultProtocol
@@ -197,7 +197,7 @@ export function AutomationContextProvider({
 
   useStopLossStateInitialization({
     stopLossTriggerData: autoContext.triggerData.stopLossTriggerData,
-    metadata: autoContext.metadata.stopLoss,
+    metadata: autoContext.metadata.stopLossMetadata,
     positionRatio: positionData.positionRatio,
   })
 

--- a/components/AutomationContextProvider.tsx
+++ b/components/AutomationContextProvider.tsx
@@ -240,23 +240,25 @@ export function AutomationContextProvider({
       automationTriggersData || automationTriggersDataInitialState
     const update = {
       automationTriggersData: resolvedAutomationTriggersData,
-      autoBuyTriggerData: extractAutoBSData({
-        triggersData: resolvedAutomationTriggersData,
-        triggerType: TriggerType.BasicBuy,
-      }),
-      autoSellTriggerData: extractAutoBSData({
-        triggersData: resolvedAutomationTriggersData,
-        triggerType: TriggerType.BasicSell,
-      }),
-      autoTakeProfitTriggerData: extractAutoTakeProfitData(resolvedAutomationTriggersData),
-      constantMultipleTriggerData: extractConstantMultipleData(resolvedAutomationTriggersData),
-      stopLossTriggerData: extractStopLossData(
-        resolvedAutomationTriggersData,
-        overwriteTriggersDefaults?.stopLossTriggerData,
-      ),
-      protocol,
       environmentData,
       positionData,
+      protocol,
+      triggerData: {
+        autoBuyTriggerData: extractAutoBSData({
+          triggersData: resolvedAutomationTriggersData,
+          triggerType: TriggerType.BasicBuy,
+        }),
+        autoSellTriggerData: extractAutoBSData({
+          triggersData: resolvedAutomationTriggersData,
+          triggerType: TriggerType.BasicSell,
+        }),
+        autoTakeProfitTriggerData: extractAutoTakeProfitData(resolvedAutomationTriggersData),
+        constantMultipleTriggerData: extractConstantMultipleData(resolvedAutomationTriggersData),
+        stopLossTriggerData: extractStopLossData(
+          resolvedAutomationTriggersData,
+          overwriteTriggersDefaults?.stopLossTriggerData,
+        ),
+      },
     }
     setAutoContext((prev) => ({
       ...prev,

--- a/components/AutomationContextProvider.tsx
+++ b/components/AutomationContextProvider.tsx
@@ -12,7 +12,10 @@ import {
 import { useAutoBSstateInitialization } from 'features/automation/common/state/useAutoBSStateInitializator'
 import { initializeMetadata } from 'features/automation/metadata/helpers'
 import {
+  AutoBSMetadata,
   AutomationDefinitionMetadata,
+  AutoTakeProfitMetadata,
+  ConstantMultipleMetadata,
   OverwriteTriggersDefaults,
   StopLossMetadata,
 } from 'features/automation/metadata/types'
@@ -73,18 +76,44 @@ export interface AutomationPositionData {
 }
 
 export interface AutomationContext {
-  autoBuyTriggerData: AutoBSTriggerData
   automationTriggersData: TriggersData
-  autoSellTriggerData: AutoBSTriggerData
-  autoTakeProfitTriggerData: AutoTakeProfitTriggerData
-  constantMultipleTriggerData: ConstantMultipleTriggerData
   environmentData: AutomationEnvironmentData
-  positionData: AutomationPositionData
-  protocol: VaultProtocol
-  stopLossTriggerData: StopLossTriggerData
   metadata: {
+    autoBuy: AutoBSMetadata
+    autoSell: AutoBSMetadata
+    autoTakeProfit: AutoTakeProfitMetadata
+    constantMultiple: ConstantMultipleMetadata
     stopLoss: StopLossMetadata
   }
+  positionData: AutomationPositionData
+  protocol: VaultProtocol
+  triggerData: {
+    autoBuyTriggerData: AutoBSTriggerData
+    autoSellTriggerData: AutoBSTriggerData
+    autoTakeProfitTriggerData: AutoTakeProfitTriggerData
+    constantMultipleTriggerData: ConstantMultipleTriggerData
+    stopLossTriggerData: StopLossTriggerData
+  }
+}
+
+export interface AutomationContextProviderProps {
+  ethBalance: BigNumber
+  context: Context
+  ethAndTokenPricesData: Tickers
+  positionData: AutomationPositionData
+  commonData: AutomationCommonData
+  protocol: VaultProtocol
+  metadata: AutomationDefinitionMetadata
+  overwriteTriggersDefaults?: OverwriteTriggersDefaults
+}
+
+const automationTriggersDataInitialState = { isAutomationEnabled: false, triggers: [] }
+const automationContextInitialState = {
+  autoBuyTriggerData: defaultAutoBSData,
+  autoSellTriggerData: defaultAutoBSData,
+  autoTakeProfitTriggerData: defaultAutoTakeProfitData,
+  constantMultipleTriggerData: defaultConstantMultipleData,
+  stopLossTriggerData: defaultStopLossData,
 }
 
 export const automationContext = React.createContext<AutomationContext | undefined>(undefined)
@@ -102,28 +131,6 @@ export function useAutomationContext(): AutomationContext {
 /*
   This component is providing computed data from cache about active automation triggers on the vault
 */
-
-const defaultAutomationTriggersData: TriggersData = { isAutomationEnabled: false, triggers: [] }
-
-const automationContextInitialState = {
-  automationTriggersData: defaultAutomationTriggersData,
-  autoBuyTriggerData: defaultAutoBSData,
-  autoSellTriggerData: defaultAutoBSData,
-  autoTakeProfitTriggerData: defaultAutoTakeProfitData,
-  constantMultipleTriggerData: defaultConstantMultipleData,
-  stopLossTriggerData: defaultStopLossData,
-}
-
-export interface AutomationContextProviderProps {
-  ethBalance: BigNumber
-  context: Context
-  ethAndTokenPricesData: Tickers
-  positionData: AutomationPositionData
-  commonData: AutomationCommonData
-  protocol: VaultProtocol
-  metadata: AutomationDefinitionMetadata
-  overwriteTriggersDefaults?: OverwriteTriggersDefaults
-}
 
 export function AutomationContextProvider({
   children,
@@ -164,21 +171,24 @@ export function AutomationContextProvider({
   )
 
   const initialAutoContext = {
-    ...automationContextInitialState,
-    ...overwriteTriggersDefaults,
+    automationTriggersData: automationTriggersDataInitialState,
     environmentData,
     positionData,
     protocol,
+    triggerData: {
+      ...automationContextInitialState,
+      ...overwriteTriggersDefaults,
+    },
   }
 
-  const initMetadata = useMemo(
+  const initializedMetadata = useMemo(
     () => initializeMetadata({ automationContext: initialAutoContext, metadata }),
     [],
   )
 
   const [autoContext, setAutoContext] = useState<AutomationContext>({
     ...initialAutoContext,
-    metadata: initMetadata,
+    metadata: initializedMetadata,
   })
 
   const { automationTriggersData$ } = useAppContext()
@@ -186,48 +196,50 @@ export function AutomationContextProvider({
   const [automationTriggersData] = useObservable(autoTriggersData$)
 
   useStopLossStateInitialization({
-    positionRatio: positionData.positionRatio,
-    stopLossTriggerData: autoContext.stopLossTriggerData,
+    stopLossTriggerData: autoContext.triggerData.stopLossTriggerData,
     metadata: autoContext.metadata.stopLoss,
+    positionRatio: positionData.positionRatio,
   })
 
   useAutoBSstateInitialization({
-    autoTriggersData: autoContext.autoSellTriggerData,
-    stopLossTriggerData: autoContext.stopLossTriggerData,
+    autoTriggersData: autoContext.triggerData.autoSellTriggerData,
+    stopLossTriggerData: autoContext.triggerData.stopLossTriggerData,
     positionRatio: positionData.positionRatio,
     type: TriggerType.BasicSell,
   })
 
   useAutoBSstateInitialization({
-    autoTriggersData: autoContext.autoBuyTriggerData,
-    stopLossTriggerData: autoContext.stopLossTriggerData,
+    autoTriggersData: autoContext.triggerData.autoBuyTriggerData,
+    stopLossTriggerData: autoContext.triggerData.stopLossTriggerData,
     positionRatio: positionData.positionRatio,
     type: TriggerType.BasicBuy,
   })
 
   useConstantMultipleStateInitialization({
-    ilk: positionData.ilk,
+    autoBuyTriggerData: autoContext.triggerData.autoBuyTriggerData,
+    autoSellTriggerData: autoContext.triggerData.autoSellTriggerData,
+    constantMultipleTriggerData: autoContext.triggerData.constantMultipleTriggerData,
+    stopLossTriggerData: autoContext.triggerData.stopLossTriggerData,
     debt: positionData.debt,
     debtFloor: positionData.debtFloor,
+    ilk: positionData.ilk,
     liquidationRatio: positionData.liquidationRatio,
-    positionRatio: positionData.positionRatio,
     lockedCollateral: positionData.lockedCollateral,
-    stopLossTriggerData: autoContext.stopLossTriggerData,
-    autoSellTriggerData: autoContext.autoSellTriggerData,
-    autoBuyTriggerData: autoContext.autoBuyTriggerData,
-    constantMultipleTriggerData: autoContext.constantMultipleTriggerData,
+    positionRatio: positionData.positionRatio,
   })
 
   useAutoTakeProfitStateInitializator({
+    autoTakeProfitTriggerData: autoContext.triggerData.autoTakeProfitTriggerData,
     debt: positionData.debt,
     lockedCollateral: positionData.lockedCollateral,
     positionRatio: positionData.positionRatio,
-    autoTakeProfitTriggerData: autoContext.autoTakeProfitTriggerData,
   })
 
   useEffect(() => {
-    const resolvedAutomationTriggersData = automationTriggersData || defaultAutomationTriggersData
+    const resolvedAutomationTriggersData =
+      automationTriggersData || automationTriggersDataInitialState
     const update = {
+      automationTriggersData: resolvedAutomationTriggersData,
       autoBuyTriggerData: extractAutoBSData({
         triggersData: resolvedAutomationTriggersData,
         triggerType: TriggerType.BasicBuy,
@@ -236,13 +248,12 @@ export function AutomationContextProvider({
         triggersData: resolvedAutomationTriggersData,
         triggerType: TriggerType.BasicSell,
       }),
+      autoTakeProfitTriggerData: extractAutoTakeProfitData(resolvedAutomationTriggersData),
+      constantMultipleTriggerData: extractConstantMultipleData(resolvedAutomationTriggersData),
       stopLossTriggerData: extractStopLossData(
         resolvedAutomationTriggersData,
         overwriteTriggersDefaults?.stopLossTriggerData,
       ),
-      constantMultipleTriggerData: extractConstantMultipleData(resolvedAutomationTriggersData),
-      autoTakeProfitTriggerData: extractAutoTakeProfitData(resolvedAutomationTriggersData),
-      automationTriggersData: resolvedAutomationTriggersData,
       protocol,
       environmentData,
       positionData,

--- a/components/vault/GeneralManageTabBar.tsx
+++ b/components/vault/GeneralManageTabBar.tsx
@@ -49,11 +49,13 @@ export function GeneralManageTabBar({
   const { t } = useTranslation()
 
   const {
-    stopLossTriggerData,
-    autoSellTriggerData,
-    autoBuyTriggerData,
-    constantMultipleTriggerData,
-    autoTakeProfitTriggerData,
+    triggerData: {
+      autoBuyTriggerData,
+      autoSellTriggerData,
+      autoTakeProfitTriggerData,
+      constantMultipleTriggerData,
+      stopLossTriggerData,
+    },
   } = useAutomationContext()
 
   const protectionEnabled =

--- a/components/vault/OptimizationControl.tsx
+++ b/components/vault/OptimizationControl.tsx
@@ -118,10 +118,8 @@ interface OptimizationControlProps {
 
 export function OptimizationControl({ vaultHistory }: OptimizationControlProps) {
   const {
-    autoBuyTriggerData,
-    autoTakeProfitTriggerData,
-    constantMultipleTriggerData,
     positionData: { debt },
+    triggerData: { autoBuyTriggerData, autoTakeProfitTriggerData, constantMultipleTriggerData },
   } = useAutomationContext()
   const { txHelpers$ } = useAppContext()
   const [txHelpersData] = useObservable(txHelpers$)

--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -103,9 +103,8 @@ function getZeroDebtProtectionBannerProps({
 export function ProtectionControl() {
   const { txHelpers$ } = useAppContext()
   const {
-    autoSellTriggerData,
-    stopLossTriggerData,
     positionData: { debt, debtFloor },
+    triggerData: { autoSellTriggerData, stopLossTriggerData },
   } = useAutomationContext()
   const [txHelpersData] = useObservable(txHelpers$)
   const [stopLossState] = useUIChanges<StopLossFormChange>(STOP_LOSS_FORM_CHANGE)

--- a/components/vault/detailsCards/VaultDetailsCardLiquidationPrice.tsx
+++ b/components/vault/detailsCards/VaultDetailsCardLiquidationPrice.tsx
@@ -99,7 +99,9 @@ export function VaultDetailsCardLiquidationPrice({
 } & AfterPillProps) {
   const openModal = useModal()
   const { t } = useTranslation()
-  const { stopLossTriggerData } = useAutomationContext()
+  const {
+    triggerData: { stopLossTriggerData },
+  } = useAutomationContext()
   const stopLossReadEnabled = useFeatureToggle('StopLossRead')
 
   const cardDetailsData = {

--- a/components/vault/detailsSection/ContentCardDynamicStopPrice.tsx
+++ b/components/vault/detailsSection/ContentCardDynamicStopPrice.tsx
@@ -9,7 +9,7 @@ import { Card, Grid, Heading, Text } from 'theme-ui'
 export interface ContentCardDynamicStopPriceModalProps {
   dynamicStopPrice: BigNumber
   dynamicStopPriceFormatted: string
-  ratioParam: string
+  ratioParamTranslationKey: string
 }
 
 interface ContentCardDynamicStopPriceProps {
@@ -19,13 +19,13 @@ interface ContentCardDynamicStopPriceProps {
   liquidationPrice: BigNumber
   liquidationRatio: BigNumber
   afterStopLossLevel: BigNumber
-  ratioParam: string
+  ratioParamTranslationKey: string
 }
 
 export function ContentCardDynamicStopPriceModal({
   dynamicStopPrice,
   dynamicStopPriceFormatted,
-  ratioParam,
+  ratioParamTranslationKey,
 }: ContentCardDynamicStopPriceModalProps) {
   const { t } = useTranslation()
 
@@ -34,7 +34,7 @@ export function ContentCardDynamicStopPriceModal({
       <Heading variant="header3">{t('manage-multiply-vault.card.dynamic-stop-loss-price')}</Heading>
       <Text as="p" variant="paragraph2" sx={{ mt: 2 }}>
         {t('manage-multiply-vault.card.dynamic-stop-loss-price-desc', {
-          ratioParam: t(ratioParam),
+          ratioParam: t(ratioParamTranslationKey),
         })}
       </Text>
       <Text as="p" variant="header4" sx={{ mt: 3, fontWeight: 'semiBold' }}>
@@ -56,7 +56,7 @@ export function ContentCardDynamicStopPrice({
   liquidationPrice,
   liquidationRatio,
   afterStopLossLevel,
-  ratioParam,
+  ratioParamTranslationKey,
 }: ContentCardDynamicStopPriceProps) {
   const { t } = useTranslation()
 
@@ -81,7 +81,7 @@ export function ContentCardDynamicStopPrice({
   const contentCardModalSettings: ContentCardDynamicStopPriceModalProps = {
     dynamicStopPrice: dynamicStopLossPrice,
     dynamicStopPriceFormatted: formatted.dynamicStopPrice,
-    ratioParam,
+    ratioParamTranslationKey,
   }
 
   const contentCardSettings: ContentCardProps = {

--- a/components/vault/detailsSection/ContentCardDynamicStopPriceWithColRatio.tsx
+++ b/components/vault/detailsSection/ContentCardDynamicStopPriceWithColRatio.tsx
@@ -44,7 +44,7 @@ export function ContentCardDynamicStopPriceWithColRatio({
   const contentCardModalSettings: ContentCardDynamicStopPriceModalProps = {
     dynamicStopPrice,
     dynamicStopPriceFormatted: formatted.dynamicStopPrice,
-    ratioParam: 'system.collateral-ratio',
+    ratioParamTranslationKey: 'system.collateral-ratio',
   }
 
   const contentCardSettings: ContentCardProps = {

--- a/components/vault/detailsSection/ContentCardLiquidationPrice.tsx
+++ b/components/vault/detailsSection/ContentCardLiquidationPrice.tsx
@@ -115,7 +115,9 @@ export function ContentCardLiquidationPrice({
   }
 
   if (stopLossReadEnabled && vaultId) {
-    const { stopLossTriggerData } = useAutomationContext()
+    const {
+      triggerData: { stopLossTriggerData },
+    } = useAutomationContext()
 
     contentCardModalSettings.isStopLossEnabled = stopLossTriggerData.isStopLossEnabled
   }

--- a/components/vault/detailsSection/ContentCardStopLossLevel.tsx
+++ b/components/vault/detailsSection/ContentCardStopLossLevel.tsx
@@ -8,7 +8,7 @@ import { Card, Grid, Heading, Text } from 'theme-ui'
 interface ContentCardStopLossCollateralRatioModalProps {
   isStopLossEnabled: boolean
   stopLossLevelFormatted: string
-  ratioParam: string
+  ratioParamTranslationKey: string
   modalDescription: string
 }
 
@@ -17,7 +17,7 @@ interface ContentCardStopLossCollateralRatioProps {
   isEditing: boolean
   stopLossLevel: BigNumber
   afterStopLossLevel: BigNumber
-  ratioParam: string
+  ratioParamTranslationKey: string
   modalDescription: string
   belowCurrentPositionRatio: string
 }
@@ -25,7 +25,7 @@ interface ContentCardStopLossCollateralRatioProps {
 function ContentCardStopLossCollateralRatioModal({
   isStopLossEnabled,
   stopLossLevelFormatted,
-  ratioParam,
+  ratioParamTranslationKey,
   modalDescription,
 }: ContentCardStopLossCollateralRatioModalProps) {
   const { t } = useTranslation()
@@ -33,13 +33,13 @@ function ContentCardStopLossCollateralRatioModal({
   return (
     <Grid gap={2}>
       <Heading variant="header3">
-        {t('protection.stop-loss-something', { value: t(ratioParam) })}
+        {t('protection.stop-loss-something', { value: t(ratioParamTranslationKey) })}
       </Heading>
       <Text as="p" variant="paragraph2" sx={{ mt: 2 }}>
         {t(modalDescription)}
       </Text>
       <Text as="p" variant="header4" sx={{ mt: 3, fontWeight: 'semiBold' }}>
-        {t('protection.current-stop-loss-something', { value: t(ratioParam) })}
+        {t('protection.current-stop-loss-something', { value: t(ratioParamTranslationKey) })}
       </Text>
       <Card as="div" variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
         <Heading variant="header3">{isStopLossEnabled ? stopLossLevelFormatted : '-'}</Heading>
@@ -53,7 +53,7 @@ export function ContentCardStopLossLevel({
   isEditing,
   stopLossLevel,
   afterStopLossLevel,
-  ratioParam,
+  ratioParamTranslationKey,
   modalDescription,
   belowCurrentPositionRatio,
 }: ContentCardStopLossCollateralRatioProps) {
@@ -71,15 +71,15 @@ export function ContentCardStopLossLevel({
   const contentCardModalSettings: ContentCardStopLossCollateralRatioModalProps = {
     isStopLossEnabled: isStopLossEnabled,
     stopLossLevelFormatted: formatted.stopLossLevel,
-    ratioParam,
+    ratioParamTranslationKey,
     modalDescription,
   }
 
   const contentCardSettings: ContentCardProps = {
-    title: t('protection.stop-loss-something', { value: t(ratioParam) }),
+    title: t('protection.stop-loss-something', { value: t(ratioParamTranslationKey) }),
     footnote: t('system.cards.stop-loss-collateral-ratio.footnote', {
       amount: belowCurrentPositionRatio,
-      value: t(ratioParam),
+      value: t(ratioParamTranslationKey),
     }),
     modal: <ContentCardStopLossCollateralRatioModal {...contentCardModalSettings} />,
   }

--- a/features/automation/common/validation/validators.ts
+++ b/features/automation/common/validation/validators.ts
@@ -29,7 +29,9 @@ export function hasMoreDebtThanMaxForStopLoss({
 }
 
 export function isStopLossTriggerHigherThanAutoBuyTarget({
-  context: { autoBuyTriggerData },
+  context: {
+    triggerData: { autoBuyTriggerData },
+  },
   stopLossLevel,
 }: AutomationValidationMethodParams<{
   stopLossLevel?: BigNumber
@@ -57,7 +59,9 @@ export function hasPotentialInsufficientEthFundsForTx({
 }
 
 export function isStopLossTriggerCloseToAutoSellTrigger({
-  context: { autoSellTriggerData },
+  context: {
+    triggerData: { autoSellTriggerData },
+  },
   sliderMax,
   stopLossLevel,
 }: AutomationValidationMethodParams<{
@@ -68,7 +72,9 @@ export function isStopLossTriggerCloseToAutoSellTrigger({
 }
 
 export function isStopLossTriggerCloseToConstantMultipleSellTrigger({
-  context: { constantMultipleTriggerData },
+  context: {
+    triggerData: { constantMultipleTriggerData },
+  },
   sliderMax,
   stopLossLevel,
 }: AutomationValidationMethodParams<{

--- a/features/automation/contexts/AaveAutomationContext.tsx
+++ b/features/automation/contexts/AaveAutomationContext.tsx
@@ -4,7 +4,7 @@ import { PreparedAaveReserveData } from 'features/aave/helpers/aavePrepareReserv
 import { ManageAaveContext } from 'features/aave/manage/state'
 import { getAutomationAavePositionData } from 'features/automation/common/context/getAutomationAavePositionData'
 import { AutomationContextInput } from 'features/automation/contexts/AutomationContextInput'
-import { aaveStopLossMetaData } from 'features/automation/metadata/aave/stopLossMetadata'
+import { getAaveStopLossMetadata } from 'features/automation/metadata/aave/stopLossMetadata'
 import { defaultStopLossData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { VaultProtocol } from 'helpers/getVaultProtocol'
 import { zero } from 'helpers/zero'
@@ -50,7 +50,7 @@ export function AaveAutomationContext({
       commonData={commonData}
       protocol={VaultProtocol.Aave}
       metadata={{
-        stopLoss: aaveStopLossMetaData,
+        stopLoss: getAaveStopLossMetadata,
       }}
       overwriteTriggersDefaults={{
         stopLossTriggerData: defaultStopLossTriggerData,

--- a/features/automation/contexts/MakerAutomationContext.tsx
+++ b/features/automation/contexts/MakerAutomationContext.tsx
@@ -1,6 +1,6 @@
 import { getAutomationMakerPositionData } from 'features/automation/common/context/getAutomationMakerPositionData'
 import { AutomationContextInput } from 'features/automation/contexts/AutomationContextInput'
-import { makerStopLossMetaData } from 'features/automation/metadata/maker/stopLossMetadata'
+import { getMakerStopLossMetadata } from 'features/automation/metadata/maker/stopLossMetadata'
 import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
 import { VaultProtocol } from 'helpers/getVaultProtocol'
 import React, { PropsWithChildren, useMemo } from 'react'
@@ -36,7 +36,7 @@ export function MakerAutomationContext({
       commonData={commonData}
       protocol={VaultProtocol.Maker}
       metadata={{
-        stopLoss: makerStopLossMetaData,
+        stopLoss: getMakerStopLossMetadata,
       }}
     >
       {children}

--- a/features/automation/metadata/aave/stopLossMetadata.ts
+++ b/features/automation/metadata/aave/stopLossMetadata.ts
@@ -25,7 +25,6 @@ import { StopLossResetData } from 'features/automation/protection/stopLoss/state
 import { formatPercent } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
 
-// eslint-disable-next-line func-style
 export function getAaveStopLossMetadata(context: ContextWithoutMetadata): StopLossMetadata {
   const {
     triggerData: {

--- a/features/automation/metadata/aave/stopLossMetadata.ts
+++ b/features/automation/metadata/aave/stopLossMetadata.ts
@@ -10,7 +10,7 @@ import {
   isStopLossTriggerHigherThanAutoBuyTarget,
 } from 'features/automation/common/validation/validators'
 import {
-  GetAutomationMetadata,
+  ContextWithoutMetadata,
   StopLossDetailCards,
   StopLossMetadata,
 } from 'features/automation/metadata/types'
@@ -26,7 +26,7 @@ import { formatPercent } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
 
 // eslint-disable-next-line func-style
-export const aaveStopLossMetaData: GetAutomationMetadata<StopLossMetadata> = (context) => {
+export function getAaveStopLossMetadata(context: ContextWithoutMetadata): StopLossMetadata {
   const {
     stopLossTriggerData: { isStopLossEnabled, stopLossLevel },
     positionData: {

--- a/features/automation/metadata/aave/stopLossMetadata.ts
+++ b/features/automation/metadata/aave/stopLossMetadata.ts
@@ -28,7 +28,9 @@ import { one } from 'helpers/zero'
 // eslint-disable-next-line func-style
 export function getAaveStopLossMetadata(context: ContextWithoutMetadata): StopLossMetadata {
   const {
-    stopLossTriggerData: { isStopLossEnabled, stopLossLevel },
+    triggerData: {
+      stopLossTriggerData: { isStopLossEnabled, stopLossLevel },
+    },
     positionData: {
       token,
       positionRatio,

--- a/features/automation/metadata/aave/stopLossMetadata.ts
+++ b/features/automation/metadata/aave/stopLossMetadata.ts
@@ -135,7 +135,7 @@ export function getAaveStopLossMetadata(context: ContextWithoutMetadata): StopLo
       sliderStep: 1,
     },
     translations: {
-      ratioParam: 'vault-changes.loan-to-value',
+      ratioParamTranslationKey: 'vault-changes.loan-to-value',
     },
     validation: {
       getAddErrors: ({ state: { stopLossLevel, txDetails } }) => ({

--- a/features/automation/metadata/helpers.ts
+++ b/features/automation/metadata/helpers.ts
@@ -22,14 +22,14 @@ export function initializeMetadata({
   const { autoTakeProfit, autoBuy, autoSell, constantMultiple, stopLoss } = metadata
 
   return {
-    autoBuy: getDefaultMetadataWithDefault<AutoBSMetadata>(autoBuy)(automationContext),
-    autoSell: getDefaultMetadataWithDefault<AutoBSMetadata>(autoSell)(automationContext),
-    autoTakeProfit: getDefaultMetadataWithDefault<AutoTakeProfitMetadata>(autoTakeProfit)(
+    autoBuyMetadata: getDefaultMetadataWithDefault<AutoBSMetadata>(autoBuy)(automationContext),
+    autoSellMetadata: getDefaultMetadataWithDefault<AutoBSMetadata>(autoSell)(automationContext),
+    autoTakeProfitMetadata: getDefaultMetadataWithDefault<AutoTakeProfitMetadata>(autoTakeProfit)(
       automationContext,
     ),
-    constantMultiple: getDefaultMetadataWithDefault<ConstantMultipleMetadata>(constantMultiple)(
-      automationContext,
-    ),
-    stopLoss: getDefaultMetadataWithDefault<StopLossMetadata>(stopLoss)(automationContext),
+    constantMultipleMetadata: getDefaultMetadataWithDefault<ConstantMultipleMetadata>(
+      constantMultiple,
+    )(automationContext),
+    stopLossMetadata: getDefaultMetadataWithDefault<StopLossMetadata>(stopLoss)(automationContext),
   }
 }

--- a/features/automation/metadata/maker/autoBSMetadata.ts
+++ b/features/automation/metadata/maker/autoBSMetadata.ts
@@ -1,4 +1,5 @@
-import { AutoBSMetadata, GetAutomationMetadata } from 'features/automation/metadata/types'
+import { AutoBSMetadata } from 'features/automation/metadata/types'
 
-// eslint-disable-next-line func-style
-export const makerAutoBSMetadata: GetAutomationMetadata<AutoBSMetadata> = () => ({})
+export function getMakerAutoBSMetadata(): AutoBSMetadata {
+  return {}
+}

--- a/features/automation/metadata/maker/autoTakeProfitMetadata.ts
+++ b/features/automation/metadata/maker/autoTakeProfitMetadata.ts
@@ -1,4 +1,5 @@
-import { AutoTakeProfitMetadata, GetAutomationMetadata } from 'features/automation/metadata/types'
+import { AutoTakeProfitMetadata } from 'features/automation/metadata/types'
 
-// eslint-disable-next-line func-style
-export const makerAutoTakeProfitMetaData: GetAutomationMetadata<AutoTakeProfitMetadata> = () => ({})
+export function getMakerAutoTakeProfitMetadata(): AutoTakeProfitMetadata {
+  return {}
+}

--- a/features/automation/metadata/maker/constantMultipleMetadata.ts
+++ b/features/automation/metadata/maker/constantMultipleMetadata.ts
@@ -1,4 +1,5 @@
-import { ConstantMultipleMetadata, GetAutomationMetadata } from 'features/automation/metadata/types'
+import { AutoTakeProfitMetadata } from 'features/automation/metadata/types'
 
-// eslint-disable-next-line func-style
-export const makerConstantMultipleMetaData: GetAutomationMetadata<ConstantMultipleMetadata> = () => ({})
+export function getMakerConstantMultipleMetadata(): AutoTakeProfitMetadata {
+  return {}
+}

--- a/features/automation/metadata/maker/stopLossMetadata.ts
+++ b/features/automation/metadata/maker/stopLossMetadata.ts
@@ -30,9 +30,11 @@ import { formatPercent } from 'helpers/formatters/format'
 
 export function getMakerStopLossMetadata(context: ContextWithoutMetadata): StopLossMetadata {
   const {
-    autoSellTriggerData,
-    stopLossTriggerData: { isStopLossEnabled, isToCollateral, stopLossLevel },
-    constantMultipleTriggerData,
+    triggerData: {
+      autoSellTriggerData,
+      stopLossTriggerData: { isStopLossEnabled, isToCollateral, stopLossLevel },
+      constantMultipleTriggerData,
+    },
     positionData: {
       positionRatio,
       nextPositionRatio,

--- a/features/automation/metadata/maker/stopLossMetadata.ts
+++ b/features/automation/metadata/maker/stopLossMetadata.ts
@@ -141,7 +141,7 @@ export function getMakerStopLossMetadata(context: ContextWithoutMetadata): StopL
       sliderStep: 1,
     },
     translations: {
-      ratioParam: 'system.collateral-ratio',
+      ratioParamTranslationKey: 'system.collateral-ratio',
     },
     validation: {
       getAddErrors: ({ state: { stopLossLevel, txDetails } }) => ({

--- a/features/automation/metadata/maker/stopLossMetadata.ts
+++ b/features/automation/metadata/maker/stopLossMetadata.ts
@@ -1,3 +1,4 @@
+/* eslint-disable func-style */
 import BigNumber from 'bignumber.js'
 import { collateralPriceAtRatio } from 'blockchain/vault.maths'
 import {
@@ -14,7 +15,7 @@ import {
   isStopLossTriggerHigherThanAutoBuyTarget,
 } from 'features/automation/common/validation/validators'
 import {
-  GetAutomationMetadata,
+  ContextWithoutMetadata,
   StopLossDetailCards,
   StopLossMetadata,
 } from 'features/automation/metadata/types'
@@ -27,8 +28,7 @@ import {
 import { StopLossResetData } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
 import { formatPercent } from 'helpers/formatters/format'
 
-// eslint-disable-next-line func-style
-export const makerStopLossMetaData: GetAutomationMetadata<StopLossMetadata> = (context) => {
+export function getMakerStopLossMetadata(context: ContextWithoutMetadata): StopLossMetadata {
   const {
     autoSellTriggerData,
     stopLossTriggerData: { isStopLossEnabled, isToCollateral, stopLossLevel },

--- a/features/automation/metadata/types.ts
+++ b/features/automation/metadata/types.ts
@@ -52,10 +52,31 @@ export interface StopLossMetadataDetailCards {
   cardsConfig?: StopLossDetailsConfig
 }
 
+type AutomationCommonMetadata<T> = {
+  settings: {
+    sliderDirection?: 'ltr' | 'rtl'
+    sliderStep: number
+  }
+  translations: {
+    ratioParam: string
+  }
+  validation: {
+    getAddErrors: AutomationMetadataValidationMethod<T>
+    getAddWarnings: AutomationMetadataValidationMethod<T>
+    cancelErrors: string[]
+    cancelWarnings: string[]
+  }
+  values: {
+    sliderMax: BigNumber
+    sliderMin: BigNumber
+  }
+}
+
+// TODO: add AutomationCommonMetadata types to all metadata features during their implementation
 export interface AutoBSMetadata {}
 export interface AutoTakeProfitMetadata {}
 export interface ConstantMultipleMetadata {}
-export interface StopLossMetadata {
+export type StopLossMetadata = AutomationCommonMetadata<StopLossFormChange> & {
   callbacks: {
     onCloseToChange?: AutomationCallbackMethod<{ optionName: string }>
     onSliderChange?: AutomationCallbackMethod<{ value: BigNumber }>
@@ -69,24 +90,11 @@ export interface StopLossMetadata {
   }
   settings: {
     fixedCloseToToken?: string
-    sliderDirection?: 'ltr' | 'rtl'
-    sliderStep: number
-  }
-  translations: {
-    ratioParam: string
-  }
-  validation: {
-    getAddErrors: AutomationMetadataValidationMethod<StopLossFormChange>
-    getAddWarnings: AutomationMetadataValidationMethod<StopLossFormChange>
-    cancelErrors: string[]
-    cancelWarnings: string[]
   }
   values: {
     collateralDuringLiquidation: BigNumber
     initialSlRatioWhenTriggerDoesntExist: BigNumber
     resetData: StopLossResetData
-    sliderMax: BigNumber
-    sliderMin: BigNumber
     triggerMaxToken: BigNumber
   }
 }

--- a/features/automation/metadata/types.ts
+++ b/features/automation/metadata/types.ts
@@ -58,7 +58,7 @@ type AutomationCommonMetadata<T> = {
     sliderStep: number
   }
   translations: {
-    ratioParam: string
+    ratioParamTranslationKey: string
   }
   validation: {
     getAddErrors: AutomationMetadataValidationMethod<T>

--- a/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyDetailsControl.tsx
@@ -15,9 +15,8 @@ export function AutoBuyDetailsControl() {
 
   const [autoBuyState] = useUIChanges<AutoBSFormChange>(AUTO_BUY_FORM_CHANGE)
   const {
-    constantMultipleTriggerData,
-    autoBuyTriggerData,
     positionData: { ilk, id, token, debt, lockedCollateral },
+    triggerData: { autoBuyTriggerData, constantMultipleTriggerData },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
+++ b/features/automation/optimization/autoBuy/controls/AutoBuyFormControl.tsx
@@ -29,9 +29,9 @@ export function AutoBuyFormControl({
 }: AutoBuyFormControlProps) {
   const [autoBuyState] = useUIChanges<AutoBSFormChange>(AUTO_BUY_FORM_CHANGE)
   const {
-    autoBuyTriggerData,
     environmentData: { canInteract },
     positionData: { id, debt, lockedCollateral, positionRatio, owner },
+    triggerData: { autoBuyTriggerData },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.AUTO_BUY

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyEditingStage.tsx
@@ -64,9 +64,8 @@ export function SidebarAutoBuyEditingStage({
   sliderMax,
 }: SidebarAutoBuyEditingStageProps) {
   const {
-    autoBuyTriggerData,
-    stopLossTriggerData,
     positionData: { id, ilk, token, debt, debtFloor, lockedCollateral, positionRatio },
+    triggerData: { autoBuyTriggerData, stopLossTriggerData },
   } = useAutomationContext()
   const { uiChanges } = useAppContext()
   const [, setHash] = useHash()

--- a/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarAutoBuyRemovalEditingStage.tsx
@@ -42,7 +42,7 @@ function AutoBuyInfoSectionControl() {
   const { t } = useTranslation()
   const {
     positionData: { positionRatio, liquidationPrice, debt },
-    autoBuyTriggerData,
+    triggerData: { autoBuyTriggerData },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
+++ b/features/automation/optimization/autoBuy/sidebars/SidebarSetupAutoBuy.tsx
@@ -72,13 +72,15 @@ export function SidebarSetupAutoBuy({
   const gasEstimation = useGasEstimationContext()
   const { uiChanges } = useAppContext()
   const {
-    autoBuyTriggerData,
-    autoSellTriggerData,
-    autoTakeProfitTriggerData,
-    constantMultipleTriggerData,
-    stopLossTriggerData,
     environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
     positionData: { nextPositionRatio, token, liquidationRatio, vaultType },
+    triggerData: {
+      autoBuyTriggerData,
+      autoSellTriggerData,
+      autoTakeProfitTriggerData,
+      constantMultipleTriggerData,
+      stopLossTriggerData,
+    },
     protocol,
   } = useAutomationContext()
 

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitDetailsControl.tsx
@@ -16,9 +16,9 @@ export function AutoTakeProfitDetailsControl() {
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
   const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
   const {
-    autoTakeProfitTriggerData,
     environmentData: { ethMarketPrice },
     positionData: { id, ilk, debt, debtOffset, positionRatio, lockedCollateral, token },
+    triggerData: { autoTakeProfitTriggerData },
   } = useAutomationContext()
 
   const { isTriggerEnabled, executionPrice } = autoTakeProfitTriggerData

--- a/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
+++ b/features/automation/optimization/autoTakeProfit/controls/AutoTakeProfitFormControl.tsx
@@ -28,9 +28,9 @@ export function AutoTakeProfitFormControl({
 }: AutoTakeProfitFormControlProps) {
   const [autoTakeProfitState] = useUIChanges<AutoTakeProfitFormChange>(AUTO_TAKE_PROFIT_FORM_CHANGE)
   const {
-    autoTakeProfitTriggerData,
     environmentData: { canInteract, tokenMarketPrice },
     positionData: { ilk, id, token, owner },
+    triggerData: { autoTakeProfitTriggerData },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitEditingStage.tsx
@@ -52,8 +52,8 @@ export function SidebarAutoTakeProfitEditingStage({
   const readOnlyAutoTakeProfitEnabled = useFeatureToggle('ReadOnlyAutoTakeProfit')
 
   const {
-    autoTakeProfitTriggerData,
     positionData: { ilk, id, positionRatio, debt, debtFloor, token },
+    triggerData: { autoTakeProfitTriggerData },
   } = useAutomationContext()
 
   useDebouncedCallback(

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarAutoTakeProfitRemovalEditingStage.tsx
@@ -40,8 +40,8 @@ export function SidebarAutoTakeProfitRemovalEditingStage({
 
 function AutoTakeProfitInfoSectionControl() {
   const {
-    autoTakeProfitTriggerData,
     positionData: { token, debt, positionRatio },
+    triggerData: { autoTakeProfitTriggerData },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
+++ b/features/automation/optimization/autoTakeProfit/sidebars/SidebarSetupAutoTakeProfit.tsx
@@ -77,12 +77,10 @@ export function SidebarSetupAutoTakeProfit({
   const { t } = useTranslation()
 
   const {
-    autoBuyTriggerData,
-    autoTakeProfitTriggerData,
-    constantMultipleTriggerData,
     environmentData: { ethMarketPrice, etherscanUrl, nextCollateralPrice, ethBalance },
     positionData: { debt, debtOffset, token, vaultType, lockedCollateral },
     protocol,
+    triggerData: { autoBuyTriggerData, autoTakeProfitTriggerData, constantMultipleTriggerData },
   } = useAutomationContext()
 
   const { isAwaitingConfirmation } = autoTakeProfitState

--- a/features/automation/optimization/common/controls/OptimizationFormControl.tsx
+++ b/features/automation/optimization/common/controls/OptimizationFormControl.tsx
@@ -23,11 +23,9 @@ interface OptimizationFormControlProps {
 
 export function OptimizationFormControl({ txHelpers }: OptimizationFormControlProps) {
   const {
-    autoBuyTriggerData,
     automationTriggersData,
-    constantMultipleTriggerData,
-    autoTakeProfitTriggerData,
     protocol,
+    triggerData: { autoBuyTriggerData, constantMultipleTriggerData, autoTakeProfitTriggerData },
   } = useAutomationContext()
 
   const { uiChanges } = useAppContext()

--- a/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
+++ b/features/automation/optimization/constantMultiple/controls/CancelConstantMultipleInfoSection.tsx
@@ -8,8 +8,8 @@ import React from 'react'
 export function CancelConstantMultipleInfoSection() {
   const { t } = useTranslation()
   const {
-    constantMultipleTriggerData,
     positionData: { positionRatio, debt, liquidationPrice },
+    triggerData: { constantMultipleTriggerData },
   } = useAutomationContext()
 
   return (

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsControl.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleDetailsControl.tsx
@@ -30,9 +30,9 @@ export function ConstantMultipleDetailsControl({
   )
 
   const {
-    constantMultipleTriggerData,
     environmentData: { tokenMarketPrice },
     positionData: { ilk, id, token, debt, lockedCollateral },
+    triggerData: { constantMultipleTriggerData },
   } = useAutomationContext()
 
   const {

--- a/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
+++ b/features/automation/optimization/constantMultiple/controls/ConstantMultipleFormControl.tsx
@@ -35,11 +35,9 @@ export function ConstantMultipleFormControl({
   )
 
   const {
-    autoBuyTriggerData,
-    autoSellTriggerData,
-    constantMultipleTriggerData,
     environmentData: { canInteract, ethMarketPrice },
     positionData: { id, owner, debt, positionRatio, lockedCollateral },
+    triggerData: { autoBuyTriggerData, autoSellTriggerData, constantMultipleTriggerData },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.CONSTANT_MULTIPLE

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarConstantMultipleEditingStage.tsx
@@ -84,11 +84,13 @@ export function SidebarConstantMultipleEditingStage({
   const { uiChanges } = useAppContext()
   const [, setHash] = useHash()
   const {
-    autoBuyTriggerData,
-    autoSellTriggerData,
-    constantMultipleTriggerData,
-    stopLossTriggerData,
     positionData: { ilk, id, positionRatio, debt, debtFloor, token },
+    triggerData: {
+      autoBuyTriggerData,
+      autoSellTriggerData,
+      constantMultipleTriggerData,
+      stopLossTriggerData,
+    },
   } = useAutomationContext()
 
   automationMultipleRangeSliderAnalytics({

--- a/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
+++ b/features/automation/optimization/constantMultiple/sidebars/SidebarSetupConstantMultiple.tsx
@@ -80,13 +80,15 @@ export function SidebarSetupConstantMultiple({
   const gasEstimation = useGasEstimationContext()
   const { uiChanges } = useAppContext()
   const {
-    autoBuyTriggerData,
-    autoSellTriggerData,
-    autoTakeProfitTriggerData,
-    constantMultipleTriggerData,
-    stopLossTriggerData,
     environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
     positionData: { debt, debtFloor, nextPositionRatio, token, vaultType },
+    triggerData: {
+      autoBuyTriggerData,
+      autoSellTriggerData,
+      autoTakeProfitTriggerData,
+      constantMultipleTriggerData,
+      stopLossTriggerData,
+    },
     protocol,
   } = useAutomationContext()
 

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsControl.tsx
@@ -13,8 +13,8 @@ import React from 'react'
 export function AutoSellDetailsControl() {
   const readOnlyAutoBSEnabled = useFeatureToggle('ReadOnlyBasicBS')
   const {
-    autoSellTriggerData,
     positionData: { debt, lockedCollateral },
+    triggerData: { autoSellTriggerData },
   } = useAutomationContext()
 
   const [autoSellState] = useUIChanges<AutoBSFormChange>(AUTO_SELL_FORM_CHANGE)

--- a/features/automation/protection/autoSell/controls/AutoSellDetailsLayout.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellDetailsLayout.tsx
@@ -43,9 +43,11 @@ export function AutoSellDetailsLayout({
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
   const {
-    autoSellTriggerData,
-    constantMultipleTriggerData: { isTriggerEnabled },
     positionData: { id, ilk, token },
+    triggerData: {
+      autoSellTriggerData,
+      constantMultipleTriggerData: { isTriggerEnabled },
+    },
   } = useAutomationContext()
 
   const isConstantMultipleEnabled = isTriggerEnabled

--- a/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
+++ b/features/automation/protection/autoSell/controls/AutoSellFormControl.tsx
@@ -30,9 +30,9 @@ export function AutoSellFormControl({
   const [autoSellState] = useUIChanges<AutoBSFormChange>(AUTO_SELL_FORM_CHANGE)
 
   const {
-    autoSellTriggerData,
     environmentData: { canInteract },
     positionData: { id, debt, lockedCollateral, positionRatio, owner },
+    triggerData: { autoSellTriggerData },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.AUTO_SELL

--- a/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAuteSellCancelEditingStage.tsx
@@ -14,7 +14,7 @@ function AutoSellInfoSectionControl() {
   const { t } = useTranslation()
   const {
     positionData: { debt, positionRatio, liquidationPrice },
-    autoSellTriggerData,
+    triggerData: { autoSellTriggerData },
   } = useAutomationContext()
 
   return (

--- a/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarAutoSellAddEditingStage.tsx
@@ -63,9 +63,8 @@ export function SidebarAutoSellAddEditingStage({
 }: SidebarAutoSellAddEditingStageProps) {
   const { uiChanges } = useAppContext()
   const {
-    autoSellTriggerData,
-    stopLossTriggerData,
     positionData: { id, ilk, debt, debtFloor, lockedCollateral, positionRatio, token },
+    triggerData: { autoSellTriggerData, stopLossTriggerData },
   } = useAutomationContext()
   const { t } = useTranslation()
   const [, setHash] = useHash()

--- a/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
+++ b/features/automation/protection/autoSell/sidebars/SidebarSetupAutoSell.tsx
@@ -75,13 +75,15 @@ export function SidebarSetupAutoSell({
   const gasEstimation = useGasEstimationContext()
   const { uiChanges } = useAppContext()
   const {
-    autoBuyTriggerData,
-    autoSellTriggerData,
-    constantMultipleTriggerData,
-    stopLossTriggerData,
     environmentData: { ethBalance, ethMarketPrice, etherscanUrl },
     positionData: { nextPositionRatio, debt, debtFloor, liquidationRatio, token, vaultType },
     protocol,
+    triggerData: {
+      autoBuyTriggerData,
+      autoSellTriggerData,
+      constantMultipleTriggerData,
+      stopLossTriggerData,
+    },
   } = useAutomationContext()
 
   const { isAwaitingConfirmation } = autoSellState

--- a/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionDetailsControl.tsx
@@ -11,7 +11,10 @@ import { useUIChanges } from 'helpers/uiChangesHook'
 import React from 'react'
 
 export function ProtectionDetailsControl() {
-  const { stopLossTriggerData, autoSellTriggerData, protocol } = useAutomationContext()
+  const {
+    protocol,
+    triggerData: { autoSellTriggerData, stopLossTriggerData },
+  } = useAutomationContext()
 
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)
 

--- a/features/automation/protection/common/controls/ProtectionFormControl.tsx
+++ b/features/automation/protection/common/controls/ProtectionFormControl.tsx
@@ -22,10 +22,9 @@ interface ProtectionFormControlProps {
 
 export function ProtectionFormControl({ txHelpers }: ProtectionFormControlProps) {
   const {
-    stopLossTriggerData,
-    autoSellTriggerData,
     automationTriggersData,
     protocol,
+    triggerData: { autoSellTriggerData, stopLossTriggerData },
   } = useAutomationContext()
 
   const [activeAutomationFeature] = useUIChanges<AutomationChangeFeature>(AUTOMATION_CHANGE_FEATURE)

--- a/features/automation/protection/stopLoss/controls/GetProtectionBannerControl.tsx
+++ b/features/automation/protection/stopLoss/controls/GetProtectionBannerControl.tsx
@@ -29,7 +29,9 @@ export function GetProtectionBannerControl({
 }: GetProtectionBannerProps) {
   const { t } = useTranslation()
   const setHash = useHash()[1]
-  const { stopLossTriggerData } = useAutomationContext()
+  const {
+    triggerData: { stopLossTriggerData },
+  } = useAutomationContext()
 
   const isAllowedForAutomation = isSupportedAutomationIlk(getNetworkName(), ilk)
 

--- a/features/automation/protection/stopLoss/controls/StopLossBannerControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossBannerControl.tsx
@@ -24,7 +24,9 @@ export function StopLossBannerControl({
   onClick,
 }: StopLossBannerControlProps & AfterPillProps) {
   const { uiChanges } = useAppContext()
-  const { stopLossTriggerData } = useAutomationContext()
+  const {
+    triggerData: { stopLossTriggerData },
+  } = useAutomationContext()
 
   if (stopLossTriggerData.isStopLossEnabled) {
     const dynamicStopPrice = liquidationPrice

--- a/features/automation/protection/stopLoss/controls/StopLossCompleteInformation.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossCompleteInformation.tsx
@@ -32,7 +32,7 @@ export function StopLossCompleteInformation({
   const {
     positionData: { token, liquidationPrice, liquidationRatio },
     metadata: {
-      stopLoss: {
+      stopLossMetadata: {
         methods: { getMaxToken },
       },
     },

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
@@ -28,7 +28,7 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
   const { t } = useTranslation()
   const {
     metadata: {
-      stopLoss: {
+      stopLossMetadata: {
         detailCards,
         methods: { getMaxToken },
         translations: { ratioParam },

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
@@ -31,7 +31,7 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
       stopLossMetadata: {
         detailCards,
         methods: { getMaxToken },
-        translations: { ratioParam },
+        translations: { ratioParamTranslationKey },
         values: {
           collateralDuringLiquidation,
           initialSlRatioWhenTriggerDoesntExist,
@@ -89,7 +89,7 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
             initialSlRatioWhenTriggerDoesntExist,
           })}
           positionRatio={positionRatio}
-          ratioParam={ratioParam}
+          ratioParamTranslationKey={ratioParamTranslationKey}
           detailCards={detailCards}
         />
       ) : (

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsControl.tsx
@@ -27,7 +27,18 @@ interface StopLossDetailsControlProps {
 export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsControlProps) {
   const { t } = useTranslation()
   const {
-    stopLossTriggerData: { isStopLossEnabled, stopLossLevel, isToCollateral },
+    metadata: {
+      stopLoss: {
+        detailCards,
+        methods: { getMaxToken },
+        translations: { ratioParam },
+        values: {
+          collateralDuringLiquidation,
+          initialSlRatioWhenTriggerDoesntExist,
+          triggerMaxToken,
+        },
+      },
+    },
     positionData: {
       positionRatio,
       nextPositionRatio,
@@ -41,17 +52,8 @@ export function StopLossDetailsControl({ isStopLossActive }: StopLossDetailsCont
       token,
       debtToken,
     },
-    metadata: {
-      stopLoss: {
-        detailCards,
-        methods: { getMaxToken },
-        translations: { ratioParam },
-        values: {
-          collateralDuringLiquidation,
-          initialSlRatioWhenTriggerDoesntExist,
-          triggerMaxToken,
-        },
-      },
+    triggerData: {
+      stopLossTriggerData: { isStopLossEnabled, stopLossLevel, isToCollateral },
     },
   } = useAutomationContext()
   const { uiChanges } = useAppContext()

--- a/features/automation/protection/stopLoss/controls/StopLossDetailsLayout.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossDetailsLayout.tsx
@@ -30,7 +30,7 @@ export interface StopLossDetailsLayoutProps {
   collateralDuringLiquidation: BigNumber
   triggerMaxToken: BigNumber
   afterMaxToken: BigNumber
-  ratioParam: string
+  ratioParamTranslationKey: string
   detailCards?: StopLossMetadataDetailCards
 }
 
@@ -51,7 +51,7 @@ export function StopLossDetailsLayout({
   afterMaxToken,
   collateralDuringLiquidation,
   triggerMaxToken,
-  ratioParam,
+  ratioParamTranslationKey,
   detailCards,
 }: StopLossDetailsLayoutProps) {
   const { t } = useTranslation()
@@ -72,7 +72,7 @@ export function StopLossDetailsLayout({
                   isEditing={isEditing}
                   stopLossLevel={stopLossLevel}
                   afterStopLossLevel={afterStopLossLevel}
-                  ratioParam={ratioParam}
+                  ratioParamTranslationKey={ratioParamTranslationKey}
                   modalDescription={cardsConfig?.stopLossLevelCard.modalDescription}
                   belowCurrentPositionRatio={
                     cardsConfig?.stopLossLevelCard.belowCurrentPositionRatio
@@ -100,7 +100,7 @@ export function StopLossDetailsLayout({
                 liquidationPrice={liquidationPrice}
                 liquidationRatio={liquidationRatio}
                 afterStopLossLevel={afterStopLossLevel}
-                ratioParam={ratioParam}
+                ratioParamTranslationKey={ratioParamTranslationKey}
               />
             )}
             {cardsSet.includes(StopLossDetailCards.ESTIMATED_TOKEN_ON_TRIGGER) && (

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -31,14 +31,14 @@ export function StopLossFormControl({
 }: StopLossFormControlProps) {
   const [stopLossState] = useUIChanges<StopLossFormChange>(STOP_LOSS_FORM_CHANGE)
   const {
-    stopLossTriggerData,
     environmentData: { canInteract },
-    positionData: { id, debt, owner },
     metadata: {
       stopLoss: {
         values: { initialSlRatioWhenTriggerDoesntExist, resetData },
       },
     },
+    positionData: { id, debt, owner },
+    triggerData: { stopLossTriggerData },
   } = useAutomationContext()
 
   const feature = AutomationFeatures.STOP_LOSS

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -33,7 +33,7 @@ export function StopLossFormControl({
   const {
     environmentData: { canInteract },
     metadata: {
-      stopLoss: {
+      stopLossMetadata: {
         values: { initialSlRatioWhenTriggerDoesntExist, resetData },
       },
     },

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -159,7 +159,6 @@ export function getDataForStopLoss(
     debt: debt || zero,
   })
 
-  // eslint-disable-next-line func-style
   function getOpenVaultStopLossMetadata(): StopLossMetadata {
     return {
       callbacks: {

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -176,7 +176,7 @@ export function getDataForStopLoss(
         sliderStep: 1,
       },
       translations: {
-        ratioParam: 'system.collateral-ratio',
+        ratioParamTranslationKey: 'system.collateral-ratio',
       },
       validation: {
         getAddErrors: () => ({}),

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLoss.ts
@@ -8,7 +8,7 @@ import {
   MIX_MAX_COL_RATIO_TRIGGER_OFFSET,
   NEXT_COLL_RATIO_OFFSET,
 } from 'features/automation/common/consts'
-import { GetAutomationMetadata, StopLossMetadata } from 'features/automation/metadata/types'
+import { StopLossMetadata } from 'features/automation/metadata/types'
 import {
   getCollateralDuringLiquidation,
   getMaxToken,
@@ -160,7 +160,7 @@ export function getDataForStopLoss(
   })
 
   // eslint-disable-next-line func-style
-  const stopLossMetadata: GetAutomationMetadata<StopLossMetadata> = (_) => {
+  function getOpenVaultStopLossMetadata(): StopLossMetadata {
     return {
       callbacks: {
         onCloseToChange: ({ optionName }) => setStopLossCloseType(optionName as CloseVaultTo),
@@ -222,7 +222,7 @@ export function getDataForStopLoss(
     },
     protocol: VaultProtocol.Maker,
     metadata: {
-      stopLoss: stopLossMetadata,
+      stopLoss: getOpenVaultStopLossMetadata,
     },
   }
 

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -135,9 +135,7 @@ export function SidebarAdjustStopLossEditingStage({
   const { t } = useTranslation()
   const { uiChanges } = useAppContext()
   const {
-    stopLossTriggerData,
     environmentData: { ethMarketPrice },
-    positionData: { id, ilk, token, debt, positionRatio },
     metadata: {
       stopLoss: {
         callbacks: { onSliderChange, onCloseToChange },
@@ -147,6 +145,8 @@ export function SidebarAdjustStopLossEditingStage({
         values: { sliderMin, sliderMax, resetData },
       },
     },
+    positionData: { id, ilk, token, debt, positionRatio },
+    triggerData: { stopLossTriggerData },
   } = useAutomationContext()
 
   useDebouncedCallback(

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -217,7 +217,9 @@ export function SidebarAdjustStopLossEditingStage({
             />
           )}
           <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-            {t('protection.set-downside-protection-desc', { ratioParam: t(ratioParamTranslationKey) })}{' '}
+            {t('protection.set-downside-protection-desc', {
+              ratioParam: t(ratioParamTranslationKey),
+            })}{' '}
             <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 2 }}>
               {t('here')}.
             </AppLink>

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -141,7 +141,7 @@ export function SidebarAdjustStopLossEditingStage({
         callbacks: { onSliderChange, onCloseToChange },
         methods: { getSliderPercentageFill, getRightBoundary },
         settings: { fixedCloseToToken, sliderStep, sliderDirection },
-        translations: { ratioParam },
+        translations: { ratioParamTranslationKey },
         values: { sliderMin, sliderMax, resetData },
       },
     },
@@ -217,7 +217,7 @@ export function SidebarAdjustStopLossEditingStage({
             />
           )}
           <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-            {t('protection.set-downside-protection-desc', { ratioParam: t(ratioParam) })}{' '}
+            {t('protection.set-downside-protection-desc', { ratioParam: t(ratioParamTranslationKey) })}{' '}
             <AppLink href="https://kb.oasis.app/help/stop-loss-protection" sx={{ fontSize: 2 }}>
               {t('here')}.
             </AppLink>
@@ -250,7 +250,7 @@ export function SidebarAdjustStopLossEditingStage({
 
               onSliderChange && onSliderChange({ value: slCollRatio })
             }}
-            leftLabel={t('protection.stop-loss-something', { value: t(ratioParam) })}
+            leftLabel={t('protection.stop-loss-something', { value: t(ratioParamTranslationKey) })}
             rightLabel={t('slider.set-stoploss.right-label')}
             direction={sliderDirection}
           />

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -53,7 +53,7 @@ export function SetDownsideProtectionInformation({
   const {
     positionData: { token },
     metadata: {
-      stopLoss: {
+      stopLossMetadata: {
         methods: { getMaxToken },
         values: { collateralDuringLiquidation },
       },
@@ -137,7 +137,7 @@ export function SidebarAdjustStopLossEditingStage({
   const {
     environmentData: { ethMarketPrice },
     metadata: {
-      stopLoss: {
+      stopLossMetadata: {
         callbacks: { onSliderChange, onCloseToChange },
         methods: { getSliderPercentageFill, getRightBoundary },
         settings: { fixedCloseToToken, sliderStep, sliderDirection },

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -72,7 +72,7 @@ export function SidebarSetupStopLoss({
   const {
     environmentData: { ethMarketPrice, etherscanUrl },
     metadata: {
-      stopLoss: {
+      stopLossMetadata: {
         methods: { getExecutionPrice },
         validation: { getAddErrors, getAddWarnings, cancelErrors, cancelWarnings },
       },

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -70,18 +70,16 @@ export function SidebarSetupStopLoss({
   const { uiChanges } = useAppContext()
   const automationContext = useAutomationContext()
   const {
-    autoSellTriggerData,
-    constantMultipleTriggerData,
-    stopLossTriggerData,
     environmentData: { ethMarketPrice, etherscanUrl },
-    positionData: { vaultType },
-    protocol,
     metadata: {
       stopLoss: {
         methods: { getExecutionPrice },
         validation: { getAddErrors, getAddWarnings, cancelErrors, cancelWarnings },
       },
     },
+    positionData: { vaultType },
+    protocol,
+    triggerData: { autoSellTriggerData, constantMultipleTriggerData, stopLossTriggerData },
   } = automationContext
   const { isAwaitingConfirmation } = stopLossState
 

--- a/features/borrow/manage/containers/ManageVaultDetails.tsx
+++ b/features/borrow/manage/containers/ManageVaultDetails.tsx
@@ -132,7 +132,9 @@ export function ManageVaultDetails(
     autoTakeProfitTriggered,
   } = props
   const { t } = useTranslation()
-  const { stopLossTriggerData } = useAutomationContext()
+  const {
+    triggerData: { stopLossTriggerData },
+  } = useAutomationContext()
 
   const afterCollRatioColor = getCollRatioColor(props, afterCollateralizationRatio)
   const showAfterPill = !inputAmountsEmpty && stage !== 'manageSuccess'

--- a/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
+++ b/features/multiply/manage/containers/ManageMultiplyVaultDetails.tsx
@@ -54,7 +54,9 @@ export function ManageMultiplyVaultDetails(props: ManageMultiplyVaultState) {
     vaultHistory,
   } = props
   const { t } = useTranslation()
-  const { stopLossTriggerData } = useAutomationContext()
+  const {
+    triggerData: { stopLossTriggerData },
+  } = useAutomationContext()
   const updatedPnlToogle = useFeatureToggle('UpdatedPnL')
 
   const afterCollRatioColor = getCollRatioColor(props, afterCollateralizationRatio)


### PR DESCRIPTION
# Unified common interface structure for metadata

Covers partialy:
https://app.shortcut.com/oazo-apps/story/6904/metadata-for-automation-structure-refinements
https://app.shortcut.com/oazo-apps/story/6905/metadata-for-automation-common-interface-for-all-features
  
## Changes 👷‍♀️

- Created common `AutomationCommonMetadata` interface that contains all data that is going to be shared between all automation features metadata,
- unified automation features trigger data and metadata: all trigger data objects are now stored inside of `triggerData` object, in the same way as all metadata are stored inside of `metadata` object,
- added `TranslationKey` suffix to keys in `translation` object in metadata interface
  
## How to test 🧪

Become manual tester for some time and go through entire Stop-Loss process.