### PR TITLE
Aave position banners

### DIFF
--- a/blockchain/aaveLiquidations.ts
+++ b/blockchain/aaveLiquidations.ts
@@ -1,0 +1,62 @@
+import { Observable, of } from 'rxjs'
+import { switchMap } from 'rxjs/operators'
+import { AaveLendingPool } from 'types/ethers-contracts'
+
+import { Context } from './network'
+
+const aaveLendingPoolGenesisBlock = 11362579 // TODO probably we would like to set here a block number of our aave deployment
+
+export interface Web3ContractEvent {
+  event: string
+  signature: string | null
+  address: string
+  returnValues: Record<string, string>
+  logIndex: number
+  transactionIndex: number
+  transactionHash: string
+  blockHash: string
+  blockNumber: number
+  raw: { data: string; topics: string[] }
+}
+
+export function getAavePositionLiquidation$(
+  context$: Observable<Context>,
+  proxyAddress: string,
+): Observable<Web3ContractEvent[]> {
+  if (!proxyAddress) {
+    return of([])
+  }
+  return context$.pipe(
+    switchMap(async ({ aaveLendingPool, contract }) => {
+      const aaveLendingPoolContract = contract<AaveLendingPool>(aaveLendingPool)
+
+      const contractCalls = Promise.all<Web3ContractEvent[], Web3ContractEvent[]>([
+        aaveLendingPoolContract.getPastEvents('LiquidationCall', {
+          filter: { user: proxyAddress },
+          fromBlock: aaveLendingPoolGenesisBlock,
+          toBlock: 'latest',
+        }),
+        aaveLendingPoolContract.getPastEvents('Deposit', {
+          filter: { onBehalfOf: proxyAddress },
+          fromBlock: aaveLendingPoolGenesisBlock,
+          toBlock: 'latest',
+        }),
+      ])
+
+      const [liquidationEvents, depositEvents] = await contractCalls
+
+      if (!liquidationEvents.length || !depositEvents.length) {
+        return []
+      }
+
+      const mostRecentDepositEvent = depositEvents[depositEvents.length - 1]
+      const mostRecentLiquidationEvent = liquidationEvents[liquidationEvents.length - 1]
+
+      if (mostRecentDepositEvent.blockNumber > mostRecentLiquidationEvent.blockNumber) {
+        return []
+      }
+
+      return [mostRecentLiquidationEvent]
+    }),
+  )
+}

--- a/blockchain/aaveLiquidations.ts
+++ b/blockchain/aaveLiquidations.ts
@@ -1,6 +1,6 @@
 import { Observable, of } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
-import { AaveLendingPool } from 'types/ethers-contracts'
+import { AaveLendingPool } from 'types/web3-v1-contracts/aave-lending-pool'
 
 import { Context } from './network'
 

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -3,6 +3,7 @@ import { createWeb3Context$ } from '@oasisdex/web3-context'
 import { trackingEvents } from 'analytics/analytics'
 import { mixpanelIdentify } from 'analytics/mixpanel'
 import { BigNumber } from 'bignumber.js'
+import { getAavePositionLiquidation$ } from 'blockchain/aaveLiquidations'
 import {
   getAaveReserveConfigurationData,
   getAaveReserveData,
@@ -647,6 +648,10 @@ export function setupAppContext() {
   )
 
   const ensName$ = memoize(curry(resolveENSName$)(context$), (address) => address)
+  const aaveLiquidations$ = memoize(
+    curry(getAavePositionLiquidation$)(context$),
+    (address) => address,
+  )
 
   const tokenAllowance$ = observe(onEveryBlock$, context$, tokenAllowance)
   const tokenBalanceRawForJoin$ = observe(onEveryBlock$, chainContext$, tokenBalanceRawForJoin)
@@ -1222,6 +1227,7 @@ export function setupAppContext() {
     hasActiveAavePosition$,
     balanceInfo$,
     once$,
+    aaveLiquidations$,
   }
 }
 

--- a/features/aave/manage/containers/AaveManageView.tsx
+++ b/features/aave/manage/containers/AaveManageView.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Card, Container, Grid } from 'theme-ui'
 
-import { PositionOwnershipBanner } from '../../../notices/VaultsNoticesView'
+import { AavePositionNoticesView } from '../../../notices/VaultsNoticesView'
 import { useAaveContext } from '../../AaveContextProvider'
 import { StrategyConfig } from '../../common/StrategyConfigTypes'
 import { PreparedAaveReserveData } from '../../helpers/aavePrepareReserveData'
@@ -28,30 +28,6 @@ import {
 interface AaveManageViewPositionViewProps {
   address: string
   strategyConfig: StrategyConfig
-}
-
-function PositionOwnership() {
-  const { stateMachine } = useManageAaveStateMachineContext()
-  const [state] = useActor(stateMachine)
-
-  const connectedAddress =
-    state.context.web3Context?.status === 'connected'
-      ? state.context.web3Context.account
-      : undefined
-
-  if (
-    state.context.connectedProxyAddress !== undefined &&
-    state.context.proxyAddress !== undefined &&
-    state.context.connectedProxyAddress === state.context.proxyAddress
-  ) {
-    return null
-  }
-  return (
-    <PositionOwnershipBanner
-      account={state.context.address}
-      connectedWalletAddress={connectedAddress}
-    />
-  )
 }
 
 function AaveManageContainer({
@@ -90,7 +66,9 @@ function AaveManageContainer({
       }}
     >
       <Container variant="vaultPageContainer">
-        <PositionOwnership />
+        <Box mb={4}>
+          <AavePositionNoticesView />
+        </Box>
         <Header strategyConfig={strategyConfig} />
         <TabBar
           variant="underline"

--- a/features/notices/VaultsNoticesView.tsx
+++ b/features/notices/VaultsNoticesView.tsx
@@ -1,10 +1,13 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import { useActor } from '@xstate/react'
 import BigNumber from 'bignumber.js'
 import { useAppContext } from 'components/AppContextProvider'
 import { AppLink } from 'components/Links'
 import { Notice } from 'components/Notice'
+import { useManageAaveStateMachineContext } from 'features/aave/manage/containers/AaveManageStateMachineContext'
+import { getAaveNoticeBanner, getLiquidatedHeaderNotice } from 'features/notices/helpers'
 import { ReclaimCollateralButton } from 'features/reclaimCollateral/reclaimCollateralView'
-import { formatAddress, formatCryptoBalance } from 'helpers/formatters/format'
+import { formatAddress, formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
 import { WithChildren } from 'helpers/types'
 import { zero } from 'helpers/zero'
@@ -13,8 +16,8 @@ import { useTranslation } from 'next-i18next'
 import React, { useEffect, useMemo, useState } from 'react'
 import { CountdownCircleTimer } from 'react-countdown-circle-timer'
 import { Box, Flex, Grid, Heading, SxStyleProp, Text } from 'theme-ui'
+import { useTheme } from 'theme/useThemeUI'
 
-import { useTheme } from '../../theme/useThemeUI'
 import { VaultNoticesState } from './vaultsNotices'
 
 type VaultNoticeProps = {
@@ -103,7 +106,7 @@ export function VaultLiquidatingNextPriceNotice({
               <Box sx={{ textAlign: 'center' }}>
                 <Heading
                   as="h3"
-                  sx={{ lineHeight: 'tight', fontWeight: 'semiBold', color: 'banner.warning' }}
+                  sx={{ lineHeight: 'tight', fontWeight: 'semiBold', color: 'warning100' }}
                 >
                   {'<2'}
                 </Heading>
@@ -127,7 +130,7 @@ export function VaultLiquidatingNextPriceNotice({
             : t('vault-notices.liquidating.subheader1')
         }
       `}
-      color="banner.warning"
+      color="warning100"
     />
   )
 }
@@ -159,12 +162,12 @@ export function VaultOwnershipBanner({
           </Text>
         )
       }
-      color="banner.muted"
+      color="primary100"
     />
   )
 }
 
-export function PositionOwnershipBanner({
+function PositionOwnershipBanner({
   account,
   connectedWalletAddress,
 }: {
@@ -192,7 +195,7 @@ export function PositionOwnershipBanner({
           </Text>
         )
       }
-      color="banner.muted"
+      color="primary100"
       mb={4}
     />
   )
@@ -223,8 +226,20 @@ export function VaultOverviewOwnershipNotice({
           </AppLink>
         </Text>
       }
-      color="banner.muted"
+      color="primary100"
     />
+  )
+}
+
+function DangerStatusFrame() {
+  return (
+    <StatusFrame
+      sx={{
+        borderColor: 'critical10',
+      }}
+    >
+      <Icon size="auto" height="24" width="6" name="exclamationMark" color="critical100" />
+    </StatusFrame>
   )
 }
 
@@ -251,20 +266,10 @@ export function VaultLiquidatingNotice({
 
   return (
     <VaultNotice
-      status={
-        <>
-          <StatusFrame
-            sx={{
-              borderColor: 'banner.dangerBorder',
-            }}
-          >
-            <Icon size="auto" height="24" width="6" name="exclamationMark" color="banner.danger" />
-          </StatusFrame>
-        </>
-      }
+      status={<DangerStatusFrame />}
       header={header}
       subheader={subheader}
-      color="banner.danger"
+      color="critical100"
     />
   )
 }
@@ -281,23 +286,24 @@ export function VaultLiquidatedNotice({
 >) {
   const { t } = useTranslation()
 
-  const header = isVaultController
-    ? t('vault-notices.liquidated.header1')
-    : t('vault-notices.liquidated.header2')
+  const header = t(getLiquidatedHeaderNotice(isVaultController), { position: t('maker-vault') })
 
   const fallbackSubheader = controller
-    ? `${t('vault-notices.liquidated.subheader3')} ${t('vault-notices.liquidated.subheader4', {
-        address: formatAddress(controller),
-      })}`
-    : t('vault-notices.liquidated.subheader3')
+    ? `${t('vault-notices.liquidated.maker.subheader3')} ${t(
+        'vault-notices.liquidated.maker.subheader4',
+        {
+          address: formatAddress(controller),
+        },
+      )}`
+    : t('vault-notices.liquidated.maker.subheader3')
 
   const subheader =
     unlockedCollateral.gt(zero) &&
     (isVaultController ? (
       <>
         <Text sx={{ mb: 3 }}>
-          {t('vault-notices.liquidated.subheader1')}{' '}
-          {t('vault-notices.liquidated.subheader2', {
+          {t('vault-notices.liquidated.maker.subheader1')}{' '}
+          {t('vault-notices.liquidated.maker.subheader2', {
             amount: formatCryptoBalance(unlockedCollateral),
             collateral: token.toUpperCase(),
           })}
@@ -310,20 +316,10 @@ export function VaultLiquidatedNotice({
 
   return (
     <VaultNotice
-      status={
-        <>
-          <StatusFrame
-            sx={{
-              borderColor: 'banner.dangerBorder',
-            }}
-          >
-            <Icon size="auto" height="24" width="6" name="exclamationMark" color="banner.danger" />
-          </StatusFrame>
-        </>
-      }
+      status={<DangerStatusFrame />}
       header={header}
       subheader={subheader}
-      color="banner.danger"
+      color="critical100"
     />
   )
 }
@@ -402,7 +398,7 @@ export function VaultNextPriceUpdateCounter({
           thresholdReachedLabel
         ) : (
           <Box sx={{ textAlign: 'center' }}>
-            <Heading as="h3" sx={{ lineHeight: '1.0', color: 'banner.warning' }}>
+            <Heading as="h3" sx={{ lineHeight: '1.0', color: 'warning100' }}>
               {remainingTime && Math.floor(remainingTime / 60)}
             </Heading>
             <Text sx={{ lineHeight: '1.0', fontSize: 1, color: 'neutral80Alt' }}>mins</Text>
@@ -464,9 +460,103 @@ export function AavePositionAlreadyOpenedNotice() {
       <VaultNotice
         header={t('vault-notices.aave-multi-position.header')}
         subheader={t('vault-notices.aave-multi-position.subheader') as string}
-        color="banner.warning"
+        color="warning100"
         withClose={false}
       />
     </Box>
   )
+}
+
+function AaveLiquidatedNotice({ isPositionController }: { isPositionController: boolean }) {
+  const { t } = useTranslation()
+  const header = t(getLiquidatedHeaderNotice(isPositionController), { position: t('position') })
+  const subheader = t('vault-notices.liquidated.aave.subheader1')
+
+  return (
+    <VaultNotice
+      status={<DangerStatusFrame />}
+      header={header}
+      subheader={subheader}
+      color="critical100"
+    />
+  )
+}
+
+function AavePositionAboveMaxLtvNotice({
+  loanToValue,
+  maxLoanToValue,
+  liquidationThreshold,
+}: {
+  loanToValue: BigNumber
+  maxLoanToValue: BigNumber
+  liquidationThreshold: BigNumber
+}) {
+  const { t } = useTranslation()
+  const header = t('vault-notices.above-max-ltv.header')
+  const subheader = t('vault-notices.above-max-ltv.subheader', {
+    loanToValue: formatPercent(loanToValue.times(100), { precision: 2 }),
+    maxLoanToValue: formatPercent(maxLoanToValue.times(100), { precision: 2 }),
+    liquidationThreshold: formatPercent(liquidationThreshold.times(100), { precision: 2 }),
+  })
+
+  return (
+    <VaultNotice
+      status={<DangerStatusFrame />}
+      header={header}
+      subheader={subheader}
+      color="critical100"
+    />
+  )
+}
+
+export function AavePositionNoticesView() {
+  const { stateMachine } = useManageAaveStateMachineContext()
+  const [state] = useActor(stateMachine)
+
+  if (!state.context.protocolData) {
+    return null
+  }
+
+  const {
+    context: {
+      address,
+      proxyAddress,
+      connectedProxyAddress,
+      web3Context,
+      protocolData: {
+        position: {
+          category: { maxLoanToValue, liquidationThreshold },
+          riskRatio: { loanToValue },
+        },
+      },
+    },
+  } = state
+
+  const connectedAddress = web3Context?.status === 'connected' ? web3Context.account : undefined
+  const isPositionController = address === connectedAddress
+
+  const banner = getAaveNoticeBanner({
+    loanToValue,
+    maxLoanToValue,
+    liquidationThreshold,
+    connectedProxyAddress,
+    proxyAddress,
+  })
+
+  switch (banner) {
+    case 'liquidated':
+      return <AaveLiquidatedNotice isPositionController={isPositionController} />
+    case 'aboveMaxLtv':
+      return (
+        <AavePositionAboveMaxLtvNotice
+          loanToValue={loanToValue}
+          maxLoanToValue={maxLoanToValue}
+          liquidationThreshold={liquidationThreshold}
+        />
+      )
+    case 'ownership':
+      return <PositionOwnershipBanner account={address} connectedWalletAddress={connectedAddress} />
+    default:
+      return null
+  }
 }

--- a/features/notices/VaultsNoticesView.tsx
+++ b/features/notices/VaultsNoticesView.tsx
@@ -7,7 +7,11 @@ import { Notice } from 'components/Notice'
 import { useManageAaveStateMachineContext } from 'features/aave/manage/containers/AaveManageStateMachineContext'
 import { getAaveNoticeBanner, getLiquidatedHeaderNotice } from 'features/notices/helpers'
 import { ReclaimCollateralButton } from 'features/reclaimCollateral/reclaimCollateralView'
-import { formatAddress, formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
+import {
+  formatAddress,
+  formatCryptoBalance,
+  formatDecimalAsPercent,
+} from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
 import { WithChildren } from 'helpers/types'
 import { zero } from 'helpers/zero'
@@ -495,9 +499,9 @@ function AavePositionAboveMaxLtvNotice({
   const { t } = useTranslation()
   const header = t('vault-notices.above-max-ltv.header')
   const subheader = t('vault-notices.above-max-ltv.subheader', {
-    loanToValue: formatPercent(loanToValue.times(100), { precision: 2 }),
-    maxLoanToValue: formatPercent(maxLoanToValue.times(100), { precision: 2 }),
-    liquidationThreshold: formatPercent(liquidationThreshold.times(100), { precision: 2 }),
+    loanToValue: formatDecimalAsPercent(loanToValue),
+    maxLoanToValue: formatDecimalAsPercent(maxLoanToValue),
+    liquidationThreshold: formatDecimalAsPercent(liquidationThreshold),
   })
 
   return (

--- a/features/notices/VaultsNoticesView.tsx
+++ b/features/notices/VaultsNoticesView.tsx
@@ -469,6 +469,7 @@ export function AavePositionAlreadyOpenedNotice() {
 
 function AaveLiquidatedNotice({ isPositionController }: { isPositionController: boolean }) {
   const { t } = useTranslation()
+
   const header = t(getLiquidatedHeaderNotice(isPositionController), { position: t('position') })
   const subheader = t('vault-notices.liquidated.aave.subheader1')
 
@@ -510,10 +511,13 @@ function AavePositionAboveMaxLtvNotice({
 }
 
 export function AavePositionNoticesView() {
+  const { aaveLiquidations$ } = useAppContext()
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state] = useActor(stateMachine)
+  const preparedAaveLiquidations$ = aaveLiquidations$(state.context.proxyAddress || '')
+  const [aaveLiquidations] = useObservable(preparedAaveLiquidations$)
 
-  if (!state.context.protocolData) {
+  if (!state.context.protocolData || !state.context.proxyAddress) {
     return null
   }
 
@@ -541,6 +545,7 @@ export function AavePositionNoticesView() {
     liquidationThreshold,
     connectedProxyAddress,
     proxyAddress,
+    aaveLiquidations,
   })
 
   switch (banner) {

--- a/features/notices/helpers.ts
+++ b/features/notices/helpers.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { Web3ContractEvent } from 'blockchain/aaveLiquidations'
 
 export function getLiquidatedHeaderNotice(isPositionController: boolean) {
   return isPositionController
@@ -12,14 +13,16 @@ export function getAaveNoticeBanner({
   liquidationThreshold,
   connectedProxyAddress,
   proxyAddress,
+  aaveLiquidations,
 }: {
   loanToValue: BigNumber
   maxLoanToValue: BigNumber
   liquidationThreshold: BigNumber
   connectedProxyAddress?: string
   proxyAddress?: string
+  aaveLiquidations?: Web3ContractEvent[]
 }) {
-  const isLiquidated = false as boolean // TODO to be implemented
+  const isLiquidated = !!aaveLiquidations?.length
   const isAboveMaxLtv = loanToValue.gt(maxLoanToValue) && loanToValue?.lt(liquidationThreshold)
   const isOwnership = !(
     connectedProxyAddress !== undefined &&

--- a/features/notices/helpers.ts
+++ b/features/notices/helpers.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { Web3ContractEvent } from 'blockchain/aaveLiquidations'
+import { allDefined } from 'helpers/allDefined'
 
 export function getLiquidatedHeaderNotice(isPositionController: boolean) {
   return isPositionController
@@ -25,9 +26,7 @@ export function getAaveNoticeBanner({
   const isLiquidated = !!aaveLiquidations?.length
   const isAboveMaxLtv = loanToValue.gt(maxLoanToValue) && loanToValue?.lt(liquidationThreshold)
   const isOwnership = !(
-    connectedProxyAddress !== undefined &&
-    proxyAddress !== undefined &&
-    connectedProxyAddress === proxyAddress
+    allDefined([connectedProxyAddress, proxyAddress]) && connectedProxyAddress === proxyAddress
   )
 
   switch (true) {

--- a/features/notices/helpers.ts
+++ b/features/notices/helpers.ts
@@ -1,0 +1,40 @@
+import BigNumber from 'bignumber.js'
+
+export function getLiquidatedHeaderNotice(isPositionController: boolean) {
+  return isPositionController
+    ? 'vault-notices.liquidated.header1'
+    : 'vault-notices.liquidated.header2'
+}
+
+export function getAaveNoticeBanner({
+  loanToValue,
+  maxLoanToValue,
+  liquidationThreshold,
+  connectedProxyAddress,
+  proxyAddress,
+}: {
+  loanToValue: BigNumber
+  maxLoanToValue: BigNumber
+  liquidationThreshold: BigNumber
+  connectedProxyAddress?: string
+  proxyAddress?: string
+}) {
+  const isLiquidated = false as boolean // TODO to be implemented
+  const isAboveMaxLtv = loanToValue.gt(maxLoanToValue) && loanToValue?.lt(liquidationThreshold)
+  const isOwnership = !(
+    connectedProxyAddress !== undefined &&
+    proxyAddress !== undefined &&
+    connectedProxyAddress === proxyAddress
+  )
+
+  switch (true) {
+    case isLiquidated:
+      return 'liquidated'
+    case isAboveMaxLtv:
+      return 'aboveMaxLtv'
+    case isOwnership:
+      return 'ownership'
+    default:
+      return undefined
+  }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -52,6 +52,8 @@
   "adding-auto-buy": "Adding Auto-Buy trigger",
   "cancelling-auto-buy": "Removing Auto-Buy trigger",
   "buy": "Buy",
+  "maker-vault": "Maker Vault",
+  "position": "Position",
   "careers": {
     "heading": "Open Roles",
     "intro": "We believe in talent. Join us to build the next generation of DeFi.",
@@ -1130,12 +1132,21 @@
       "subheader3": "This Vault is now available for liquidation and can be liquidated at anytime."
     },
     "liquidated": {
-      "header1": "Your Maker Vault got liquidated",
-      "header2": "This Maker Vault got liquidated",
-      "subheader1": "This Maker Vault has been liquidated. A portion of your collateral has been auctioned to pay back your Dai debt.",
-      "subheader2": "You can reclaim {{ amount }} {{ collateral }}",
-      "subheader3": "This Maker Vault has been liquidated. A portion of collateral has been auctioned to pay back the Dai debt.",
-      "subheader4": "If this is your vault, connect with address: {{ address }} to reclaim the remaining collateral."
+      "header1": "Your {{position}} got liquidated",
+      "header2": "This {{position}} got liquidated",
+      "maker": {
+        "subheader1": "This Maker Vault has been liquidated. A portion of your collateral has been auctioned to pay back your Dai debt.",
+        "subheader2": "You can reclaim {{ amount }} {{ collateral }}",
+        "subheader3": "This Maker Vault has been liquidated. A portion of collateral has been auctioned to pay back the Dai debt.",
+        "subheader4": "If this is your vault, connect with address: {{ address }} to reclaim the remaining collateral."
+      },
+      "aave": {
+        "subheader1": "A liquidation has happened on this Position."
+      }
+    },
+    "above-max-ltv": {
+      "header": "This position is currently higher than the maximum loan to value and can only be reduced.",
+      "subheader": "The current loan to value of {{loanToValue}} is higher than the maximum loan to value of {{maxLoanToValue}} allowed by the protocol. Therefore this position can only be de-risked. If the loan to value of the position reaches {{liquidationThreshold}} the position will be available for liquidation."
     },
     "aave-multi-position": {
       "header": "This position is affected by other assets on AAVE",


### PR DESCRIPTION
# [Aave position banners](https://app.shortcut.com/oazo-apps/story/6421/ui-liquidation-banner)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added `AavePositionNoticesView` which provide handling for all banners within aave position view
- added `getAavePositionLiquidation$` observable which gets info about liquidation events from `aaveLendingPool` contract, if liquidation happened but later user perform deposit action banner wont be shown
- small adjustment to copies
  
## How to test 🧪
  <Please explain how to test your changes>

- to test `ownership` banner just visit aave multiply position when connected / not connected
- to test `liquidated` banner you will need to mock proxy address in `AavePositionNoticesView` when assigning value to `preparedAaveLiquidations$`,  you can use following address `0xf3704de41D39688514775FD65722d346c06042aD`
- to test `aboveMaxLtv` banner you can just hardcode banner to `aboveMaxLtv` and check whether values within copies and basically condition makes sense
