### PR TITLE
Feature toggles available outside components

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -89,7 +89,12 @@ export function loadFeatureToggles(testFeaturesFlaggedEnabled: Array<Feature> = 
   }
 }
 
-export function useFeatureToggle(feature: Feature): boolean {
+export function getFeatureToggle(feature: Feature): boolean {
   const userEnabledFeatures = localStorage.getItem(FT_LOCAL_STORAGE_KEY)
+
   return JSON.parse(userEnabledFeatures || '{}')[feature] || configuredFeatures[feature]
+}
+
+export function useFeatureToggle(feature: Feature): boolean {
+  return getFeatureToggle(feature)
 }


### PR DESCRIPTION
# Feature toggles available outside components
  
## Changes 👷‍♀️

- Created `getFeatureToggle` method that allows to use feature toggles outside of components.
  
## How to test 🧪

- Check if hook still works as intended (for feature set to both `false` and `true` as default for all possible states),
- check if `getFeatureToggle` works as intended outside of component context.
