### PR TITLE
FIX - Fix undefinded provider

### DIFF
--- a/blockchain/readOnlyEnhancedProviderProxy.ts
+++ b/blockchain/readOnlyEnhancedProviderProxy.ts
@@ -22,13 +22,19 @@ function getHandler(chainIdPromise: Promise<number | string>): ProxyHandler<any>
     return async function (chainIdPromise: Promise<number | string>) {
       if (!provider) {
         const chainId = fixChainId(await chainIdPromise)
+        console.log(chainId)
+        console.log(jsonRpcBatchProvider)
         if (jsonRpcBatchProvider === undefined) {
           jsonRpcBatchProvider = new JsonRpcBatchProvider(networksById[chainId].infuraUrl, chainId)
+          console.log(jsonRpcBatchProvider)
           provider = skipCache(chainId.toString())
             ? jsonRpcBatchProvider
             : new JsonRpcCachedProvider(networksById[chainId].infuraUrl, chainId)
+        } else {
+          provider = jsonRpcBatchProvider
         }
       }
+      console.log(provider)
       return provider
     }
   })()


### PR DESCRIPTION
# [Title](https://shortcutLink)

Therwe was an error while connecting/disconnecting wallet on the owner page
  
## Changes 👷‍♀️
added 
```
else {
          provider = jsonRpcBatchProvider
        }
```

in the provider definition. When wallet was disconnecte/connected the provider was unknown
## How to test 🧪
go to eg. http://localhost:3000/owner/0x4Eb7F19D6eFcACE59EaED70220da5002709f9B71#multiply

connect and disconnet wallet with and without the change