### PR TITLE
🧿 Ajna empty page

### DIFF
--- a/components/FeatureToggleRedirect.tsx
+++ b/components/FeatureToggleRedirect.tsx
@@ -1,0 +1,21 @@
+import { Feature, useFeatureToggle } from 'helpers/useFeatureToggle'
+import { useRouter } from 'next/router'
+import { PropsWithChildren } from 'react'
+
+export type FeatureToggleRedirectProps = {
+  feature: Feature
+  redirectUrl?: string
+}
+
+export function WithFeatureToggleRedirect({
+  children,
+  feature,
+  redirectUrl = '/',
+}: PropsWithChildren<FeatureToggleRedirectProps>) {
+  const { replace } = useRouter()
+  const featureEnabled = useFeatureToggle(feature)
+
+  if (!featureEnabled) void replace(redirectUrl)
+
+  return featureEnabled ? <>{children}</> : null
+}

--- a/components/FeatureToggleRedirect.tsx
+++ b/components/FeatureToggleRedirect.tsx
@@ -1,6 +1,6 @@
 import { Feature, useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useRouter } from 'next/router'
-import { PropsWithChildren } from 'react'
+import React, { PropsWithChildren } from 'react'
 
 export type FeatureToggleRedirectProps = {
   feature: Feature

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -24,6 +24,7 @@ export type Feature =
   | 'AaveMultiplySTETHUSDC'
   | 'FollowVaults'
   | 'AaveProtection'
+  | 'Ajna'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -46,6 +47,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   AaveMultiplySTETHUSDC: false,
   FollowVaults: false,
   AaveProtection: false,
+  Ajna: false,
   // your feature here....
 }
 

--- a/pages/ajna/index.tsx
+++ b/pages/ajna/index.tsx
@@ -6,7 +6,12 @@ function AjnaPage() {
   return (
     <WithFeatureToggleRedirect feature="Ajna">
       <Box sx={{ width: '100%' }}>
-        <Text sx={{ backgroundColor: 'interactive100' }}>Text component with background set to interactive100</Text>
+        <Text sx={{ backgroundColor: 'interactive100' }}>
+          Text component with background set to interactive100
+        </Text>
+        <Text sx={{ backgroundColor: 'interactive50' }}>
+          Text component with background set to interactive50
+        </Text>
         <ThemeProvider
           theme={{
             colors: {
@@ -14,7 +19,12 @@ function AjnaPage() {
             },
           }}
         >
-          <Text sx={{ backgroundColor: 'interactive100' }}>Text component with background set to interactive100, with overwriting ThemeProvider</Text>
+          <Text sx={{ backgroundColor: 'interactive100' }}>
+            Text component with background set to interactive100, with overwriting ThemeProvider
+          </Text>
+          <Text sx={{ backgroundColor: 'interactive50' }}>
+            Text component with background set to interactive100, with overwriting ThemeProvider
+          </Text>
         </ThemeProvider>
       </Box>
     </WithFeatureToggleRedirect>

--- a/pages/ajna/index.tsx
+++ b/pages/ajna/index.tsx
@@ -1,0 +1,24 @@
+import { WithFeatureToggleRedirect } from 'components/FeatureToggleRedirect'
+import React from 'react'
+import { Box, Text, ThemeProvider } from 'theme-ui'
+
+function AjnaPage() {
+  return (
+    <WithFeatureToggleRedirect feature="Ajna">
+      <Box sx={{ width: '100%' }}>
+        <Text sx={{ backgroundColor: 'interactive100' }}>Text component with background set to interactive100</Text>
+        <ThemeProvider
+          theme={{
+            colors: {
+              interactive100: '#b5179e',
+            },
+          }}
+        >
+          <Text sx={{ backgroundColor: 'interactive100' }}>Text component with background set to interactive100, with overwriting ThemeProvider</Text>
+        </ThemeProvider>
+      </Box>
+    </WithFeatureToggleRedirect>
+  )
+}
+
+export default AjnaPage


### PR DESCRIPTION
# Ajna empty page

Covers:
https://app.shortcut.com/oazo-apps/story/7032/research-extended-theme-ui
and partialy:
https://app.shortcut.com/oazo-apps/story/7011/spike-front-end-architecture
https://app.shortcut.com/oazo-apps/story/7034/research-page-blocked-by-feature-flag
  
## Changes 👷‍♀️

- Created empty Ajna page as a playground for testing spike features,
- Added `Ajna` feature flag,
- Created `WithFeatureToggleRedirect` component that redirects to selected page if user doesn't have required feature flag set to `true`,
- Tested partial overwriting of theme in `theme.ui`.
  
## How to test 🧪

- Go to `/ajna` page with and without `Ajna` feature flag turned on.
