### PR TITLE
Fix variable annual fee issue

### DIFF
--- a/features/aave/common/StrategyConfigTypes.ts
+++ b/features/aave/common/StrategyConfigTypes.ts
@@ -38,7 +38,7 @@ export type AaveHeaderProps = {
 
 export type ManageSectionComponentProps = {
   aaveReserveState: AaveReserveConfigurationData
-  aaveReserveDataETH: PreparedAaveReserveData
+  aaveReserveDataDebtToken: PreparedAaveReserveData
 }
 
 type AaveHeader = (props: AaveHeaderProps) => JSX.Element

--- a/features/aave/manage/containers/AaveManageView.tsx
+++ b/features/aave/manage/containers/AaveManageView.tsx
@@ -32,11 +32,11 @@ interface AaveManageViewPositionViewProps {
 function AaveManageContainer({
   strategyConfig,
   aaveReserveState,
-  aaveReserveDataETH,
+  aaveReserveDataDebtToken,
   address,
 }: {
   aaveReserveState: AaveReserveConfigurationData
-  aaveReserveDataETH: PreparedAaveReserveData
+  aaveReserveDataDebtToken: PreparedAaveReserveData
   strategyConfig: StrategyConfig
   address: string
 }) {
@@ -61,7 +61,6 @@ function AaveManageContainer({
       aaveManageVault={{
         address,
         aaveReserveState,
-        aaveReserveDataETH,
         strategyConfig,
         context: state.context,
       }}
@@ -82,7 +81,7 @@ function AaveManageContainer({
                   <Box>
                     <VaultDetails
                       aaveReserveState={aaveReserveState}
-                      aaveReserveDataETH={aaveReserveDataETH}
+                      aaveReserveDataDebtToken={aaveReserveDataDebtToken}
                       strategyConfig={strategyConfig}
                       currentPosition={state.context.currentPosition}
                       collateralPrice={state.context.collateralPrice}
@@ -130,8 +129,8 @@ export function AaveManagePositionView({
     aaveManageStateMachine,
     wrappedGetAaveReserveData$,
   } = useAaveContext()
-  const [aaveReserveDataCollateral, aaveReserveDataCollateralError] = useObservable(
-    wrappedGetAaveReserveData$(strategyConfig.tokens.collateral),
+  const [aaveReserveDataDebt, aaveReserveDataDebtError] = useObservable(
+    wrappedGetAaveReserveData$(strategyConfig.tokens.debt),
   )
   const [aaveReserveState, aaveReserveStateError] = useObservable(aaveSTETHReserveConfigurationData)
   return (
@@ -140,17 +139,17 @@ export function AaveManagePositionView({
       address={address}
       strategy={strategyConfig}
     >
-      <WithErrorHandler error={[aaveReserveStateError, aaveReserveDataCollateralError]}>
+      <WithErrorHandler error={[aaveReserveStateError, aaveReserveDataDebtError]}>
         <WithLoadingIndicator
-          value={[aaveReserveState, aaveReserveDataCollateral]}
+          value={[aaveReserveState, aaveReserveDataDebt]}
           customLoader={<VaultContainerSpinner />}
         >
-          {([_aaveReserveState, _aaveReserveDataCollateral]) => {
+          {([_aaveReserveState, _aaveReserveDataDebt]) => {
             return (
               <AaveManageContainer
                 strategyConfig={strategyConfig}
                 aaveReserveState={_aaveReserveState}
-                aaveReserveDataETH={_aaveReserveDataCollateral}
+                aaveReserveDataDebtToken={_aaveReserveDataDebt}
                 address={address}
               />
             )

--- a/features/automation/contexts/AaveAutomationContext.tsx
+++ b/features/automation/contexts/AaveAutomationContext.tsx
@@ -1,6 +1,5 @@
 import { AaveReserveConfigurationData } from 'blockchain/calls/aave/aaveProtocolDataProvider'
 import { StrategyConfig } from 'features/aave/common/StrategyConfigTypes'
-import { PreparedAaveReserveData } from 'features/aave/helpers/aavePrepareReserveData'
 import { ManageAaveContext } from 'features/aave/manage/state'
 import { getAutomationAavePositionData } from 'features/automation/common/context/getAutomationAavePositionData'
 import { AutomationContextInput } from 'features/automation/contexts/AutomationContextInput'
@@ -13,7 +12,6 @@ import React, { PropsWithChildren, useMemo } from 'react'
 export interface AaveManageVaultState {
   address: string
   aaveReserveState: AaveReserveConfigurationData
-  aaveReserveDataETH: PreparedAaveReserveData
   strategyConfig: StrategyConfig
   context: ManageAaveContext
 }

--- a/features/earn/aave/components/ManageSectionComponent.tsx
+++ b/features/earn/aave/components/ManageSectionComponent.tsx
@@ -11,13 +11,13 @@ import { PositionInfoComponent } from './PositionInfoComponent'
 
 export type ManageSectionComponentProps = {
   aaveReserveState: AaveReserveConfigurationData
-  aaveReserveDataETH: PreparedAaveReserveData
+  aaveReserveDataDebtToken: PreparedAaveReserveData
   strategyConfig: StrategyConfig
 }
 
 export function ManageSectionComponent({
   aaveReserveState,
-  aaveReserveDataETH,
+  aaveReserveDataDebtToken,
   strategyConfig,
 }: ManageSectionComponentProps) {
   const { stateMachine } = useManageAaveStateMachineContext()
@@ -40,7 +40,7 @@ export function ManageSectionComponent({
 
   return (
     <PositionInfoComponent
-      aaveReserveDataETH={aaveReserveDataETH}
+      aaveReserveDataDebtToken={aaveReserveDataDebtToken}
       accountData={accountData}
       apy={simulations?.apy}
       tokens={strategyConfig.tokens}

--- a/features/earn/aave/components/PositionInfoComponent.tsx
+++ b/features/earn/aave/components/PositionInfoComponent.tsx
@@ -32,7 +32,7 @@ const getLiquidationPriceRatioColor = (ratio: BigNumber) => {
 }
 
 type PositionInfoComponentProps = {
-  aaveReserveDataETH: PreparedAaveReserveData
+  aaveReserveDataDebtToken: PreparedAaveReserveData
   tokens: StrategyConfig['tokens']
   oraclePrice: BigNumber
   accountData: AaveUserAccountData
@@ -41,7 +41,7 @@ type PositionInfoComponentProps = {
 }
 
 export const PositionInfoComponent = ({
-  aaveReserveDataETH,
+  aaveReserveDataDebtToken,
   tokens,
   oraclePrice,
   accountData,
@@ -163,8 +163,10 @@ export const PositionInfoComponent = ({
           <DetailsSectionFooterItem
             title={t('system.variable-annual-fee')}
             value={
-              aaveReserveDataETH?.variableBorrowRate
-                ? formatPercent(aaveReserveDataETH.variableBorrowRate.times(100), { precision: 2 })
+              aaveReserveDataDebtToken?.variableBorrowRate
+                ? formatPercent(aaveReserveDataDebtToken.variableBorrowRate.times(100), {
+                    precision: 2,
+                  })
                 : zero.toString()
             }
           />

--- a/features/earn/aave/components/ViewPositionSectionComponent.tsx
+++ b/features/earn/aave/components/ViewPositionSectionComponent.tsx
@@ -9,13 +9,13 @@ import { PositionInfoComponent } from './PositionInfoComponent'
 
 export type ViewPositionSectionComponentProps = {
   aaveReserveState: AaveReserveConfigurationData
-  aaveReserveDataETH: PreparedAaveReserveData
+  aaveReserveDataDebtToken: PreparedAaveReserveData
   aaveProtocolData?: AaveProtocolData
   strategyConfig: StrategyConfig
 }
 
 export function ViewPositionSectionComponent({
-  aaveReserveDataETH,
+  aaveReserveDataDebtToken,
   aaveProtocolData,
   strategyConfig,
 }: ViewPositionSectionComponentProps) {
@@ -29,7 +29,7 @@ export function ViewPositionSectionComponent({
 
   return (
     <PositionInfoComponent
-      aaveReserveDataETH={aaveReserveDataETH}
+      aaveReserveDataDebtToken={aaveReserveDataDebtToken}
       accountData={accountData}
       apy={simulations?.apy}
       tokens={strategyConfig.tokens}


### PR DESCRIPTION
# [Variable Annual Fee broken for steth/eth earn](https://app.shortcut.com/oazo-apps/story/7056/variable-annual-fee-broken-for-steth-eth-earn)
  
## Changes 👷‍♀️
- uses reserve data from debt token
- renames the data passed around
  
## How to test 🧪
- open an AAVE earn position and observe the the variable annual fee represents the debt token (eth in this case):
  - variable annual fee info from aave protocol is available [here](https://docs.aave.com/developers/v/2.0/deployed-contracts/deployed-contracts) from the `ProtocolData` contract