### PR TITLE
Include `useStateReducer` to `useStopLossReducer`

### DIFF
--- a/features/automation/common/state/automationFeatureChange.ts
+++ b/features/automation/common/state/automationFeatureChange.ts
@@ -1,4 +1,7 @@
+import { TxStatus } from '@oasisdex/transactions'
+import BigNumber from 'bignumber.js'
 import { AutomationFeatures } from 'features/automation/common/types'
+import { TxError } from 'helpers/types'
 
 export type AutomationTypes = 'Protection' | 'Optimization'
 export type AutomationProtectionFeatures =
@@ -9,6 +12,18 @@ export type AutomationOptimizationFeatures =
   | AutomationFeatures.CONSTANT_MULTIPLE
   | AutomationFeatures.AUTO_TAKE_PROFIT
 export type AutomationFormType = 'add' | 'remove'
+
+export interface AutomationTxDetails {
+  txCost?: BigNumber
+  txError?: TxError
+  txHash?: string
+  txStatus?: TxStatus
+}
+export interface AutomationCommonState {
+  currentForm: AutomationFormType
+  isAwaitingConfirmation: boolean
+  txDetails?: AutomationTxDetails
+}
 
 export const AUTOMATION_CHANGE_FEATURE = 'automationChangeFeature'
 

--- a/features/automation/common/state/automationFeatureTxHandlers.ts
+++ b/features/automation/common/state/automationFeatureTxHandlers.ts
@@ -126,10 +126,10 @@ export function getAutomationFeatureTxHandlers({
 
         dispatch({
           type: 'partial-update',
-          partialUpdate: {
+          state: {
             ...resetData,
-            txDetails: {}, // this most likely should be always included in resetData
             currentForm: 'add',
+            txDetails: {}, // this most likely should be always included in resetData
           },
         })
 
@@ -190,7 +190,7 @@ export function getAutomationFeatureTxHandlers({
 
     dispatch({
       type: 'partial-update',
-      partialUpdate: {
+      state: {
         ...resetData,
         currentForm: isAddForm ? 'remove' : 'add',
       },

--- a/features/automation/common/types.ts
+++ b/features/automation/common/types.ts
@@ -7,7 +7,7 @@ import { AUTO_TAKE_PROFIT_FORM_CHANGE } from 'features/automation/optimization/a
 import { CONSTANT_MULTIPLE_FORM_CHANGE } from 'features/automation/optimization/constantMultiple/state/constantMultipleFormChange'
 import {
   STOP_LOSS_PUBLISH_KEY,
-  StopLossFormAction,
+  StopLossAction,
 } from 'features/automation/protection/stopLoss/state/useStopLossReducer'
 import { Dispatch } from 'react'
 
@@ -77,4 +77,4 @@ export type AutomationPublishType =
 
 export type AutoBSTriggerTypes = TriggerType.BasicBuy | TriggerType.BasicSell
 
-export type AutomationDispatches = Dispatch<StopLossFormAction>
+export type AutomationDispatches = Dispatch<StopLossAction>

--- a/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossFormControl.tsx
@@ -35,7 +35,7 @@ export function StopLossFormControl({
     positionData: { id, debt, owner },
     triggerData: { stopLossTriggerData },
     reducers: {
-      stopLossReducer: { stopLossState, dispatch },
+      stopLossReducer: { stopLossState, dispatchStopLoss },
     },
   } = useAutomationContext()
 
@@ -108,7 +108,7 @@ export function StopLossFormControl({
             : CloseVaultToEnum.DAI,
         },
       }}
-      dispatch={dispatch}
+      dispatch={dispatchStopLoss}
     >
       {(textButtonHandler, txHandler) => (
         <SidebarSetupStopLoss

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -263,10 +263,7 @@ export function SidebarAdjustStopLossEditingStage({
           {!isOpenFlow && (
             <SidebarResetButton
               clear={() => {
-                dispatchStopLoss({
-                  type: 'partial-update',
-                  state: resetData,
-                })
+                dispatchStopLoss({ type: 'partial-update', state: resetData })
               }}
             />
           )}

--- a/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarAdjustStopLossEditingStage.tsx
@@ -145,7 +145,7 @@ export function SidebarAdjustStopLossEditingStage({
     positionData: { id, ilk, token, debt, positionRatio },
     triggerData: { stopLossTriggerData },
     reducers: {
-      stopLossReducer: { dispatch },
+      stopLossReducer: { dispatchStopLoss, updateStopLossState },
     },
   } = useAutomationContext()
 
@@ -198,10 +198,7 @@ export function SidebarAdjustStopLossEditingStage({
               collateralTokenSymbol={token}
               isCollateralActive={stopLossState.collateralActive}
               onClickHandler={(optionName: string) => {
-                dispatch({
-                  type: 'close-type',
-                  toCollateral: optionName === closeVaultOptions[0],
-                })
+                updateStopLossState('collateralActive', optionName === closeVaultOptions[0])
 
                 trackingEvents.automation.buttonClick(
                   AutomationEventIds.CloseToX,
@@ -239,15 +236,12 @@ export function SidebarAdjustStopLossEditingStage({
             rightBoundry={rightBoundry}
             leftBoundry={stopLossState.stopLossLevel}
             onChange={(slCollRatio) => {
-              if (stopLossState.collateralActive === undefined) {
-                dispatch({
-                  type: 'close-type',
-                  toCollateral: false,
-                })
-              }
-              dispatch({
-                type: 'stop-loss-level',
-                stopLossLevel: slCollRatio,
+              dispatchStopLoss({
+                type: 'partial-update',
+                state: {
+                  ...(stopLossState.collateralActive === undefined && { collateralActive: false }),
+                  stopLossLevel: slCollRatio,
+                },
               })
 
               onSliderChange && onSliderChange({ value: slCollRatio })
@@ -269,9 +263,9 @@ export function SidebarAdjustStopLossEditingStage({
           {!isOpenFlow && (
             <SidebarResetButton
               clear={() => {
-                dispatch({
+                dispatchStopLoss({
                   type: 'partial-update',
-                  partialUpdate: resetData,
+                  state: resetData,
                 })
               }}
             />

--- a/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
+++ b/features/automation/protection/stopLoss/sidebars/SidebarSetupStopLoss.tsx
@@ -75,7 +75,7 @@ export function SidebarSetupStopLoss({
     protocol,
     triggerData: { autoSellTriggerData, constantMultipleTriggerData, stopLossTriggerData },
     reducers: {
-      stopLossReducer: { dispatch, stopLossState },
+      stopLossReducer: { stopLossState, updateStopLossState },
     },
   } = automationContext
   const { isAwaitingConfirmation } = stopLossState
@@ -211,17 +211,9 @@ export function SidebarSetupStopLoss({
         isLoading: stage === 'txInProgress',
         action: () => {
           if (!isAwaitingConfirmation && stage !== 'txSuccess' && !isRemoveForm) {
-            dispatch({
-              type: 'is-awaiting-confirmation',
-              isAwaitingConfirmation: true,
-            })
+            updateStopLossState('isAwaitingConfirmation', true)
           } else {
-            if (isAwaitingConfirmation) {
-              dispatch({
-                type: 'is-awaiting-confirmation',
-                isAwaitingConfirmation: false,
-              })
-            }
+            if (isAwaitingConfirmation) updateStopLossState('isAwaitingConfirmation', false)
             txHandler({
               callOnSuccess: () => {
                 uiChanges.publish(TAB_CHANGE_SUBJECT, {
@@ -239,14 +231,8 @@ export function SidebarSetupStopLoss({
           label: textButtonLabel,
           hidden: isFirstSetup && !isAwaitingConfirmation,
           action: () => {
-            if (isAwaitingConfirmation) {
-              dispatch({
-                type: 'is-awaiting-confirmation',
-                isAwaitingConfirmation: false,
-              })
-            } else {
-              textButtonHandler()
-            }
+            if (isAwaitingConfirmation) updateStopLossState('isAwaitingConfirmation', false)
+            else textButtonHandler()
           },
         },
       }),

--- a/features/automation/protection/stopLoss/state/stopLossTxHandlers.ts
+++ b/features/automation/protection/stopLoss/state/stopLossTxHandlers.ts
@@ -33,7 +33,7 @@ export function getStopLossTxHandlers({
 }: GetStopLossTxHandlersParams): StopLossTxHandlers {
   const {
     reducers: {
-      stopLossReducer: { dispatch },
+      stopLossReducer: { updateStopLossState },
     },
   } = useAutomationContext()
 
@@ -55,10 +55,7 @@ export function getStopLossTxHandlers({
 
   function textButtonHandlerExtension() {
     if (isAddForm) {
-      dispatch({
-        type: 'stop-loss-level',
-        stopLossLevel: zero,
-      })
+      updateStopLossState('stopLossLevel', zero)
     }
   }
 

--- a/features/automation/protection/stopLoss/state/useStopLossReducer.ts
+++ b/features/automation/protection/stopLoss/state/useStopLossReducer.ts
@@ -72,12 +72,7 @@ export function useStopLossReducer({
     })
   }, [triggerId.toNumber(), positionRatio.toNumber()])
   useEffect(() => {
-    dispatch({
-      type: 'partial-update',
-      state: {
-        txDetails: {},
-      },
-    })
+    dispatch({ type: 'tx-details', txDetails: {} })
   }, [positionRatio.toNumber()])
 
   return {

--- a/helpers/useStateReducer.ts
+++ b/helpers/useStateReducer.ts
@@ -22,13 +22,7 @@ export function useStateReducer<S, R>({
   }
 
   function updateState<K extends keyof S, V extends S[K]>(key: K, value: V) {
-    dispatch({
-      type: 'partial-update',
-      state: {
-        ...state,
-        [key]: value,
-      },
-    })
+    dispatch({ type: 'partial-update', state: { ...state, [key]: value } })
   }
 
   const [state, dispatch] = useReducer(combinedReducer, defaults)

--- a/helpers/useStateReducer.ts
+++ b/helpers/useStateReducer.ts
@@ -1,0 +1,37 @@
+import { Reducer, useReducer } from 'react'
+
+interface UpdateAnyAction<S> {
+  type: 'partial-update'
+  state: Partial<S>
+}
+export type StateReducerActions<S, A> = UpdateAnyAction<S> | A
+
+interface StateReducerProps<S, R> {
+  defaults: S
+  reducer: Reducer<S, R>
+}
+
+export function useStateReducer<S, R>({
+  defaults,
+  reducer,
+}: StateReducerProps<S, R | UpdateAnyAction<S>>) {
+  function combinedReducer(state: S, action: R | UpdateAnyAction<S>) {
+    return 'type' in action && action.type === 'partial-update'
+      ? { ...state, ...action.state }
+      : reducer(state, action)
+  }
+
+  function updateState<K extends keyof S, V extends S[K]>(key: K, value: V) {
+    dispatch({
+      type: 'partial-update',
+      state: {
+        ...state,
+        [key]: value,
+      },
+    })
+  }
+
+  const [state, dispatch] = useReducer(combinedReducer, defaults)
+
+  return { dispatch, state, updateState }
+}


### PR DESCRIPTION
# Include `useStateReducer` to `useStopLossReducer`

Extracted best parts from [use-state-reducer](https://github.com/OasisDEX/oasis-borrow/tree/pk/use-state-reducer) branch to [auto-ui-changes-to-use-reducer-switch](https://github.com/OasisDEX/oasis-borrow/tree/sp/auto-ui-changes-to-use-reducer-switch). 
  
## Changes 👷‍♀️

- Added `useStateReducer` hook as parent to to `useStopLossReducer` and to be used in all feature state reducers,
- fixed type errors.
  
## How to test 🧪

See if Stop-loss is still working.
