### PR TITLE
Rename to ⚡ `Reducto`

### DIFF
--- a/features/automation/protection/stopLoss/state/useStopLossReducer.ts
+++ b/features/automation/protection/stopLoss/state/useStopLossReducer.ts
@@ -6,7 +6,7 @@ import {
 } from 'features/automation/common/state/automationFeatureChange'
 import { StopLossMetadata } from 'features/automation/metadata/types'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
-import { StateReducerActions, useStateReducer } from 'helpers/useStateReducer'
+import { ReductoActions, useReducto } from 'helpers/useStateReducer'
 import { useEffect } from 'react'
 
 export type StopLossResetData = Pick<
@@ -31,7 +31,7 @@ interface StopLosssActionTxDetails {
   txDetails: AutomationTxDetails
 }
 
-export type StopLossAction = StateReducerActions<StopLossState, StopLosssActionTxDetails>
+export type StopLossAction = ReductoActions<StopLossState, StopLosssActionTxDetails>
 
 function stopLossReducer(state: StopLossState, action: StopLossAction) {
   switch (action.type) {
@@ -49,7 +49,7 @@ export function useStopLossReducer({
   positionRatio,
   stopLossTriggerData: { isToCollateral, triggerId },
 }: StopLossReducerProps) {
-  const { dispatch, state, updateState } = useStateReducer<StopLossState, StopLossAction>({
+  const { dispatch, state, updateState } = useReducto<StopLossState, StopLossAction>({
     defaults: {
       stopLossLevel: initialSlRatioWhenTriggerDoesntExist,
       collateralActive: isToCollateral,

--- a/helpers/useStateReducer.ts
+++ b/helpers/useStateReducer.ts
@@ -1,21 +1,21 @@
 import { Reducer, useReducer } from 'react'
 
-interface UpdateAnyAction<S> {
+interface PartialUpdateAction<S> {
   type: 'partial-update'
   state: Partial<S>
 }
-export type StateReducerActions<S, A> = UpdateAnyAction<S> | A
+export type ReductoActions<S, A> = PartialUpdateAction<S> | A
 
-interface StateReducerProps<S, R> {
+interface ReductoProps<S, R> {
   defaults: S
   reducer: Reducer<S, R>
 }
 
-export function useStateReducer<S, R>({
+export function useReducto<S, R>({
   defaults,
   reducer,
-}: StateReducerProps<S, R | UpdateAnyAction<S>>) {
-  function combinedReducer(state: S, action: R | UpdateAnyAction<S>) {
+}: ReductoProps<S, R | PartialUpdateAction<S>>) {
+  function combinedReducer(state: S, action: R | PartialUpdateAction<S>) {
     return 'type' in action && action.type === 'partial-update'
       ? { ...state, ...action.state }
       : reducer(state, action)

--- a/helpers/useStateReducer.ts
+++ b/helpers/useStateReducer.ts
@@ -1,10 +1,10 @@
 import { Reducer, useReducer } from 'react'
 
-interface PartialUpdateAction<S> {
+interface ReductoPartialUpdateAction<S> {
   type: 'partial-update'
   state: Partial<S>
 }
-export type ReductoActions<S, A> = PartialUpdateAction<S> | A
+export type ReductoActions<S, A> = ReductoPartialUpdateAction<S> | A
 
 interface ReductoProps<S, R> {
   defaults: S
@@ -14,8 +14,8 @@ interface ReductoProps<S, R> {
 export function useReducto<S, R>({
   defaults,
   reducer,
-}: ReductoProps<S, R | PartialUpdateAction<S>>) {
-  function combinedReducer(state: S, action: R | PartialUpdateAction<S>) {
+}: ReductoProps<S, R | ReductoPartialUpdateAction<S>>) {
+  function combinedReducer(state: S, action: R | ReductoPartialUpdateAction<S>) {
     return 'type' in action && action.type === 'partial-update'
       ? { ...state, ...action.state }
       : reducer(state, action)


### PR DESCRIPTION
# Rename to ⚡  `Reducto`

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/iOVri1dITGg/0.jpg)](https://www.youtube.com/watch?v=iOVri1dITGg&t=72s)
  
## Changes 👷‍♀️

Changed old and boring name `useStateReducer` to new, fancy, sexy and shiny `useReducto`.
