### PR TITLE
Fixed after col ratio below trigger ratio

### DIFF
--- a/features/borrow/manage/pipes/viewStateTransforms/manageVaultConditions.ts
+++ b/features/borrow/manage/pipes/viewStateTransforms/manageVaultConditions.ts
@@ -303,6 +303,7 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
     paybackAmount,
     afterCollateralizationRatio,
     afterCollateralizationRatioAtNextPrice,
+    collateralizationRatioAtNextPrice,
     ilkData: {
       liquidationRatio,
       collateralizationDangerThreshold,
@@ -523,6 +524,7 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioBelowStopLossRatio =
     !!stopLossData?.isStopLossEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: stopLossData.stopLossLevel,
@@ -533,6 +535,7 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioBelowAutoSellRatio =
     !!autoSellData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoSellData.execCollRatio.div(100),
@@ -542,6 +545,7 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioAboveAutoBuyRatio =
     !!autoBuyData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoBuyData.execCollRatio.div(100),
@@ -551,6 +555,7 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioBelowConstantMultipleSellRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.sellExecutionCollRatio.div(100),
@@ -560,6 +565,7 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioAboveConstantMultipleBuyRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.buyExecutionCollRatio.div(100),

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -433,18 +433,27 @@ export function daiAllowanceProgressionDisabledValidator({
 }
 
 export function afterCollRatioThresholdRatioValidator({
+  collateralizationRatioAtNextPrice,
   afterCollateralizationRatio,
   afterCollateralizationRatioAtNextPrice,
   threshold,
   margin = new BigNumber(0.02),
   type,
 }: {
+  collateralizationRatioAtNextPrice: BigNumber
   afterCollateralizationRatio: BigNumber
   afterCollateralizationRatioAtNextPrice: BigNumber
   threshold: BigNumber
   margin?: BigNumber
   type: 'below' | 'above'
 }) {
+  if (
+    afterCollateralizationRatioAtNextPrice.gt(collateralizationRatioAtNextPrice) &&
+    type === 'below'
+  ) {
+    return false
+  }
+
   if (afterCollateralizationRatio.isZero() || afterCollateralizationRatioAtNextPrice.isZero()) {
     return false
   }

--- a/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
@@ -320,6 +320,7 @@ export const defaultManageMultiplyVaultConditions: ManageVaultConditions = {
 
 export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(state: VS): VS {
   const {
+    collateralizationRatioAtNextPrice,
     afterCollateralizationRatio,
     afterCollateralizationRatioAtNextPrice,
     afterDebt,
@@ -593,6 +594,7 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioBelowStopLossRatio =
     !!stopLossData?.isStopLossEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: stopLossData.stopLossLevel,
@@ -603,6 +605,7 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioBelowAutoSellRatio =
     !!autoSellData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoSellData.execCollRatio.div(100),
@@ -612,6 +615,7 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioAboveAutoBuyRatio =
     !!autoBuyData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoBuyData.execCollRatio.div(100),
@@ -621,6 +625,7 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioBelowConstantMultipleSellRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.sellExecutionCollRatio.div(100),
@@ -630,6 +635,7 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioAboveConstantMultipleBuyRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
+      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.buyExecutionCollRatio.div(100),


### PR DESCRIPTION
# [Fixed after col ratio below trigger ratio](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed after col ratio below trigger ratio validation
  
## How to test 🧪
  <Please explain how to test your changes>

- if SL is enabled and current col ratio is close to SL ratio error shouldn't be visible when user try to deposit (basically when `afterCollateralizationRatioAtNextPrice` is greater than `collateralizationRatioAtNextPrice` error shouldn't be displayed)
