### PR TITLE
[UI] AAVE Multiply adjusting UI

### DIFF
--- a/components/vault/VaultActionInput.tsx
+++ b/components/vault/VaultActionInput.tsx
@@ -9,7 +9,7 @@ import React, { ChangeEvent, useState } from 'react'
 import { createNumberMask } from 'text-mask-addons'
 import { Box, Grid, Text } from 'theme-ui'
 
-export type VaultAction = 'Deposit' | 'Withdraw' | 'Generate' | 'Payback' | 'Sell' | 'Buy'
+export type VaultAction = 'Deposit' | 'Withdraw' | 'Generate' | 'Payback' | 'Sell' | 'Buy' | 'Enter'
 const FIAT_PRECISION = 2
 
 export const PlusIcon = () => (

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -32,6 +32,7 @@ import { getAvailableDPMProxy$ } from './common/services/getAvailableDPMProxy'
 import {
   getAdjustAaveParametersMachine,
   getCloseAaveParametersMachine,
+  getDepositBorrowAaveMachine,
   getOpenAaveParametersMachine,
 } from './common/services/getParametersMachines'
 import { getStrategyInfo$ } from './common/services/getStrategyInfo'
@@ -150,6 +151,7 @@ export function setupAaveContext({
   const openAaveParameters = getOpenAaveParametersMachine(txHelpers$, gasEstimation$)
   const closeAaveParameters = getCloseAaveParametersMachine(txHelpers$, gasEstimation$)
   const adjustAaveParameters = getAdjustAaveParametersMachine(txHelpers$, gasEstimation$)
+  const depositBorrowAaveMachine = getDepositBorrowAaveMachine(txHelpers$, gasEstimation$)
 
   const commonTransactionServices = transactionContextService(context$)
 
@@ -236,6 +238,7 @@ export function setupAaveContext({
     adjustAaveParameters,
     allowanceStateMachine,
     operationExecutorTransactionMachine,
+    depositBorrowAaveMachine,
   )
 
   const getAaveReserveData$ = observe(

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -116,20 +116,23 @@ export type BaseViewProps<AaveEvent extends EventObject> = {
 }
 
 export function contextToTransactionParameters(context: BaseAaveContext): OperationExecutorTxMeta {
-  const isBorrowOrPaybackDebt = [
-    ManageDebtActionsEnum.BORROW_DEBT,
-    ManageDebtActionsEnum.PAYBACK_DEBT,
-  ].includes(context.manageTokenInput!.manageTokenAction as ManageDebtActionsEnum)
+  const isBorrowOrPaybackDebt = context.manageTokenInput
+    ? [ManageDebtActionsEnum.BORROW_DEBT, ManageDebtActionsEnum.PAYBACK_DEBT].includes(
+        context.manageTokenInput.manageTokenAction as ManageDebtActionsEnum,
+      )
+    : false
   const isAmountFromUserInputNeeded = (context.transactionToken || context.tokens.deposit) === 'ETH'
+
   return {
     kind: TxMetaKind.operationExecutor,
     calls: context.strategy!.transaction.calls as any,
     operationName: context.strategy!.transaction.operationName,
     token: isBorrowOrPaybackDebt ? context.tokens.debt : context.tokens.deposit,
     proxyAddress: context.effectiveProxyAddress!,
-    amount: isAmountFromUserInputNeeded
-      ? context.userInput.amount || context.manageTokenInput?.manageTokenActionValue
-      : zero,
+    amount:
+      isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
+        ? context.userInput.amount || context.manageTokenInput?.manageTokenActionValue
+        : zero,
   }
 }
 

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -15,6 +15,7 @@ import {
 import { TransactionStateMachineResultEvents } from '../../stateMachines/transaction'
 import { TransactionParametersStateMachineResponseEvent } from '../../stateMachines/transactionParameters'
 import { UserSettingsState } from '../../userSettings/userSettings'
+import { getTxTokenAndAmount } from '../helpers/getTxTokenAndAmount'
 import { AaveProtocolData } from '../manage/services'
 import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from '../strategyConfig'
 
@@ -116,24 +117,18 @@ export type BaseViewProps<AaveEvent extends EventObject> = {
 }
 
 export function contextToTransactionParameters(context: BaseAaveContext): OperationExecutorTxMeta {
-  const isBorrowOrPaybackDebt = context.manageTokenInput
-    ? [ManageDebtActionsEnum.BORROW_DEBT, ManageDebtActionsEnum.PAYBACK_DEBT].includes(
-        context.manageTokenInput.manageTokenAction as ManageDebtActionsEnum,
-      )
-    : false
-  const isAmountFromUserInputNeeded = (context.transactionToken || context.tokens.deposit) === 'ETH'
-
-  return {
+  const { token, amount } = getTxTokenAndAmount(context)
+  const txParams = {
     kind: TxMetaKind.operationExecutor,
     calls: context.strategy!.transaction.calls as any,
     operationName: context.strategy!.transaction.operationName,
-    token: isBorrowOrPaybackDebt ? context.tokens.debt : context.tokens.deposit,
     proxyAddress: context.effectiveProxyAddress!,
-    amount:
-      isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
-        ? context.userInput.amount || context.manageTokenInput?.manageTokenActionValue
-        : zero,
+    token,
+    amount,
   }
+  console.log('txParams', txParams)
+
+  return txParams
 }
 
 function allowanceForToken(

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -118,7 +118,7 @@ export type BaseViewProps<AaveEvent extends EventObject> = {
 
 export function contextToTransactionParameters(context: BaseAaveContext): OperationExecutorTxMeta {
   const { token, amount } = getTxTokenAndAmount(context)
-  const txParams = {
+  return {
     kind: TxMetaKind.operationExecutor,
     calls: context.strategy!.transaction.calls as any,
     operationName: context.strategy!.transaction.operationName,
@@ -126,9 +126,6 @@ export function contextToTransactionParameters(context: BaseAaveContext): Operat
     token,
     amount,
   }
-  console.log('txParams', txParams)
-
-  return txParams
 }
 
 function allowanceForToken(

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -158,8 +158,6 @@ export function isAllowanceNeeded(context: BaseAaveContext): boolean {
     context.manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.PAYBACK_DEBT ||
     (context.userInput.amount || zero).gt(zero)
 
-  console.log(`isDepositingAction: ${isDepositingAction}`)
-
   return (
     isDepositingAction &&
     (context.userInput.amount || context.manageTokenInput?.manageTokenActionValue || zero).gt(

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -23,8 +23,8 @@ type UserInput = {
   amount?: BigNumber
 }
 export type ManageTokenInput = {
-  manageTokenAction?: ManageDebtActionsEnum | ManageCollateralActionsEnum | undefined
-  manageTokenActionValue?: BigNumber | undefined
+  manageTokenAction?: ManageDebtActionsEnum | ManageCollateralActionsEnum
+  manageTokenActionValue?: BigNumber
 }
 
 export type IStrategyInfo = {

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -16,10 +16,16 @@ import { TransactionStateMachineResultEvents } from '../../stateMachines/transac
 import { TransactionParametersStateMachineResponseEvent } from '../../stateMachines/transactionParameters'
 import { UserSettingsState } from '../../userSettings/userSettings'
 import { AaveProtocolData } from '../manage/services'
+import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from '../strategyConfig'
 
 type UserInput = {
   riskRatio?: IRiskRatio
   amount?: BigNumber
+}
+type ManageTokenInput = {
+  manageCollateralAction?: ManageCollateralActionsEnum
+  manageDebtAction?: ManageDebtActionsEnum
+  manageTokenActionValue?: BigNumber
 }
 
 export type IStrategyInfo = {
@@ -28,15 +34,34 @@ export type IStrategyInfo = {
   collateralToken: string
 }
 
+export type UpdateCollateralActionType = {
+  type: 'UPDATE_COLLATERAL_TOKEN_ACTION'
+  manageTokenAction: ManageTokenInput['manageCollateralAction']
+}
+
+export type UpdateDebtActionType = {
+  type: 'UPDATE_DEBT_TOKEN_ACTION'
+  manageTokenAction: ManageTokenInput['manageDebtAction']
+}
+
+export type UpdateTokenActionValueType = {
+  type: 'UPDATE_TOKEN_ACTION_VALUE'
+  manageTokenActionValue: ManageTokenInput['manageTokenActionValue']
+}
+
 export type BaseAaveEvent =
   | { type: 'PRICES_RECEIVED'; collateralPrice: BigNumber; debtPrice: BigNumber }
   | { type: 'USER_SETTINGS_CHANGED'; userSettings: UserSettingsState }
   | { type: 'WEB3_CONTEXT_CHANGED'; web3Context: Context }
   | { type: 'RESET_RISK_RATIO' }
+  | { type: 'CLOSE_POSITION' }
   | { type: 'CONNECTED_PROXY_ADDRESS_RECEIVED'; connectedProxyAddress: string | undefined }
   | { type: 'DMP_PROXY_RECEIVED'; userDpmProxy: UserDpmProxy }
   | { type: 'SET_BALANCE'; tokenBalance: BigNumber; tokenPrice: BigNumber }
   | { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
+  | UpdateCollateralActionType
+  | UpdateDebtActionType
+  | UpdateTokenActionValueType
   | { type: 'UPDATE_STRATEGY_INFO'; strategyInfo: IStrategyInfo }
   | { type: 'UPDATE_PROTOCOL_DATA'; protocolData: AaveProtocolData }
   | { type: 'UPDATE_ALLOWANCE'; tokenAllowance: BigNumber }
@@ -46,6 +71,7 @@ export type BaseAaveEvent =
 
 export interface BaseAaveContext {
   userInput: UserInput
+  manageTokenInput?: ManageTokenInput
   tokens: {
     collateral: string
     debt: string

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -33,6 +33,12 @@ export type IStrategyInfo = {
   collateralToken: string
 }
 
+export type StrategyTokenAllowance = {
+  collateral: BigNumber
+  debt: BigNumber
+  deposit: BigNumber
+}
+
 export type UpdateCollateralActionType = {
   type: 'UPDATE_COLLATERAL_TOKEN_ACTION'
   manageTokenAction: ManageCollateralActionsEnum
@@ -63,7 +69,7 @@ export type BaseAaveEvent =
   | UpdateTokenActionValueType
   | { type: 'UPDATE_STRATEGY_INFO'; strategyInfo: IStrategyInfo }
   | { type: 'UPDATE_PROTOCOL_DATA'; protocolData: AaveProtocolData }
-  | { type: 'UPDATE_ALLOWANCE'; tokenAllowance: BigNumber }
+  | { type: 'UPDATE_ALLOWANCE'; allowance: StrategyTokenAllowance }
   | TransactionParametersStateMachineResponseEvent
   | TransactionStateMachineResultEvents
   | AllowanceStateMachineResponseEvent
@@ -84,7 +90,7 @@ export interface BaseAaveContext {
   strategy?: IPositionTransition
   estimatedGasPrice?: HasGasEstimation
   tokenBalance?: BigNumber
-  tokenAllowance?: BigNumber
+  allowance?: StrategyTokenAllowance
   tokenPrice?: BigNumber
   collateralPrice?: BigNumber
   debtPrice?: BigNumber
@@ -124,5 +130,5 @@ export function isAllowanceNeeded(context: BaseAaveContext): boolean {
     return false
   }
 
-  return (context.userInput.amount || zero).gt(context.tokenAllowance || zero)
+  return (context.userInput.amount || zero).gt(context.allowance?.deposit || zero)
 }

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -152,7 +152,18 @@ export function isAllowanceNeeded(context: BaseAaveContext): boolean {
 
   const allowance = allowanceForToken(token, context)
 
-  return (context.userInput.amount || context.manageTokenInput?.manageTokenActionValue || zero).gt(
-    allowance || zero,
+  const isDepositingAction =
+    context.manageTokenInput?.manageTokenAction ===
+      ManageCollateralActionsEnum.DEPOSIT_COLLATERAL ||
+    context.manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.PAYBACK_DEBT ||
+    (context.userInput.amount || zero).gt(zero)
+
+  console.log(`isDepositingAction: ${isDepositingAction}`)
+
+  return (
+    isDepositingAction &&
+    (context.userInput.amount || context.manageTokenInput?.manageTokenActionValue || zero).gt(
+      allowance || zero,
+    )
   )
 }

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -22,9 +22,8 @@ type UserInput = {
   riskRatio?: IRiskRatio
   amount?: BigNumber
 }
-type ManageTokenInput = {
-  manageCollateralAction?: ManageCollateralActionsEnum
-  manageDebtAction?: ManageDebtActionsEnum
+export type ManageTokenInput = {
+  manageTokenAction?: ManageDebtActionsEnum | ManageCollateralActionsEnum
   manageTokenActionValue?: BigNumber
 }
 
@@ -36,12 +35,12 @@ export type IStrategyInfo = {
 
 export type UpdateCollateralActionType = {
   type: 'UPDATE_COLLATERAL_TOKEN_ACTION'
-  manageTokenAction: ManageTokenInput['manageCollateralAction']
+  manageTokenAction: ManageCollateralActionsEnum
 }
 
 export type UpdateDebtActionType = {
   type: 'UPDATE_DEBT_TOKEN_ACTION'
-  manageTokenAction: ManageTokenInput['manageDebtAction']
+  manageTokenAction: ManageDebtActionsEnum
 }
 
 export type UpdateTokenActionValueType = {

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -1,6 +1,8 @@
 import { IPosition, IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
 import { BigNumber } from 'bignumber.js'
+import { SidebarSectionHeaderDropdown } from 'components/sidebar/SidebarSectionHeader'
 import { WithArrow } from 'components/WithArrow'
+import { ManageAaveEvent } from 'features/aave/manage/state'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Flex, Grid, Link, Text } from 'theme-ui'
@@ -16,7 +18,11 @@ import { getLiquidationPriceAccountingForPrecision } from '../../../shared/liqui
 import { BaseViewProps } from '../BaseAaveContext'
 import { StrategyInformationContainer } from './informationContainer'
 
-type RaisedEvents = { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio } | { type: 'RESET_RISK_RATIO' }
+type RaisedEvents =
+  | { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
+  | ({
+      type: 'RESET_RISK_RATIO'
+    } & ManageAaveEvent)
 
 export type AdjustRiskViewProps = BaseViewProps<RaisedEvents> & {
   primaryButton: SidebarSectionFooterButtonSettings
@@ -24,6 +30,7 @@ export type AdjustRiskViewProps = BaseViewProps<RaisedEvents> & {
   viewLocked?: boolean // locks whole view
   showWarring?: boolean // displays warning
   onChainPosition?: IPosition
+  dropdownConfig?: SidebarSectionHeaderDropdown
   title: string
 }
 
@@ -75,6 +82,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
     viewLocked = false,
     showWarring = false,
     onChainPosition,
+    dropdownConfig,
     title,
   }: AdjustRiskViewProps) {
     const { t } = useTranslation()
@@ -246,6 +254,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
         disabled: viewLocked || primaryButton.disabled || !state.context.strategy,
       },
       textButton, // this is going back button, no need to block it
+      dropdown: dropdownConfig,
     }
 
     return <SidebarSection {...sidebarSectionProps} />

--- a/features/aave/common/components/informationContainer/FeesInformation.tsx
+++ b/features/aave/common/components/informationContainer/FeesInformation.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Swap } from '@oasisdex/oasis-actions'
 import { Box, Flex, Grid, Text } from '@theme-ui/components'
+import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -21,6 +22,13 @@ interface FeesInformationProps {
 export function FeesInformation({ estimatedGasPrice, swap }: FeesInformationProps) {
   const { t } = useTranslation()
   const [showBreakdown, setShowBreakdown] = React.useState(false)
+  if (
+    !allDefined(swap.tokenFee, swap.collectFeeFrom, swap[swap.collectFeeFrom].symbol) ||
+    swap[swap.collectFeeFrom].symbol === ''
+  ) {
+    return null
+  }
+
   const oasisFeeDisplayInDebtToken = formatAmount(
     amountFromWei(swap.tokenFee, swap[swap.collectFeeFrom].symbol),
     swap[swap.collectFeeFrom].symbol,

--- a/features/aave/common/components/informationContainer/FeesInformation.tsx
+++ b/features/aave/common/components/informationContainer/FeesInformation.tsx
@@ -1,7 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Swap } from '@oasisdex/oasis-actions'
 import { Box, Flex, Grid, Text } from '@theme-ui/components'
-import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -22,12 +21,6 @@ interface FeesInformationProps {
 export function FeesInformation({ estimatedGasPrice, swap }: FeesInformationProps) {
   const { t } = useTranslation()
   const [showBreakdown, setShowBreakdown] = React.useState(false)
-  if (
-    !allDefined(swap.tokenFee, swap.collectFeeFrom, swap[swap.collectFeeFrom].symbol) ||
-    swap[swap.collectFeeFrom].symbol === ''
-  ) {
-    return null
-  }
 
   const oasisFeeDisplayInDebtToken = formatAmount(
     amountFromWei(swap.tokenFee, swap[swap.collectFeeFrom].symbol),

--- a/features/aave/common/components/informationContainer/PriceImpact.tsx
+++ b/features/aave/common/components/informationContainer/PriceImpact.tsx
@@ -2,13 +2,12 @@ import { IPositionTransition } from '@oasisdex/oasis-actions'
 import { amountFromWei } from '@oasisdex/utils'
 import { Text } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
-import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 import { VaultChangesInformationItem } from '../../../../../components/vault/VaultChangesInformation'
 import { formatCryptoBalance, formatPercent } from '../../../../../helpers/formatters/format'
-import { one } from '../../../../../helpers/zero'
+import { one, zero } from '../../../../../helpers/zero'
 import { calculatePriceImpact } from '../../../../shared/priceImpact'
 
 interface PriceImpactProps {
@@ -36,20 +35,19 @@ export function PriceImpact({
     sourceToken,
   } = transactionParameters.simulation.swap
 
-  let swapPrice
-  if (!allDefined(toTokenAmount, fromTokenAmount) || !transactionParameters.simulation.swap) {
+  console.log('swap', transactionParameters.simulation.swap)
+  if (fromTokenAmount.eq(zero) || toTokenAmount.eq(zero)) {
     return <></>
   }
 
-  if (sourceToken.symbol === tokens.collateral) {
-    swapPrice = amountFromWei(toTokenAmount, targetToken.precision).div(
-      amountFromWei(fromTokenAmount, sourceToken.precision),
-    )
-  } else {
-    swapPrice = amountFromWei(fromTokenAmount, sourceToken.precision).div(
-      amountFromWei(toTokenAmount, targetToken.precision),
-    )
-  }
+  const swapPrice =
+    sourceToken.symbol === tokens.collateral
+      ? amountFromWei(toTokenAmount, targetToken.precision).div(
+          amountFromWei(fromTokenAmount, sourceToken.precision),
+        )
+      : amountFromWei(fromTokenAmount, sourceToken.precision).div(
+          amountFromWei(toTokenAmount, targetToken.precision),
+        )
 
   const marketPrice = collateralPrice?.div(debtPrice || one) || one
 

--- a/features/aave/common/components/informationContainer/PriceImpact.tsx
+++ b/features/aave/common/components/informationContainer/PriceImpact.tsx
@@ -35,7 +35,6 @@ export function PriceImpact({
     sourceToken,
   } = transactionParameters.simulation.swap
 
-  console.log('swap', transactionParameters.simulation.swap)
   if (fromTokenAmount.eq(zero) || toTokenAmount.eq(zero)) {
     return <></>
   }

--- a/features/aave/common/components/informationContainer/PriceImpact.tsx
+++ b/features/aave/common/components/informationContainer/PriceImpact.tsx
@@ -2,6 +2,7 @@ import { IPositionTransition } from '@oasisdex/oasis-actions'
 import { amountFromWei } from '@oasisdex/utils'
 import { Text } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
+import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -36,6 +37,9 @@ export function PriceImpact({
   } = transactionParameters.simulation.swap
 
   let swapPrice
+  if (!allDefined(toTokenAmount, fromTokenAmount) || !transactionParameters.simulation.swap) {
+    return <></>
+  }
 
   if (sourceToken.symbol === tokens.collateral) {
     swapPrice = amountFromWei(toTokenAmount, targetToken.precision).div(

--- a/features/aave/common/components/informationContainer/TransactionTokenAmount.tsx
+++ b/features/aave/common/components/informationContainer/TransactionTokenAmount.tsx
@@ -8,6 +8,7 @@ import { amountFromWei } from '../../../../../blockchain/utils'
 import { VaultChangesInformationItem } from '../../../../../components/vault/VaultChangesInformation'
 import { AppSpinner } from '../../../../../helpers/AppSpinner'
 import { formatAmount, formatFiatBalance } from '../../../../../helpers/formatters/format'
+import { zero } from '../../../../../helpers/zero'
 
 interface BuyingTokenAmountProps {
   transactionParameters: IPositionTransition
@@ -21,6 +22,10 @@ export function TransactionTokenAmount({
   collateralPrice,
 }: BuyingTokenAmountProps) {
   const { t } = useTranslation()
+
+  if (transactionParameters.simulation.swap.toTokenAmount.lte(zero)) {
+    return <></>
+  }
   const isBuyingCollateral =
     transactionParameters.simulation.swap.targetToken.symbol === tokens.collateral
 

--- a/features/aave/common/components/informationContainer/TransactionTokenAmount.tsx
+++ b/features/aave/common/components/informationContainer/TransactionTokenAmount.tsx
@@ -1,6 +1,7 @@
 import { IPositionTransition } from '@oasisdex/oasis-actions'
 import { Flex, Text } from '@theme-ui/components'
 import BigNumber from 'bignumber.js'
+import { allDefined } from 'helpers/allDefined'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -23,15 +24,15 @@ export function TransactionTokenAmount({
 }: BuyingTokenAmountProps) {
   const { t } = useTranslation()
 
-  if (transactionParameters.simulation.swap.toTokenAmount.lte(zero)) {
+  const { toTokenAmount, fromTokenAmount, targetToken } = transactionParameters.simulation.swap
+
+  if (!allDefined(toTokenAmount, fromTokenAmount) || toTokenAmount?.lte(zero)) {
     return <></>
   }
-  const isBuyingCollateral =
-    transactionParameters.simulation.swap.targetToken.symbol === tokens.collateral
+  const isBuyingCollateral = targetToken.symbol === tokens.collateral
 
-  const collateralMovement = isBuyingCollateral
-    ? transactionParameters.simulation.swap.toTokenAmount
-    : transactionParameters.simulation.swap.fromTokenAmount
+  const collateralMovement = isBuyingCollateral ? toTokenAmount : fromTokenAmount
+
   const amount = amountFromWei(collateralMovement, tokens.collateral)
 
   const labelKey = isBuyingCollateral ? 'vault-changes.buying-token' : 'vault-changes.selling-token'

--- a/features/aave/common/services/getParametersMachines.ts
+++ b/features/aave/common/services/getParametersMachines.ts
@@ -6,8 +6,10 @@ import { createTransactionParametersStateMachine } from '../../../stateMachines/
 import {
   AdjustAaveParameters,
   CloseAaveParameters,
+  DepositBorrowAaveParameters,
   getAdjustAaveParameters,
   getCloseAaveParameters,
+  getDepositBorrowAaveParameters,
   getOpenAaveParameters,
   OpenAaveParameters,
 } from '../../oasisActionsLibWrapper'
@@ -42,5 +44,16 @@ export function getAdjustAaveParametersMachine(
     txHelpers$,
     gasPriceEstimation$,
     (parameters: AdjustAaveParameters) => getAdjustAaveParameters(parameters),
+  )
+}
+
+export function getDepositBorrowAaveMachine(
+  txHelpers$: Observable<TxHelpers>,
+  gasPriceEstimation$: (gas: number) => Observable<HasGasEstimation>,
+) {
+  return createTransactionParametersStateMachine(
+    txHelpers$,
+    gasPriceEstimation$,
+    (parameters: DepositBorrowAaveParameters) => getDepositBorrowAaveParameters(parameters),
   )
 }

--- a/features/aave/common/services/getParametersMachines.ts
+++ b/features/aave/common/services/getParametersMachines.ts
@@ -6,11 +6,11 @@ import { createTransactionParametersStateMachine } from '../../../stateMachines/
 import {
   AdjustAaveParameters,
   CloseAaveParameters,
-  DepositBorrowAaveParameters,
   getAdjustAaveParameters,
   getCloseAaveParameters,
-  getDepositBorrowAaveParameters,
+  getManageAaveParameters,
   getOpenAaveParameters,
+  ManageAaveParameters,
   OpenAaveParameters,
 } from '../../oasisActionsLibWrapper'
 
@@ -54,6 +54,6 @@ export function getDepositBorrowAaveMachine(
   return createTransactionParametersStateMachine(
     txHelpers$,
     gasPriceEstimation$,
-    (parameters: DepositBorrowAaveParameters) => getDepositBorrowAaveParameters(parameters),
+    (parameters: ManageAaveParameters) => getManageAaveParameters(parameters),
   )
 }

--- a/features/aave/helpers/getTxTokenAndAmount.ts
+++ b/features/aave/helpers/getTxTokenAndAmount.ts
@@ -1,0 +1,21 @@
+import { zero } from 'helpers/zero'
+
+import { BaseAaveContext } from '../common/BaseAaveContext'
+import { ManageDebtActionsEnum } from '../strategyConfig'
+
+export function getTxTokenAndAmount(context: BaseAaveContext) {
+  const isBorrowOrPaybackDebt = context.manageTokenInput
+    ? [ManageDebtActionsEnum.BORROW_DEBT, ManageDebtActionsEnum.PAYBACK_DEBT].includes(
+        context.manageTokenInput.manageTokenAction as ManageDebtActionsEnum,
+      )
+    : false
+  const isAmountFromUserInputNeeded = (context.transactionToken || context.tokens.deposit) === 'ETH'
+
+  return {
+    amount:
+      isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
+        ? context.userInput.amount! || context.manageTokenInput?.manageTokenActionValue
+        : zero,
+    token: isBorrowOrPaybackDebt ? context.tokens.debt : context.tokens.collateral,
+  }
+}

--- a/features/aave/helpers/getTxTokenAndAmount.ts
+++ b/features/aave/helpers/getTxTokenAndAmount.ts
@@ -2,21 +2,25 @@ import BigNumber from 'bignumber.js'
 import { zero } from 'helpers/zero'
 
 import { BaseAaveContext } from '../common/BaseAaveContext'
-import { ManageDebtActionsEnum } from '../strategyConfig'
+import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from '../strategyConfig'
 
 export function getTxTokenAndAmount(context: BaseAaveContext) {
+  const isDepositingAction =
+    context.manageTokenInput?.manageTokenAction ===
+      ManageCollateralActionsEnum.DEPOSIT_COLLATERAL ||
+    context.manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.PAYBACK_DEBT
+
   const isBorrowOrPaybackDebt = context.manageTokenInput
     ? [ManageDebtActionsEnum.BORROW_DEBT, ManageDebtActionsEnum.PAYBACK_DEBT].includes(
         context.manageTokenInput.manageTokenAction as ManageDebtActionsEnum,
       )
     : false
-  const isAmountFromUserInputNeeded = (context.transactionToken || context.tokens.deposit) === 'ETH'
 
-  console.log(`isAmountFromUserInputNeeded: ${isAmountFromUserInputNeeded}`)
+  const isAmountFromUserInputNeeded = (context.transactionToken || context.tokens.deposit) === 'ETH'
 
   return {
     amount:
-      isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
+      isAmountFromUserInputNeeded && isDepositingAction
         ? context.userInput.amount || context.manageTokenInput!.manageTokenActionValue
         : zero,
     token: context.userInput.amount

--- a/features/aave/helpers/getTxTokenAndAmount.ts
+++ b/features/aave/helpers/getTxTokenAndAmount.ts
@@ -14,7 +14,7 @@ export function getTxTokenAndAmount(context: BaseAaveContext) {
   return {
     amount:
       isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
-        ? context.userInput.amount! || context.manageTokenInput?.manageTokenActionValue
+        ? context.userInput.amount || context.manageTokenInput?.manageTokenActionValue
         : zero,
     token: isBorrowOrPaybackDebt ? context.tokens.debt : context.tokens.collateral,
   }

--- a/features/aave/helpers/getTxTokenAndAmount.ts
+++ b/features/aave/helpers/getTxTokenAndAmount.ts
@@ -12,12 +12,18 @@ export function getTxTokenAndAmount(context: BaseAaveContext) {
     : false
   const isAmountFromUserInputNeeded = (context.transactionToken || context.tokens.deposit) === 'ETH'
 
+  console.log(`isAmountFromUserInputNeeded: ${isAmountFromUserInputNeeded}`)
+
   return {
     amount:
       isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
         ? context.userInput.amount || context.manageTokenInput!.manageTokenActionValue
         : zero,
-    token: isBorrowOrPaybackDebt ? context.tokens.debt : context.tokens.collateral,
+    token: context.userInput.amount
+      ? context.tokens.deposit
+      : isBorrowOrPaybackDebt
+      ? context.tokens.debt
+      : context.tokens.collateral,
   } as {
     amount: BigNumber
     token: string

--- a/features/aave/helpers/getTxTokenAndAmount.ts
+++ b/features/aave/helpers/getTxTokenAndAmount.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { zero } from 'helpers/zero'
 
 import { BaseAaveContext } from '../common/BaseAaveContext'
@@ -14,8 +15,11 @@ export function getTxTokenAndAmount(context: BaseAaveContext) {
   return {
     amount:
       isAmountFromUserInputNeeded && !isBorrowOrPaybackDebt
-        ? context.userInput.amount || context.manageTokenInput?.manageTokenActionValue
+        ? context.userInput.amount || context.manageTokenInput!.manageTokenActionValue
         : zero,
     token: isBorrowOrPaybackDebt ? context.tokens.debt : context.tokens.collateral,
+  } as {
+    amount: BigNumber
+    token: string
   }
 }

--- a/features/aave/manage/containers/AaveManageStateMachineContext.tsx
+++ b/features/aave/manage/containers/AaveManageStateMachineContext.tsx
@@ -1,4 +1,5 @@
 import { useInterpret } from '@xstate/react'
+import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from 'features/aave/strategyConfig'
 import { env } from 'process'
 import React from 'react'
 
@@ -25,6 +26,12 @@ function setupManageAaveStateContext({
       totalSteps: 3,
       strategyConfig: strategy,
       userInput: {},
+      manageTokenInput: {
+        // defaults for the manage collateral/debt are set here
+        manageCollateralAction: ManageCollateralActionsEnum.DEPOSIT_COLLATERAL,
+        manageDebtAction: ManageDebtActionsEnum.BORROW_DEBT,
+        manageTokenActionValue: undefined, // just to provide any value when debugging
+      },
       positionCreatedBy: positionCreatedBy,
       positionId: positionId,
     }),

--- a/features/aave/manage/containers/AaveManageStateMachineContext.tsx
+++ b/features/aave/manage/containers/AaveManageStateMachineContext.tsx
@@ -1,11 +1,16 @@
 import { useInterpret } from '@xstate/react'
-import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from 'features/aave/strategyConfig'
 import { env } from 'process'
 import React from 'react'
 
 import { IStrategyConfig, ProxyType } from '../../common/StrategyConfigTypes'
 import { PositionId } from '../../types'
 import { ManageAaveStateMachine } from '../state'
+
+export const defaultManageTokenInputValues = {
+  // defaults for the manage collateral/debt are set here
+  manageTokenAction: undefined,
+  manageTokenActionValue: undefined, // just to provide any value when debugging
+}
 
 function setupManageAaveStateContext({
   machine,
@@ -26,12 +31,7 @@ function setupManageAaveStateContext({
       totalSteps: 3,
       strategyConfig: strategy,
       userInput: {},
-      manageTokenInput: {
-        // defaults for the manage collateral/debt are set here
-        manageCollateralAction: ManageCollateralActionsEnum.DEPOSIT_COLLATERAL,
-        manageDebtAction: ManageDebtActionsEnum.BORROW_DEBT,
-        manageTokenActionValue: undefined, // just to provide any value when debugging
-      },
+      manageTokenInput: defaultManageTokenInputValues,
       positionCreatedBy: positionCreatedBy,
       positionId: positionId,
     }),

--- a/features/aave/manage/services/getManageAavePositionStateMachineServices.ts
+++ b/features/aave/manage/services/getManageAavePositionStateMachineServices.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { isEqual } from 'lodash'
-import { Observable } from 'rxjs'
+import { combineLatest, Observable } from 'rxjs'
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators'
 
 import { Context } from '../../../../blockchain/network'
@@ -9,7 +9,7 @@ import { TokenBalances } from '../../../../blockchain/tokens'
 import { TxHelpers } from '../../../../components/AppContext'
 import { allDefined } from '../../../../helpers/allDefined'
 import { UserSettingsState } from '../../../userSettings/userSettings'
-import { IStrategyInfo } from '../../common/BaseAaveContext'
+import { IStrategyInfo, StrategyTokenAllowance } from '../../common/BaseAaveContext'
 import { getPricesFeed$ } from '../../common/services/getPricesFeed'
 import { ProxiesRelatedWithPosition } from '../../helpers/getProxiesRelatedWithPosition'
 import { PositionId } from '../../types'
@@ -117,12 +117,25 @@ export function getManageAavePositionStateMachineServices(
     },
     allowance$: (context) => {
       return proxiesRelatedWithPosition$(context.positionId).pipe(
-        switchMap((result) =>
-          tokenAllowance$(context.tokens.deposit, result.dsProxy || result.dpmProxy?.proxy!),
+        map((result) => result.dsProxy || result.dpmProxy?.proxy),
+        filter(allDefined),
+        switchMap((proxyAddress) => {
+          return combineLatest([
+            tokenAllowance$(context.tokens.deposit, proxyAddress!),
+            tokenAllowance$(context.tokens.collateral, proxyAddress!),
+            tokenAllowance$(context.tokens.debt, proxyAddress!),
+          ])
+        }),
+        map(
+          ([deposit, collateral, debt]): StrategyTokenAllowance => ({
+            collateral,
+            debt,
+            deposit,
+          }),
         ),
         map((allowance) => ({
           type: 'UPDATE_ALLOWANCE',
-          tokenAllowance: allowance,
+          allowance: allowance,
         })),
         distinctUntilChanged(isEqual),
       )

--- a/features/aave/manage/services/getManageAavePositionStateMachineServices.ts
+++ b/features/aave/manage/services/getManageAavePositionStateMachineServices.ts
@@ -121,9 +121,9 @@ export function getManageAavePositionStateMachineServices(
         filter(allDefined),
         switchMap((proxyAddress) => {
           return combineLatest([
-            tokenAllowance$(context.tokens.deposit, proxyAddress!),
-            tokenAllowance$(context.tokens.collateral, proxyAddress!),
-            tokenAllowance$(context.tokens.debt, proxyAddress!),
+            tokenAllowance$(context.tokens.deposit, proxyAddress),
+            tokenAllowance$(context.tokens.collateral, proxyAddress),
+            tokenAllowance$(context.tokens.debt, proxyAddress),
           ])
         }),
         map(

--- a/features/aave/manage/services/getManageAaveStateMachine.ts
+++ b/features/aave/manage/services/getManageAaveStateMachine.ts
@@ -6,7 +6,7 @@ import { TransactionParametersStateMachine } from '../../../stateMachines/transa
 import {
   AdjustAaveParameters,
   CloseAaveParameters,
-  DepositBorrowAaveParameters,
+  ManageAaveParameters,
 } from '../../oasisActionsLibWrapper'
 import {
   createManageAaveStateMachine,
@@ -23,7 +23,7 @@ export function getManageAaveStateMachine(
     transactionParameters: OperationExecutorTxMeta,
     transactionDef: TransactionDef<OperationExecutorTxMeta>,
   ) => TransactionStateMachine<OperationExecutorTxMeta>,
-  depositBorrowAaveMachine: TransactionParametersStateMachine<DepositBorrowAaveParameters>,
+  depositBorrowAaveMachine: TransactionParametersStateMachine<ManageAaveParameters>,
 ): ManageAaveStateMachine {
   return createManageAaveStateMachine(
     closeParametersMachine,

--- a/features/aave/manage/services/getManageAaveStateMachine.ts
+++ b/features/aave/manage/services/getManageAaveStateMachine.ts
@@ -3,7 +3,11 @@ import { OperationExecutorTxMeta } from '../../../../blockchain/calls/operationE
 import { AllowanceStateMachine } from '../../../stateMachines/allowance'
 import { TransactionStateMachine } from '../../../stateMachines/transaction'
 import { TransactionParametersStateMachine } from '../../../stateMachines/transactionParameters'
-import { AdjustAaveParameters, CloseAaveParameters } from '../../oasisActionsLibWrapper'
+import {
+  AdjustAaveParameters,
+  CloseAaveParameters,
+  DepositBorrowAaveParameters,
+} from '../../oasisActionsLibWrapper'
 import {
   createManageAaveStateMachine,
   ManageAaveStateMachine,
@@ -19,12 +23,14 @@ export function getManageAaveStateMachine(
     transactionParameters: OperationExecutorTxMeta,
     transactionDef: TransactionDef<OperationExecutorTxMeta>,
   ) => TransactionStateMachine<OperationExecutorTxMeta>,
+  depositBorrowAaveMachine: TransactionParametersStateMachine<DepositBorrowAaveParameters>,
 ): ManageAaveStateMachine {
   return createManageAaveStateMachine(
     closeParametersMachine,
     adjustParametersMachine,
     allowanceMachine,
     transactionStateMachine,
+    depositBorrowAaveMachine,
   ).withConfig({
     services: {
       ...services,

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -352,7 +352,10 @@ export function SidebarManageAaveVault() {
         panel: 'manageCollateral',
         action: () => {
           if (!state.matches('frontend.manageCollateral')) {
-            send('MANAGE_COLLATERAL')
+            send({
+              type: 'MANAGE_COLLATERAL',
+              manageTokenAction: ManageCollateralActionsEnum.DEPOSIT_COLLATERAL,
+            })
           }
         },
       },
@@ -367,7 +370,7 @@ export function SidebarManageAaveVault() {
         panel: 'manageDebt',
         action: () => {
           if (!state.matches('frontend.manageDebt')) {
-            send('MANAGE_DEBT')
+            send({ type: 'MANAGE_DEBT', manageTokenAction: ManageDebtActionsEnum.BORROW_DEBT })
           }
         },
       },

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -153,7 +153,7 @@ function GetReviewingSidebarProps({
         content: (
           <Grid gap={3}>
             <ActionPills
-              active={state.context.manageTokenInput?.manageCollateralAction!}
+              active={state.context.manageTokenInput?.manageTokenAction!}
               items={Object.values(ManageCollateralActionsEnum).map((action) => ({
                 id: action,
                 label: t(`system.actions.multiply.${action}`),
@@ -180,7 +180,7 @@ function GetReviewingSidebarProps({
         content: (
           <Grid gap={3}>
             <ActionPills
-              active={state.context.manageTokenInput?.manageDebtAction!}
+              active={state.context.manageTokenInput?.manageTokenAction!}
               items={Object.values(ManageDebtActionsEnum).map((action) => ({
                 id: action,
                 label: t(`system.actions.multiply.${action}`),

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -172,6 +172,7 @@ function GetReviewingSidebarProps({
               onChange={handleNumericInput(updateTokenActionValue)}
               hasError={false}
             />
+            <StrategyInformationContainer state={state} />
           </Grid>
         ),
       }
@@ -199,6 +200,7 @@ function GetReviewingSidebarProps({
               onChange={handleNumericInput(updateTokenActionValue)}
               hasError={false}
             />
+            <StrategyInformationContainer state={state} />
           </Grid>
         ),
       }

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@makerdao/dai-ui-icons'
-import { IPosition, IStrategy, OPERATION_NAMES } from '@oasisdex/oasis-actions'
+import { IPosition, IPositionTransition, OPERATION_NAMES } from '@oasisdex/oasis-actions'
 import { useActor } from '@xstate/react'
 import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -230,8 +230,6 @@ function ManageAaveReviewingStateView({
 
   const allowanceNeeded = isAllowanceNeeded(state.context)
 
-  console.log('allowanceNeeded', allowanceNeeded)
-
   const label = allowanceNeeded
     ? t('set-allowance-for', {
         token: state.context.transactionToken || state.context.strategyConfig.tokens.deposit,

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -113,7 +113,7 @@ function GetReviewingSidebarProps({
 }: ManageAaveStateProps): Pick<SidebarSectionProps, 'title' | 'content'> {
   const { t } = useTranslation()
   const { collateral, debt } = state.context.tokens
-  const [closeToToken, setCloseToToken] = useState(collateral)
+  const [closeToToken, setCloseToToken] = useState(debt) // only close to debt is available ATM
 
   const updateCollateralTokenAction = (manageTokenAction: ManageCollateralActionsEnum) => {
     send({ type: 'UPDATE_COLLATERAL_TOKEN_ACTION', manageTokenAction })
@@ -136,6 +136,7 @@ function GetReviewingSidebarProps({
               items={[collateral, debt].map((token) => ({
                 id: token,
                 label: t('close-to', { token }),
+                disabled: token === collateral, // only close to debt is available ATM
                 action: () => curry(setCloseToToken)(token),
               }))}
             />

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -424,12 +424,9 @@ export function createManageAaveStateMachine(
         validTransactionParameters: ({ proxyAddress, strategy }) => {
           return allDefined(proxyAddress, strategy)
         },
-        canChangePosition: ({ web3Context, ownerAddress, currentPosition }) => {
-          return (
-            allDefined(web3Context, ownerAddress, currentPosition) &&
-            web3Context!.account === ownerAddress
-          )
-        },
+        canChangePosition: ({ web3Context, ownerAddress, currentPosition }) =>
+          allDefined(web3Context, ownerAddress, currentPosition) &&
+          web3Context!.account === ownerAddress,
         isAllowanceNeeded,
       },
       actions: {
@@ -438,40 +435,39 @@ export function createManageAaveStateMachine(
             manageTokenAction: defaultManageTokenInputValues.manageTokenAction,
             manageTokenActionValue: defaultManageTokenInputValues.manageTokenActionValue,
           },
+          strategy: undefined,
         })),
-        updateCollateralTokenAction: assign(
-          (
-            { manageTokenInput },
-            { manageTokenAction = ManageCollateralActionsEnum.DEPOSIT_COLLATERAL },
-          ) => ({
-            manageTokenInput: Object.assign(manageTokenInput!, { manageTokenAction }),
-          }),
-        ),
-        updateDebtTokenAction: assign(
-          ({ manageTokenInput }, { manageTokenAction = ManageDebtActionsEnum.BORROW_DEBT }) => ({
-            manageTokenInput: Object.assign(manageTokenInput!, { manageTokenAction }),
-          }),
-        ),
+        updateCollateralTokenAction: assign(({ manageTokenInput }, { manageTokenAction }) => ({
+          manageTokenInput: {
+            ...manageTokenInput!,
+            manageTokenAction: manageTokenAction || ManageCollateralActionsEnum.DEPOSIT_COLLATERAL,
+          },
+        })),
+        updateDebtTokenAction: assign(({ manageTokenInput }, { manageTokenAction }) => ({
+          manageTokenInput: {
+            ...manageTokenInput!,
+            manageTokenAction: manageTokenAction || ManageDebtActionsEnum.BORROW_DEBT,
+          },
+        })),
         updateTokenActionValue: assign(({ manageTokenInput }, { manageTokenActionValue }) => ({
-          manageTokenInput: Object.assign(manageTokenInput!, { manageTokenActionValue }),
+          manageTokenInput: {
+            ...manageTokenInput!,
+            manageTokenActionValue,
+          },
         })),
-        userInputRiskRatio: assign((context, event) => {
-          return {
-            userInput: {
-              ...context.userInput,
-              riskRatio: event.riskRatio,
-            },
-          }
-        }),
-        reset: assign((context) => {
-          return {
-            userInput: {
-              ...context.userInput,
-              riskRatio: undefined,
-            },
-            strategy: undefined,
-          }
-        }),
+        userInputRiskRatio: assign((context, event) => ({
+          userInput: {
+            ...context.userInput,
+            riskRatio: event.riskRatio,
+          },
+        })),
+        reset: assign((context) => ({
+          userInput: {
+            ...context.userInput,
+            riskRatio: undefined,
+          },
+          strategy: undefined,
+        })),
         riskRatioEvent: (context) => {
           trackingEvents.earn.stETHAdjustRiskMoveSlider(context.userInput.riskRatio!.loanToValue)
         },

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -462,6 +462,7 @@ export function createManageAaveStateMachine(
               slippage: context.userSettings!.slippage,
               currentPosition: context.currentPosition!,
               manageTokenInput: context.manageTokenInput,
+              proxyType: context.positionCreatedBy,
             },
           }),
           { to: (context) => context.refParametersMachine! },
@@ -509,7 +510,7 @@ export function createManageAaveStateMachine(
           refAllowanceStateMachine: spawn(
             allowanceStateMachine.withContext({
               token: context.tokens.deposit,
-              spender: context.connectedProxyAddress!,
+              spender: context.proxyAddress!,
               allowanceType: 'unlimited',
               minimumAmount: context.userInput.amount!,
             }),

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -150,7 +150,7 @@ export function createManageAaveStateMachine(
               },
             },
             loading: {
-              entry: ['requestParameters'],
+              entry: ['requestParameters', 'requestManageParameters'],
               on: {
                 STRATEGY_RECEIVED: {
                   target: 'idle',
@@ -243,7 +243,7 @@ export function createManageAaveStateMachine(
               },
             },
             manageCollateral: {
-              entry: ['spawnDepositBorrowMachine', 'requestManageParameters'],
+              entry: ['spawnDepositBorrowMachine'],
               exit: ['killCurrentParametersMachine'],
               on: {
                 START_TRANSACTION: {
@@ -262,7 +262,7 @@ export function createManageAaveStateMachine(
               },
             },
             manageDebt: {
-              entry: ['spawnDepositBorrowMachine', 'requestManageParameters'],
+              entry: ['spawnDepositBorrowMachine'],
               exit: ['killCurrentParametersMachine'],
               on: {
                 START_TRANSACTION: {
@@ -353,15 +353,18 @@ export function createManageAaveStateMachine(
         },
         UPDATE_COLLATERAL_TOKEN_ACTION: {
           cond: 'canChangePosition',
+          target: '#manageAaveStateMachine.background.debouncing',
           actions: ['resetTokenActionValue', 'updateCollateralTokenAction'],
         },
         UPDATE_DEBT_TOKEN_ACTION: {
           cond: 'canChangePosition',
+          target: '#manageAaveStateMachine.background.debouncing',
           actions: ['resetTokenActionValue', 'updateDebtTokenAction'],
         },
         UPDATE_TOKEN_ACTION_VALUE: {
           cond: 'canChangePosition',
-          actions: ['updateTokenActionValue', 'requestManageParameters'],
+          target: '#manageAaveStateMachine.background.debouncing',
+          actions: ['updateTokenActionValue'],
         },
       },
     },

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -453,6 +453,10 @@ export function createManageAaveStateMachine(
             type: 'VARIABLES_RECEIVED',
             parameters: {
               amount: context.manageTokenInput?.manageTokenActionValue || zero,
+              token:
+                context.manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT
+                  ? context.tokens.debt
+                  : context.tokens.collateral,
               proxyAddress: context.effectiveProxyAddress!,
               context: context.web3Context!,
               slippage: context.userSettings!.slippage,

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -439,19 +439,19 @@ export function createManageAaveStateMachine(
         })),
         updateCollateralTokenAction: assign(({ manageTokenInput }, { manageTokenAction }) => ({
           manageTokenInput: {
-            ...manageTokenInput!,
+            ...manageTokenInput,
             manageTokenAction: manageTokenAction || ManageCollateralActionsEnum.DEPOSIT_COLLATERAL,
           },
         })),
         updateDebtTokenAction: assign(({ manageTokenInput }, { manageTokenAction }) => ({
           manageTokenInput: {
-            ...manageTokenInput!,
+            ...manageTokenInput,
             manageTokenAction: manageTokenAction || ManageDebtActionsEnum.BORROW_DEBT,
           },
         })),
         updateTokenActionValue: assign(({ manageTokenInput }, { manageTokenActionValue }) => ({
           manageTokenInput: {
-            ...manageTokenInput!,
+            ...manageTokenInput,
             manageTokenActionValue,
           },
         })),

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -290,7 +290,7 @@ export function createManageAaveStateMachine(
                 BACK_TO_EDITING: {
                   target: 'editing',
                 },
-                START_TRANSACTION: {
+                NEXT_STEP: {
                   cond: 'validTransactionParameters',
                   target: 'txInProgress',
                   actions: ['riskRatioConfirmTransactionEvent'],
@@ -300,7 +300,7 @@ export function createManageAaveStateMachine(
             reviewingClosing: {
               entry: ['closePositionEvent'],
               on: {
-                START_TRANSACTION: {
+                NEXT_STEP: {
                   cond: 'validTransactionParameters',
                   target: 'txInProgress',
                   actions: ['closePositionTransactionEvent'],

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -493,10 +493,11 @@ export function createManageAaveStateMachine(
         ),
         requestManageParameters: send(
           (context): TransactionParametersStateMachineEvent<ManageAaveParameters> => {
-            const isBorrowOrPaybackDebt = [
-              ManageDebtActionsEnum.BORROW_DEBT,
-              ManageDebtActionsEnum.PAYBACK_DEBT,
-            ].includes(context.manageTokenInput!.manageTokenAction as ManageDebtActionsEnum)
+            const isBorrowOrPaybackDebt = context.manageTokenInput
+              ? [ManageDebtActionsEnum.BORROW_DEBT, ManageDebtActionsEnum.PAYBACK_DEBT].includes(
+                  context.manageTokenInput.manageTokenAction as ManageDebtActionsEnum,
+                )
+              : false
             return {
               type: 'VARIABLES_RECEIVED',
               parameters: {

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -280,8 +280,6 @@ function getTokensInBaseUnit({
       ? amountToWei(manageTokenInput?.manageTokenActionValue || zero, currentPosition.debt.symbol)
       : zero
 
-  console.log(`results`, collateralInBaseUnit.toString(), debtInBaseUnit.toString())
-
   return [collateralInBaseUnit, debtInBaseUnit]
 }
 
@@ -341,7 +339,7 @@ export async function getManageAaveParameters(
           collectFeeFrom: 'sourceToken',
         }
         if (manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT) {
-          borrowDepositStratArgs.borrowAmount = debt
+          borrowDepositStratArgs.borrowAmount = debt || ZERO
           borrowDepositStratArgs.collectFeeFrom = 'targetToken'
         }
         if (

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -22,7 +22,7 @@ import { paybackWithdraw } from '@oasisdex/oasis-actions/lib/src/strategies/aave
 function getAddressesFromContext(context: Context) {
   return {
     DAI: context.tokens['DAI'].address,
-    ETH: context.tokens['WETH'].address, // TODO FIX AFTER LIB CHANGE
+    ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // TODO FIX AFTER LIB CHANGE
     WETH: context.tokens['WETH'].address,
     stETH: context.tokens['STETH'].address,
     USDC: context.tokens['USDC'].address,
@@ -347,8 +347,7 @@ export async function getManageAaveParameters(
         if (
           manageTokenInput?.manageTokenAction === ManageCollateralActionsEnum.DEPOSIT_COLLATERAL
         ) {
-          borrowDepositStratArgs.entryToken =
-            addresses[currentPosition.collateral.symbol as keyof typeof addresses]
+          borrowDepositStratArgs.entryToken = currentPosition.collateral.symbol
           borrowDepositStratArgs.entryTokenAmount = manageTokenInput?.manageTokenActionValue
         }
         const borrowDepositStratDeps: Parameters<typeof strategies.aave.depositBorrow>[1] = {
@@ -361,7 +360,7 @@ export async function getManageAaveParameters(
           isDPMProxy: proxyType === ProxyType.DpmProxy,
         }
 
-        return strategies.aave.depositBorrow(borrowDepositStratArgs, borrowDepositStratDeps)
+        return await strategies.aave.depositBorrow(borrowDepositStratArgs, borrowDepositStratDeps)
       default:
         throw Error('Not implemented')
     }

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -4,7 +4,8 @@ import {
   IPositionTransition,
   IRiskRatio,
   Position,
-  strategies, ZERO,
+  strategies,
+  ZERO,
 } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { providers } from 'ethers'
@@ -348,7 +349,7 @@ export async function getManageAaveParameters(
           borrowDepositStratArgs.entryToken = {
             amountInBaseUnit: manageTokenInput?.manageTokenActionValue || ZERO,
             symbol: currentPosition.collateral.symbol as AAVETokens,
-            precision: currentPosition.collateral.precision
+            precision: currentPosition.collateral.precision,
           }
         }
         const borrowDepositStratDeps: Parameters<typeof strategies.aave.depositBorrow>[1] = {

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -87,6 +87,7 @@ export interface DepositBorrowAaveParameters {
   proxyAddress: string
   manageTokenInput?: ManageTokenInput
   amount: BigNumber
+  token?: string
 }
 
 function checkContext(context: Context, msg: string): asserts context is ContextConnected {

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -1,4 +1,11 @@
-import { AAVETokens, IPosition, IPositionTransition, IRiskRatio, Position, strategies } from '@oasisdex/oasis-actions'
+import {
+  AAVETokens,
+  IPosition,
+  IPositionTransition,
+  IRiskRatio,
+  Position,
+  strategies,
+} from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { providers } from 'ethers'
 
@@ -249,20 +256,30 @@ export async function getAdjustAaveParameters({
   }
 }
 
-function getTokensInBaseUnit({ manageTokenInput, currentPosition }: ManageAaveParameters): [collateralInBaseUnit: BigNumber, debtInBaseUnit: BigNumber] {
+function getTokensInBaseUnit({
+  manageTokenInput,
+  currentPosition,
+}: ManageAaveParameters): [BigNumber, BigNumber] {
   console.log('manageTokenInput', manageTokenInput?.manageTokenAction)
   console.log('manageTone', manageTokenInput?.manageTokenActionValue?.toString())
   if (!manageTokenInput?.manageTokenAction) {
     return [zero, zero]
   }
 
-  const collateralInBaseUnit = manageTokenInput?.manageTokenAction in [ManageCollateralActionsEnum.WITHDRAW_COLLATERAL, ManageCollateralActionsEnum.DEPOSIT_COLLATERAL]
-  ? amountToWei(manageTokenInput?.manageTokenActionValue || zero, currentPosition.collateral.symbol)
-    : zero
+  const collateralInBaseUnit =
+    manageTokenInput?.manageTokenAction === ManageCollateralActionsEnum.WITHDRAW_COLLATERAL ||
+    manageTokenInput.manageTokenAction === ManageCollateralActionsEnum.DEPOSIT_COLLATERAL
+      ? amountToWei(
+          manageTokenInput?.manageTokenActionValue || zero,
+          currentPosition.collateral.symbol,
+        )
+      : zero
 
-  const debtInBaseUnit = manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT || manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.PAYBACK_DEBT
-  ? amountToWei(manageTokenInput?.manageTokenActionValue || zero, currentPosition.debt.symbol)
-    : zero
+  const debtInBaseUnit =
+    manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT ||
+    manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.PAYBACK_DEBT
+      ? amountToWei(manageTokenInput?.manageTokenActionValue || zero, currentPosition.debt.symbol)
+      : zero
 
   console.log(`results`, collateralInBaseUnit.toString(), debtInBaseUnit.toString())
 

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -341,13 +341,14 @@ export async function getManageAaveParameters(
           collectFeeFrom: 'sourceToken',
         }
         if (manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT) {
-          borrowDepositStratArgs.borrowAmount = manageTokenInput?.manageTokenActionValue
+          borrowDepositStratArgs.borrowAmount = debt
+          borrowDepositStratArgs.collectFeeFrom = 'targetToken'
         }
         if (
           manageTokenInput?.manageTokenAction === ManageCollateralActionsEnum.DEPOSIT_COLLATERAL
         ) {
           borrowDepositStratArgs.entryToken = {
-            amountInBaseUnit: manageTokenInput?.manageTokenActionValue || ZERO,
+            amountInBaseUnit: collateral || ZERO,
             symbol: currentPosition.collateral.symbol as AAVETokens,
             precision: currentPosition.collateral.precision,
           }
@@ -361,6 +362,7 @@ export async function getManageAaveParameters(
           user: context.account,
           isDPMProxy: proxyType === ProxyType.DpmProxy,
         }
+
         return await strategies.aave.depositBorrow(borrowDepositStratArgs, borrowDepositStratDeps)
       default:
         throw Error('Not implemented')

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -287,7 +287,7 @@ function getTokensInBaseUnit({
 
 export async function getManageAaveParameters(
   parameters: ManageAaveParameters,
-): Promise<IPositionTransition | undefined> {
+): Promise<IPositionTransition> {
   try {
     const {
       context,

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -362,7 +362,6 @@ export async function getManageAaveParameters(
           user: context.account,
           isDPMProxy: proxyType === ProxyType.DpmProxy,
         }
-
         return await strategies.aave.depositBorrow(borrowDepositStratArgs, borrowDepositStratDeps)
       default:
         throw Error('Not implemented')

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -250,6 +250,8 @@ export async function getAdjustAaveParameters({
 }
 
 function getTokensInBaseUnit({ manageTokenInput, currentPosition }: ManageAaveParameters): [collateralInBaseUnit: BigNumber, debtInBaseUnit: BigNumber] {
+  console.log('manageTokenInput', manageTokenInput?.manageTokenAction)
+  console.log('manageTone', manageTokenInput?.manageTokenActionValue?.toString())
   if (!manageTokenInput?.manageTokenAction) {
     return [zero, zero]
   }
@@ -258,9 +260,11 @@ function getTokensInBaseUnit({ manageTokenInput, currentPosition }: ManageAavePa
   ? amountToWei(manageTokenInput?.manageTokenActionValue || zero, currentPosition.collateral.symbol)
     : zero
 
-  const debtInBaseUnit = manageTokenInput?.manageTokenAction in [ManageDebtActionsEnum.PAYBACK_DEBT, ManageDebtActionsEnum.BORROW_DEBT]
+  const debtInBaseUnit = manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT || manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.PAYBACK_DEBT
   ? amountToWei(manageTokenInput?.manageTokenActionValue || zero, currentPosition.debt.symbol)
     : zero
+
+  console.log(`results`, collateralInBaseUnit.toString(), debtInBaseUnit.toString())
 
   return [collateralInBaseUnit, debtInBaseUnit]
 }

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -18,12 +18,11 @@ import { zero } from '../../helpers/zero'
 import { ManageTokenInput } from './common/BaseAaveContext'
 import { ProxyType } from './common/StrategyConfigTypes'
 import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from './strategyConfig'
-import { paybackWithdraw } from '@oasisdex/oasis-actions/lib/src/strategies/aave/paybackWithdraw' //TODO: Temporary solution
 
 function getAddressesFromContext(context: Context) {
   return {
     DAI: context.tokens['DAI'].address,
-    ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // TODO FIX AFTER LIB CHANGE
+    ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     WETH: context.tokens['WETH'].address,
     STETH: context.tokens['STETH'].address,
     USDC: context.tokens['USDC'].address,
@@ -305,7 +304,7 @@ export async function getManageAaveParameters(
     switch (manageTokenInput?.manageTokenAction) {
       case ManageDebtActionsEnum.PAYBACK_DEBT:
       case ManageCollateralActionsEnum.WITHDRAW_COLLATERAL:
-        type types = Parameters<typeof paybackWithdraw>
+        type types = Parameters<typeof strategies.aave.paybackWithdraw>
 
         const paybackWithdrawStratArgs: types[0] = {
           slippage,
@@ -331,7 +330,10 @@ export async function getManageAaveParameters(
           isDPMProxy: proxyType === ProxyType.DpmProxy,
         }
 
-        return await paybackWithdraw(paybackWithdrawStratArgs, paybackWithdrawStratDeps)
+        return await strategies.aave.paybackWithdraw(
+          paybackWithdrawStratArgs,
+          paybackWithdrawStratDeps,
+        )
       case ManageDebtActionsEnum.BORROW_DEBT:
       case ManageCollateralActionsEnum.DEPOSIT_COLLATERAL:
         const borrowDepositStratArgs: Parameters<typeof strategies.aave.depositBorrow>[0] = {

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -17,11 +17,6 @@ import { zero } from '../../helpers/zero'
 import { ManageTokenInput } from './common/BaseAaveContext'
 import { ProxyType } from './common/StrategyConfigTypes'
 import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from './strategyConfig'
-import { AAVEStrategyAddresses } from '@oasisdex/oasis-actions/lib/src/operations/aave/addresses'
-import {
-  Address,
-  IPositionTransitionDependencies,
-} from '@oasisdex/oasis-actions/lib/src/strategies/types/IPositionRepository'
 
 function getAddressesFromContext(context: Context) {
   return {
@@ -272,13 +267,7 @@ export async function getDepositBorrowAaveParameters({
     const provider = new providers.JsonRpcProvider(context.infuraUrl, context.chainId)
     const addresses = getAddressesFromContext(context)
 
-    const stratArgs: {
-      entryToken?: Address
-      entryTokenAmount?: BigNumber
-      slippage?: BigNumber
-      borrowAmount?: BigNumber
-      collectFeeFrom: 'sourceToken' | 'targetToken'
-    } = {
+    const stratArgs: Parameters<typeof strategies.aave.depositBorrow[1]> = {
       slippage,
       collectFeeFrom: 'sourceToken' as const,
     }
@@ -296,7 +285,7 @@ export async function getDepositBorrowAaveParameters({
         break
     }
 
-    const stratDeps: IPositionTransitionDependencies<AAVEStrategyAddresses> = {
+    const stratDeps: Parameters<typeof strategies.aave.depositBorrow[2]> = {
       addresses,
       currentPosition,
       provider: provider,

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -17,6 +17,15 @@ import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from '../mul
 import { adjustRiskView } from './common/components/SidebarAdjustRiskView'
 import { IStrategyConfig, ProxyType } from './common/StrategyConfigTypes'
 
+export enum ManageCollateralActionsEnum {
+  DEPOSIT_COLLATERAL = 'deposit-collateral',
+  WITHDRAW_COLLATERAL = 'withdraw-collateral',
+}
+export enum ManageDebtActionsEnum {
+  BORROW_DEBT = 'borrow-debt',
+  PAYBACK_DEBT = 'payback-debt',
+}
+
 export const strategies: Array<IStrategyConfig> = [
   {
     urlSlug: 'stETHeth',

--- a/helpers/api/tokenTickers.ts
+++ b/helpers/api/tokenTickers.ts
@@ -3,29 +3,6 @@ import { getCoingeckoTickers } from 'server/services/coingecko'
 import { getCoinPaprikaTickers } from 'server/services/coinPaprika'
 
 export async function tokenTickers() {
-  return {
-    'eth-ethereum': 1334.258465143443,
-    'usdc-usd-coin': 0.9991509192670103,
-    'dai-dai': 0.9993865595295941,
-    'steth-lido-staked-ether': 1320.5983637874394,
-    'weth-weth': 1328.789027770681,
-    'wbtc-wrapped-bitcoin': 17916.97654729976,
-    'usdp-paxos-standard-token': 0.99823445715842,
-    'gusd-gemini-dollar': 1.0007410295770038,
-    'mkr-maker': 604.415049614932,
-    'renbtc-renbtc': 18105.408329982565,
-    'mkr-usd': 604.27,
-    'eth-usd': 1335.6,
-    'MANA-USD': 0.3901,
-    'LINK-USD': 6.865,
-    'YFI-USD': 6508.68,
-    'UNI-USD': 6.115,
-    'MATIC-USD': 0.9273,
-    'dai-usd': 0.9998,
-    'wrapped-steth': 1454.19,
-    'rocket-pool-eth': 1431.83,
-    gnosis: 93.87,
-  }
   const results = await Promise.all([
     getCoinPaprikaTickers(),
     getCoinbaseTickers(),

--- a/helpers/api/tokenTickers.ts
+++ b/helpers/api/tokenTickers.ts
@@ -3,6 +3,29 @@ import { getCoingeckoTickers } from 'server/services/coingecko'
 import { getCoinPaprikaTickers } from 'server/services/coinPaprika'
 
 export async function tokenTickers() {
+  return {
+    'eth-ethereum': 1334.258465143443,
+    'usdc-usd-coin': 0.9991509192670103,
+    'dai-dai': 0.9993865595295941,
+    'steth-lido-staked-ether': 1320.5983637874394,
+    'weth-weth': 1328.789027770681,
+    'wbtc-wrapped-bitcoin': 17916.97654729976,
+    'usdp-paxos-standard-token': 0.99823445715842,
+    'gusd-gemini-dollar': 1.0007410295770038,
+    'mkr-maker': 604.415049614932,
+    'renbtc-renbtc': 18105.408329982565,
+    'mkr-usd': 604.27,
+    'eth-usd': 1335.6,
+    'MANA-USD': 0.3901,
+    'LINK-USD': 6.865,
+    'YFI-USD': 6508.68,
+    'UNI-USD': 6.115,
+    'MATIC-USD': 0.9273,
+    'dai-usd': 0.9998,
+    'wrapped-steth': 1454.19,
+    'rocket-pool-eth': 1431.83,
+    gnosis: 93.87,
+  }
   const results = await Promise.all([
     getCoinPaprikaTickers(),
     getCoinbaseTickers(),

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.0.4-alpha.deposit-v9",
+    "@oasisdex/oasis-actions": "0.1.0",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.0.4-alpha.deposit-v6",
+    "@oasisdex/oasis-actions": "0.0.4-alpha.deposit-v9",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.0.4-alpha.53",
+    "@oasisdex/oasis-actions": "0.0.4-alpha.deposit-v6",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.0.4-alpha.52",
+    "@oasisdex/oasis-actions": "0.0.4-alpha.53",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.1.0",
+    "@oasisdex/oasis-actions": "0.1.1",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -1818,7 +1818,7 @@
         "confirm-btn": "确认",
         "close-description": "为了关闭你的金库，你的部分仓位将会出售以付清尚未偿还的债务，而剩余的抵押品将会发送至你的钱包地址。",
         "stop-close": "下次再说",
-        "eth-after-closing": "关闭金库后的 {{ closingToken }}",
+        "token-amount-after-closing": "关闭金库后的 {{token}}",
         "retry-btn": "再试一次"
       }
     }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -33,6 +33,7 @@
   "adding-auto-sell": "Adding Auto-Sell",
   "cancelling-auto-sell": "Cancelling Auto-Sell",
   "adjust-your-position": "Adjust your position",
+  "adjust": "Adjust",
   "adjust-your-position-additional": "Adjust multiple with this transaction",
   "after": "After",
   "after-closing": "{{token}} after closing",
@@ -68,6 +69,7 @@
   "close": "Close",
   "close-notification": "Close notification",
   "close-to": "Close to {{token}}",
+  "closing-to": "Closing to {{token}}",
   "close-vault": "Close Vault",
   "coming-soon": "Coming soon",
   "completed": "Completed",
@@ -917,6 +919,12 @@
     "multiply-buy-coll": "Buy Collateral ({{token}}) with DAI",
     "multiply-reduce-debt": "Reduce Vault's debt",
     "pnl-value": "PnL: {{value}}",
+    "manage-token": "Manage {{token}}",
+    "manage-collateral-token": "Manage collateral ({{token}})",
+    "manage-debt-token": "Manage debt ({{token}})",
+    "manage-collateral": "Manage collateral",
+    "manage-debt": "Manage debt",
+    "close-position": "Close position",
     "actions": {
       "common": {
         "close-vault": "Close vault",
@@ -931,7 +939,12 @@
         "adjust": "Adjust",
         "buy-coll": "Buy Coll.",
         "reduce-debt": "Reduce Debt",
-        "switch-to-borrow": "Switch to Borrow"
+        "withdraw": "Withdraw",
+        "switch-to-borrow": "Switch to Borrow",
+        "deposit-collateral": "Deposit collateral",
+        "withdraw-collateral": "Withdraw collateral",
+        "payback-debt": "Payback debt",
+        "borrow-debt": "Borrow debt"
       },
       "earn": {
         "vault-overview": "Vault overview"
@@ -1980,12 +1993,13 @@
         "adjust-risk": "Adjust Risk",
         "deposit": "Deposit ETH",
         "title": "Your Earn position",
-        "close-title": "Close position to {{ debtToken }}",
+        "close-title": "Close position to ETH",
+        "close-to-title": "Close position to {{token}}",
         "close": "Close vault",
         "confirm-btn": "Confirm",
         "close-description": "To close your vault, a part of your position will be sold to payback the outstanding debt. The rest of your collateral will be send to your address.",
         "stop-close": "Not right now",
-        "eth-after-closing": "{{ closingToken }} after closing",
+        "token-amount-after-closing": "{{token}} after closing",
         "retry-btn": "Retry",
         "adjust-title": "Confirm adjustment",
         "adjust-description": "You are about to adjust the risk level of your vault. Please confirm the changes below.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1269,7 +1269,7 @@
         "confirm-btn": "Confirmar",
         "close-description": "Para cerrar tu Vault, una parte de tu posición será vendida para pagar la deuda pendiente. El resto de tu colateral será enviado a tu cartera",
         "stop-close": "No ahora",
-        "eth-after-closing": "{{ closingToken }} luego de cerrar posición",
+        "token-amount-after-closing": "{{token}} luego de cerrar posición",
         "retry-btn": "Reintentar"
       }
     }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -874,7 +874,7 @@
         "confirm-btn": "Confirm",
         "close-description": "To close your vault, a part of your position will be sold to payback the outstanding debt. The rest of your collateral will be send to your address.",
         "stop-close": "Not right now",
-        "eth-after-closing": "{{ closingToken }} after closing",
+        "token-amount-after-closing": "{{token}} after closing",
         "retry-btn": "Retry"
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.0.tgz#6635fe3dfd74d7fd8a9e53aaf3af3c59e89cb4b2"
-  integrity sha512-4Otl5OnQcnsjO+I9AmwRxLpGukjvS3DPBlWP85DawXt8Ml89L5HGv5jFxahgqtlIvwhcAK8UY77NWxKnQJElBg==
+"@oasisdex/oasis-actions@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.1.tgz#ac6e29e0f72b853995f23f5a22dd2c0e634203f9"
+  integrity sha512-hgjwTZj1P2BqtxC7gMbecHxB33bdZBuUOCZ71+EHF3xYtfdjqZQJV42lSsDaqIGKKdlG4kmWX1g1FmK3wSsVKQ==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.0.4-alpha.deposit-v9":
-  version "0.0.4-alpha.deposit-v9"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.0.4-alpha.deposit-v9.tgz#ac4df1a192bfc17086bac4d342060eb15bcb7876"
-  integrity sha512-Berijw/PpuQe8eBJ7Oop9UvyrzYpTXAYXyesJu5IW+6qpgC7NXRO99piJPhJihSSrkdd0Z5NIuC+EFDNOqdu2g==
+"@oasisdex/oasis-actions@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.0.tgz#6635fe3dfd74d7fd8a9e53aaf3af3c59e89cb4b2"
+  integrity sha512-4Otl5OnQcnsjO+I9AmwRxLpGukjvS3DPBlWP85DawXt8Ml89L5HGv5jFxahgqtlIvwhcAK8UY77NWxKnQJElBg==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.0.4-alpha.53":
-  version "0.0.4-alpha.53"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.0.4-alpha.53.tgz#a300fa4b67930d6e0d113bd9f1d32b052db3fa7b"
-  integrity sha512-LWG+vxv6se83E++DY5+L9oG0YTZejCUBp1mQu0kahfNxx2pw25PySe90m7qvp8LVqai+taVVFQtvxxq05YAj5w==
+"@oasisdex/oasis-actions@0.0.4-alpha.deposit-v9":
+  version "0.0.4-alpha.deposit-v9"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.0.4-alpha.deposit-v9.tgz#ac4df1a192bfc17086bac4d342060eb15bcb7876"
+  integrity sha512-Berijw/PpuQe8eBJ7Oop9UvyrzYpTXAYXyesJu5IW+6qpgC7NXRO99piJPhJihSSrkdd0Z5NIuC+EFDNOqdu2g==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5639,7 +5639,6 @@
     bignumber.js "9.0.1"
     ethers "5.6.2"
     lodash "^4.17.21"
-    utility-types "^3.10.0"
 
 "@oasisdex/transactions@^0.1.0":
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,14 +5631,15 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.0.4-alpha.52":
-  version "0.0.4-alpha.52"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.0.4-alpha.52.tgz#aea997b3c3970384ed88a3e1ebf2727d67153bec"
-  integrity sha512-E1UHB56Ll/O8tjzD64MlC1kSAVo0xHhZGuKlKrrIGfyzNCRItiYZd9F8q8eOLzaLOuPr5uRxRlXQ33KAQGsFQQ==
+"@oasisdex/oasis-actions@0.0.4-alpha.53":
+  version "0.0.4-alpha.53"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.0.4-alpha.53.tgz#a300fa4b67930d6e0d113bd9f1d32b052db3fa7b"
+  integrity sha512-LWG+vxv6se83E++DY5+L9oG0YTZejCUBp1mQu0kahfNxx2pw25PySe90m7qvp8LVqai+taVVFQtvxxq05YAj5w==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"
     lodash "^4.17.21"
+    utility-types "^3.10.0"
 
 "@oasisdex/transactions@^0.1.0":
   version "0.1.0"


### PR DESCRIPTION
# [[UI] Close to Collateral token in AAVE](https://app.shortcut.com/oazo-apps/story/7003/ui-close-to-collateral-token-in-aave)
# [[UI] Payback debt, withdraw collateral (no multiplying)](https://app.shortcut.com/oazo-apps/story/6815/ui-payback-debt-withdraw-collateral-no-multiplying)
# [[UI] Deposit Collateral, borrow debt (no multiplying)](https://app.shortcut.com/oazo-apps/story/6814/ui-deposit-collateral-borrow-debt-no-multiplying)
  
## Changes 👷‍♀️
 - added Payback debt, withdraw collateral, deposit collateral, borrow debt to the sidebar in the Aave multiply positions
 - should work with aave steth/eth position
## How to test 🧪
 - go to any Aave position and try to do any above actions using the sidebar