### PR TITLE
fix load manage vault

### DIFF
--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -266,7 +266,7 @@ export function createManageAaveStateMachine(
           actions: ['updateContext', 'calculateEffectiveProxyAddress'],
         },
         WEB3_CONTEXT_CHANGED: {
-          actions: 'updateContext',
+          actions: ['updateContext', 'calculateEffectiveProxyAddress'],
         },
         GAS_PRICE_ESTIMATION_RECEIVED: {
           actions: 'updateContext',

--- a/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -161,7 +161,8 @@ function OpenAaveEditingStateView({ state, send, isLoading }: OpenAaveStateProps
   if (
     state.context.strategyConfig.proxyType === ProxyType.DsProxy &&
     state.context.hasOpenedPosition &&
-    state.context.positionRelativeAddress !== undefined
+    state.context.positionRelativeAddress !== undefined &&
+    !state.context.positionRelativeAddress.endsWith('undefined')
   ) {
     void router.replace(state.context.positionRelativeAddress, getCustomNetworkParameter()) // redirects to active position if user has one
   }

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -300,7 +300,7 @@ export function createOpenAaveStateMachine(
           actions: ['updateContext', 'calculateEffectiveProxyAddress', 'setTotalSteps'],
         },
         WEB3_CONTEXT_CHANGED: {
-          actions: 'updateContext',
+          actions: ['updateContext', 'calculateEffectiveProxyAddress'],
         },
         GAS_PRICE_ESTIMATION_RECEIVED: {
           actions: 'updateContext',
@@ -481,17 +481,19 @@ export function createOpenAaveStateMachine(
           ),
         })),
         calculateEffectiveProxyAddress: assign((context) => {
-          const proxyAddressToUse =
-            context.strategyConfig.proxyType === ProxyType.DpmProxy
-              ? context.userDpmProxy?.proxy
-              : context.connectedProxyAddress
+          const shouldUseDpmProxy =
+            context.strategyConfig.proxyType === ProxyType.DpmProxy &&
+            context.userDpmProxy !== undefined
+
+          const proxyAddressToUse = shouldUseDpmProxy
+            ? context.userDpmProxy?.proxy
+            : context.connectedProxyAddress
 
           const contextConnected = (context.web3Context as any) as ContextConnected | undefined
 
-          const address =
-            context.strategyConfig.proxyType === ProxyType.DpmProxy
-              ? `/aave/${context.userDpmProxy?.vaultId}`
-              : `/aave/${contextConnected?.account}`
+          const address = shouldUseDpmProxy
+            ? `/aave/${context.userDpmProxy?.vaultId}`
+            : `/aave/${contextConnected?.account}`
 
           return {
             effectiveProxyAddress: proxyAddressToUse,


### PR DESCRIPTION
# [While already owning a position on maker multiply and then going to opening a new position it automatically redirects to `/aave/undefined`](https://app.shortcut.com/oazo-apps/story/7144/while-already-owning-a-position-on-maker-multiply-and-then-going-to-opening-a-new-position-it-automatically-redirects-to)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- recalc proxy things when web3 context is changed
  
## How to test 🧪
  <Please explain how to test your changes>

1. Step 1 - open Maker ETH position (borrow or multiply) using first account on HH
2. Step 2 - open an aave position
3. Step 3 - go to the position at the end of the flow by clicking the button, or click action on Earn product card (hitting URL directly doesn't reproduce)
    - Expected: navigate to the position
    - Actual: it redirects to /aave/undefined when clicking the opening link and shows a client-side error <- ensure this doesn't happen.

- ensure that a previously-created DS proxy is reused.
- closing position puts funds back in the wallet
