### PR TITLE
use debt liquidity on product cards

### DIFF
--- a/components/productCards/ProductCardMultiplyAave.tsx
+++ b/components/productCards/ProductCardMultiplyAave.tsx
@@ -19,7 +19,6 @@ type ProductCardMultiplyAaveProps = {
 
 const aaveMultiplyCalcValueBasis = {
   amount: new BigNumber(100),
-  token: 'ETH',
 }
 
 export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAaveProps) {
@@ -44,13 +43,13 @@ export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAavePro
       banner={{
         title: t('product-card-banner.with', {
           value: aaveMultiplyCalcValueBasis.amount.toString(),
-          token: aaveMultiplyCalcValueBasis.token,
+          token: strategy.tokens.deposit,
         }),
-        description: t(`product-card-banner.aave.${cardData.symbol}`, {
+        description: t(`product-card-banner.multiply`, {
           value: maximumMultiple
             ? maximumMultiple.multiple.times(aaveMultiplyCalcValueBasis.amount).toFormat(0)
             : zero.toString(),
-          token: cardData.symbol,
+          token: strategy.tokens.deposit,
         }),
         isLoading: !maximumMultiple,
       }}

--- a/components/productCards/ProductCardMultiplyAave.tsx
+++ b/components/productCards/ProductCardMultiplyAave.tsx
@@ -24,18 +24,9 @@ const aaveMultiplyCalcValueBasis = {
 
 export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAaveProps) {
   const { t } = useTranslation()
-  const {
-    aaveAvailableLiquidityInUSDC$,
-    wrappedGetAaveReserveData$,
-    aaveReserveConfigurationData$,
-  } = useAaveContext()
+  const { wrappedGetAaveReserveData$, aaveReserveConfigurationData$ } = useAaveContext()
   const [strategy] = getAaveStrategy(cardData.symbol)
-  const [aaveAvailableLiquidityInUSDC] = useObservable(
-    aaveAvailableLiquidityInUSDC$({ token: strategy.tokens.collateral }),
-  )
-  const [collateralReserveData] = useObservable(
-    wrappedGetAaveReserveData$(strategy.tokens.collateral),
-  )
+  const [debtReserveData] = useObservable(wrappedGetAaveReserveData$(strategy.tokens.debt))
   const [collateralReserveConfigurationData] = useObservable(
     aaveReserveConfigurationData$({ token: strategy.tokens.collateral }),
   )
@@ -74,16 +65,16 @@ export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAavePro
         },
         {
           title: t('system.liquidity-available'),
-          value: aaveAvailableLiquidityInUSDC ? (
-            formatHugeNumbersToShortHuman(aaveAvailableLiquidityInUSDC)
+          value: debtReserveData ? (
+            formatHugeNumbersToShortHuman(debtReserveData.availableLiquidity)
           ) : (
             <AppSpinner />
           ),
         },
         {
           title: t('system.variable-annual-fee'),
-          value: collateralReserveData?.variableBorrowRate ? (
-            formatPercent(collateralReserveData.variableBorrowRate.times(100), {
+          value: debtReserveData?.variableBorrowRate ? (
+            formatPercent(debtReserveData.variableBorrowRate.times(100), {
               precision: 2,
             })
           ) : (

--- a/features/aave/helpers/aavePrepareReserveData.ts
+++ b/features/aave/helpers/aavePrepareReserveData.ts
@@ -3,11 +3,12 @@ import {
   AaveReserveDataParameters,
   AaveReserveDataReply,
 } from 'blockchain/calls/aave/aaveProtocolDataProvider'
-import { amountFromRay } from 'blockchain/utils'
+import { amountFromRay, amountFromWei } from 'blockchain/utils'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 export type PreparedAaveReserveData = {
+  availableLiquidity: BigNumber
   variableBorrowRate: BigNumber
   liquidityRate: BigNumber
 }
@@ -19,8 +20,9 @@ export function createAavePrepareReserveData$(
   return aaveReserveData$({ token }).pipe(
     map((reserveData: AaveReserveDataReply) => ({
       // TODO: if/when all things below are required from observe(aaveReserveData$), we can get rid of this file
-      variableBorrowRate: amountFromRay(new BigNumber(reserveData.variableBorrowRate)),
+      availableLiquidity: amountFromWei(new BigNumber(reserveData.availableLiquidity), token),
       liquidityRate: amountFromRay(new BigNumber(reserveData.liquidityRate)), // the current variable borrow rate. Expressed in ray
+      variableBorrowRate: amountFromRay(new BigNumber(reserveData.variableBorrowRate)),
     })),
   )
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1437,7 +1437,6 @@
     },
     "aave": {
       "stETHeth": "Get up to {{value}} ETH exposure to stETH",
-      "stETHusdc": "Get up to {{value}} ETH exposure"
     }
   },
   "product-card-title": {


### PR DESCRIPTION
# Product card updates

- https://app.shortcut.com/oazo-apps/story/7142/product-cards-data-liquidity-available-and-variable-annual-fee-are-looking-at-the-collateral-token-in-stead-of-the-debt-token
- https://app.shortcut.com/oazo-apps/story/7146/product-cards-on-homepage-on-multiply-tabs-have-earn-content
  
## Changes 👷‍♀️
  <Please add short list of changes>
- uses the debt token to show the liquidity-available-and-variable-annual-fee
- updates the card banners to be the same as the other multiply cards
  
## How to test 🧪
- go to multiply tab and see card using debt data and showing the right banner
