### PR TITLE
🧿 Ajna dropdown navigation

### DIFF
--- a/components/navigation/Navigation.tsx
+++ b/components/navigation/Navigation.tsx
@@ -20,7 +20,7 @@ export function Navigation({ brandingLink = '/', links, panels, pill }: Navigati
     <Container
       as="header"
       variant="navigation"
-      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: '24px' }}
+      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 3 }}
     >
       <NavigationBranding link={brandingLink} pill={pill} />
       <NavigationMenu links={links} panels={panels} />

--- a/components/navigation/Navigation.tsx
+++ b/components/navigation/Navigation.tsx
@@ -20,7 +20,12 @@ export function Navigation({ brandingLink = '/', links, panels, pill }: Navigati
     <Container
       as="header"
       variant="navigation"
-      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 3 }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mt: 3,
+      }}
     >
       <NavigationBranding link={brandingLink} pill={pill} />
       <NavigationMenu links={links} panels={panels} />

--- a/components/navigation/NavigationMenu.tsx
+++ b/components/navigation/NavigationMenu.tsx
@@ -29,7 +29,15 @@ export function NavigationMenu({ links, panels }: NavigationMenuProps) {
   return (
     <Box sx={{ position: 'relative' }} onMouseLeave={() => closeDropdown()}>
       {((links && links.length > 0) || (panels && panels.length > 0)) && (
-        <Flex as="ul" sx={{ listStyle: 'none', columnGap: '40px', px: '40px', py: 2 }}>
+        <Flex
+          as="ul"
+          sx={{
+            listStyle: 'none',
+            columnGap: '40px',
+            px: '40px',
+            py: 2,
+          }}
+        >
           {panels?.map((panel) => (
             <NavigationMenuPanel
               key={`panel-${panel.label}`}

--- a/components/navigation/NavigationMenu.tsx
+++ b/components/navigation/NavigationMenu.tsx
@@ -29,7 +29,7 @@ export function NavigationMenu({ links, panels }: NavigationMenuProps) {
   return (
     <Box sx={{ position: 'relative' }} onMouseLeave={() => closeDropdown()}>
       {((links && links.length > 0) || (panels && panels.length > 0)) && (
-        <Flex as="ul" sx={{ p: 0, listStyle: 'none', columnGap: '48px', px: '48px' }}>
+        <Flex as="ul" sx={{ listStyle: 'none', columnGap: '40px', px: '40px', py: 2 }}>
           {panels?.map((panel) => (
             <NavigationMenuPanel
               key={`panel-${panel.label}`}

--- a/components/navigation/NavigationMenuDropdown.tsx
+++ b/components/navigation/NavigationMenuDropdown.tsx
@@ -10,10 +10,20 @@ import { Box, Flex, Grid, Heading, Text } from 'theme-ui'
 
 export interface NavigationMenuDropdownProps {
   arrowPosition: number
-  currentPanel?: string
+  currentPanel: string
   isPanelOpen: boolean
   isPanelSwitched: boolean
   panels: NavigationMenuPanelType[]
+}
+
+function getDropdownTranslation(
+  labelsMap: string[],
+  activePanel: string,
+  currentPanel: string,
+): string {
+  if (activePanel === currentPanel) return '0'
+  else if (labelsMap.indexOf(currentPanel) > labelsMap.indexOf(activePanel)) return '-20%'
+  else return '20%'
 }
 
 export function NavigationMenuDropdown({
@@ -27,12 +37,14 @@ export function NavigationMenuDropdown({
   const [width, setWidth] = useState<number>(0)
   const [height, setHeight] = useState<number>(0)
 
+  const labelsMap = panels.map((panel) => panel.label)
+
   useEffect(() => {
     if (ref.current) {
       setWidth(ref.current.offsetWidth)
       setHeight(ref.current.offsetHeight)
     }
-  }, [currentPanel])
+  }, [currentPanel, isPanelOpen])
 
   return (
     <Flex
@@ -47,7 +59,7 @@ export function NavigationMenuDropdown({
           position: 'absolute',
           top: '100%',
           left: '-7px',
-          mt: '10px',
+          mt: '-6px',
           transform: isPanelOpen ? 'translateY(0)' : 'translateY(20px)',
           transition: 'transform 200ms',
           zIndex: 2,
@@ -68,124 +80,164 @@ export function NavigationMenuDropdown({
         sx={{
           position: 'absolute',
           top: '100%',
-          left: '-500px',
-          right: '-500px',
+          left: '-100%',
+          right: '-100%',
           justifyContent: 'center',
-          pt: 3,
           transform: isPanelOpen ? 'translateY(0)' : 'translateY(-5px)',
           transition: 'transform 200ms',
+          pointerEvents: 'none',
         }}
       >
         <Flex
           sx={{
+            position: 'relative',
+            p: 4,
             borderRadius: 'large',
             bg: 'neutral10',
             boxShadow: 'buttonMenu',
-            height: '600px',
-            ...(width > 0 && { width: width + 64 }),
-            ...(height > 0 && { height: height + 64 }),
-            p: 4,
-            ...(isPanelSwitched && { transition: 'width 200ms, height 200ms' }),
+            pointerEvents: 'auto',
+            overflow: 'hidden',
           }}
         >
-          {panels.map(({ description, label, learn, links, otherAssets }, i) => (
-            <Flex
-              key={i}
-              sx={{
-                position: 'absolute',
-                flexDirection: 'column',
-                rowGap: 4,
-                ...(isPanelSwitched && { transition: 'opacity 200ms' }),
-                ...(currentPanel === label
-                  ? { opacity: 1, pointerEvents: 'auto' }
-                  : { opacity: 0, pointerEvents: 'none' }),
-              }}
-              {...(currentPanel === label && { ref })}
-            >
-              <Box>
-                <Heading
+          <Flex
+            sx={{
+              flexDirection: 'column',
+              ...(width > 0 && { width }),
+              ...(height > 0 && { height }),
+              ...(isPanelSwitched && { transition: 'width 200ms, height 200ms' }),
+            }}
+          >
+            {panels.map(({ description, label, learn, links, otherAssets }, i) => (
+              <Flex sx={{ ml: '-100%', transform: 'translateX(50%)' }}>
+                <Flex
+                  key={i}
                   sx={{
-                    fontSize: '28px',
-                    fontWeight: 'bold',
-                    mb: 1,
-                    color: 'primary100',
-                    letterSpacing: '-0.02em',
+                    position: 'absolute',
+                    flexDirection: 'column',
+                    rowGap: 4,
+                    // ml: '100%',
+                    ...(isPanelSwitched && { transition: 'opacity 200ms, transform 200ms' }),
+                    ...(currentPanel === label
+                      ? { opacity: 1, pointerEvents: 'auto' }
+                      : { opacity: 0, pointerEvents: 'none' }),
+                    transform: `translateX(${getDropdownTranslation(
+                      labelsMap,
+                      label,
+                      currentPanel,
+                    )})`,
                   }}
+                  {...(currentPanel === label && { ref })}
                 >
-                  {label}
-                </Heading>
-                <Text as="p" sx={{ fontSize: '14px', color: 'neutral80' }}>
-                  {description}{' '}
-                  {learn && (
-                    <AppLink href={learn.link}>
-                      <WithArrow
-                        gap={1}
-                        sx={{ display: 'inline-block', ...getAjnaWithArrowColorScheme() }}
-                      >
-                        {learn.label}
-                      </WithArrow>
-                    </AppLink>
-                  )}
-                </Text>
-              </Box>
-              <Grid
-                as="ul"
-                sx={{
-                  gap: 4,
-                  gridTemplateColumns: 'repeat(2, 1fr)',
-                  p: '0',
-                  listStyle: 'none',
-                }}
-              >
-                {links.map(({ icon, footnote, link, title }, i) => (
-                  <Flex key={i} as="li">
-                    <AppLink
-                      href={link}
-                      sx={{ display: 'flex', alignItems: 'center', fontWeight: 'regular' }}
+                  <Box>
+                    <Heading
+                      sx={{
+                        fontSize: '28px',
+                        fontWeight: 'bold',
+                        mb: 1,
+                        color: 'primary100',
+                        letterSpacing: '-0.02em',
+                      }}
                     >
-                      <Icon size={48} name={icon} sx={{ flexShrink: 0 }} />
-                      <Flex sx={{ flexDirection: 'column', ml: 3 }}>
-                        <Text
-                          as="span"
-                          sx={{ fontSize: 4, fontWeight: 'semiBold', color: 'primary100' }}
-                        >
-                          {title}
-                        </Text>
-                        <Text as="span" sx={{ fontSize: 2, color: 'neutral80' }}>
-                          {footnote}
-                        </Text>
-                      </Flex>
-                    </AppLink>
-                  </Flex>
-                ))}
-              </Grid>
-              {otherAssets && otherAssets?.length > 0 && (
-                <Box sx={{ pt: '24px', borderTop: '1px solid', borderColor: 'neutral20' }}>
-                  <Heading
-                    as="h3"
+                      {label}
+                    </Heading>
+                    <Flex sx={{ columnGap: 1 }}>
+                      <Text
+                        as="p"
+                        sx={{ fontSize: '14px', color: 'neutral80', lineHeight: '22px' }}
+                      >
+                        {description}
+                      </Text>
+                      {learn && (
+                        <AppLink href={learn.link}>
+                          <WithArrow
+                            gap={1}
+                            sx={{ display: 'inline-block', ...getAjnaWithArrowColorScheme() }}
+                          >
+                            {learn.label}
+                          </WithArrow>
+                        </AppLink>
+                      )}
+                    </Flex>
+                  </Box>
+                  <Grid
+                    as="ul"
                     sx={{
-                      fontSize: '16px',
-                      fontWeight: 'semiBold',
-                      mb: 3,
-                      color: 'primary100',
+                      gap: 4,
+                      gridTemplateColumns: 'repeat( 2, 1fr )',
+                      p: '0',
+                      listStyle: 'none',
                     }}
                   >
-                    Other assets you can borrow against
-                  </Heading>
-                  <Flex
-                    as="ul"
-                    sx={{ flexWrap: 'wrap', columnGap: 3, rowGap: 2, listStyle: 'none', p: 0 }}
-                  >
-                    {otherAssets.map(({ link, token }, i) => (
-                      <Box key={i} as="li">
-                        <AssetPill icon={getToken(token).iconCircle} label={token} link={link} />
-                      </Box>
+                    {links.map(({ icon, footnote, link, title }, i) => (
+                      <Flex key={i} as="li" sx={{ flexGrow: 1, flexBasis: 0 }}>
+                        <AppLink
+                          href={link}
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            fontWeight: 'regular',
+                            '&:hover': {
+                              '.dropdownLinkTitle': {
+                                color: 'neutral80',
+                              },
+                            },
+                          }}
+                        >
+                          <Icon size={48} name={icon} sx={{ flexShrink: 0 }} />
+                          <Flex sx={{ flexDirection: 'column', ml: 3 }}>
+                            <Text
+                              as="p"
+                              className="dropdownLinkTitle"
+                              sx={{
+                                fontSize: 4,
+                                fontWeight: 'semiBold',
+                                color: 'primary100',
+                                transition: 'color 200ms',
+                              }}
+                            >
+                              {title}
+                            </Text>
+                            <Text
+                              as="p"
+                              sx={{ fontSize: 2, color: 'neutral80', whiteSpace: 'nowrap' }}
+                            >
+                              {footnote}
+                            </Text>
+                          </Flex>
+                        </AppLink>
+                      </Flex>
                     ))}
-                  </Flex>
-                </Box>
-              )}
-            </Flex>
-          ))}
+                  </Grid>
+                  {otherAssets && otherAssets?.length > 0 && (
+                    <Box sx={{ pt: '24px', borderTop: '1px solid', borderColor: 'neutral20' }}>
+                      <Heading
+                        as="h3"
+                        sx={{
+                          fontSize: '16px',
+                          fontWeight: 'semiBold',
+                          mb: 3,
+                          color: 'primary100',
+                        }}
+                      >
+                        Other assets you can borrow against
+                      </Heading>
+                      <Flex as="ul" sx={{ columnGap: 3, rowGap: 2, listStyle: 'none', p: 0 }}>
+                        {otherAssets.map(({ link, token }, i) => (
+                          <Box key={i} as="li">
+                            <AssetPill
+                              icon={getToken(token).iconCircle}
+                              label={token}
+                              link={link}
+                            />
+                          </Box>
+                        ))}
+                      </Flex>
+                    </Box>
+                  )}
+                </Flex>
+              </Flex>
+            ))}
+          </Flex>
         </Flex>
       </Flex>
     </Flex>

--- a/components/navigation/NavigationMenuDropdown.tsx
+++ b/components/navigation/NavigationMenuDropdown.tsx
@@ -1,12 +1,8 @@
-import { Icon } from '@makerdao/dai-ui-icons'
-import { getToken } from 'blockchain/tokensMetadata'
-import { AssetPill } from 'components/AssetPill'
-import { AppLink } from 'components/Links'
+import { NavigationMenuDropdownContent } from 'components/navigation/NavigationMenuDropdownContent'
 import { NavigationMenuPanelType } from 'components/navigation/NavigationMenuPanel'
-import { WithArrow } from 'components/WithArrow'
-import { getAjnaWithArrowColorScheme } from 'features/ajna/common/helpers'
+import { NavigationMenuPointer } from 'components/navigation/NavigationMenuPointer'
 import React, { useEffect, useRef, useState } from 'react'
-import { Box, Flex, Grid, Heading, Text } from 'theme-ui'
+import { Flex } from 'theme-ui'
 
 export interface NavigationMenuDropdownProps {
   arrowPosition: number
@@ -54,28 +50,11 @@ export function NavigationMenuDropdown({
         transition: 'opacity 200ms',
       }}
     >
-      <Box
-        sx={{
-          position: 'absolute',
-          top: '100%',
-          left: '-7px',
-          mt: '-6px',
-          transform: isPanelOpen ? 'translateY(0)' : 'translateY(20px)',
-          transition: 'transform 200ms',
-          zIndex: 2,
-        }}
-      >
-        <Box
-          sx={{
-            width: '14px',
-            height: '14px',
-            borderRadius: 2,
-            bg: 'neutral10',
-            transform: `translateX(${arrowPosition}px) scaleY(1.3) rotate(45deg)`,
-            ...(isPanelSwitched && { transition: 'transform 200ms' }),
-          }}
-        />
-      </Box>
+      <NavigationMenuPointer
+        arrowPosition={arrowPosition}
+        isPanelOpen={isPanelOpen}
+        isPanelSwitched={isPanelSwitched}
+      />
       <Flex
         sx={{
           position: 'absolute',
@@ -95,8 +74,8 @@ export function NavigationMenuDropdown({
             borderRadius: 'large',
             bg: 'neutral10',
             boxShadow: 'buttonMenu',
-            pointerEvents: 'auto',
             overflow: 'hidden',
+            pointerEvents: 'auto',
           }}
         >
           <Flex
@@ -107,7 +86,7 @@ export function NavigationMenuDropdown({
               ...(isPanelSwitched && { transition: 'width 200ms, height 200ms' }),
             }}
           >
-            {panels.map(({ description, label, learn, links, otherAssets }, i) => (
+            {panels.map(({ label, ...panel }, i) => (
               <Flex sx={{ ml: '-100%', transform: 'translateX(50%)' }}>
                 <Flex
                   key={i}
@@ -126,112 +105,7 @@ export function NavigationMenuDropdown({
                   }}
                   {...(currentPanel === label && { ref })}
                 >
-                  <Box>
-                    <Heading
-                      sx={{
-                        fontSize: '28px',
-                        fontWeight: 'bold',
-                        mb: 1,
-                        color: 'primary100',
-                        letterSpacing: '-0.02em',
-                      }}
-                    >
-                      {label}
-                    </Heading>
-                    <Flex sx={{ columnGap: 1 }}>
-                      <Text
-                        as="p"
-                        sx={{ fontSize: '14px', color: 'neutral80', lineHeight: '22px' }}
-                      >
-                        {description}
-                      </Text>
-                      {learn && (
-                        <AppLink href={learn.link}>
-                          <WithArrow
-                            gap={1}
-                            sx={{ display: 'inline-block', ...getAjnaWithArrowColorScheme() }}
-                          >
-                            {learn.label}
-                          </WithArrow>
-                        </AppLink>
-                      )}
-                    </Flex>
-                  </Box>
-                  <Grid
-                    as="ul"
-                    sx={{
-                      gap: 4,
-                      gridTemplateColumns: 'repeat( 2, 1fr )',
-                      p: '0',
-                      listStyle: 'none',
-                    }}
-                  >
-                    {links.map(({ icon, footnote, link, title }, i) => (
-                      <Flex key={i} as="li" sx={{ flexGrow: 1, flexBasis: 0 }}>
-                        <AppLink
-                          href={link}
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            fontWeight: 'regular',
-                            '&:hover': {
-                              '.dropdownLinkTitle': {
-                                color: 'neutral80',
-                              },
-                            },
-                          }}
-                        >
-                          <Icon size={48} name={icon} sx={{ flexShrink: 0 }} />
-                          <Flex sx={{ flexDirection: 'column', ml: 3 }}>
-                            <Text
-                              as="p"
-                              className="dropdownLinkTitle"
-                              sx={{
-                                fontSize: 4,
-                                fontWeight: 'semiBold',
-                                color: 'primary100',
-                                transition: 'color 200ms',
-                              }}
-                            >
-                              {title}
-                            </Text>
-                            <Text
-                              as="p"
-                              sx={{ fontSize: 2, color: 'neutral80', whiteSpace: 'nowrap' }}
-                            >
-                              {footnote}
-                            </Text>
-                          </Flex>
-                        </AppLink>
-                      </Flex>
-                    ))}
-                  </Grid>
-                  {otherAssets && otherAssets?.length > 0 && (
-                    <Box sx={{ pt: '24px', borderTop: '1px solid', borderColor: 'neutral20' }}>
-                      <Heading
-                        as="h3"
-                        sx={{
-                          fontSize: '16px',
-                          fontWeight: 'semiBold',
-                          mb: 3,
-                          color: 'primary100',
-                        }}
-                      >
-                        Other assets you can borrow against
-                      </Heading>
-                      <Flex as="ul" sx={{ columnGap: 3, rowGap: 2, listStyle: 'none', p: 0 }}>
-                        {otherAssets.map(({ link, token }, i) => (
-                          <Box key={i} as="li">
-                            <AssetPill
-                              icon={getToken(token).iconCircle}
-                              label={token}
-                              link={link}
-                            />
-                          </Box>
-                        ))}
-                      </Flex>
-                    </Box>
-                  )}
+                  <NavigationMenuDropdownContent label={label} {...panel} />
                 </Flex>
               </Flex>
             ))}

--- a/components/navigation/NavigationMenuDropdown.tsx
+++ b/components/navigation/NavigationMenuDropdown.tsx
@@ -115,11 +115,9 @@ export function NavigationMenuDropdown({
                     position: 'absolute',
                     flexDirection: 'column',
                     rowGap: 4,
-                    // ml: '100%',
+                    opacity: currentPanel === label ? 1 : 0,
+                    pointerEvents: isPanelOpen && currentPanel === label ? 'auto' : 'none',
                     ...(isPanelSwitched && { transition: 'opacity 200ms, transform 200ms' }),
-                    ...(currentPanel === label
-                      ? { opacity: 1, pointerEvents: 'auto' }
-                      : { opacity: 0, pointerEvents: 'none' }),
                     transform: `translateX(${getDropdownTranslation(
                       labelsMap,
                       label,

--- a/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/components/navigation/NavigationMenuDropdownContent.tsx
@@ -1,0 +1,120 @@
+import { Icon } from '@makerdao/dai-ui-icons'
+import { getToken } from 'blockchain/tokensMetadata'
+import { AssetPill } from 'components/AssetPill'
+import { AppLink } from 'components/Links'
+import { NavigationMenuPanelType } from 'components/navigation/NavigationMenuPanel'
+import { WithArrow } from 'components/WithArrow'
+import { getAjnaWithArrowColorScheme } from 'features/ajna/common/helpers'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Box, Flex, Grid, Heading, Text } from 'theme-ui'
+
+export type NavigationMenuDropdownContentProps = NavigationMenuPanelType
+
+export function NavigationMenuDropdownContent({
+  label,
+  description,
+  learn,
+  links,
+  otherAssets,
+}: NavigationMenuDropdownContentProps) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <Box>
+        <Heading
+          sx={{
+            fontSize: '28px',
+            fontWeight: 'bold',
+            mb: 1,
+            color: 'primary100',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {label}
+        </Heading>
+        <Flex sx={{ columnGap: 1 }}>
+          <Text as="p" sx={{ fontSize: '14px', color: 'neutral80', lineHeight: '22px' }}>
+            {description}
+          </Text>
+          {learn && (
+            <AppLink href={learn.link}>
+              <WithArrow gap={1} sx={{ display: 'inline-block', ...getAjnaWithArrowColorScheme() }}>
+                {learn.label}
+              </WithArrow>
+            </AppLink>
+          )}
+        </Flex>
+      </Box>
+      <Grid
+        as="ul"
+        sx={{
+          gap: 4,
+          gridTemplateColumns: 'repeat( 2, 1fr )',
+          p: '0',
+          listStyle: 'none',
+        }}
+      >
+        {links.map(({ icon, footnote, link, title }, i) => (
+          <Flex key={i} as="li" sx={{ flexGrow: 1, flexBasis: 0 }}>
+            <AppLink
+              href={link}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                fontWeight: 'regular',
+                '&:hover': {
+                  '.dropdownLinkTitle': {
+                    color: 'neutral80',
+                  },
+                },
+              }}
+            >
+              <Icon size={48} name={icon} sx={{ flexShrink: 0 }} />
+              <Flex sx={{ flexDirection: 'column', ml: 3 }}>
+                <Text
+                  as="p"
+                  className="dropdownLinkTitle"
+                  sx={{
+                    fontSize: 4,
+                    fontWeight: 'semiBold',
+                    color: 'primary100',
+                    transition: 'color 200ms',
+                  }}
+                >
+                  {title}
+                </Text>
+                <Text as="p" sx={{ fontSize: 2, color: 'neutral80', whiteSpace: 'nowrap' }}>
+                  {footnote}
+                </Text>
+              </Flex>
+            </AppLink>
+          </Flex>
+        ))}
+      </Grid>
+      {otherAssets && otherAssets?.length > 0 && (
+        <Box sx={{ pt: '24px', borderTop: '1px solid', borderColor: 'neutral20' }}>
+          <Heading
+            as="h3"
+            sx={{
+              fontSize: '16px',
+              fontWeight: 'semiBold',
+              mb: 3,
+              color: 'primary100',
+            }}
+          >
+            {t('ajna.navigation.common.other-assets')}
+          </Heading>
+          <Flex as="ul" sx={{ columnGap: 3, rowGap: 2, listStyle: 'none', p: 0 }}>
+            {otherAssets.map(({ link, token }, i) => (
+              <Box key={i} as="li">
+                <AssetPill icon={getToken(token).iconCircle} label={token} link={link} />
+              </Box>
+            ))}
+          </Flex>
+        </Box>
+      )}
+    </>
+  )
+}

--- a/components/navigation/NavigationMenuLink.tsx
+++ b/components/navigation/NavigationMenuLink.tsx
@@ -12,7 +12,7 @@ type NavigationMenuPanelLinkProps = NavigationMenuPanelLinkType & {
 
 export function NavigationMenuLink({ label, link, onMouseEnter }: NavigationMenuPanelLinkProps) {
   return (
-    <Box as="li" onMouseEnter={onMouseEnter}>
+    <Box as="li" sx={{ p: 1 }} onMouseEnter={onMouseEnter}>
       <AppLink
         href={link}
         sx={{

--- a/components/navigation/NavigationMenuLink.tsx
+++ b/components/navigation/NavigationMenuLink.tsx
@@ -12,7 +12,13 @@ type NavigationMenuPanelLinkProps = NavigationMenuPanelLinkType & {
 
 export function NavigationMenuLink({ label, link, onMouseEnter }: NavigationMenuPanelLinkProps) {
   return (
-    <Box as="li" sx={{ p: 1 }} onMouseEnter={onMouseEnter}>
+    <Box
+      as="li"
+      sx={{
+        p: 1,
+      }}
+      onMouseEnter={onMouseEnter}
+    >
       <AppLink
         href={link}
         sx={{

--- a/components/navigation/NavigationMenuPanel.tsx
+++ b/components/navigation/NavigationMenuPanel.tsx
@@ -36,6 +36,7 @@ export function NavigationMenuPanel({
   return (
     <Box
       as="li"
+      sx={{ p: 1 }}
       onMouseEnter={(e) => {
         const target = e.target as HTMLDivElement
 

--- a/components/navigation/NavigationMenuPointer.tsx
+++ b/components/navigation/NavigationMenuPointer.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Box } from 'theme-ui'
+
+export interface NavigationMenuPointerProps {
+  arrowPosition: number
+  isPanelOpen: boolean
+  isPanelSwitched: boolean
+}
+
+export function NavigationMenuPointer({
+  arrowPosition,
+  isPanelOpen,
+  isPanelSwitched,
+}: NavigationMenuPointerProps) {
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: '100%',
+        left: '-7px',
+        mt: '-6px',
+        transform: isPanelOpen ? 'translateY(0)' : 'translateY(20px)',
+        transition: 'transform 200ms',
+        zIndex: 2,
+      }}
+    >
+      <Box
+        sx={{
+          width: '14px',
+          height: '14px',
+          borderRadius: 2,
+          bg: 'neutral10',
+          transform: `translateX(${arrowPosition}px) scaleY(1.3) rotate(45deg)`,
+          ...(isPanelSwitched && { transition: 'transform 200ms' }),
+        }}
+      />
+    </Box>
+  )
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2098,5 +2098,12 @@
       "amountBiggerThanBalance": "You cannot deposit more Dai than the amount in your wallet",
       "amountBiggerThanDeposit": "You cannot withdraw more than {{totalValue}} DAI"
     }
+  },
+  "ajna": {
+    "navigation": {
+      "common": {
+        "other-assets": "Other assets you can borrow against"
+      }
+    }
   }
 }


### PR DESCRIPTION
# 🧿 Ajna dropdown navigation

Still missing right panel for wallet connection and other services.

[Tab-1671125085929.webm](https://user-images.githubusercontent.com/16230404/207927355-d9895e2c-4650-47df-ba9e-1b06459e5bd1.webm)
  
## Changes 👷‍♀️

- Fixed issues with dropdown animation,
- split navigation component into smaller chunks to increase readability.
  
## How to test 🧪

- Go to `/ajna` page with `Ajna` feature flag enabled. Without it there should be redirect to homepage,
- compare with figma design: https://www.figma.com/file/XAUn9bc0mlzIS63d9yDUUF/Ajna-x-Oasis?node-id=1268%3A55941&t=ZOXqgZr578kCXQWQ-0.
