### PR TITLE
Added action handling maximum balance

### DIFF
--- a/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
@@ -27,6 +27,9 @@ export function SidebarOpenAaveVaultEditingState(props: OpenAaveEditingStateProp
         maxAmount={state.context.tokenBalance}
         showMax={true}
         maxAmountLabel={t('balance')}
+        onSetMax={() => {
+          send({ type: 'SET_AMOUNT', amount: state.context.tokenBalance! })
+        }}
         onChange={handleNumericInput((amount) => {
           if (amount) {
             send({ type: 'SET_AMOUNT', amount: amount })


### PR DESCRIPTION
# [Clicking on balance does nothing.](https://app.shortcut.com/oazo-apps/story/7188/clicking-on-balance-does-nothing)

  
## Changes 👷‍♀️
- aave multiply opening
- clicking on balance now does something
  
## How to test 🧪
- go to aave multiply opening
- click on balance
- input should update with your balance value
