### PR TITLE
🧿 User actions for Ajna navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@makerdao/dai-ui-icons'
 import { getMixpanelUserContext, trackingEvents } from 'analytics/analytics'
 import { ContextConnected } from 'blockchain/network'
 import { AppLink } from 'components/Links'
+import { ConnectWalletButton } from 'components/navigation/content/ConnectWalletButton'
 import { LANDING_PILLS } from 'content/landing'
 import { DISCOVER_URL } from 'features/discover/helpers'
 import { getUnreadNotificationCount } from 'features/notifications/helpers'
@@ -18,6 +19,7 @@ import { useObservable } from 'helpers/observableHook'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { WithChildren } from 'helpers/types'
 import { useUIChanges } from 'helpers/uiChangesHook'
+import { useAccount } from 'helpers/useAccount'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useOnboarding } from 'helpers/useOnboarding'
 import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
@@ -81,17 +83,6 @@ function BasicHeader({
   )
 }
 
-export function useVaultCount() {
-  const { accountData$ } = useAppContext()
-  const [accountData] = useObservable(accountData$)
-
-  // TODO: Add aave vault.
-
-  const count = accountData?.numberOfVaults !== undefined ? accountData.numberOfVaults : undefined
-
-  return count && count > 0 ? count : null
-}
-
 function PositionsLink({ sx, children }: { sx?: SxStyleProp } & WithChildren) {
   const { context$ } = useAppContext()
   const [context] = useObservable(context$)
@@ -116,7 +107,7 @@ function PositionsLink({ sx, children }: { sx?: SxStyleProp } & WithChildren) {
 }
 
 function PositionsButton({ sx }: { sx?: SxStyleProp }) {
-  const vaultCount = useVaultCount()
+  const { amountOfPositions } = useAccount()
 
   return (
     <PositionsLink sx={{ position: 'relative', ...sx }}>
@@ -126,7 +117,7 @@ function PositionsButton({ sx }: { sx?: SxStyleProp }) {
       >
         <Icon name="home" size="auto" width="20" />
       </Button>
-      {vaultCount && (
+      {amountOfPositions && (
         <Flex
           sx={{
             position: 'absolute',
@@ -142,7 +133,7 @@ function PositionsButton({ sx }: { sx?: SxStyleProp }) {
             zIndex: 'menu',
           }}
         >
-          {vaultCount}
+          {amountOfPositions}
         </Flex>
       )}
     </PositionsLink>
@@ -231,7 +222,7 @@ function UserDesktopMenu() {
   const [context] = useObservable(context$)
   const [accountData] = useObservable(accountData$)
   const [web3Context] = useObservable(web3Context$)
-  const vaultCount = useVaultCount()
+  const { amountOfPositions } = useAccount()
   const [exchangeOnboarded] = useOnboarding('Exchange')
   const [exchangeOpened, setExchangeOpened] = useState(false)
   const [widgetUiChanges] = useObservable(
@@ -273,7 +264,7 @@ function UserDesktopMenu() {
             width="20"
             sx={{ mr: [2, 0, 2], position: 'relative', top: '-1px', flexShrink: 0 }}
           />
-          {t('my-positions')} {vaultCount && `(${vaultCount})`}
+          {t('my-positions')} {amountOfPositions && `(${amountOfPositions})`}
         </PositionsLink>
         <PositionsButton sx={{ mr: 3, display: ['none', 'flex', 'none'] }} />
         <Box>
@@ -882,36 +873,13 @@ function MobileMenu() {
 }
 
 function DisconnectedHeader() {
-  const { t } = useTranslation()
-
   return (
     <>
       <Box sx={{ display: ['none', 'block'] }}>
         <BasicHeader variant="appContainer">
           <MainNavigation />
           <Grid sx={{ alignItems: 'center', columnGap: 3, gridAutoFlow: 'column' }}>
-            <AppLink
-              variant="buttons.secondary"
-              href="/connect"
-              sx={{
-                boxShadow: 'cardLanding',
-                bg: 'neutral10',
-                textDecoration: 'none',
-                display: 'inline-flex',
-                alignItems: 'center',
-                '&:hover svg': {
-                  transform: 'translateX(8px)',
-                },
-                flexShrink: 0,
-              }}
-            >
-              <Text variant="boldParagraph2">{t('connect-wallet-button')}</Text>
-              <Icon
-                name="arrow_right"
-                size="15px"
-                sx={{ position: 'relative', left: '6px', transition: '0.2s' }}
-              />
-            </AppLink>
+            <ConnectWalletButton />
             <LanguageDropdown
               sx={{ '@media (max-width: 1330px)': { '.menu': { right: '-6px' } } }}
             />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -287,7 +287,7 @@ function UserDesktopMenu() {
               ':hover': { color: 'primary100' },
             }}
           >
-            {showNewUniswapWidgetBeacon && (
+            {!showNewUniswapWidgetBeacon && (
               <Icon
                 name="new_beacon"
                 sx={{

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -287,7 +287,7 @@ function UserDesktopMenu() {
               ':hover': { color: 'primary100' },
             }}
           >
-            {!showNewUniswapWidgetBeacon && (
+            {showNewUniswapWidgetBeacon && (
               <Icon
                 name="new_beacon"
                 sx={{

--- a/components/navigation/Navigation.tsx
+++ b/components/navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+import { NavigationActions } from 'components/navigation/NavigationActions'
 import {
   NavigationBranding,
   NavigationBrandingPill,
@@ -5,17 +6,18 @@ import {
 import { NavigationMenu } from 'components/navigation/NavigationMenu'
 import { NavigationMenuPanelLinkType } from 'components/navigation/NavigationMenuLink'
 import { NavigationMenuPanelType } from 'components/navigation/NavigationMenuPanel'
-import React from 'react'
-import { Box, Container } from 'theme-ui'
+import React, { ReactNode } from 'react'
+import { Container } from 'theme-ui'
 
 interface NavigationProps {
+  actions?: ReactNode
   brandingLink?: string
   links?: NavigationMenuPanelLinkType[]
   panels?: NavigationMenuPanelType[]
   pill?: NavigationBrandingPill
 }
 
-export function Navigation({ brandingLink = '/', links, panels, pill }: NavigationProps) {
+export function Navigation({ actions, brandingLink = '/', links, panels, pill }: NavigationProps) {
   return (
     <Container
       as="header"
@@ -29,7 +31,7 @@ export function Navigation({ brandingLink = '/', links, panels, pill }: Navigati
     >
       <NavigationBranding link={brandingLink} pill={pill} />
       <NavigationMenu links={links} panels={panels} />
-      <Box>Panels</Box>
+      <NavigationActions>{actions}</NavigationActions>
     </Container>
   )
 }

--- a/components/navigation/NavigationActions.tsx
+++ b/components/navigation/NavigationActions.tsx
@@ -1,0 +1,8 @@
+import React, { PropsWithChildren } from 'react'
+import { Flex } from 'theme-ui'
+
+interface NavigationActionsProps {}
+
+export function NavigationActions({ children }: PropsWithChildren<NavigationActionsProps>) {
+  return <Flex sx={{ columnGap: 2 }}>{children}</Flex>
+}

--- a/components/navigation/NavigationActions.tsx
+++ b/components/navigation/NavigationActions.tsx
@@ -4,5 +4,5 @@ import { Flex } from 'theme-ui'
 interface NavigationActionsProps {}
 
 export function NavigationActions({ children }: PropsWithChildren<NavigationActionsProps>) {
-  return <Flex sx={{ columnGap: 2 }}>{children}</Flex>
+  return <Flex sx={{ columnGap: 2, py: 2 }}>{children}</Flex>
 }

--- a/components/navigation/NavigationMenuDropdown.tsx
+++ b/components/navigation/NavigationMenuDropdown.tsx
@@ -87,9 +87,8 @@ export function NavigationMenuDropdown({
             }}
           >
             {panels.map(({ label, ...panel }, i) => (
-              <Flex sx={{ ml: '-100%', transform: 'translateX(50%)' }}>
+              <Flex key={i} sx={{ ml: '-100%', transform: 'translateX(50%)' }}>
                 <Flex
-                  key={i}
                   sx={{
                     position: 'absolute',
                     flexDirection: 'column',

--- a/components/navigation/NavigationMenuOrb.tsx
+++ b/components/navigation/NavigationMenuOrb.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
 import { useToggle } from 'helpers/useToggle'
-import React from 'react'
+import React, { PropsWithChildren, useEffect, useRef } from 'react'
 import { Box, Button } from 'theme-ui'
 
 export interface NavigationMenuOrbProps {
@@ -9,6 +9,8 @@ export interface NavigationMenuOrbProps {
   iconSize?: number
   isDisabled?: boolean
   beacon?: boolean | number
+  onClose?: () => void
+  onOpen?: () => void
 }
 
 export function NavigationOrb({
@@ -16,9 +18,20 @@ export function NavigationOrb({
   iconSize = 16,
   isDisabled,
   beacon,
-}: NavigationMenuOrbProps) {
+  children,
+  onClose,
+  onOpen,
+}: PropsWithChildren<NavigationMenuOrbProps>) {
   const [isOpen, toggleIsOpen, setIsOpen] = useToggle(false)
+  const didMountRef = useRef(false)
   const ref = useOutsideElementClickHandler(() => setIsOpen(false))
+
+  useEffect(() => {
+    if (didMountRef.current) {
+      if (isOpen && onOpen) onOpen()
+      else if (!isOpen && onClose) onClose()
+    } else didMountRef.current = true
+  }, [isOpen])
 
   return (
     <Box ref={ref} sx={{ position: 'relative' }}>
@@ -93,7 +106,7 @@ export function NavigationOrb({
           position: 'absolute',
           top: '100%',
           right: 0,
-          mt: 1,
+          mt: 2,
           backgroundColor: 'neutral10',
           boxShadow: 'buttonMenu',
           borderRadius: 'large',
@@ -105,7 +118,7 @@ export function NavigationOrb({
           zIndex: 1,
         }}
       >
-        -
+        {children}
       </Box>
     </Box>
   )

--- a/components/navigation/NavigationMenuOrb.tsx
+++ b/components/navigation/NavigationMenuOrb.tsx
@@ -1,0 +1,57 @@
+import { Icon } from '@makerdao/dai-ui-icons'
+import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
+import { useToggle } from 'helpers/useToggle'
+import React from 'react'
+import { Box, Button } from 'theme-ui'
+
+export interface NavigationMenuOrbProps {
+  icon?: string
+  iconSize?: number
+  isDisabled?: boolean
+}
+
+export function NavigationOrb({ icon, iconSize = 16, isDisabled }: NavigationMenuOrbProps) {
+  const [isOpen, toggleIsOpen, setIsOpen] = useToggle(false)
+  const ref = useOutsideElementClickHandler(() => setIsOpen(false))
+
+  return (
+    <Box ref={ref} sx={{ position: 'relative' }}>
+      <Button
+        variant="menuButtonRound"
+        onClick={toggleIsOpen}
+        disabled={isDisabled}
+        sx={{
+          position: 'relative',
+          width: 'auto',
+          minWidth: '50px',
+          color: isOpen ? 'primary100' : 'neutral80',
+          boxShadow: 'buttonMenu',
+          transition: 'background-color 200ms',
+          '&:hover': { boxShadow: 'buttonMenu' },
+          ':hover': { color: 'primary100' },
+        }}
+      >
+        {icon && <Icon name={icon} size={iconSize} sx={{ transition: 'color 200ms' }} />}
+      </Button>
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '100%',
+          right: 0,
+          mt: 1,
+          backgroundColor: 'neutral10',
+          boxShadow: 'buttonMenu',
+          borderRadius: 'large',
+          opacity: isOpen ? 1 : 0,
+          transform: isOpen ? 'translateY(0)' : 'translateY(-5px)',
+          pointerEvents: isOpen ? 'auto' : 'none',
+          transition: 'opacity 200ms, transform 200ms',
+          overflowY: 'auto',
+          zIndex: 1,
+        }}
+      >
+        -
+      </Box>
+    </Box>
+  )
+}

--- a/components/navigation/NavigationMenuOrb.tsx
+++ b/components/navigation/NavigationMenuOrb.tsx
@@ -8,9 +8,15 @@ export interface NavigationMenuOrbProps {
   icon?: string
   iconSize?: number
   isDisabled?: boolean
+  beacon?: boolean | number
 }
 
-export function NavigationOrb({ icon, iconSize = 16, isDisabled }: NavigationMenuOrbProps) {
+export function NavigationOrb({
+  icon,
+  iconSize = 16,
+  isDisabled,
+  beacon,
+}: NavigationMenuOrbProps) {
   const [isOpen, toggleIsOpen, setIsOpen] = useToggle(false)
   const ref = useOutsideElementClickHandler(() => setIsOpen(false))
 
@@ -31,6 +37,55 @@ export function NavigationOrb({ icon, iconSize = 16, isDisabled }: NavigationMen
           ':hover': { color: 'primary100' },
         }}
       >
+        {typeof beacon === 'boolean' && (
+          <Box
+            sx={{
+              position: 'absolute',
+              top: '3px',
+              right: '3px',
+              width: '10px',
+              height: '10px',
+              borderRadius: 'round',
+              bg: 'interactive100',
+              '&::before, &::after': {
+                content: '""',
+                position: 'absolute',
+                borderRadius: 'round',
+                bg: 'interactive100',
+                opacity: 0.1,
+              },
+              '&::before': {
+                top: '-3px',
+                right: '-3px',
+                bottom: '-3px',
+                left: '-3px',
+              },
+              '&::after': {
+                top: '-6px',
+                right: '-6px',
+                bottom: '-6px',
+                left: '-6px',
+              },
+            }}
+          ></Box>
+        )}
+        {typeof beacon === 'number' && (
+          <Box
+            as="span"
+            sx={{
+              position: 'absolute',
+              top: '-3px',
+              right: '-10px',
+              px: 2,
+              fontWeight: 'semiBold',
+              color: 'neutral10',
+              borderRadius: 'rounder',
+              bg: 'interactive100',
+            }}
+          >
+            11
+          </Box>
+        )}
         {icon && <Icon name={icon} size={iconSize} sx={{ transition: 'color 200ms' }} />}
       </Button>
       <Box

--- a/components/navigation/NavigationMenuOrb.tsx
+++ b/components/navigation/NavigationMenuOrb.tsx
@@ -1,27 +1,28 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
 import { useToggle } from 'helpers/useToggle'
-import React, { PropsWithChildren, useEffect, useRef } from 'react'
+import React, { ReactNode, useEffect, useRef } from 'react'
 import { Box, Button } from 'theme-ui'
 
 export interface NavigationMenuOrbProps {
+  beacon?: boolean | number
+  children: (isOpen: boolean) => ReactNode
   icon?: string
   iconSize?: number
   isDisabled?: boolean
-  beacon?: boolean | number
   onClose?: () => void
   onOpen?: () => void
 }
 
 export function NavigationOrb({
+  beacon,
+  children,
   icon,
   iconSize = 16,
   isDisabled,
-  beacon,
-  children,
   onClose,
   onOpen,
-}: PropsWithChildren<NavigationMenuOrbProps>) {
+}: NavigationMenuOrbProps) {
   const [isOpen, toggleIsOpen, setIsOpen] = useToggle(false)
   const didMountRef = useRef(false)
   const ref = useOutsideElementClickHandler(() => setIsOpen(false))
@@ -96,7 +97,7 @@ export function NavigationOrb({
               bg: 'interactive100',
             }}
           >
-            11
+            {beacon}
           </Box>
         )}
         {icon && <Icon name={icon} size={iconSize} sx={{ transition: 'color 200ms' }} />}
@@ -118,7 +119,7 @@ export function NavigationOrb({
           zIndex: 1,
         }}
       >
-        {children}
+        {children(isOpen)}
       </Box>
     </Box>
   )

--- a/components/navigation/content/ConnectWalletButton.tsx
+++ b/components/navigation/content/ConnectWalletButton.tsx
@@ -1,0 +1,34 @@
+import { AppLink } from 'components/Links'
+import { WithArrow } from 'components/WithArrow'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+export function ConnectWalletButton() {
+  const { t } = useTranslation()
+
+  return (
+    <AppLink
+      variant="buttons.secondary"
+      href="/connect"
+      sx={{
+        display: 'flex',
+        flexShrink: 0,
+        p: 0,
+        textDecoration: 'none',
+        bg: 'neutral10',
+        boxShadow: 'buttonMenu',
+      }}
+    >
+      <WithArrow
+        sx={{
+          py: 2,
+          pl: 4,
+          pr: '40px',
+          fontSize: '16px',
+        }}
+      >
+        {t('connect-wallet-button')}
+      </WithArrow>
+    </AppLink>
+  )
+}

--- a/components/navigation/content/MyPositionsLink.tsx
+++ b/components/navigation/content/MyPositionsLink.tsx
@@ -11,7 +11,9 @@ export function MyPositionsLink() {
   return (
     <>
       {t('my-positions')} (
-      {amountOfPositions || (
+      {amountOfPositions !== undefined && amountOfPositions >= 0 ? (
+        amountOfPositions
+      ) : (
         <Spinner
           size={14}
           color={ajnaExtensionTheme.colors.neutral80}

--- a/components/navigation/content/MyPositionsLink.tsx
+++ b/components/navigation/content/MyPositionsLink.tsx
@@ -1,0 +1,24 @@
+import { useAccount } from 'helpers/useAccount'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { ajnaExtensionTheme } from 'theme'
+import { Spinner } from 'theme-ui'
+
+export function MyPositionsLink() {
+  const { t } = useTranslation()
+  const { amountOfPositions } = useAccount()
+
+  return (
+    <>
+      {t('my-positions')} (
+      {amountOfPositions || (
+        <Spinner
+          size={14}
+          color={ajnaExtensionTheme.colors.neutral80}
+          sx={{ verticalAlign: 'text-bottom' }}
+        />
+      )}
+      )
+    </>
+  )
+}

--- a/components/navigation/content/NotificationsOrb.tsx
+++ b/components/navigation/content/NotificationsOrb.tsx
@@ -1,0 +1,22 @@
+import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
+import { NotificationsCenter } from 'components/notifications/NotificationsCenter'
+import { getUnreadNotificationCount } from 'features/notifications/helpers'
+import { NOTIFICATION_CHANGE, NotificationChange } from 'features/notifications/notificationChange'
+import { useUIChanges } from 'helpers/uiChangesHook'
+import React from 'react'
+
+export function NotificationsOrb() {
+  const [notificationsState] = useUIChanges<NotificationChange>(NOTIFICATION_CHANGE)
+  const unreadNotificationCount = getUnreadNotificationCount(notificationsState?.allNotifications)
+
+  return (
+    <NavigationOrb
+      icon="bell"
+      iconSize={16}
+      isDisabled={!notificationsState}
+      {...(unreadNotificationCount > 0 && { beacon: unreadNotificationCount })}
+    >
+      {(isOpen) => <NotificationsCenter isOpen={isOpen} />}
+    </NavigationOrb>
+  )
+}

--- a/components/navigation/content/SwapOrb.tsx
+++ b/components/navigation/content/SwapOrb.tsx
@@ -8,7 +8,7 @@ export function SwapOrb() {
 
   return (
     <NavigationOrb icon="exchange" iconSize={20} {...(!exchangeOnboarded && { beacon: true })}>
-      <UniswapWidget />
+      {() => <UniswapWidget />}
     </NavigationOrb>
   )
 }

--- a/components/navigation/content/SwapOrb.tsx
+++ b/components/navigation/content/SwapOrb.tsx
@@ -1,0 +1,14 @@
+import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
+import { UniswapWidget } from 'components/uniswapWidget/UniswapWidget'
+import { useOnboarding } from 'helpers/useOnboarding'
+import React from 'react'
+
+export function SwapOrb() {
+  const [exchangeOnboarded] = useOnboarding('Exchange')
+
+  return (
+    <NavigationOrb icon="exchange" iconSize={20} {...(!exchangeOnboarded && { beacon: true })}>
+      <UniswapWidget />
+    </NavigationOrb>
+  )
+}

--- a/components/notifications/NotificationsCenter.tsx
+++ b/components/notifications/NotificationsCenter.tsx
@@ -1,38 +1,30 @@
 import { CommonAnalyticsSections, NotificationsEventIds, trackingEvents } from 'analytics/analytics'
 import { NotificationCardsWrapper } from 'components/notifications/NotificationCardsWrapper'
+import { NotificationsCenterContent } from 'components/notifications/NotificationsCenterContent'
+import { NotificationsCenterHeader } from 'components/notifications/NotificationsCenterHeader'
 import { NotificationsError } from 'components/notifications/NotificationsError'
+import { NotificationPreferenceCardWrapper } from 'components/notifications/NotificationsPrefrenceCardWrapper'
 import { useNotificationSocket } from 'components/NotificationSocketProvider'
 import { NOTIFICATION_CHANGE, NotificationChange } from 'features/notifications/notificationChange'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { throttle } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect, useMemo, useState } from 'react'
-import { theme } from 'theme'
 import { Box, Grid } from 'theme-ui'
 import { useOnMobile } from 'theme/useBreakpointIndex'
 
-import { NotificationsCenterContent } from './NotificationsCenterContent'
-import { NotificationsCenterHeader } from './NotificationsCenterHeader'
-import { NotificationPreferenceCardWrapper } from './NotificationsPrefrenceCardWrapper'
-
 export function NotificationsCenter({ isOpen }: { isOpen: boolean }) {
-  const { analyticsData } = useNotificationSocket()
-  const onMobile = useOnMobile()
-  const [showPreferencesTab, setShowPrefencesTab] = useState(false)
-  const [notificationsState] = useUIChanges<NotificationChange>(NOTIFICATION_CHANGE)
   const { t } = useTranslation()
-
-  const notificationCenterStyles = useMemo(
-    () => ({
-      right: onMobile ? '8px' : '0',
-      width: onMobile ? '95%' : 380,
-    }),
-    [onMobile],
-  )
+  const [showPreferencesTab, setShowPrefencesTab] = useState(false)
+  const { analyticsData } = useNotificationSocket()
+  const [notificationsState] = useUIChanges<NotificationChange>(NOTIFICATION_CHANGE)
+  const onMobile = useOnMobile()
 
   useEffect(() => {
     setShowPrefencesTab(false)
   }, [analyticsData.walletAddress, isOpen])
+
+  const notificationCenterStyles = useMemo(() => ({ width: onMobile ? '95%' : 380 }), [onMobile])
 
   const handleScroll = throttle(() => {
     trackingEvents.notifications.scroll(
@@ -43,23 +35,7 @@ export function NotificationsCenter({ isOpen }: { isOpen: boolean }) {
   }, 500)
 
   return (
-    <Box
-      sx={{
-        bg: 'white',
-        position: 'absolute',
-        mt: 2,
-        borderRadius: 'large',
-        boxShadow: theme.shadows.buttonMenu,
-        pt: 2,
-        px: 2,
-        // TODO: Needs to be calculated but possibly be easier to get designers to adapt to this as its simpler from dev perspective & looks just as good
-        ...notificationCenterStyles,
-        opacity: isOpen ? 1 : 0,
-        transform: isOpen ? 'translateY(0)' : 'translateY(-5px)',
-        pointerEvents: isOpen ? 'auto' : 'none',
-        transition: 'opacity 200ms, transform 200ms',
-      }}
-    >
+    <Box sx={{ ...notificationCenterStyles }}>
       <NotificationsCenterHeader
         onButtonClick={() => {
           trackingEvents.notifications.buttonClick(

--- a/components/notifications/NotificationsIconButton.tsx
+++ b/components/notifications/NotificationsIconButton.tsx
@@ -84,7 +84,24 @@ export function NotificationsIconButton({
         </>
       </Button>
 
-      <NotificationsCenter isOpen={notificationsPanelOpen} />
+      <Box
+        sx={{
+          bg: 'white',
+          position: 'absolute',
+          right: 0,
+          mt: 2,
+          borderRadius: 'large',
+          boxShadow: 'buttonMenu',
+          pt: 2,
+          px: 2,
+          opacity: notificationsPanelOpen ? 1 : 0,
+          transform: notificationsPanelOpen ? 'translateY(0)' : 'translateY(-5px)',
+          pointerEvents: notificationsPanelOpen ? 'auto' : 'none',
+          transition: 'opacity 200ms, transform 200ms',
+        }}
+      >
+        <NotificationsCenter isOpen={notificationsPanelOpen} />
+      </Box>
     </Box>
   )
 }

--- a/components/notifications/NotificationsIconButton.tsx
+++ b/components/notifications/NotificationsIconButton.tsx
@@ -23,8 +23,6 @@ export function NotificationsIconButton({
 }: NotificationsIconButtonProps) {
   const { analyticsData } = useNotificationSocket()
 
-  notificationsCount = 99
-
   const handleButtonClick = () => {
     onButtonClick()
     trackingEvents.notifications.buttonClick(

--- a/components/notifications/NotificationsIconButton.tsx
+++ b/components/notifications/NotificationsIconButton.tsx
@@ -23,6 +23,8 @@ export function NotificationsIconButton({
 }: NotificationsIconButtonProps) {
   const { analyticsData } = useNotificationSocket()
 
+  notificationsCount = 99
+
   const handleButtonClick = () => {
     onButtonClick()
     trackingEvents.notifications.buttonClick(

--- a/features/ajna/controls/AjnaNavigationController.tsx
+++ b/features/ajna/controls/AjnaNavigationController.tsx
@@ -164,8 +164,8 @@ export function AjnaNavigationController() {
       actions={
         isConnected ? (
           <>
-            <NavigationOrb icon="exchange" iconSize={20} />
-            <NavigationOrb icon="bell" />
+            <NavigationOrb icon="exchange" iconSize={20} beacon />
+            <NavigationOrb icon="bell" beacon={11} />
           </>
         ) : (
           <ConnectWalletButton />

--- a/features/ajna/controls/AjnaNavigationController.tsx
+++ b/features/ajna/controls/AjnaNavigationController.tsx
@@ -1,24 +1,19 @@
-import { useAppContext } from 'components/AppContextProvider'
-import { useVaultCount } from 'components/Header'
+import { ConnectWalletButton } from 'components/navigation/content/ConnectWalletButton'
+import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
 import { Navigation } from 'components/navigation/Navigation'
-import { useObservable } from 'helpers/observableHook'
+import { useAccount } from 'helpers/useAccount'
 import React from 'react'
-import { ajnaExtensionTheme } from 'theme'
-import { Spinner } from 'theme-ui'
 
 export function AjnaNavigationController() {
-  const { context$ } = useAppContext()
-  const [context] = useObservable(context$)
-  const vaultCount = useVaultCount()
-
-  const isConnected = context?.status === 'connected'
+  const { isConnected } = useAccount()
 
   return (
     <Navigation
+      pill={{ label: 'Ajna', color: ['#f154db', '#974eea'] }}
       panels={[
         {
-          description: 'Borrow against your favorite crypto assets.',
           label: 'Borrow',
+          description: 'Borrow against your favorite crypto assets.',
           learn: {
             label: 'Learn more about Borrow',
             link: 'https://kb.oasis.app/',
@@ -93,8 +88,8 @@ export function AjnaNavigationController() {
           ],
         },
         {
-          description: 'Multiply your exposure to your favorite crypto assets.',
           label: 'Multiply',
+          description: 'Multiply your exposure to your favorite crypto assets.',
           learn: {
             label: 'Learn more about Multiply',
             link: 'https://kb.oasis.app/',
@@ -119,8 +114,8 @@ export function AjnaNavigationController() {
           ],
         },
         {
-          description: 'Put your crypto assets to work today.',
           label: 'Earn',
+          description: 'Put your crypto assets to work today.',
           learn: {
             label: 'Learn more about Earn',
             link: 'https://kb.oasis.app/',
@@ -159,27 +154,13 @@ export function AjnaNavigationController() {
         ...(isConnected
           ? [
               {
-                label: (
-                  <>
-                    My positions (
-                    {vaultCount !== null ? (
-                      vaultCount
-                    ) : (
-                      <Spinner
-                        size={14}
-                        color={ajnaExtensionTheme.colors.neutral80}
-                        sx={{ verticalAlign: 'text-bottom' }}
-                      />
-                    )}
-                    )
-                  </>
-                ),
+                label: <MyPositionsLink />,
                 link: '/my',
               },
             ]
           : []),
       ]}
-      pill={{ label: 'Ajna', color: ['#f154db', '#974eea'] }}
+      actions={isConnected ? 'Wallet connected' : <ConnectWalletButton />}
     />
   )
 }

--- a/features/ajna/controls/AjnaNavigationController.tsx
+++ b/features/ajna/controls/AjnaNavigationController.tsx
@@ -1,8 +1,8 @@
 import { ConnectWalletButton } from 'components/navigation/content/ConnectWalletButton'
 import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
+import { NotificationsOrb } from 'components/navigation/content/NotificationsOrb'
 import { SwapOrb } from 'components/navigation/content/SwapOrb'
 import { Navigation } from 'components/navigation/Navigation'
-import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
 import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 
@@ -166,7 +166,7 @@ export function AjnaNavigationController() {
         isConnected ? (
           <>
             <SwapOrb />
-            <NavigationOrb icon="bell" beacon={11} />
+            <NotificationsOrb />
           </>
         ) : (
           <ConnectWalletButton />

--- a/features/ajna/controls/AjnaNavigationController.tsx
+++ b/features/ajna/controls/AjnaNavigationController.tsx
@@ -1,6 +1,7 @@
 import { ConnectWalletButton } from 'components/navigation/content/ConnectWalletButton'
 import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
 import { Navigation } from 'components/navigation/Navigation'
+import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
 import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 
@@ -160,7 +161,16 @@ export function AjnaNavigationController() {
             ]
           : []),
       ]}
-      actions={isConnected ? 'Wallet connected' : <ConnectWalletButton />}
+      actions={
+        isConnected ? (
+          <>
+            <NavigationOrb icon="exchange" iconSize={20} />
+            <NavigationOrb icon="bell" />
+          </>
+        ) : (
+          <ConnectWalletButton />
+        )
+      }
     />
   )
 }

--- a/features/ajna/controls/AjnaNavigationController.tsx
+++ b/features/ajna/controls/AjnaNavigationController.tsx
@@ -1,5 +1,6 @@
 import { ConnectWalletButton } from 'components/navigation/content/ConnectWalletButton'
 import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
+import { SwapOrb } from 'components/navigation/content/SwapOrb'
 import { Navigation } from 'components/navigation/Navigation'
 import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
 import { useAccount } from 'helpers/useAccount'
@@ -164,7 +165,7 @@ export function AjnaNavigationController() {
       actions={
         isConnected ? (
           <>
-            <NavigationOrb icon="exchange" iconSize={20} beacon />
+            <SwapOrb />
             <NavigationOrb icon="bell" beacon={11} />
           </>
         ) : (

--- a/helpers/useAccount.ts
+++ b/helpers/useAccount.ts
@@ -1,0 +1,18 @@
+import { useAppContext } from 'components/AppContextProvider'
+import { useObservable } from 'helpers/observableHook'
+
+interface AccountState {
+  amountOfPositions?: number
+  isConnected: boolean
+}
+
+export function useAccount(): AccountState {
+  const { accountData$, context$ } = useAppContext()
+  const [context] = useObservable(context$)
+  const [accountData] = useObservable(accountData$)
+
+  return {
+    amountOfPositions: accountData?.numberOfVaults,
+    isConnected: context?.status === 'connected',
+  }
+}

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -460,6 +460,7 @@ export const oasisBaseTheme = {
       borderRadius: 'round',
       px: 4,
       py: 2,
+      transition: 'background-color 200ms',
       '&:focus': {
         outline: 'none',
       },


### PR DESCRIPTION
# 🧿 User actions for Ajna navigation

![image](https://user-images.githubusercontent.com/16230404/208407507-059cbb7d-a3a8-48b5-80ac-2e6a5b4626ed.png)
![image](https://user-images.githubusercontent.com/16230404/208404772-67a89e1b-55ca-45bc-8efb-0d541025126b.png)

#### TODO:
- Add wallet controllers,
- mobile support.
  
## Changes 👷‍♀️

- Created `NavigationOrb` component which is a common component for all user actions and panels in navigation,
- implemented `SwapOrb` and `NotificationsOrb` using `NavigationOrb` so both of them can use the same styling, animation and interaction,
- added "Connect wallet" button to Ajna navigation,
- created `useAccount` hook that contains selected information about user based on global context as a shorthand; for now it's if user is connected and how many positions he has open. That should be further whenever there is opportunity for something to be moved there,
  
## How to test 🧪

- Go to `/ajna` page with `Ajna` feature flag enabled. Without it there should be redirect to homepage,
- test if orbs behavior is similar to those on main landing page (but better 😎),
- test if orbs on main landing page wasn't somehow affected by this changes.
