### PR TITLE
Remove 0 showing next to my positions

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -117,7 +117,7 @@ function PositionsButton({ sx }: { sx?: SxStyleProp }) {
       >
         <Icon name="home" size="auto" width="20" />
       </Button>
-      {amountOfPositions && (
+      {Boolean(amountOfPositions) && (
         <Flex
           sx={{
             position: 'absolute',
@@ -264,7 +264,7 @@ function UserDesktopMenu() {
             width="20"
             sx={{ mr: [2, 0, 2], position: 'relative', top: '-1px', flexShrink: 0 }}
           />
-          {t('my-positions')} {amountOfPositions && `(${amountOfPositions})`}
+          {t('my-positions')} {Boolean(amountOfPositions) && `(${amountOfPositions})`}
         </PositionsLink>
         <PositionsButton sx={{ mr: 3, display: ['none', 'flex', 'none'] }} />
         <Box>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -117,7 +117,7 @@ function PositionsButton({ sx }: { sx?: SxStyleProp }) {
       >
         <Icon name="home" size="auto" width="20" />
       </Button>
-      {Boolean(amountOfPositions) && (
+      {!!amountOfPositions && (
         <Flex
           sx={{
             position: 'absolute',
@@ -264,7 +264,7 @@ function UserDesktopMenu() {
             width="20"
             sx={{ mr: [2, 0, 2], position: 'relative', top: '-1px', flexShrink: 0 }}
           />
-          {t('my-positions')} {Boolean(amountOfPositions) && `(${amountOfPositions})`}
+          {t('my-positions')} {!!amountOfPositions && `(${amountOfPositions})`}
         </PositionsLink>
         <PositionsButton sx={{ mr: 3, display: ['none', 'flex', 'none'] }} />
         <Box>


### PR DESCRIPTION
# Remove `0` showing next to my positions

![image](https://user-images.githubusercontent.com/16230404/208442591-2c83cfcb-55e1-478e-a64a-befe3e8ba3e6.png)
  
## Changes 👷‍♀️

- Fixed issue with condition that was rendering `0` when user has no open vaults next to "My positions" link in navigation.
  
## How to test 🧪

Use two different wallets to test it. One that already has vaults and one that doesn't. When connected, check if number of vaults is displayed correctly and there's no `0` when you don't have any.
