### PR TITLE
Show pill only on reviewing step before tx is executed

### DIFF
--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -39,7 +39,11 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
       collateralPrice={state.context.collateralPrice}
       tokenPrice={state.context.tokenPrice}
       debtPrice={state.context.debtPrice}
-      nextPosition={state.matches('frontend.reviewing') ? state.context.strategy?.simulation.position : undefined}
+      nextPosition={
+        state.matches('frontend.reviewing')
+          ? state.context.strategy?.simulation.position
+          : undefined
+      }
     />
   )
 }

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -39,7 +39,7 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
       collateralPrice={state.context.collateralPrice}
       tokenPrice={state.context.tokenPrice}
       debtPrice={state.context.debtPrice}
-      nextPosition={state.context.strategy?.simulation.position}
+      nextPosition={state.matches('frontend.reviewing') ? state.context.strategy?.simulation.position : undefined}
     />
   )
 }


### PR DESCRIPTION
# [Wait with order information + 'after' pills until user has touched the risk slider.](https://app.shortcut.com/oazo-apps/story/7238/wait-with-order-information-after-pills-until-user-has-touched-the-risk-slider)
  
## Changes 👷‍♀️
- Only show after t/x pills once the user hits the review step
  
## How to test 🧪
- Open an aave multiply position and double check pills only appear in the last step before submitting the t/x can use url like:  `http://localhost:3000/multiply/aave/open/stETHusdc?network=hardhat#simulate`
