### PR TITLE
fix aave dsproxy positions not displaying if no dpm proxy positions

### DIFF
--- a/features/aave/services/readPositionCreatedEvents.ts
+++ b/features/aave/services/readPositionCreatedEvents.ts
@@ -1,6 +1,6 @@
 import { utils } from 'ethers'
 import { combineLatest, from, Observable } from 'rxjs'
-import { map, switchMap } from 'rxjs/operators'
+import { map, startWith, switchMap } from 'rxjs/operators'
 
 import positionCreatedAbi from '../../../blockchain/abi/position-created.json'
 import { Context } from '../../../blockchain/network'
@@ -72,5 +72,6 @@ export function createReadPositionCreatedEvents$(
         }),
       )
     }),
+    startWith([]),
   )
 }


### PR DESCRIPTION
## How to test 🧪

- create steth/eth position using DS proxy
- make sure no DPM positions
- 👉 position should be shown on overview page
- create a DPM position
- 👉 position should not be shown twice