### PR TITLE
Automation validation update

### DIFF
--- a/features/borrow/manage/pipes/viewStateTransforms/manageVaultConditions.ts
+++ b/features/borrow/manage/pipes/viewStateTransforms/manageVaultConditions.ts
@@ -31,7 +31,6 @@ import {
   withdrawCollateralOnVaultUnderDebtFloorValidator,
 } from 'features/form/commonValidators'
 import { isNullish } from 'helpers/functions'
-import { STOP_LOSS_MARGIN } from 'helpers/multiply/calculations'
 import { UnreachableCaseError } from 'helpers/UnreachableCaseError'
 import { zero } from 'helpers/zero'
 
@@ -303,7 +302,6 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
     paybackAmount,
     afterCollateralizationRatio,
     afterCollateralizationRatioAtNextPrice,
-    collateralizationRatioAtNextPrice,
     ilkData: {
       liquidationRatio,
       collateralizationDangerThreshold,
@@ -524,18 +522,15 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioBelowStopLossRatio =
     !!stopLossData?.isStopLossEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: stopLossData.stopLossLevel,
       type: 'below',
-      margin: STOP_LOSS_MARGIN,
     })
 
   const afterCollRatioBelowAutoSellRatio =
     !!autoSellData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoSellData.execCollRatio.div(100),
@@ -545,7 +540,6 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioAboveAutoBuyRatio =
     !!autoBuyData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoBuyData.execCollRatio.div(100),
@@ -555,7 +549,6 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioBelowConstantMultipleSellRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.sellExecutionCollRatio.div(100),
@@ -565,7 +558,6 @@ export function applyManageVaultConditions<VaultState extends ManageStandardBorr
   const afterCollRatioAboveConstantMultipleBuyRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.buyExecutionCollRatio.div(100),

--- a/features/form/commonValidators.ts
+++ b/features/form/commonValidators.ts
@@ -433,27 +433,16 @@ export function daiAllowanceProgressionDisabledValidator({
 }
 
 export function afterCollRatioThresholdRatioValidator({
-  collateralizationRatioAtNextPrice,
   afterCollateralizationRatio,
   afterCollateralizationRatioAtNextPrice,
   threshold,
-  margin = new BigNumber(0.02),
   type,
 }: {
-  collateralizationRatioAtNextPrice: BigNumber
   afterCollateralizationRatio: BigNumber
   afterCollateralizationRatioAtNextPrice: BigNumber
   threshold: BigNumber
-  margin?: BigNumber
   type: 'below' | 'above'
 }) {
-  if (
-    afterCollateralizationRatioAtNextPrice.gt(collateralizationRatioAtNextPrice) &&
-    type === 'below'
-  ) {
-    return false
-  }
-
   if (afterCollateralizationRatio.isZero() || afterCollateralizationRatioAtNextPrice.isZero()) {
     return false
   }
@@ -462,12 +451,12 @@ export function afterCollRatioThresholdRatioValidator({
     case 'below':
       return (
         afterCollateralizationRatio.lt(threshold) ||
-        afterCollateralizationRatioAtNextPrice.minus(margin).lte(threshold)
+        afterCollateralizationRatioAtNextPrice.lte(threshold)
       )
     case 'above':
       return (
         afterCollateralizationRatio.gt(threshold) ||
-        afterCollateralizationRatioAtNextPrice.plus(margin).gte(threshold)
+        afterCollateralizationRatioAtNextPrice.gte(threshold)
       )
     default:
       return false

--- a/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultConditions.ts
@@ -1,7 +1,6 @@
 import { FLASH_MINT_LIMIT_PER_TX } from 'components/constants'
 import { SLIPPAGE_WARNING_THRESHOLD } from 'features/userSettings/userSettings'
 import { isNullish } from 'helpers/functions'
-import { STOP_LOSS_MARGIN } from 'helpers/multiply/calculations'
 import { UnreachableCaseError } from 'helpers/UnreachableCaseError'
 import { zero } from 'helpers/zero'
 
@@ -320,7 +319,6 @@ export const defaultManageMultiplyVaultConditions: ManageVaultConditions = {
 
 export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(state: VS): VS {
   const {
-    collateralizationRatioAtNextPrice,
     afterCollateralizationRatio,
     afterCollateralizationRatioAtNextPrice,
     afterDebt,
@@ -594,18 +592,15 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioBelowStopLossRatio =
     !!stopLossData?.isStopLossEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: stopLossData.stopLossLevel,
       type: 'below',
-      margin: STOP_LOSS_MARGIN,
     })
 
   const afterCollRatioBelowAutoSellRatio =
     !!autoSellData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoSellData.execCollRatio.div(100),
@@ -615,7 +610,6 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioAboveAutoBuyRatio =
     !!autoBuyData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: autoBuyData.execCollRatio.div(100),
@@ -625,7 +619,6 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioBelowConstantMultipleSellRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.sellExecutionCollRatio.div(100),
@@ -635,7 +628,6 @@ export function applyManageVaultConditions<VS extends ManageMultiplyVaultState>(
   const afterCollRatioAboveConstantMultipleBuyRatio =
     !!constantMultipleData?.isTriggerEnabled &&
     afterCollRatioThresholdRatioValidator({
-      collateralizationRatioAtNextPrice,
       afterCollateralizationRatio,
       afterCollateralizationRatioAtNextPrice,
       threshold: constantMultipleData.buyExecutionCollRatio.div(100),


### PR DESCRIPTION
# [Automation validation update](https://app.shortcut.com/oazo-apps/story/7319/automation-validation-bug)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed unnecessary margin from method which validates col ratios and given threshold
  
## How to test 🧪
  <Please explain how to test your changes>

- users should be always able to deposit to vault when SL is enabled
- user shouldn't be able to reopen vault when SL is active and new col ratio will be below SL trigger ratio
