### PR TITLE
Fixed an error while switching tabs on sidebar

### DIFF
--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -223,8 +223,6 @@ export function createManageAaveStateMachine(
               },
             },
             manageCollateral: {
-              entry: ['spawnDepositBorrowMachine'],
-              exit: ['killCurrentParametersMachine'],
               on: {
                 NEXT_STEP: [
                   {
@@ -248,8 +246,6 @@ export function createManageAaveStateMachine(
               },
             },
             manageDebt: {
-              entry: ['spawnDepositBorrowMachine'],
-              exit: ['killCurrentParametersMachine'],
               on: {
                 NEXT_STEP: [
                   {
@@ -396,6 +392,8 @@ export function createManageAaveStateMachine(
           cond: 'canChangePosition',
           target: 'frontend.manageCollateral',
           actions: [
+            'killCurrentParametersMachine',
+            'spawnDepositBorrowMachine',
             'resetTokenActionValue',
             'updateCollateralTokenAction',
             'setTransactionTokenToCollateral',
@@ -404,7 +402,13 @@ export function createManageAaveStateMachine(
         MANAGE_DEBT: {
           cond: 'canChangePosition',
           target: 'frontend.manageDebt',
-          actions: ['resetTokenActionValue', 'updateDebtTokenAction', 'setTransactionTokenToDebt'],
+          actions: [
+            'killCurrentParametersMachine',
+            'spawnDepositBorrowMachine',
+            'resetTokenActionValue',
+            'updateDebtTokenAction',
+            'setTransactionTokenToDebt',
+          ],
         },
         UPDATE_COLLATERAL_TOKEN_ACTION: {
           cond: 'canChangePosition',
@@ -534,15 +538,15 @@ export function createManageAaveStateMachine(
             'transactionMachine',
           ),
         })),
-        spawnDepositBorrowMachine: assign((_) => ({
-          refParametersMachine: spawn(depositBorrowAaveMachine, 'transactionParameters'),
-        })),
         killTransactionMachine: pure((context) => {
           if (context.refTransactionMachine && context.refTransactionMachine.stop) {
             context.refTransactionMachine.stop()
           }
           return undefined
         }),
+        spawnDepositBorrowMachine: assign((_) => ({
+          refParametersMachine: spawn(depositBorrowAaveMachine, 'transactionParameters'),
+        })),
         spawnAdjustParametersMachine: assign((_) => ({
           refParametersMachine: spawn(adjustParametersStateMachine, 'transactionParameters'),
         })),


### PR DESCRIPTION
# [AAVE Multiply bugfixes](https://app.shortcut.com/oazo-apps/story/7085/placeholder-aave-multiply-bugfixes)

## Changes 👷‍♀️
- changed how and when the borrowDeposit machine is spawned and killed

## How to test 🧪
- go to your steth/eth position
- while switching tabs in the sidebar there should be no error 
