### PR TITLE
Resetting the form value when removing the amount or switching tabs

### DIFF
--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -48,6 +48,44 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
   )
 }
 
+function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
+  const { t } = useTranslation()
+  const { stateMachine } = useOpenAaveStateMachineContext()
+  const [, send] = useActor(stateMachine)
+  return (
+    <TabBar
+      variant="underline"
+      sections={[
+        {
+          value: 'simulate',
+          label: t('open-vault.simulate'),
+          content: (
+            <Grid variant="vaultContainer">
+              <Box>
+                <SimulateSectionComponent config={strategyConfig} />
+              </Box>
+              <Box>{<SidebarOpenAaveVault />}</Box>
+            </Grid>
+          ),
+        },
+        {
+          value: 'position-info',
+          label: t('system.position-info'),
+          content: (
+            <Card variant="faq">
+              <AaveFaq />
+            </Card>
+          ),
+          callback: () => {
+            // this resets the amount value in the sidebar
+            send({ type: 'SET_AMOUNT', amount: undefined })
+          },
+        },
+      ]}
+    />
+  )
+}
+
 function AaveOpenContainer({
   aaveStateMachine,
   config,
@@ -55,39 +93,13 @@ function AaveOpenContainer({
   aaveStateMachine: OpenAaveStateMachine
   config: IStrategyConfig
 }) {
-  const { t } = useTranslation()
   const Header = config.viewComponents.headerOpen
   return (
     <OpenAaveStateMachineContextProvider machine={aaveStateMachine} config={config}>
       <Container variant="vaultPageContainer">
         <AavePositionNotice />
         <Header strategyConfig={config} />
-        <TabBar
-          variant="underline"
-          sections={[
-            {
-              value: 'simulate',
-              label: t('open-vault.simulate'),
-              content: (
-                <Grid variant="vaultContainer">
-                  <Box>
-                    <SimulateSectionComponent config={config} />
-                  </Box>
-                  <Box>{<SidebarOpenAaveVault />}</Box>
-                </Grid>
-              ),
-            },
-            {
-              value: 'position-info',
-              label: t('system.position-info'),
-              content: (
-                <Card variant="faq">
-                  <AaveFaq />
-                </Card>
-              ),
-            },
-          ]}
-        />
+        <TabSectionComponent strategyConfig={config} />
         <Survey for="earn" />
       </Container>
     </OpenAaveStateMachineContextProvider>

--- a/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
@@ -31,9 +31,7 @@ export function SidebarOpenAaveVaultEditingState(props: OpenAaveEditingStateProp
           send({ type: 'SET_AMOUNT', amount: state.context.tokenBalance! })
         }}
         onChange={handleNumericInput((amount) => {
-          if (amount) {
-            send({ type: 'SET_AMOUNT', amount: amount })
-          }
+          send({ type: 'SET_AMOUNT', amount })
         })}
         currencyCode={state.context.tokens.deposit}
         disabled={false}

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -61,7 +61,7 @@ function getTransactionDef(context: OpenAaveContext): TransactionDef<OperationEx
 export type OpenAaveEvent =
   | { type: 'BACK_TO_EDITING' }
   | { type: 'RETRY' }
-  | { type: 'SET_AMOUNT'; amount: BigNumber }
+  | { type: 'SET_AMOUNT'; amount?: BigNumber }
   | { type: 'NEXT_STEP' }
   | { type: 'UPDATE_META_INFO'; hasOpenedPosition: boolean }
   | BaseAaveEvent
@@ -364,14 +364,13 @@ export function createOpenAaveStateMachine(
             totalSteps: totalSteps,
           }
         }),
-        setAmount: assign((context, event) => {
-          return {
-            userInput: {
-              ...context.userInput,
-              amount: event.amount,
-            },
-          }
-        }),
+        setAmount: assign((context, event) => ({
+          userInput: {
+            ...context.userInput,
+            amount: event.amount,
+          },
+          strategy: event.amount ? context.strategy : undefined,
+        })),
         calculateAuxiliaryAmount: assign((context) => {
           return {
             auxiliaryAmount: context.userInput.amount?.times(context.tokenPrice || zero),

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -21,14 +21,15 @@ const handler = async function (req: NextApiRequest, res: NextApiResponse<{ stat
       userId,
     } = req.body
 
-    mixpanel.track(`${eventName}`, {
-      ...eventBody,
-      distinct_id: distinctId,
-      $current_url: currentUrl,
-      $initial_referrer: initialReferrer,
-      $initial_referring_domain: initialReferrerHost,
-      $user_id: userId,
-    })
+    !currentUrl.endsWith('vault-info') && // disables tracking for this particular tab
+      mixpanel.track(`${eventName}`, {
+        ...eventBody,
+        distinct_id: distinctId,
+        $current_url: currentUrl,
+        $initial_referrer: initialReferrer,
+        $initial_referring_domain: initialReferrerHost,
+        $user_id: userId,
+      })
 
     res.json({ status: 200 })
   } catch (err) {


### PR DESCRIPTION
# [Open position form keeps state ](https://app.shortcut.com/oazo-apps/story/7190/open-position-form-keeps-state)
  
## Changes 👷‍♀️
- Resetting the form value when removing the amount or switching tabs on earn steth/eth open view  

## How to test 🧪
- go to earn steth/eth open view
- input an amount
- delete it, transaction info should dissapear
- input some amount again
- switch tabs to Position info (on the left)
- switch back to Overview tab
- value and transaction info should be gone