### PR TITLE
Fixed app crashing when going to payback debt tab on Aave multiply position

### DIFF
--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -121,7 +121,7 @@ function calculateMaxDebtAmount(context: ManageAaveContext): BigNumber {
     context.currentPosition?.debt.symbol || '',
   )
 
-  const currentBalance = context.balance?.debt.balance || zero
+  const currentBalance = context.balance?.debt?.balance || zero
 
   return currentDebt.lte(currentBalance) ? currentDebt : currentBalance
 }


### PR DESCRIPTION
# [App goes blank when selecting payback USDC](https://app.shortcut.com/oazo-apps/story/7387/app-goes-blank-when-selecting-payback-usdc)

## Changes 👷‍♀️
 - fixed dot notation
  
## How to test 🧪
- to payback debt tab on Aave multiply position
- app should'nt crash