### PR TITLE
Speed up fast-refresh

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -48,11 +48,8 @@ const conf = withBundleAnalyzer(
           },
         })
 
-        if (isProduction) {
-        }
-
         config.optimization = {
-          minimize: true,
+          minimize: config.mode !== 'development',
           minimizer: [
             new TerserPlugin({
               // TODO: Figure out how to disable mangling partially without breaking the aplication.
@@ -62,6 +59,20 @@ const conf = withBundleAnalyzer(
               },
             }),
           ],
+          splitChunks:
+            !isServer && config.mode !== 'development'
+              ? {
+                  chunks: 'all',
+                  minChunks: 2,
+                  enforce: true,
+                  cacheGroups: {
+                    vendors: {
+                      test: /[\\/]node_modules[\\/]/,
+                      name: 'vendors-chunk',
+                    },
+                  },
+                }
+              : {},
         }
         // Moment.js locales take up a lot of space, so it's good to remove unused ones. "en" is there by default and can not be removed
         // config.plugins.push(new MomentLocalesPlugin({ localesToKeep: ['es', 'pt'] }))


### PR DESCRIPTION
I'm not gonna describe anything, just let you be the judge:

Before:
```
[Fast Refresh] rebuilding
[Fast Refresh] done in 15479ms
[Fast Refresh] rebuilding
[Fast Refresh] done in 12827ms
[Fast Refresh] rebuilding
[Fast Refresh] done in 15019ms
```

After:
```
[Fast Refresh] rebuilding
[Fast Refresh] done in 1376ms
[Fast Refresh] rebuilding
[Fast Refresh] done in 2145ms
[Fast Refresh] rebuilding
[Fast Refresh] done in 1336ms
```

Also the cold start time is cut in half (1 vs 1/2 minute on my device).