### PR TITLE
Fixed decimal places input on Aave multiply

### DIFF
--- a/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
@@ -1,6 +1,7 @@
+import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Grid } from 'theme-ui'
+import { Box, Grid } from 'theme-ui'
 import { Sender, StateFrom } from 'xstate'
 
 import { VaultActionInput } from '../../../../components/vault/VaultActionInput'
@@ -18,24 +19,37 @@ export function SidebarOpenAaveVaultEditingState(props: OpenAaveEditingStateProp
 
   return (
     <Grid gap={3}>
-      <VaultActionInput
-        action={'Deposit'}
-        amount={state.context.userInput?.amount}
-        hasAuxiliary={true}
-        auxiliaryAmount={state.context.auxiliaryAmount}
-        hasError={false}
-        maxAmount={state.context.tokenBalance}
-        showMax={true}
-        maxAmountLabel={t('balance')}
-        onSetMax={() => {
-          send({ type: 'SET_AMOUNT', amount: state.context.tokenBalance! })
-        }}
-        onChange={handleNumericInput((amount) => {
-          send({ type: 'SET_AMOUNT', amount })
-        })}
-        currencyCode={state.context.tokens.deposit}
-        disabled={false}
-      />
+      <WithLoadingIndicator
+        // this loader seems to be pointless, but undefined tokenUsdPrice (below) breaks the proper decimals input so it needs to be there
+        value={[state.context.collateralPrice]}
+        customLoader={
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <AppSpinner size={24} />
+          </Box>
+        }
+      >
+        {([collateralPrice]) => (
+          <VaultActionInput
+            action={'Deposit'}
+            amount={state.context.userInput?.amount}
+            hasAuxiliary={true}
+            auxiliaryAmount={state.context.auxiliaryAmount}
+            hasError={false}
+            maxAmount={state.context.tokenBalance}
+            showMax={true}
+            maxAmountLabel={t('balance')}
+            onSetMax={() => {
+              send({ type: 'SET_AMOUNT', amount: state.context.tokenBalance! })
+            }}
+            onChange={handleNumericInput((amount) => {
+              send({ type: 'SET_AMOUNT', amount })
+            })}
+            currencyCode={state.context.tokens.deposit}
+            disabled={false}
+            tokenUsdPrice={collateralPrice}
+          />
+        )}
+      </WithLoadingIndicator>
     </Grid>
   )
 }


### PR DESCRIPTION
# [UI doesn't allow sufficient decimal precision for WBTC](https://app.shortcut.com/oazo-apps/story/7405/ui-doesn-t-allow-sufficient-decimal-precision-for-wbtc)

## Changes 👷‍♀️
- added a loader which prevents displaying value input before the token price is known
  
## How to test 🧪
- go do Aave multiply (any kind)
- you should be able to input a precise amount of chosen token (down to ~0.01 USD in auxiliary)
