### PR TITLE
Changed how the Liquidation Threshold in Aave multiply overview is displayed

### DIFF
--- a/components/vault/detailsSection/ContentCardLtv.tsx
+++ b/components/vault/detailsSection/ContentCardLtv.tsx
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { ContentCardProps, DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
-import { formatDecimalAsPercent } from 'helpers/formatters/format'
+import { formatDecimalAsPercent, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { theme } from 'theme'
@@ -39,7 +39,7 @@ export function ContentCardLtv({
   const formatted = {
     loanToValue: formatDecimalAsPercent(loanToValue),
     afterLoanToValue: afterLoanToValue && formatDecimalAsPercent(afterLoanToValue),
-    liquidationThreshold: liquidationThreshold,
+    liquidationThreshold: formatPercent(liquidationThreshold.times(100)),
   }
 
   const contentCardSettings: ContentCardProps = {


### PR DESCRIPTION
# [Liquidation threshold is shown as decimal number](https://app.shortcut.com/oazo-apps/story/7375/liquidation-threshold-is-shown-as-decimal-number)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- changed how the Liquidation Threshold in Aave multiply overview is displayed

## How to test 🧪
- go to your Aave multiply position
- Liq Threshold should be (for example) 80% instead of 0.8
