### PR TITLE
Reduced precision of USDC (to 2) in order information in Aave multiply

### DIFF
--- a/features/aave/common/components/informationContainer/OutstandingDebtInformation.tsx
+++ b/features/aave/common/components/informationContainer/OutstandingDebtInformation.tsx
@@ -16,14 +16,18 @@ interface DebtCollateralInformation {
 }
 
 function formatDebtAmount(pos: IPosition) {
-  return `${formatAmount(amountFromWei(pos.debt.amount, pos.debt.symbol), pos.debt.symbol)} ${
-    pos.debt.symbol
-  }`
+  return `${formatAmount(
+    amountFromWei(pos.debt.amount, pos.debt.symbol),
+    pos.debt.symbol === 'USDC' ? 'USD' : pos.debt.symbol,
+  )} ${pos.debt.symbol}`
 }
 
 function formatCollateralAmount(pos: IPosition) {
   return `${formatAmount(
-    amountFromWei(pos.collateral.amount, pos.collateral.symbol),
+    amountFromWei(
+      pos.collateral.amount,
+      pos.collateral.symbol === 'USDC' ? 'USD' : pos.collateral.symbol,
+    ),
     pos.collateral.symbol,
   )} ${pos.collateral.symbol}`
 }

--- a/features/aave/common/components/informationContainer/TransactionTokenAmount.tsx
+++ b/features/aave/common/components/informationContainer/TransactionTokenAmount.tsx
@@ -45,7 +45,8 @@ export function TransactionTokenAmount({
       value={
         <Flex>
           <Text>
-            {formatAmount(amount, tokens.collateral)} {tokens.collateral}
+            {formatAmount(amount, tokens.collateral === 'USDC' ? 'USD' : tokens.collateral)}{' '}
+            {tokens.collateral}
             {` `}
             <Text as="span" sx={{ color: 'neutral80' }}>
               {price ? `$${formatFiatBalance(price)}` : <AppSpinner />}


### PR DESCRIPTION
# [Showing all USDC decimal places is cumbersome in order confirmation](https://app.shortcut.com/oazo-apps/story/7240/showing-all-usdc-decimal-places-is-cumbersome-in-order-confirmation)

  
## Changes 👷‍♀️
  <Please add short list of changes>
- Reduced precision of USDC (to 2) in order information in Aave multiply
  
## How to test 🧪
- go to open/modify aave multiply position
- all data related to USDC in the order information (outstanding debt for example) should be precise up to two decimals
