### PR TITLE
[SC-7392] Fix withdrawing ETH collateral

### DIFF
--- a/features/aave/helpers/getTxTokenAndAmount.ts
+++ b/features/aave/helpers/getTxTokenAndAmount.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import { zero } from 'helpers/zero'
 
 import { BaseAaveContext } from '../common/BaseAaveContext'
-import { ManageDebtActionsEnum } from '../strategyConfig'
+import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from '../strategyConfig'
 
 export function getTxTokenAndAmount(context: BaseAaveContext) {
   // FIX IT whole logic below should be happening in xstate machine probably, we should not do that here
@@ -13,11 +13,15 @@ export function getTxTokenAndAmount(context: BaseAaveContext) {
     : false
   const isBorrowingDebt =
     context.manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT
+
+  const isWithdrawingCollateral =
+    context.manageTokenInput?.manageTokenAction === ManageCollateralActionsEnum.WITHDRAW_COLLATERAL
+
   const amountAndToken = {
     amount: context.userInput.amount || context.manageTokenInput?.manageTokenActionValue || zero,
     token: context.userInput.amount ? context.tokens.deposit : context.tokens.collateral,
   }
-  if (isBorrowingDebt) {
+  if (isBorrowingDebt || isWithdrawingCollateral) {
     amountAndToken.amount = zero
   }
   if (isBorrowOrPaybackDebt) {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.1.6",
+    "@oasisdex/oasis-actions": "0.1.7",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.6.tgz#1fd105a2c9bbf1242296254a89a489671f94f407"
-  integrity sha512-BKGfDPKzxIdIEc3rSGCmZcdNzXvyP9kwN5GQS+5f8OsLl1CfNKM0BTHbN8RUyJXBCyo9WnCVG0pDuKCPlCcK6w==
+"@oasisdex/oasis-actions@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.7.tgz#8d1b40dba67cc00a19e1cbb9d42a6147b8aff8ae"
+  integrity sha512-iKx3XvcZPe9/Ctk0XuJwtnY66T8NSuDmtlHSMG/2OU0Lz8xkUzy1W3mvxn/nNwdpAh//L/58nstfDEh6LeO+gw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# Changes
- Library version bump (skipped one action (`SendToken`). With new DPM Implementation we can use `ReturnFunds`).
- Fix the transaction amount for withdrawing. 
