### PR TITLE
Added Aave Earn and Multiply cards on the assets page

### DIFF
--- a/components/productCards/ProductCardsContainer.tsx
+++ b/components/productCards/ProductCardsContainer.tsx
@@ -50,20 +50,24 @@ function ProductCardsContainer(props: ProductCardsContainerProps) {
               <ProductCard cardData={cardData} key={cardData.ilk} />
             ))}
             {aaveStrategyCards.map((tokenData) => {
-              if (getAaveStrategy(tokenData.symbol)[0].type === 'Multiply') {
-                return (
-                  <ProductCardMultiplyAave
-                    cardData={tokenData}
-                    key={`ProductCardEarnAave_${tokenData.symbol}`}
-                  />
-                )
+              switch (getAaveStrategy(tokenData.symbol)[0].type) {
+                case 'Multiply':
+                  return (
+                    <ProductCardMultiplyAave
+                      cardData={tokenData}
+                      key={`ProductCardMultiplyAave_${tokenData.symbol}`}
+                    />
+                  )
+                case 'Earn':
+                  return (
+                    <ProductCardEarnAave
+                      cardData={tokenData}
+                      key={`ProductCardEarnAave_${tokenData.symbol}`}
+                    />
+                  )
+                default:
+                  return null
               }
-              return (
-                <ProductCardEarnAave
-                  cardData={tokenData}
-                  key={`ProductCardEarnAave_${tokenData.symbol}`}
-                />
-              )
             })}
           </ProductCardsWrapper>
         )}

--- a/components/productCards/ProductCardsContainer.tsx
+++ b/components/productCards/ProductCardsContainer.tsx
@@ -35,7 +35,7 @@ function ProductCardsContainer(props: ProductCardsContainerProps) {
   const [productCardsData, productCardsDataError] = useObservable(
     productCardsData$(props.strategies.maker),
   )
-  const aaveStrategyCards = getTokens(props.strategies.aave)
+  const aaveStrategyCards = getTokens(props.strategies.aave ?? [])
 
   return (
     <WithErrorHandler error={[productCardsDataError]}>

--- a/components/productCards/ProductCardsContainer.tsx
+++ b/components/productCards/ProductCardsContainer.tsx
@@ -1,5 +1,6 @@
 import { getTokens } from 'blockchain/tokensMetadata'
 import { ProductCardEarnDsr } from 'components/productCards/ProductCardEarnDsr'
+import { getAaveStrategy } from 'features/aave/strategyConfig'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from 'helpers/observableHook'
@@ -11,6 +12,7 @@ import { useAppContext } from '../AppContextProvider'
 import { ProductCardBorrow } from './ProductCardBorrow'
 import { ProductCardEarnAave } from './ProductCardEarnAave'
 import { ProductCardEarnMaker } from './ProductCardEarnMaker'
+import { ProductCardMultiplyAave } from './ProductCardMultiplyAave'
 import { ProductCardMultiplyMaker } from './ProductCardMultiplyMaker'
 import { ProductCardsLoader, ProductCardsWrapper } from './ProductCardsWrapper'
 
@@ -47,12 +49,22 @@ function ProductCardsContainer(props: ProductCardsContainerProps) {
             {_productCardsData.map((cardData) => (
               <ProductCard cardData={cardData} key={cardData.ilk} />
             ))}
-            {aaveStrategyCards.map((tokenData) => (
-              <ProductCardEarnAave
-                cardData={tokenData}
-                key={`ProductCardEarnAave_${tokenData.symbol}`}
-              />
-            ))}
+            {aaveStrategyCards.map((tokenData) => {
+              if (getAaveStrategy(tokenData.symbol)[0].type === 'Multiply') {
+                return (
+                  <ProductCardMultiplyAave
+                    cardData={tokenData}
+                    key={`ProductCardEarnAave_${tokenData.symbol}`}
+                  />
+                )
+              }
+              return (
+                <ProductCardEarnAave
+                  cardData={tokenData}
+                  key={`ProductCardEarnAave_${tokenData.symbol}`}
+                />
+              )
+            })}
           </ProductCardsWrapper>
         )}
       </WithLoadingIndicator>

--- a/components/productCards/ProductCardsFilter.tsx
+++ b/components/productCards/ProductCardsFilter.tsx
@@ -65,7 +65,6 @@ export function ProductCardsFilter({
   function handleHover(filter: string) {
     setHover(filter)
   }
-
   return (
     <>
       <Box sx={{ display: ['none', 'block'] }}>
@@ -120,7 +119,11 @@ export function ProductCardsFilter({
             {([_productCardsData]) => (
               <ProductCardsWrapper>
                 {otherStrategies
-                  .filter(({ protocol }) => protocol === 'aave')
+                  .filter(
+                    ({ protocol, name }) =>
+                      protocol === 'aave' &&
+                      name.toLocaleUpperCase().includes(currentFilter.toLocaleUpperCase()),
+                  )
                   .map((cardData) => (
                     <ProductCardMultiplyAave key={cardData.symbol} cardData={cardData} />
                   ))}

--- a/features/asset/AssetView.tsx
+++ b/features/asset/AssetView.tsx
@@ -35,8 +35,6 @@ export function AssetView({ content }: { content: AssetPageContent }) {
   const { t } = useTranslation()
 
   const aaveStrategies = aaveAssets[content.slug as keyof typeof aaveAssets] ?? []
-  console.log('aaveStrategies', aaveStrategies)
-
   const tabs = () => {
     const borrowTab = content.borrowIlks && {
       label: t('landing.tabs.maker.borrow.tabLabel'),

--- a/features/asset/AssetView.tsx
+++ b/features/asset/AssetView.tsx
@@ -3,6 +3,7 @@ import { AppLink } from 'components/Links'
 import { TabBar, TabSection } from 'components/TabBar'
 import { WithArrow } from 'components/WithArrow'
 import { AssetPageContent } from 'content/assets'
+import { getAaveEnabledStrategies } from 'helpers/productCards'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Flex, Grid, Heading, Text } from 'theme-ui'
@@ -13,8 +14,28 @@ import {
   MultiplyProductCardsContainer,
 } from '../../components/productCards/ProductCardsContainer'
 
+const aaveAssets = {
+  // not putting this to ASSETS_PAGES cause we need feature toggles
+  eth: {
+    multiply: getAaveEnabledStrategies([
+      { strategy: 'ethusdc', featureToggle: 'AaveMultiplyETHUSDC' },
+      { strategy: 'stETHusdc', featureToggle: 'AaveMultiplySTETHUSDC' },
+    ]),
+    earn: getAaveEnabledStrategies([{ strategy: 'stETHeth', featureToggle: 'AaveEarnSTETHETH' }]),
+  },
+  btc: {
+    multiply: getAaveEnabledStrategies([
+      { strategy: 'wBTCusdc', featureToggle: 'AaveMultiplyWBTCUSDC' },
+    ]),
+    earn: [],
+  },
+}
+
 export function AssetView({ content }: { content: AssetPageContent }) {
   const { t } = useTranslation()
+
+  const aaveStrategies = aaveAssets[content.slug as keyof typeof aaveAssets] ?? []
+  console.log('aaveStrategies', aaveStrategies)
 
   const tabs = () => {
     const borrowTab = content.borrowIlks && {
@@ -32,7 +53,9 @@ export function AssetView({ content }: { content: AssetPageContent }) {
       value: 'multiply',
       content: (
         <Box sx={{ mt: 5 }}>
-          <MultiplyProductCardsContainer strategies={{ maker: content.multiplyIlks, aave: [] }} />
+          <MultiplyProductCardsContainer
+            strategies={{ maker: content.multiplyIlks, aave: aaveStrategies.multiply }}
+          />
         </Box>
       ),
     }
@@ -42,7 +65,9 @@ export function AssetView({ content }: { content: AssetPageContent }) {
       value: 'earn',
       content: (
         <Box sx={{ mt: 5 }}>
-          <EarnProductCardsContainer strategies={{ maker: content.earnIlks, aave: [] }} />
+          <EarnProductCardsContainer
+            strategies={{ maker: content.earnIlks, aave: aaveStrategies.earn }}
+          />
         </Box>
       ),
     }

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -190,7 +190,9 @@ export function mapTokenToFilter(token: string) {
   return tokenKeyedFilters[token]
 }
 
-function getAaveEnabledStrategies(strategies: { strategy: string; featureToggle: Feature }[]) {
+export function getAaveEnabledStrategies(
+  strategies: { strategy: string; featureToggle: Feature }[],
+) {
   return strategies
     .filter(({ featureToggle }) => getFeatureToggle(featureToggle))
     .map((item) => item.strategy)

--- a/pages/asset/[asset].tsx
+++ b/pages/asset/[asset].tsx
@@ -1,6 +1,8 @@
 import { WithConnection } from 'components/connectWallet/ConnectWallet'
+import { DeferedContextProvider } from 'components/DeferedContextProvider'
 import { ProductPagesLayout } from 'components/Layouts'
 import { AssetPageContent, ASSETS_PAGES, assetsPageContentBySlug } from 'content/assets'
+import { aaveContext, AaveContextProvider } from 'features/aave/AaveContextProvider'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { GetServerSidePropsContext, GetStaticPaths } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -43,13 +45,17 @@ function AssetPage({ content }: { content: AssetPageContent }) {
   }
 
   return (
-    <WithConnection>
-      <WithTermsOfService>
-        <WithWalletAssociatedRisk>
-          <AssetView content={content} />
-        </WithWalletAssociatedRisk>
-      </WithTermsOfService>
-    </WithConnection>
+    <AaveContextProvider>
+      <DeferedContextProvider context={aaveContext}>
+        <WithConnection>
+          <WithTermsOfService>
+            <WithWalletAssociatedRisk>
+              <AssetView content={content} />
+            </WithWalletAssociatedRisk>
+          </WithTermsOfService>
+        </WithConnection>
+      </DeferedContextProvider>
+    </AaveContextProvider>
   )
 }
 


### PR DESCRIPTION
# [No aave multiply cards showing on Assets/ETH/Multiply page](https://app.shortcut.com/oazo-apps/story/7309/no-aave-multiply-cards-showing-on-assets-eth-multiply-page)
# [AAVE multiply cards appear in all assets](https://app.shortcut.com/oazo-apps/story/7420/aave-multiply-cards-appear-in-all-assets)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- Added Aave Earn and Multiply cards on the assets page
- Removed AAVE multiply cards in all assets
  
## How to test 🧪
  <Please explain how to test your changes>
- go to `/asset/eth` or `/asset/btc`
- there should be Aave product cards on the bottom
- go to `/multiply` page, the cards should respect the current filter