### PR TITLE
Updated allowance copy on Aave allowance flow

### DIFF
--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -41,7 +41,7 @@ function AllowanceInfoStateViewContent({
   return (
     <Grid gap={3}>
       <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-        {t('vault-form.subtext.allowance', { token })}
+        {t('vault-form.subtext.commonAllowance', { token })}
       </Text>
       <Radio
         onChange={() => send({ type: 'SET_ALLOWANCE', allowanceType: 'unlimited' })}
@@ -124,7 +124,7 @@ function AllowanceInProgressStateViewContent({ state }: Pick<AllowanceViewStateP
   return (
     <Grid gap={3}>
       <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-        {t('vault-form.subtext.allowance', { token })}
+        {t('vault-form.subtext.commonAllowance', { token })}
       </Text>
       <TxStatusCardProgress
         text={t('setting-allowance-for', { token })}
@@ -162,7 +162,7 @@ function AllowanceSuccessStateView({ state, send, steps }: AllowanceViewStatePro
     content: (
       <Grid gap={3}>
         <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-          {t('vault-form.subtext.allowance', { token })}
+          {t('vault-form.subtext.commonAllowance', { token })}
         </Text>
         <TxStatusCardSuccess
           text={t('setting-allowance-for', { token })}
@@ -191,7 +191,7 @@ function AllowanceRetryStateView({ state, send }: AllowanceViewStateProps) {
     content: (
       <Grid gap={3}>
         <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-          {t('vault-form.subtext.allowance', { token })}
+          {t('vault-form.subtext.commonAllowance', { token })}
         </Text>
       </Grid>
     ),

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1307,6 +1307,7 @@
       "proxy-progress": "Read more on smart proxy in the <1>Knowledge Base</1>.",
       "allowance": "Specify an allowance to set a maximum on the amount of tokens the vault contracts can interact with.",
       "daiAllowance": "Specify an allowance to set a maximum on the amount of tokens the vault contracts can interact with.",
+      "commonAllowance": "Select a maximum allowance amount for your Smart DeFi Account. Your Smart Defi Account will be able to interact with up to:",
       "confirm": "This will update your vault to a multiply vault. It does not require a transaction. You will be able to switch it back to the Borrow view.",
       "review-manage": "Here you can review the details of the changes to your vault.",
       "confirm-in-progress": "Your Vault is currently being created.",


### PR DESCRIPTION
# [Allowance Copy is unclear: refers to vault](https://app.shortcut.com/oazo-apps/story/7255/allowance-copy-is-unclear-refers-to-vault)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- Updated allowance copy on Aave allowance flow
  
## How to test 🧪
- go to allowance flow (eg. wbtc/usdc aave multiply)
- allowance copy should mention "Smart DeFi Account" and not 'vaults' 
