### PR TITLE
[7243] re add multiple value to order info, move slider button

### DIFF
--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -196,6 +196,14 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
             <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.decrease-risk')}</Text>
             <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.increase-risk')}</Text>
           </Flex>
+
+          <SidebarResetButton
+            clear={() => {
+              send({ type: 'RESET_RISK_RATIO' })
+            }}
+            disabled={viewLocked || !state.context.userInput.riskRatio}
+          />
+
           {collateralToken && debtToken && viewConfig.link && (
             <Link target="_blank" href={viewConfig.link.url}>
               <WithArrow variant="paragraph4" sx={{ color: 'interactive100' }}>
@@ -240,13 +248,6 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
             )
           )}
           <StrategyInformationContainer state={state} />
-
-          <SidebarResetButton
-            clear={() => {
-              send({ type: 'RESET_RISK_RATIO' })
-            }}
-            disabled={viewLocked || !state.context.userInput.riskRatio}
-          />
         </Grid>
       ),
       primaryButton: {

--- a/features/aave/common/components/informationContainer/StrategyInformationContainer.tsx
+++ b/features/aave/common/components/informationContainer/StrategyInformationContainer.tsx
@@ -9,6 +9,7 @@ import { zero } from '../../../../../helpers/zero'
 import { UserSettingsState } from '../../../../userSettings/userSettings'
 import { FeesInformation } from './FeesInformation'
 import { LtvInformation } from './LtvInformation'
+import { MultiplyInformation } from './MultiplyInformation'
 import {
   OutstandingDebtInformation,
   TotalCollateralInformation,
@@ -49,11 +50,11 @@ export function StrategyInformationContainer({ state }: OpenAaveInformationConta
       )}
       {simulationHasSwap && <PriceImpact {...state.context} transactionParameters={strategy} />}
       {simulationHasSwap && <SlippageInformation {...state.context.userSettings!} />}
-      {/*<MultiplyInformation*/}
-      {/*  {...state.context}*/}
-      {/*  transactionParameters={strategy}*/}
-      {/*  currentPosition={currentPosition}*/}
-      {/*/>*/}
+      <MultiplyInformation
+        {...state.context}
+        transactionParameters={strategy}
+        currentPosition={currentPosition}
+      />
       <OutstandingDebtInformation
         currentPosition={currentPosition}
         newPosition={strategy.simulation.position}


### PR DESCRIPTION
- multiple was missing from order info here: https://app.shortcut.com/oazo-apps/story/7243/inconsistent-information-in-order-vs-tvl-selected
- reset button moved up: https://app.shortcut.com/oazo-apps/story/7307/reset-text-button-needs-to-be-moved-up