### PR TITLE
7260 - price movement is incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.1.7",
+    "@oasisdex/oasis-actions": "0.1.8",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.7.tgz#8d1b40dba67cc00a19e1cbb9d42a6147b8aff8ae"
-  integrity sha512-iKx3XvcZPe9/Ctk0XuJwtnY66T8NSuDmtlHSMG/2OU0Lz8xkUzy1W3mvxn/nNwdpAh//L/58nstfDEh6LeO+gw==
+"@oasisdex/oasis-actions@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.8.tgz#dad106c9244af65a70adf07afa7148af5b408ac9"
+  integrity sha512-gQ47FRaVsd11ooYtCXxXqU07M2QLLhLiEW81IMS1SDh0kBDXaPXNmD59kQ0lJnTqay6eTcdgIP7PVB9kCsIQxQ==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [price movement is incorrect](https://app.shortcut.com/oazo-apps/story/7260/bug-100-price-movement-is-incorrect)

<img width="530" alt="image" src="https://user-images.githubusercontent.com/3783198/212387565-e62cdd4b-b081-455d-8eb4-b6b72dcd5128.png">


## Changes 👷‍♀️
  <Please add short list of changes>
- consumes new version of library
  
## How to test 🧪
  <Please explain how to test your changes>
- go to open a steth/eth, wbtc/usdc, and eth/usdc aave position
- observe that price movement is calculated correctly, along with warning threshold when movement is <= 20%
- check open and manage


Related PR: https://github.com/OasisDEX/oasis-earn-sc/pull/165