### PR TITLE
[SC-7451] Possibility to payback all

### DIFF
--- a/components/vault/VaultActionInput.tsx
+++ b/components/vault/VaultActionInput.tsx
@@ -33,6 +33,7 @@ export const MinusIcon = () => (
 interface VaultActionInputProps {
   action: VaultAction
   currencyCode: string
+  currencyDigits?: number
   tokenUsdPrice?: BigNumber
   onChange: (e: ChangeEvent<HTMLInputElement>) => void
   disabled?: boolean
@@ -70,6 +71,7 @@ interface VaultActionInputProps {
 export function VaultActionInput({
   action,
   currencyCode,
+  currencyDigits,
   tokenUsdPrice = one,
   amount,
   onChange,
@@ -110,13 +112,15 @@ export function VaultActionInput({
 
   const toggleResolved = typeof defaultToggle === 'boolean' ? defaultToggle : toggleStatus
 
-  const currencyDigits =
-    currencyCode !== 'USD'
-      ? calculateTokenPrecisionByValue({
-          token: currencyCode,
-          usdPrice: tokenUsdPrice,
-        })
-      : FIAT_PRECISION
+  if (currencyDigits === undefined) {
+    currencyDigits =
+      currencyCode !== 'USD'
+        ? calculateTokenPrecisionByValue({
+            token: currencyCode,
+            usdPrice: tokenUsdPrice,
+          })
+        : FIAT_PRECISION
+  }
 
   const auxiliaryDigits = auxiliaryCurrencyCode
     ? calculateTokenPrecisionByValue({

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -208,6 +208,7 @@ function GetReviewingSidebarProps({
             <VaultActionInput
               action="Enter"
               currencyCode={collateral}
+              currencyDigits={getToken(collateral).digits}
               maxAmountLabel={t('balance')}
               maxAmount={maxCollateralAmount}
               showMax={true}
@@ -261,6 +262,7 @@ function GetReviewingSidebarProps({
             <VaultActionInput
               action="Enter"
               currencyCode={debt}
+              currencyDigits={getToken(debt).digits}
               maxAmountLabel={t('balance')}
               maxAmount={maxDebtAmount}
               showMax={true}


### PR DESCRIPTION
# Changes
- `VaultActionInput` has optional `currencyDigits` in props 
- On manage AAVE position we can specify amount with full precision. 