### PR TITLE
Fixes error when there's no yields available for steth/eth (eg. goerli net)

### DIFF
--- a/features/aave/common/stEthYield.ts
+++ b/features/aave/common/stEthYield.ts
@@ -181,21 +181,21 @@ export async function getAaveStEthYield(
   })
   return {
     annualisedYield7days:
-      response.yield7days && new BigNumber(response.yield7days.yield.netAnnualisedYield),
+      response.yield7days?.yield && new BigNumber(response.yield7days.yield.netAnnualisedYield),
     annualisedYield7daysOffset:
-      response.yield7daysOffset &&
+      response.yield7daysOffset?.yield &&
       new BigNumber(response.yield7daysOffset.yield.netAnnualisedYield),
     annualisedYield30days:
-      response.yield30days && new BigNumber(response.yield30days.yield.netAnnualisedYield),
+      response.yield30days?.yield && new BigNumber(response.yield30days.yield.netAnnualisedYield),
     annualisedYield90days:
-      response.yield90days && new BigNumber(response.yield90days.yield.netAnnualisedYield),
+      response.yield90days?.yield && new BigNumber(response.yield90days.yield.netAnnualisedYield),
     annualisedYield90daysOffset:
-      response.yield90daysOffset &&
+      response.yield90daysOffset?.yield &&
       new BigNumber(response.yield90daysOffset.yield.netAnnualisedYield),
     annualisedYield1Year:
-      response.yield1year && new BigNumber(response.yield1year.yield.netAnnualisedYield),
+      response.yield1year?.yield && new BigNumber(response.yield1year.yield.netAnnualisedYield),
     annualisedYieldSinceInception:
-      response.yieldSinceInception &&
+      response.yieldSinceInception?.yield &&
       new BigNumber(response.yieldSinceInception.yield.netAnnualisedYield),
   }
 }


### PR DESCRIPTION
# [Can't access my positions page](https://app.shortcut.com/oazo-apps/story/7438/can-t-access-my-positions-page)
  
## Changes 👷‍♀️
- quick fix which prevents an error when displaying steth/eth earn product page on goerli (which does not support it fully)
  
## How to test 🧪
- go to a page which displays steth/eth product card (eg. `/earn`) using hardhat
- everything should work just fine
- switch network to goerli (`/earn?network=goerli`)
- everything should work fine, except the yields are not loading (but not crashing the app)
