### PR TITLE
Fixed Aave Multiply product cards order + tagged as New

### DIFF
--- a/components/productCards/ProductCardMultiplyAave.tsx
+++ b/components/productCards/ProductCardMultiplyAave.tsx
@@ -34,8 +34,6 @@ export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAavePro
     collateralReserveConfigurationData?.ltv &&
     new RiskRatio(collateralReserveConfigurationData.ltv, RiskRatio.TYPE.LTV)
 
-  console.log('cardData', cardData)
-
   return (
     <ProductCard
       tokenImage={cardData.bannerIcon}

--- a/components/productCards/ProductCardMultiplyAave.tsx
+++ b/components/productCards/ProductCardMultiplyAave.tsx
@@ -34,6 +34,8 @@ export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAavePro
     collateralReserveConfigurationData?.ltv &&
     new RiskRatio(collateralReserveConfigurationData.ltv, RiskRatio.TYPE.LTV)
 
+  console.log('cardData', cardData)
+
   return (
     <ProductCard
       tokenImage={cardData.bannerIcon}
@@ -85,6 +87,7 @@ export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAavePro
           value: <ProductCardProtocolLink ilk={cardData.symbol} protocol={cardData.protocol} />,
         },
       ]}
+      floatingLabelText={t('product-card.tags.new')}
       button={{
         link: `/multiply/aave/open/${strategy.urlSlug}`,
         text: t('nav.multiply'),

--- a/components/productCards/ProductCardsContainer.tsx
+++ b/components/productCards/ProductCardsContainer.tsx
@@ -42,13 +42,6 @@ function ProductCardsContainer(props: ProductCardsContainerProps) {
       <WithLoadingIndicator value={[productCardsData]} customLoader={<ProductCardsLoader />}>
         {([_productCardsData]) => (
           <ProductCardsWrapper>
-            {/* TODO prepare proper handling for DSR */}
-            {props.strategies.maker.includes('DSR') && daiSavingsRate ? (
-              <ProductCardEarnDsr />
-            ) : null}
-            {_productCardsData.map((cardData) => (
-              <ProductCard cardData={cardData} key={cardData.ilk} />
-            ))}
             {aaveStrategyCards.map((tokenData) => {
               switch (getAaveStrategy(tokenData.symbol)[0].type) {
                 case 'Multiply':
@@ -69,6 +62,13 @@ function ProductCardsContainer(props: ProductCardsContainerProps) {
                   return null
               }
             })}
+            {/* TODO prepare proper handling for DSR */}
+            {props.strategies.maker.includes('DSR') && daiSavingsRate ? (
+              <ProductCardEarnDsr />
+            ) : null}
+            {_productCardsData.map((cardData) => (
+              <ProductCard cardData={cardData} key={cardData.ilk} />
+            ))}
           </ProductCardsWrapper>
         )}
       </WithLoadingIndicator>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1504,6 +1504,7 @@
     },
     "tags": {
       "lowest-fees-for-borrowing": "Lowest fees for Borrowing",
+      "new": "New",
       "staking-rewards": "Staking rewards",
       "automation-enabled": "Automation Enabled",
       "max-exposure": "Max {{token}} exposure"


### PR DESCRIPTION
# [chore: fix order + add tags to aave cards](https://app.shortcut.com/oazo-apps/story/7525/chore-fix-order-add-tags-to-aave-cards)

## Changes 👷‍♀️
- changed Aave Multiply product cards order
- tagged them as New
  
## How to test 🧪
- view the changes on the home page and on `/multiply` or `/assets` page
