### PR TITLE
Changed Aave multiply close to X copy

### DIFF
--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -178,7 +178,7 @@ function GetReviewingSidebarProps({
               }))}
             />
             <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-              {t('manage-earn.aave.vault-form.close-description')}
+              {t('manage-earn.aave.vault-form.close-description', { closeToToken })}
             </Text>
             <BalanceAfterClose state={state} send={send} token={closeToToken} />
             <StrategyInformationContainer state={state} />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2030,7 +2030,7 @@
         "close-to-title": "Close position to {{token}}",
         "close": "Close vault",
         "confirm-btn": "Confirm",
-        "close-description": "To close your vault, a part of your position will be sold to payback the outstanding debt. The rest of your collateral will be send to your address.",
+        "close-description": "To close your position, all your collateral will be sold to pay back the outstanding debt. The remaining {{closeToToken}} will be sent to your address.",
         "stop-close": "Not right now",
         "token-amount-after-closing": "{{token}} after closing",
         "retry-btn": "Retry",


### PR DESCRIPTION
# [Close to USDC copy is wrong](https://app.shortcut.com/oazo-apps/story/7397/close-to-usdc-copy-is-wrong)

## Changes 👷‍♀️
- changed the copy in the sidebar on Close to collateral/debt view
  
## How to test 🧪
- go to your position
- select Close position
- the copy should mention the position and not the vault
