### PR TITLE
aave marketing mentions behind feature flag.  change AAVE to Aave.

### DIFF
--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -122,6 +122,7 @@ export function HomepageView() {
 
   const referralsEnabled = useFeatureToggle('Referrals')
   const notificationsEnabled = useFeatureToggle('Notifications')
+  const dpmEnabled = useFeatureToggle('AaveUseDpmProxy')
   const { context$, checkReferralLocal$, userReferral$ } = useAppContext()
   const [context] = useObservable(context$)
   const [checkReferralLocal] = useObservable(checkReferralLocal$)
@@ -151,15 +152,17 @@ export function HomepageView() {
         animationTimingFunction: 'cubic-bezier(0.7, 0.01, 0.6, 1)',
       }}
     >
-      <Flex
-        sx={{
-          justifyContent: 'center',
-          mt: '80px',
-          mb: 0,
-        }}
-      >
-        <HomePageBanner heading={t('ref.banner')} link="/earn/aave/open/stETHeth" />
-      </Flex>
+      {dpmEnabled && (
+        <Flex
+          sx={{
+            justifyContent: 'center',
+            mt: '80px',
+            mb: 0,
+          }}
+        >
+          <HomePageBanner heading={t('ref.banner')} link="/earn/aave/open/stETHeth" />
+        </Flex>
+      )}
       {referralsEnabled && landedWithRef && context?.status === 'connectedReadonly' && (
         <NewReferralModal />
       )}
@@ -205,12 +208,14 @@ export function HomepageView() {
                       <AppLink href="/multiply" variant="inText">
                         {t('landing.tabs.maker.multiply.tabParaLinkContent')}
                       </AppLink>
-                      <Box sx={{ mt: 3 }}>
-                        {t('landing.tabs.maker.multiply.aaveTabParaContent')}{' '}
-                        <AppLink href="/multiply" variant="inText">
-                          {t('landing.tabs.maker.multiply.aaveTabParaLinkContent')}
-                        </AppLink>
-                      </Box>
+                      {dpmEnabled && (
+                        <Box sx={{ mt: 3 }}>
+                          {t('landing.tabs.maker.multiply.aaveTabParaContent')}{' '}
+                          <AppLink href="/multiply" variant="inText">
+                            {t('landing.tabs.maker.multiply.aaveTabParaLinkContent')}
+                          </AppLink>
+                        </Box>
+                      )}
                     </>
                   }
                   cards={

--- a/features/multiply/MultiplyView.tsx
+++ b/features/multiply/MultiplyView.tsx
@@ -9,12 +9,13 @@ import { ProductCardMultiplyMaker } from '../../components/productCards/ProductC
 import { ProductCardsFilter } from '../../components/productCards/ProductCardsFilter'
 import { ProductHeader } from '../../components/ProductHeader'
 import { multiplyPageCardsData, productCardsConfig } from '../../helpers/productCards'
+import { useFeatureToggle } from '../../helpers/useFeatureToggle'
 
 export function MultiplyView() {
   const { t } = useTranslation()
   const tab = window.location.hash.replace(/^#/, '')
   const aaveMultiplyStrategies = getTokens(aaveStrategiesList('Multiply').map(({ name }) => name))
-
+  const dpmEnabled = useFeatureToggle('AaveUseDpmProxy')
   return (
     <Grid
       sx={{
@@ -32,19 +33,21 @@ export function MultiplyView() {
         }}
         scrollToId={tab}
       />
-      <Text
-        variant="paragraph1"
-        sx={{
-          color: 'neutral80',
-          mt: '-50px',
-          textAlign: 'center',
-        }}
-      >
-        {t('product-page.multiply.aaveDescription')}{' '}
-        <AppLink href="/multiply" sx={{ fontSize: 4, fontWeight: 'body' }}>
-          {t('product-page.multiply.aaveLink')}
-        </AppLink>
-      </Text>
+      {dpmEnabled && (
+        <Text
+          variant="paragraph1"
+          sx={{
+            color: 'neutral80',
+            mt: '-50px',
+            textAlign: 'center',
+          }}
+        >
+          {t('product-page.multiply.aaveDescription')}{' '}
+          <AppLink href="/multiply" sx={{ fontSize: 4, fontWeight: 'body' }}>
+            {t('product-page.multiply.aaveLink')}
+          </AppLink>
+        </Text>
+      )}
       <ProductCardsFilter
         filters={productCardsConfig.multiply.cardsFilters}
         selectedFilter={tab}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -427,7 +427,7 @@
           "tabLabel": "Multiply on Oasis",
           "tabParaContent": "Multiply your exposure to your favorite crypto assets. Browse our featured products here.",
           "tabParaLinkContent": "See all Multiply collateral types →",
-          "aaveTabParaContent": "We've launched multiply functionality for AAVE.",
+          "aaveTabParaContent": "We've launched multiply functionality for Aave.",
           "aaveTabParaLinkContent": "Read more →"
         },
         "earn": {
@@ -1577,7 +1577,7 @@
       "title": "Oasis Multiply",
       "description": "Multiply your exposure to your favorite crypto assets. Browse our featured products or select a asset.",
       "link": "Learn more about Multiply ->",
-      "aaveDescription": "We've launched multiply functionality for AAVE.",
+      "aaveDescription": "We've launched multiply functionality for Aave.",
       "aaveLink": "Read more →"
     },
     "borrow": {
@@ -1958,7 +1958,7 @@
     "coll-ratio-too-close-to-dust-limit": "Constant Multiple is not available as your current Col. Ratio is close to dust limit. Please <0>adjust your Col. Ratio</0> before using Constant Multiple."
   },
   "ref": {
-    "banner": "We've launched multiply functionality for AAVE. Read more here",
+    "banner": "We've launched multiply functionality for Aave. Read more here",
     "ref-a-friend": "Refer a Friend",
     "intro-1": "Refer someone to us and you both get rewarded with 5% of all fees they generate on Oasis.app... forever! Read more about ",
     "intro-link": "Oasis Refer a Friend",


### PR DESCRIPTION
- aave marketing mentions behind feature flag. 
- change AAVE to Aave.
  
## How to test 🧪

- set AaveDpm feature flag to false
- observe no aave-related copy on homepage or multiply page
- enable feature flag
- observe copy displays on homepage or multiply page