### PR TITLE
Fixed the comparison on canOpenPosition guard

### DIFF
--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -332,7 +332,7 @@ export function createOpenAaveStateMachine(
           allDefined(userInput, effectiveProxyAddress, strategy),
         canOpenPosition: ({ tokenBalance, userInput, effectiveProxyAddress, hasOpenedPosition }) =>
           allDefined(tokenBalance, userInput.amount, effectiveProxyAddress, !hasOpenedPosition) &&
-          tokenBalance!.gt(userInput.amount!),
+          tokenBalance!.gte(userInput.amount!),
         isAllowanceNeeded,
       },
       actions: {


### PR DESCRIPTION
# [Can't open WBTC/USDC position allowance bug](https://app.shortcut.com/oazo-apps/story/7532/can-t-open-wbtc-usdc-position-allowance-bug)

  
## Changes 👷‍♀️
- fixed one comparison which blocked providing all of your funds
  
## How to test 🧪
- go to opening eg. wbtc/usdc position
- click on `Balance` in the sidebar to deploy all of your tokens
- all should be fine
