### PR TITLE
DS proxy steth/eth positions don't display

### DIFF
--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash'
 import { combineLatest, iif, Observable, of } from 'rxjs'
-import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators'
+import { distinctUntilChanged, map, switchMap } from 'rxjs/operators'
 
 import { AaveConfigurationData } from '../../../blockchain/calls/aave/aaveLendingPool'
 import { IStrategyConfig } from '../common/StrategyConfigTypes'
@@ -20,7 +20,6 @@ export function getStrategyConfig$(
   return proxiesForPosition$(positionId).pipe(
     switchMap(({ dsProxy, dpmProxy }) => {
       const effectiveProxyAddress = dsProxy || dpmProxy?.proxy
-      console.log('effectiveProxyAddress', effectiveProxyAddress)
       return combineLatest(
         iif(
           () => effectiveProxyAddress !== undefined,

--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash'
 import { combineLatest, iif, Observable, of } from 'rxjs'
-import { distinctUntilChanged, map, switchMap } from 'rxjs/operators'
+import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators'
 
 import { AaveConfigurationData } from '../../../blockchain/calls/aave/aaveLendingPool'
 import { IStrategyConfig } from '../common/StrategyConfigTypes'
@@ -20,6 +20,7 @@ export function getStrategyConfig$(
   return proxiesForPosition$(positionId).pipe(
     switchMap(({ dsProxy, dpmProxy }) => {
       const effectiveProxyAddress = dsProxy || dpmProxy?.proxy
+      console.log('effectiveProxyAddress', effectiveProxyAddress)
       return combineLatest(
         iif(
           () => effectiveProxyAddress !== undefined,
@@ -27,7 +28,9 @@ export function getStrategyConfig$(
           of([]),
         ),
         aaveReservesList$(),
-        effectiveProxyAddress ? lastCreatedPositionForProxy$(effectiveProxyAddress) : of(undefined),
+        effectiveProxyAddress && effectiveProxyAddress === dpmProxy?.proxy
+          ? lastCreatedPositionForProxy$(effectiveProxyAddress)
+          : of(undefined),
       )
     }),
     map(([aaveUserConfiguration, aaveReservesList, lastCreatedPosition]) => {


### PR DESCRIPTION
# [DS proxy steth/eth positions don't display](https://app.shortcut.com/oazo-apps/story/7561/ds-proxy-steth-eth-positions-don-t-display)
  
## Changes 👷‍♀️

- only attempts to read position created events when DPM proxy is used
  
## How to test 🧪

- ensure overview can be loaded: http://localhost:3000/owner/0x0F8C58eDf65cbD972D175bFE481bc16fA8dEee45?network=hardhat#simulate
- ensure ds proxy position can be loaded
- local HH: steal steal proxy `0x1182CB8f6F83b76109cCA9A2ED0748390D7fB508` (for wallet `0x0F8C58eDf65cbD972D175bFE481bc16fA8dEee45` above)
- ensure that the position can be changed and closed