### PR TITLE
Aave SL overview validation

### DIFF
--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -2,6 +2,8 @@ import { IPosition, IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
 import { BigNumber } from 'bignumber.js'
 import { SidebarSectionHeaderDropdown } from 'components/sidebar/SidebarSectionHeader'
 import { WithArrow } from 'components/WithArrow'
+import { StopLossAaveErrorMessage } from 'features/aave/manage/components/StopLossAaveErrorMessage'
+import { ManageAaveAutomation } from 'features/aave/manage/sidebars/SidebarManageAaveVault'
 import { ManageAaveEvent } from 'features/aave/manage/state'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -32,6 +34,7 @@ export type AdjustRiskViewProps = BaseViewProps<RaisedEvents> & {
   onChainPosition?: IPosition
   dropdownConfig?: SidebarSectionHeaderDropdown
   title: string
+  automation?: ManageAaveAutomation
 }
 
 export function richFormattedBoundary({ value, unit }: { value: string; unit: string }) {
@@ -84,6 +87,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
     onChainPosition,
     dropdownConfig,
     title,
+    automation,
   }: AdjustRiskViewProps) {
     const { t } = useTranslation()
 
@@ -135,6 +139,11 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
       state.context.userInput.riskRatio?.loanToValue ||
       onChainPosition?.riskRatio.loanToValue ||
       viewConfig.riskRatios.default.loanToValue
+
+    const stopLossError =
+      automation?.stopLoss.isStopLossEnabled &&
+      automation?.stopLoss.stopLossLevel &&
+      sliderValue.gte(automation?.stopLoss.stopLossLevel)
 
     const sidebarSectionProps: SidebarSectionProps = {
       title,
@@ -203,6 +212,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
               </WithArrow>
             </Link>
           )}
+          {stopLossError && <StopLossAaveErrorMessage />}
           {showWarring ? (
             <MessageCard
               messages={[t('manage-earn-vault.has-asset-already')]}
@@ -241,7 +251,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
       ),
       primaryButton: {
         ...primaryButton,
-        disabled: viewLocked || primaryButton.disabled || !state.context.strategy,
+        disabled: viewLocked || primaryButton.disabled || !state.context.strategy || stopLossError,
       },
       textButton, // this is going back button, no need to block it
       dropdown: dropdownConfig,

--- a/features/aave/helpers/aaveAutomationHelpers.tsx
+++ b/features/aave/helpers/aaveAutomationHelpers.tsx
@@ -1,0 +1,5 @@
+import BigNumber from 'bignumber.js'
+
+export function isLtvGreaterThanThreshold(ltv: BigNumber, threshold: BigNumber) {
+  return ltv.gt(threshold)
+}

--- a/features/aave/helpers/aaveAutomationHelpers.tsx
+++ b/features/aave/helpers/aaveAutomationHelpers.tsx
@@ -1,5 +1,0 @@
-import BigNumber from 'bignumber.js'
-
-export function isLtvGreaterThanThreshold(ltv: BigNumber, threshold: BigNumber) {
-  return ltv.gt(threshold)
-}

--- a/features/aave/manage/components/StopLossAaveErrorMessage.tsx
+++ b/features/aave/manage/components/StopLossAaveErrorMessage.tsx
@@ -1,0 +1,15 @@
+import { MessageCard } from 'components/MessageCard'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+export function StopLossAaveErrorMessage() {
+  const { t } = useTranslation()
+
+  return (
+    <MessageCard
+      messages={[t('manage-earn-vault.after-ltv-ratio-below-stop-loss-ltv')]}
+      type="error"
+      withBullet={false}
+    />
+  )
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -677,7 +677,8 @@
     "liquidation-threshold": "Liq Threshold: {{percentage}}",
     "has-asset-already": "There is an active AAVE position open in this address. Therefore, you cannot open a stETH earn position. Close your AAVE position first to continue.",
     "net-value-modal": "Net Value",
-    "net-value-calculation": "The current net value is calculated based on the oracle price of {{stETHPrice}} stETH/ETH."
+    "net-value-calculation": "The current net value is calculated based on the oracle price of {{stETHPrice}} stETH/ETH.",
+    "after-ltv-ratio-below-stop-loss-ltv": "You cannot make adjustments to your position which take it below your Stop-Loss Loan to Value"
   },
   "aave-position-modal": {
     "liquidation-price": {


### PR DESCRIPTION
# [Aave SL overview validation](https://app.shortcut.com/oazo-apps/story/6732/aave-position-actions-validation)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added error when user have active stop loss trigger on aave multiply position and tries to change ltv to value greater than stop loss ltv
  
## How to test 🧪
  <Please explain how to test your changes>

- in order to test it you will need local deployment of automation v2 using hardhat and local instance of cache (ping me if you need help)
- enable `AaveProtection` feature toggle, add stop loss trigger and then try to change your postion (adjust ltv, withdraw collateral, borrow debt) so the ltv will be above stop loss ltv (error should popup and button should be disabled)
