### PR TITLE
Aave Open flow in 1 step (deposit + adjust) + simulation w/no wallet

### DIFF
--- a/blockchain/config.ts
+++ b/blockchain/config.ts
@@ -489,6 +489,8 @@ const hardhat: NetworkConfig = {
   ), */
 }
 
+export const ethNullAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+
 export const networksById = keyBy([main, kovan, hardhat, goerli], 'id')
 export const networksByName = keyBy([main, kovan, hardhat, goerli], 'name')
 

--- a/components/dumb/SliderValuePicker.tsx
+++ b/components/dumb/SliderValuePicker.tsx
@@ -14,6 +14,7 @@ export interface SliderValuePickerProps {
   maxBoundry: BigNumber
   lastValue: BigNumber
   disabled: boolean
+  disabledVisually?: boolean
   leftBoundryStyling?: SxStyleProp
   rightBoundryStyling?: SxStyleProp
   step: number
@@ -36,7 +37,12 @@ export function SliderValuePicker(props: SliderValuePickerProps) {
     : 'neutral60'
 
   return (
-    <Grid gap={2}>
+    <Grid
+      gap={2}
+      sx={{
+        opacity: props.disabledVisually && props.disabled ? 0.6 : 1,
+      }}
+    >
       <Flex
         sx={{
           variant: 'text.paragraph4',

--- a/components/vault/detailsSection/ContentCardLtv.tsx
+++ b/components/vault/detailsSection/ContentCardLtv.tsx
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { ContentCardProps, DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
 import { formatDecimalAsPercent, formatPercent } from 'helpers/formatters/format'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { theme } from 'theme'
@@ -48,9 +49,10 @@ export function ContentCardLtv({
     footnote: `${t('manage-earn-vault.liquidation-threshold', {
       percentage: formatted.liquidationThreshold,
     })}`,
-    customBackground: afterLoanToValue
-      ? getLTVRatioColor(liquidationThreshold.minus(loanToValue).times(100))
-      : 'transparent',
+    customBackground:
+      afterLoanToValue && !liquidationThreshold.eq(zero)
+        ? getLTVRatioColor(liquidationThreshold.minus(loanToValue).times(100))
+        : 'transparent',
   }
 
   if (afterLoanToValue) {

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -200,7 +200,7 @@ export function setupAaveContext({
   )
 
   const openAaveStateMachineServices = getOpenAavePositionStateMachineServices(
-    connectedContext$,
+    context$,
     txHelpers$,
     tokenBalances$,
     proxyForAccount$,

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -74,7 +74,7 @@ export type BaseAaveEvent =
   | { type: 'RESET_RISK_RATIO' }
   | { type: 'CLOSE_POSITION' }
   | { type: 'CONNECTED_PROXY_ADDRESS_RECEIVED'; connectedProxyAddress: string | undefined }
-  | { type: 'DMP_PROXY_RECEIVED'; userDpmAccount: UserDpmAccount }
+  | { type: 'DPM_PROXY_RECEIVED'; userDpmAccount: UserDpmAccount }
   | { type: 'SET_BALANCE'; balance: StrategyTokenBalance }
   | { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
   | UpdateCollateralActionType

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -9,14 +9,12 @@ import { Flex, Grid, Link, Text } from 'theme-ui'
 
 import { SliderValuePicker } from '../../../../components/dumb/SliderValuePicker'
 import { MessageCard } from '../../../../components/MessageCard'
-import { SidebarSection, SidebarSectionProps } from '../../../../components/sidebar/SidebarSection'
 import { SidebarSectionFooterButtonSettings } from '../../../../components/sidebar/SidebarSectionFooter'
 import { SidebarResetButton } from '../../../../components/vault/sidebar/SidebarResetButton'
 import { formatPercent } from '../../../../helpers/formatters/format'
 import { zero } from '../../../../helpers/zero'
 import { getLiquidationPriceAccountingForPrecision } from '../../../shared/liquidationPrice'
 import { BaseViewProps } from '../BaseAaveContext'
-import { StrategyInformationContainer } from './informationContainer'
 
 type RaisedEvents =
   | { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
@@ -77,13 +75,9 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
     state,
     send,
     isLoading,
-    primaryButton,
-    textButton,
     viewLocked = false,
     showWarring = false,
     onChainPosition,
-    dropdownConfig,
-    title,
   }: AdjustRiskViewProps) {
     const { t } = useTranslation()
 
@@ -136,117 +130,105 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
       onChainPosition?.riskRatio.loanToValue ||
       viewConfig.riskRatios.default.loanToValue
 
-    const sidebarSectionProps: SidebarSectionProps = {
-      title,
-      content: (
-        <Grid gap={3}>
-          <SliderValuePicker
-            leftLabel={t('open-earn.aave.vault-form.configure-multiple.liquidation-price')}
-            leftBoundry={liquidationPrice}
-            leftBoundryFormatter={(value) => {
-              if (isLoading()) {
-                return '...'
-              } else {
-                return viewConfig.liquidationPriceFormatter(value)
-              }
-            }}
-            rightBoundry={viewConfig.rightBoundary.valueExtractor({
-              oracleAssetPrice,
-              ltv: sliderValue,
-            })}
-            rightBoundryFormatter={(value) => {
-              return viewConfig.rightBoundary.formatter(value)
-            }}
-            rightLabel={t(viewConfig.rightBoundary.translationKey)}
-            onChange={(ltv) => {
-              send({ type: 'SET_RISK_RATIO', riskRatio: new RiskRatio(ltv, RiskRatio.TYPE.LTV) })
-            }}
-            leftBoundryStyling={{
-              color: isWarning ? 'warning100' : 'neutral100',
-            }}
-            minBoundry={minRisk}
-            maxBoundry={maxRisk || zero}
-            lastValue={sliderValue}
-            disabled={viewLocked}
-            step={0.01}
-            sliderPercentageFill={
-              maxRisk
-                ? sliderValue.minus(minRisk).times(100).dividedBy(maxRisk.minus(minRisk))
-                : new BigNumber(0)
+    return (
+      <Grid gap={3}>
+        <SliderValuePicker
+          leftLabel={t('open-earn.aave.vault-form.configure-multiple.liquidation-price')}
+          leftBoundry={liquidationPrice}
+          leftBoundryFormatter={(value) => {
+            if (isLoading()) {
+              return '...'
+            } else {
+              return viewConfig.liquidationPriceFormatter(value)
             }
-          />
-          <Flex
-            sx={{
-              variant: 'text.paragraph4',
-              justifyContent: 'space-between',
-              color: 'neutral80',
-            }}
-          >
-            <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.decrease-risk')}</Text>
-            <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.increase-risk')}</Text>
-          </Flex>
+          }}
+          rightBoundry={viewConfig.rightBoundary.valueExtractor({
+            oracleAssetPrice,
+            ltv: sliderValue,
+          })}
+          rightBoundryFormatter={(value) => {
+            return viewConfig.rightBoundary.formatter(value)
+          }}
+          rightLabel={t(viewConfig.rightBoundary.translationKey)}
+          onChange={(ltv) => {
+            send({ type: 'SET_RISK_RATIO', riskRatio: new RiskRatio(ltv, RiskRatio.TYPE.LTV) })
+          }}
+          leftBoundryStyling={{
+            color: isWarning ? 'warning100' : 'neutral100',
+          }}
+          minBoundry={minRisk}
+          maxBoundry={maxRisk || zero}
+          lastValue={sliderValue}
+          disabled={viewLocked}
+          step={0.01}
+          sliderPercentageFill={
+            maxRisk
+              ? sliderValue.minus(minRisk).times(100).dividedBy(maxRisk.minus(minRisk))
+              : new BigNumber(0)
+          }
+        />
+        <Flex
+          sx={{
+            variant: 'text.paragraph4',
+            justifyContent: 'space-between',
+            color: 'neutral80',
+          }}
+        >
+          <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.decrease-risk')}</Text>
+          <Text as="span">{t('open-earn.aave.vault-form.configure-multiple.increase-risk')}</Text>
+        </Flex>
 
-          <SidebarResetButton
-            clear={() => {
-              send({ type: 'RESET_RISK_RATIO' })
-            }}
-            disabled={viewLocked || !state.context.userInput.riskRatio}
-          />
+        <SidebarResetButton
+          clear={() => {
+            send({ type: 'RESET_RISK_RATIO' })
+          }}
+          disabled={viewLocked || !state.context.userInput.riskRatio}
+        />
 
-          {collateralToken && debtToken && viewConfig.link && (
-            <Link target="_blank" href={viewConfig.link.url}>
-              <WithArrow variant="paragraph4" sx={{ color: 'interactive100' }}>
-                {t(viewConfig.link.textTranslationKey, {
-                  collateralToken,
-                  debtToken,
-                })}
-              </WithArrow>
-            </Link>
-          )}
-          {showWarring ? (
+        {collateralToken && debtToken && viewConfig.link && (
+          <Link target="_blank" href={viewConfig.link.url}>
+            <WithArrow variant="paragraph4" sx={{ color: 'interactive100' }}>
+              {t(viewConfig.link.textTranslationKey, {
+                collateralToken,
+                debtToken,
+              })}
+            </WithArrow>
+          </Link>
+        )}
+        {showWarring ? (
+          <MessageCard
+            messages={[t('manage-earn-vault.has-asset-already')]}
+            type="error"
+            withBullet={false}
+          />
+        ) : (
+          state.context.strategy && (
             <MessageCard
-              messages={[t('manage-earn-vault.has-asset-already')]}
-              type="error"
-              withBullet={false}
-            />
-          ) : (
-            state.context.strategy && (
-              <MessageCard
-                messages={[
-                  isWarning
-                    ? t('open-earn.aave.vault-form.configure-multiple.vault-message-warning', {
-                        collateralToken,
-                        priceMovement: formatPercent(priceMovementUntilLiquidationPercent, {
-                          precision: 2,
-                        }),
-                        debtToken,
-                        liquidationPenalty,
-                      })
-                    : t('open-earn.aave.vault-form.configure-multiple.vault-message-ok', {
-                        collateralToken,
-                        priceMovement: formatPercent(priceMovementUntilLiquidationPercent, {
-                          precision: 2,
-                        }),
-                        debtToken,
-                        liquidationPenalty,
+              messages={[
+                isWarning
+                  ? t('open-earn.aave.vault-form.configure-multiple.vault-message-warning', {
+                      collateralToken,
+                      priceMovement: formatPercent(priceMovementUntilLiquidationPercent, {
+                        precision: 2,
                       }),
-                ]}
-                withBullet={false}
-                type={isWarning ? 'warning' : 'ok'}
-              />
-            )
-          )}
-          <StrategyInformationContainer state={state} />
-        </Grid>
-      ),
-      primaryButton: {
-        ...primaryButton,
-        disabled: viewLocked || primaryButton.disabled || !state.context.strategy,
-      },
-      textButton, // this is going back button, no need to block it
-      dropdown: dropdownConfig,
-    }
-
-    return <SidebarSection {...sidebarSectionProps} />
+                      debtToken,
+                      liquidationPenalty,
+                    })
+                  : t('open-earn.aave.vault-form.configure-multiple.vault-message-ok', {
+                      collateralToken,
+                      priceMovement: formatPercent(priceMovementUntilLiquidationPercent, {
+                        precision: 2,
+                      }),
+                      debtToken,
+                      liquidationPenalty,
+                    }),
+              ]}
+              withBullet={false}
+              type={isWarning ? 'warning' : 'ok'}
+            />
+          )
+        )}
+      </Grid>
+    )
   }
 }

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -9,12 +9,14 @@ import { Flex, Grid, Link, Text } from 'theme-ui'
 
 import { SliderValuePicker } from '../../../../components/dumb/SliderValuePicker'
 import { MessageCard } from '../../../../components/MessageCard'
+import { SidebarSection, SidebarSectionProps } from '../../../../components/sidebar/SidebarSection'
 import { SidebarSectionFooterButtonSettings } from '../../../../components/sidebar/SidebarSectionFooter'
 import { SidebarResetButton } from '../../../../components/vault/sidebar/SidebarResetButton'
 import { formatPercent } from '../../../../helpers/formatters/format'
 import { zero } from '../../../../helpers/zero'
 import { getLiquidationPriceAccountingForPrecision } from '../../../shared/liquidationPrice'
 import { BaseViewProps } from '../BaseAaveContext'
+import { StrategyInformationContainer } from './informationContainer'
 
 type RaisedEvents =
   | { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
@@ -30,6 +32,7 @@ export type AdjustRiskViewProps = BaseViewProps<RaisedEvents> & {
   onChainPosition?: IPosition
   dropdownConfig?: SidebarSectionHeaderDropdown
   title: string
+  noSidebar?: boolean
 }
 
 export function richFormattedBoundary({ value, unit }: { value: string; unit: string }) {
@@ -75,9 +78,14 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
     state,
     send,
     isLoading,
+    primaryButton,
+    textButton,
     viewLocked = false,
     showWarring = false,
     onChainPosition,
+    dropdownConfig,
+    title,
+    noSidebar,
   }: AdjustRiskViewProps) {
     const { t } = useTranslation()
 
@@ -130,7 +138,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
       onChainPosition?.riskRatio.loanToValue ||
       viewConfig.riskRatios.default.loanToValue
 
-    return (
+    const sidebarContent = (
       <Grid gap={3}>
         <SliderValuePicker
           leftLabel={t('open-earn.aave.vault-form.configure-multiple.liquidation-price')}
@@ -228,7 +236,24 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
             />
           )
         )}
+        <StrategyInformationContainer state={state} />
       </Grid>
     )
+    if (noSidebar) {
+      return sidebarContent
+    }
+
+    const sidebarSectionProps: SidebarSectionProps = {
+      title,
+      content: sidebarContent,
+      primaryButton: {
+        ...primaryButton,
+        disabled: viewLocked || primaryButton.disabled || !state.context.strategy,
+      },
+      textButton, // this is going back button, no need to block it
+      dropdown: dropdownConfig,
+    }
+
+    return <SidebarSection {...sidebarSectionProps} />
   }
 }

--- a/features/aave/helpers/hasUserInteracted.ts
+++ b/features/aave/helpers/hasUserInteracted.ts
@@ -1,0 +1,13 @@
+import { BaseAaveContext } from '../common/BaseAaveContext'
+
+export function hasUserInteracted(state: { context: BaseAaveContext }) {
+  // determines whether user inputted value on the aave multiply page
+  // returns true if
+  // - there is a riskRatio defined - meaning he moved the slider, or there is a position on chain (from protocolData)
+  // - there is a simulation in context - meaning riskRatio AND the amount is provided
+  return (
+    (state.context.userInput.riskRatio?.loanToValue ||
+      state.context.protocolData?.position.riskRatio.loanToValue) &&
+    state.context.strategy?.simulation.position
+  )
+}

--- a/features/aave/helpers/isUserWalletConnected.ts
+++ b/features/aave/helpers/isUserWalletConnected.ts
@@ -1,0 +1,5 @@
+import { BaseAaveContext } from '../common/BaseAaveContext'
+
+export function isUserWalletConnected(context: BaseAaveContext) {
+  return context.web3Context && context.web3Context?.status === 'connected'
+}

--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -8,6 +8,7 @@ import {
   ZERO,
 } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
+import { ethNullAddress } from 'blockchain/config'
 import { providers } from 'ethers'
 
 import { Context, ContextConnected } from '../../blockchain/network'
@@ -22,7 +23,7 @@ import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from './strategyCo
 function getAddressesFromContext(context: Context) {
   return {
     DAI: context.tokens['DAI'].address,
-    ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    ETH: ethNullAddress,
     WETH: context.tokens['WETH'].address,
     STETH: context.tokens['STETH'].address,
     USDC: context.tokens['USDC'].address,
@@ -121,8 +122,6 @@ export async function getOpenAaveParameters({
   positionType,
 }: OpenAaveParameters): Promise<IPositionTransition> {
   try {
-    checkContext(context, 'open position')
-
     const _collateralToken = {
       symbol: collateralToken as AAVETokens,
       precision: getToken(collateralToken).precision,
@@ -168,7 +167,7 @@ export async function getOpenAaveParameters({
       provider: context.rpcProvider,
       getSwapData: getOneInchCall(context.swapAddress),
       proxy: proxyAddress,
-      user: context.account,
+      user: proxyAddress !== ethNullAddress ? context.account! : ethNullAddress, // mocking the address before wallet connection
       isDPMProxy: proxyType === ProxyType.DpmProxy,
     }
 

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -1,5 +1,6 @@
 import { useActor } from '@xstate/react'
 import { TabBar } from 'components/TabBar'
+import { hasUserInteracted } from 'features/aave/helpers/hasUserInteracted'
 import { Survey } from 'features/survey'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -39,9 +40,7 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
       tokenPrice={state.context.tokenPrice}
       debtPrice={state.context.debtPrice}
       nextPosition={
-        state.matches('frontend.reviewing')
-          ? state.context.strategy?.simulation.position
-          : undefined
+        hasUserInteracted(state) ? state.context.strategy?.simulation.position : undefined
       }
     />
   )

--- a/features/aave/open/services/getOpenAaveStateMachine.ts
+++ b/features/aave/open/services/getOpenAaveStateMachine.ts
@@ -9,7 +9,7 @@ import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators'
 
 import { TransactionDef } from '../../../../blockchain/calls/callsHelpers'
 import { OperationExecutorTxMeta } from '../../../../blockchain/calls/operationExecutor'
-import { ContextConnected } from '../../../../blockchain/network'
+import { Context } from '../../../../blockchain/network'
 import { Tickers } from '../../../../blockchain/prices'
 import { TokenBalances } from '../../../../blockchain/tokens'
 import { UserDpmAccount } from '../../../../blockchain/userDpmProxies'
@@ -33,7 +33,7 @@ import { OpenAaveParameters } from '../../oasisActionsLibWrapper'
 import { createOpenAaveStateMachine, OpenAaveStateMachineServices } from '../state'
 
 export function getOpenAavePositionStateMachineServices(
-  context$: Observable<ContextConnected>,
+  context$: Observable<Context>,
   txHelpers$: Observable<TxHelpers>,
   tokenBalances$: Observable<TokenBalances>,
   connectedProxy$: Observable<string | undefined>,

--- a/features/aave/open/services/getOpenAaveStateMachine.ts
+++ b/features/aave/open/services/getOpenAaveStateMachine.ts
@@ -162,7 +162,7 @@ export function getOpenAavePositionStateMachineServices(
     },
     dpmProxy$: (_) => {
       return userDpmProxy$.pipe(
-        map((proxy) => ({ type: 'DMP_PROXY_RECEIVED', userDpmAccount: proxy })),
+        map((proxy) => ({ type: 'DPM_PROXY_RECEIVED', userDpmAccount: proxy })),
         distinctUntilChanged(isEqual),
       )
     },

--- a/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -151,6 +151,8 @@ function EditingStateViewSidebarPrimaryButton({
 
 function OpenAaveEditingStateView({ state, send, isLoading }: OpenAaveStateProps) {
   const { t } = useTranslation()
+  const { hasOpenedPosition } = state.context
+  const AdjustRiskView = state.context.strategyConfig.viewComponents.adjustRiskView
 
   const amountTooHigh =
     state.context.userInput.amount?.gt(state.context.tokenBalance || zero) ?? false
@@ -166,6 +168,29 @@ function OpenAaveEditingStateView({ state, send, isLoading }: OpenAaveStateProps
             type="error"
           />
         )}
+        <AdjustRiskView
+          title={
+            state.context.strategyConfig.type === 'Earn'
+              ? t('sidebar-titles.open-earn-position')
+              : t('sidebar-titles.open-multiply-position')
+          }
+          state={state}
+          send={send}
+          isLoading={isLoading}
+          primaryButton={{
+            steps: [state.context.currentStep, state.context.totalSteps],
+            isLoading: isLoading(),
+            disabled: !state.can('NEXT_STEP'),
+            label: t(state.context.strategyConfig.viewComponents.sidebarButton),
+            action: () => send('NEXT_STEP'),
+          }}
+          textButton={{
+            label: t('open-earn.aave.vault-form.back-to-editing'),
+            action: () => send('BACK_TO_EDITING'),
+          }}
+          viewLocked={hasOpenedPosition}
+          showWarring={hasOpenedPosition}
+        />
         <StrategyInformationContainer state={state} />
       </Grid>
     ),
@@ -205,14 +230,11 @@ function OpenAaveSuccessStateView({ state }: OpenAaveStateProps) {
 export function SidebarOpenAaveVault() {
   const { stateMachine } = useOpenAaveStateMachineContext()
   const [state, send] = useActor(stateMachine)
-  const { t } = useTranslation()
-  const { hasOpenedPosition } = state.context
 
   function loading(): boolean {
     return isLoading(state)
   }
 
-  const AdjustRiskView = state.context.strategyConfig.viewComponents.adjustRiskView
   switch (true) {
     case state.matches('frontend.editing'):
       return <OpenAaveEditingStateView state={state} send={send} isLoading={loading} />
@@ -230,32 +252,6 @@ export function SidebarOpenAaveVault() {
         <AllowanceView
           allowanceMachine={state.context.refAllowanceStateMachine!}
           steps={[state.context.currentStep, state.context.totalSteps]}
-        />
-      )
-    case state.matches('frontend.settingMultiple'):
-      return (
-        <AdjustRiskView
-          title={
-            state.context.strategyConfig.type === 'Earn'
-              ? t('sidebar-titles.open-earn-position')
-              : t('sidebar-titles.open-multiply-position')
-          }
-          state={state}
-          send={send}
-          isLoading={loading}
-          primaryButton={{
-            steps: [state.context.currentStep, state.context.totalSteps],
-            isLoading: isLoading(state),
-            disabled: !state.can('NEXT_STEP'),
-            label: t(state.context.strategyConfig.viewComponents.sidebarButton),
-            action: () => send('NEXT_STEP'),
-          }}
-          textButton={{
-            label: t('open-earn.aave.vault-form.back-to-editing'),
-            action: () => send('BACK_TO_EDITING'),
-          }}
-          viewLocked={hasOpenedPosition}
-          showWarring={hasOpenedPosition}
         />
       )
     case state.matches('frontend.reviewing'):

--- a/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -190,6 +190,7 @@ function OpenAaveEditingStateView({ state, send, isLoading }: OpenAaveStateProps
           }}
           viewLocked={hasOpenedPosition}
           showWarring={hasOpenedPosition}
+          noSidebar
         />
         <StrategyInformationContainer state={state} />
       </Grid>

--- a/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVaultEditingState.tsx
@@ -1,7 +1,6 @@
-import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Box, Grid } from 'theme-ui'
+import { Grid } from 'theme-ui'
 import { Sender, StateFrom } from 'xstate'
 
 import { VaultActionInput } from '../../../../components/vault/VaultActionInput'
@@ -19,37 +18,25 @@ export function SidebarOpenAaveVaultEditingState(props: OpenAaveEditingStateProp
 
   return (
     <Grid gap={3}>
-      <WithLoadingIndicator
-        // this loader seems to be pointless, but undefined tokenUsdPrice (below) breaks the proper decimals input so it needs to be there
-        value={[state.context.collateralPrice]}
-        customLoader={
-          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-            <AppSpinner size={24} />
-          </Box>
-        }
-      >
-        {([collateralPrice]) => (
-          <VaultActionInput
-            action={'Deposit'}
-            amount={state.context.userInput?.amount}
-            hasAuxiliary={true}
-            auxiliaryAmount={state.context.auxiliaryAmount}
-            hasError={false}
-            maxAmount={state.context.tokenBalance}
-            showMax={true}
-            maxAmountLabel={t('balance')}
-            onSetMax={() => {
-              send({ type: 'SET_AMOUNT', amount: state.context.tokenBalance! })
-            }}
-            onChange={handleNumericInput((amount) => {
-              send({ type: 'SET_AMOUNT', amount })
-            })}
-            currencyCode={state.context.tokens.deposit}
-            disabled={false}
-            tokenUsdPrice={collateralPrice}
-          />
-        )}
-      </WithLoadingIndicator>
+      <VaultActionInput
+        action={'Deposit'}
+        amount={state.context.userInput?.amount}
+        hasAuxiliary={true}
+        auxiliaryAmount={state.context.auxiliaryAmount}
+        hasError={false}
+        maxAmount={state.context.tokenBalance}
+        showMax={true}
+        maxAmountLabel={t('balance')}
+        onSetMax={() => {
+          send({ type: 'SET_AMOUNT', amount: state.context.tokenBalance! })
+        }}
+        onChange={handleNumericInput((amount) => {
+          send({ type: 'SET_AMOUNT', amount })
+        })}
+        currencyCode={state.context.tokens.deposit}
+        disabled={false}
+        tokenUsdPrice={state.context.collateralPrice}
+      />
     </Grid>
   )
 }

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -171,6 +171,14 @@ export function createOpenAaveStateMachine(
                   target: '#openAaveStateMachine.background.debouncing',
                   actions: ['setAmount', 'calculateAuxiliaryAmount'],
                 },
+                SET_RISK_RATIO: {
+                  target: '#openAaveStateMachine.background.debouncing',
+                  actions: 'setRiskRatio',
+                },
+                RESET_RISK_RATIO: {
+                  target: '#openAaveStateMachine.background.debouncing',
+                  actions: 'resetRiskRatio',
+                },
                 NEXT_STEP: [
                   {
                     target: 'dpmProxyCreating',
@@ -188,7 +196,7 @@ export function createOpenAaveStateMachine(
                     actions: 'incrementCurrentStep',
                   },
                   {
-                    target: 'settingMultiple',
+                    target: 'reviewing',
                     cond: 'canOpenPosition',
                     actions: 'incrementCurrentStep',
                   },
@@ -220,27 +228,6 @@ export function createOpenAaveStateMachine(
               exit: ['killAllowanceMachine'],
               on: {
                 ALLOWANCE_SUCCESS: {
-                  target: 'editing',
-                },
-              },
-            },
-            settingMultiple: {
-              entry: 'eventConfirmDeposit',
-              on: {
-                SET_RISK_RATIO: {
-                  target: '#openAaveStateMachine.background.debouncing',
-                  actions: 'setRiskRatio',
-                },
-                RESET_RISK_RATIO: {
-                  target: '#openAaveStateMachine.background.debouncing',
-                  actions: 'resetRiskRatio',
-                },
-                NEXT_STEP: {
-                  target: 'reviewing',
-                  cond: 'validTransactionParameters',
-                  actions: 'incrementCurrentStep',
-                },
-                BACK_TO_EDITING: {
                   target: 'editing',
                 },
               },
@@ -323,7 +310,7 @@ export function createOpenAaveStateMachine(
         UPDATE_ALLOWANCE: {
           actions: 'updateContext',
         },
-        DMP_PROXY_RECEIVED: {
+        DPM_PROXY_RECEIVED: {
           actions: ['updateContext', 'calculateEffectiveProxyAddress', 'setTotalSteps'],
         },
       },

--- a/features/multiply/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/multiply/aave/components/AaveMultiplyPositionData.tsx
@@ -52,7 +52,9 @@ function calcViewValuesForPosition(
 
   const totalExposure = collateral
 
-  const liquidationPrice = debt.div(collateral.times(position.category.liquidationThreshold))
+  const liquidationPrice = NaNIsZero(
+    debt.div(collateral.times(position.category.liquidationThreshold)),
+  )
 
   const costOfBorrowingDebt = debtVariableBorrowRate.times(debt).times(debtTokenPrice)
   const profitFromProvidingCollateral = collateralLiquidityRate
@@ -120,7 +122,7 @@ export function AaveMultiplyPositionData({
         <DetailsSectionContentCardWrapper>
           <DetailsSectionContentCard
             title={t('system.liquidation-price')}
-            value={`${formatPrecision(NaNIsZero(currentPositionThings.liquidationPrice), 2)} ${
+            value={`${formatPrecision(currentPositionThings.liquidationPrice, 2)} ${
               currentPosition.debt.symbol
             }`}
             change={
@@ -136,7 +138,8 @@ export function AaveMultiplyPositionData({
               }
             }
             footnote={
-              !currentPositionThings.liquidationPrice.isNaN()
+              !currentPositionThings.liquidationPrice.isNaN() &&
+              !currentPositionThings.liquidationPrice.eq(zero)
                 ? `${t('manage-earn-vault.below-current-price', {
                     percentage: belowCurrentPricePercentage,
                   })}`

--- a/features/stateMachines/transactionParameters/transactionParametersStateMachine.ts
+++ b/features/stateMachines/transactionParameters/transactionParametersStateMachine.ts
@@ -1,5 +1,6 @@
 import { IPositionTransition } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
+import { ethNullAddress } from 'blockchain/config'
 import { isEqual } from 'lodash'
 import { Observable } from 'rxjs'
 import { distinctUntilChanged, map } from 'rxjs/operators'
@@ -78,7 +79,13 @@ export function createTransactionParametersStateMachine<T extends BaseTransactio
             onDone: [
               {
                 target: 'estimating',
+                cond: 'hasRealProxyAddress',
                 actions: ['serviceUpdateContext', 'sendStrategy', 'sendGasEstimation'],
+              },
+              {
+                target: 'idle',
+                cond: 'hasMockProxyAddress',
+                actions: ['serviceUpdateContext', 'sendStrategy'],
               },
             ],
             onError: {
@@ -180,6 +187,14 @@ export function createTransactionParametersStateMachine<T extends BaseTransactio
           ),
         txHelpers$: (_) =>
           txHelpers$.pipe(map((txHelper) => ({ type: 'TX_HELPER_CHANGED', txHelper }))),
+      },
+      guards: {
+        hasRealProxyAddress: ({ parameters }) => {
+          return parameters?.proxyAddress !== ethNullAddress
+        },
+        hasMockProxyAddress: ({ parameters }) => {
+          return parameters?.proxyAddress === ethNullAddress
+        },
       },
     },
   )

--- a/pages/api/tokensPrices.tsx
+++ b/pages/api/tokensPrices.tsx
@@ -1,39 +1,17 @@
 import { withSentry } from '@sentry/nextjs'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-// import { cacheObject } from '../../helpers/api/cacheObject'
-// import { tokenTickers } from '../../helpers/api/tokenTickers'
+import { cacheObject } from '../../helpers/api/cacheObject'
+import { tokenTickers } from '../../helpers/api/tokenTickers'
 
-// const getTicker = cacheObject(tokenTickers, 2 * 60)
+const getTicker = cacheObject(tokenTickers, 2 * 60)
 
 async function tokensPricesHandler(req: NextApiRequest, res: NextApiResponse) {
   switch (req.method) {
     case 'GET':
-      // const tickers = await getTicker()
+      const tickers = await getTicker()
       res.setHeader('Cache-Control', 'public, s-maxage=90, stale-while-revalidate=119')
-      return res.status(200).json({
-        'eth-ethereum': 1334.258465143443,
-        'usdc-usd-coin': 0.9991509192670103,
-        'dai-dai': 0.9993865595295941,
-        'steth-lido-staked-ether': 1320.5983637874394,
-        'weth-weth': 1328.789027770681,
-        'wbtc-wrapped-bitcoin': 17916.97654729976,
-        'usdp-paxos-standard-token': 0.99823445715842,
-        'gusd-gemini-dollar': 1.0007410295770038,
-        'mkr-maker': 604.415049614932,
-        'renbtc-renbtc': 18105.408329982565,
-        'mkr-usd': 604.27,
-        'eth-usd': 1335.6,
-        'MANA-USD': 0.3901,
-        'LINK-USD': 6.865,
-        'YFI-USD': 6508.68,
-        'UNI-USD': 6.115,
-        'MATIC-USD': 0.9273,
-        'dai-usd': 0.9998,
-        'wrapped-steth': 1454.19,
-        'rocket-pool-eth': 1431.83,
-        gnosis: 93.87,
-      })
+      return res.status(200).json(tickers.data)
     default:
       return res.status(405).end()
   }

--- a/pages/api/tokensPrices.tsx
+++ b/pages/api/tokensPrices.tsx
@@ -1,17 +1,39 @@
 import { withSentry } from '@sentry/nextjs'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import { cacheObject } from '../../helpers/api/cacheObject'
-import { tokenTickers } from '../../helpers/api/tokenTickers'
+// import { cacheObject } from '../../helpers/api/cacheObject'
+// import { tokenTickers } from '../../helpers/api/tokenTickers'
 
-const getTicker = cacheObject(tokenTickers, 2 * 60)
+// const getTicker = cacheObject(tokenTickers, 2 * 60)
 
 async function tokensPricesHandler(req: NextApiRequest, res: NextApiResponse) {
   switch (req.method) {
     case 'GET':
-      const tickers = await getTicker()
+      // const tickers = await getTicker()
       res.setHeader('Cache-Control', 'public, s-maxage=90, stale-while-revalidate=119')
-      return res.status(200).json(tickers.data)
+      return res.status(200).json({
+        'eth-ethereum': 1334.258465143443,
+        'usdc-usd-coin': 0.9991509192670103,
+        'dai-dai': 0.9993865595295941,
+        'steth-lido-staked-ether': 1320.5983637874394,
+        'weth-weth': 1328.789027770681,
+        'wbtc-wrapped-bitcoin': 17916.97654729976,
+        'usdp-paxos-standard-token': 0.99823445715842,
+        'gusd-gemini-dollar': 1.0007410295770038,
+        'mkr-maker': 604.415049614932,
+        'renbtc-renbtc': 18105.408329982565,
+        'mkr-usd': 604.27,
+        'eth-usd': 1335.6,
+        'MANA-USD': 0.3901,
+        'LINK-USD': 6.865,
+        'YFI-USD': 6508.68,
+        'UNI-USD': 6.115,
+        'MATIC-USD': 0.9273,
+        'dai-usd': 0.9998,
+        'wrapped-steth': 1454.19,
+        'rocket-pool-eth': 1431.83,
+        gnosis: 93.87,
+      })
     default:
       return res.status(405).end()
   }

--- a/pages/earn/[protocol]/open/[strategy].tsx
+++ b/pages/earn/[protocol]/open/[strategy].tsx
@@ -1,14 +1,14 @@
-import { WithWalletConnection } from 'components/connectWallet/ConnectWallet'
+import { WithConnection } from 'components/connectWallet/ConnectWallet'
+import { DeferedContextProvider } from 'components/DeferedContextProvider'
 import { AppLayout } from 'components/Layouts'
 import { AaveOpenView } from 'features/aave/open/containers/AaveOpenView'
 import { Survey } from 'features/survey'
-import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
-import { AaveContextProvider } from '../../../../features/aave/AaveContextProvider'
+import { aaveContext, AaveContextProvider } from '../../../../features/aave/AaveContextProvider'
 import { loadStrategyFromSlug } from '../../../../features/aave/strategyConfig'
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
@@ -32,15 +32,13 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 function OpenVault({ strategy }: { strategy: string }) {
   return (
     <AaveContextProvider>
-      <WithWalletConnection>
-        <WithTermsOfService>
-          <BackgroundLight />
-
+      <WithConnection>
+        <BackgroundLight />
+        <DeferedContextProvider context={aaveContext}>
           <AaveOpenView config={loadStrategyFromSlug(strategy)} />
-
-          <Survey for="earn" />
-        </WithTermsOfService>
-      </WithWalletConnection>
+        </DeferedContextProvider>
+        <Survey for="earn" />
+      </WithConnection>
     </AaveContextProvider>
   )
 }

--- a/pages/multiply/[protocol]/open/[strategy].tsx
+++ b/pages/multiply/[protocol]/open/[strategy].tsx
@@ -1,14 +1,14 @@
-import { WithWalletConnection } from 'components/connectWallet/ConnectWallet'
+import { WithConnection } from 'components/connectWallet/ConnectWallet'
+import { DeferedContextProvider } from 'components/DeferedContextProvider'
 import { AppLayout } from 'components/Layouts'
 import { AaveOpenView } from 'features/aave/open/containers/AaveOpenView'
 import { Survey } from 'features/survey'
-import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
-import { AaveContextProvider } from '../../../../features/aave/AaveContextProvider'
+import { aaveContext, AaveContextProvider } from '../../../../features/aave/AaveContextProvider'
 import { loadStrategyFromSlug } from '../../../../features/aave/strategyConfig'
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
@@ -33,15 +33,13 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 function OpenVault({ strategy }: { strategy: string }) {
   return (
     <AaveContextProvider>
-      <WithWalletConnection>
-        <WithTermsOfService>
-          <BackgroundLight />
-
+      <WithConnection>
+        <BackgroundLight />
+        <DeferedContextProvider context={aaveContext}>
           <AaveOpenView config={loadStrategyFromSlug(strategy)} />
-
-          <Survey for="earn" />
-        </WithTermsOfService>
-      </WithWalletConnection>
+        </DeferedContextProvider>
+        <Survey for="earn" />
+      </WithConnection>
     </AaveContextProvider>
   )
 }


### PR DESCRIPTION
# [Open flow in 1 step (deposit + adjust) in stead of 2](https://app.shortcut.com/oazo-apps/story/7220/open-flow-in-1-step-deposit-adjust-in-stead-of-2)

## Changes 👷‍♀️
- moved the risk adjustment to the first step, available immediately after inputting the amount
- moved the wallet requirement further down the flow so the user is able to simulate the position without wallet connection
  
## How to test 🧪
- go to any aave (earn or multiply) view with no wallet connection
- deposit amount and risk adjustment should be on one view
- you should be able to simulate the position
- you should be redirected to `/connect` when it's necessary
