### PR TITLE
Aave protection indication owner page

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -1044,18 +1044,25 @@ export function setupAppContext() {
     ),
   )
 
+  const automationTriggersData$ = memoize(
+    curry(createAutomationTriggersData)(chainContext$, onEveryBlock$, proxiesRelatedWithPosition$),
+  )
+
   const aavePositions$ = memoize(
     curry(createAavePosition$)(
       {
         dsProxy$: proxyAddress$,
         userDpmProxies$,
       },
+      {
+        tickerPrices$: tokenPriceUSD$,
+        context$,
+        automationTriggersData$,
+        readPositionCreatedEvents$,
+      },
       aaveProtocolData$,
       getAaveAssetsPrices$,
-      tokenPriceUSD$,
       wrappedGetAaveReserveData$,
-      context$,
-      readPositionCreatedEvents$,
       aaveAvailableLiquidityInUSDC$,
       strategyConfig$,
     ),
@@ -1223,10 +1230,6 @@ export function setupAppContext() {
   const productCardsWithBalance$ = createProductCardsWithBalance$(
     ilksWithBalance$,
     oraclePriceDataLean$,
-  )
-
-  const automationTriggersData$ = memoize(
-    curry(createAutomationTriggersData)(chainContext$, onEveryBlock$, proxiesRelatedWithPosition$),
   )
 
   const vaultsHistoryAndValue$ = memoize(

--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -5,6 +5,11 @@ import { UserDpmAccount } from 'blockchain/userDpmProxies'
 import { VaultWithType, VaultWithValue } from 'blockchain/vaults'
 import { PreparedAaveReserveData } from 'features/aave/helpers/aavePrepareReserveData'
 import { AaveProtocolData } from 'features/aave/manage/services'
+import { TriggersData } from 'features/automation/api/automationTriggersData'
+import {
+  extractStopLossData,
+  StopLossTriggerData,
+} from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { zero } from 'helpers/zero'
 import { combineLatest, Observable, of } from 'rxjs'
 import { map, startWith, switchMap } from 'rxjs/operators'
@@ -97,6 +102,7 @@ export type AavePosition = Position & {
   isOwner: boolean
   type: 'multiply' | 'earn'
   liquidity: BigNumber
+  stopLossData?: StopLossTriggerData
 }
 
 export function createPositions$(
@@ -128,6 +134,7 @@ type BuildPositionArgs = {
   tickerPrices$: (tokens: string[]) => Observable<Tickers>
   wrappedGetAaveReserveData$: (token: string) => Observable<PreparedAaveReserveData>
   aaveAvailableLiquidityInUSDC$: (reserveDataParameters: { token: string }) => Observable<BigNumber>
+  automationTriggersData$: (id: BigNumber) => Observable<TriggersData>
 }
 
 function buildPosition(
@@ -148,95 +155,110 @@ function buildPosition(
     observables.aaveAvailableLiquidityInUSDC$({
       token: debtTokenSymbol,
     }),
+    positionIdIsAddress(positionId)
+      ? of(undefined)
+      : observables.automationTriggersData$(new BigNumber(positionId)),
   ).pipe(
-    map(([protocolData, assetPrices, tickerPrices, preparedAaveReserve, liquidity]) => {
-      const {
-        position: {
-          riskRatio: { multiple },
-          debt,
-          collateral,
-          category: { liquidationThreshold },
-        },
-      } = protocolData
+    map(
+      ([protocolData, assetPrices, tickerPrices, preparedAaveReserve, liquidity, triggersData]) => {
+        const {
+          position: {
+            riskRatio: { multiple },
+            debt,
+            collateral,
+            category: { liquidationThreshold },
+          },
+        } = protocolData
 
-      const isDebtZero = debt.amount.isZero()
+        const isDebtZero = debt.amount.isZero()
 
-      const tickerCollateralTokenPriceInUsd = tickerPrices[collateral.symbol]
-      const tickerDebtTokenPriceInUsd = tickerPrices[debt.symbol]
+        const tickerCollateralTokenPriceInUsd = tickerPrices[collateral.symbol]
+        const tickerDebtTokenPriceInUsd = tickerPrices[debt.symbol]
 
-      const oracleCollateralTokenPriceInEth = assetPrices[0]
-      const oracleDebtTokenPriceInEth = assetPrices[1]
+        const oracleCollateralTokenPriceInEth = assetPrices[0]
+        const oracleDebtTokenPriceInEth = assetPrices[1]
 
-      const collateralToken = positionCreatedEvent.collateralTokenSymbol
-      const debtToken = positionCreatedEvent.debtTokenSymbol
+        const collateralToken = positionCreatedEvent.collateralTokenSymbol
+        const debtToken = positionCreatedEvent.debtTokenSymbol
 
-      const collateralNotWei = amountFromPrecision(
-        collateral.amount,
-        new BigNumber(collateral.precision),
-      )
-      const debtNotWei = amountFromPrecision(debt.amount, new BigNumber(debt.precision))
+        const collateralNotWei = amountFromPrecision(
+          collateral.amount,
+          new BigNumber(collateral.precision),
+        )
+        const debtNotWei = amountFromPrecision(debt.amount, new BigNumber(debt.precision))
 
-      const netValueInEthAccordingToOracle = collateralNotWei
-        .times(oracleCollateralTokenPriceInEth)
-        .minus(debtNotWei.times(oracleDebtTokenPriceInEth))
+        const netValueInEthAccordingToOracle = collateralNotWei
+          .times(oracleCollateralTokenPriceInEth)
+          .minus(debtNotWei.times(oracleDebtTokenPriceInEth))
 
-      const liquidationPrice = !isDebtZero
-        ? debtNotWei.div(collateralNotWei.times(liquidationThreshold))
-        : zero
+        const liquidationPrice = !isDebtZero
+          ? debtNotWei.div(collateralNotWei.times(liquidationThreshold))
+          : zero
 
-      const variableBorrowRate = preparedAaveReserve.variableBorrowRate
+        const variableBorrowRate = preparedAaveReserve.variableBorrowRate
 
-      const fundingCost = !isDebtZero
-        ? debtNotWei
-            .times(oracleDebtTokenPriceInEth)
-            .div(netValueInEthAccordingToOracle)
-            .multipliedBy(variableBorrowRate)
-            .times(100)
-        : zero
+        const fundingCost = !isDebtZero
+          ? debtNotWei
+              .times(oracleDebtTokenPriceInEth)
+              .div(netValueInEthAccordingToOracle)
+              .multipliedBy(variableBorrowRate)
+              .times(100)
+          : zero
 
-      const netValueUsd = collateralNotWei
-        .times(tickerCollateralTokenPriceInUsd)
-        .minus(debtNotWei.times(tickerDebtTokenPriceInUsd))
+        const netValueUsd = collateralNotWei
+          .times(tickerCollateralTokenPriceInUsd)
+          .minus(debtNotWei.times(tickerDebtTokenPriceInUsd))
 
-      const isOwner = context.status === 'connected' && context.account === walletAddress
+        const isOwner = context.status === 'connected' && context.account === walletAddress
 
-      return {
-        token: collateralToken,
-        title: `${collateralToken}/${debtToken} AAVE`,
-        url: `/aave/${positionId}`,
-        id: positionIdIsAddress(positionId) ? formatAddress(positionId) : positionId,
-        netValue: netValueUsd,
-        multiple,
-        liquidationPrice,
-        fundingCost,
-        contentsUsd: netValueUsd,
-        isOwner,
-        lockedCollateral: collateralNotWei,
-        type: mappymap[positionCreatedEvent.positionType],
-        liquidity: liquidity,
-      }
-    }),
+        return {
+          token: collateralToken,
+          title: `${collateralToken}/${debtToken} AAVE`,
+          url: `/aave/${positionId}`,
+          id: positionIdIsAddress(positionId) ? formatAddress(positionId) : positionId,
+          netValue: netValueUsd,
+          multiple,
+          liquidationPrice,
+          fundingCost,
+          contentsUsd: netValueUsd,
+          isOwner,
+          lockedCollateral: collateralNotWei,
+          type: mappymap[positionCreatedEvent.positionType],
+          liquidity: liquidity,
+          stopLossData: triggersData ? extractStopLossData(triggersData) : undefined,
+        }
+      },
+    ),
   )
 }
 
 export function createAavePosition$(
   proxyAddresses: ProxyAddresses,
+  environment: {
+    tickerPrices$: (tokens: string[]) => Observable<Tickers>
+    context$: Observable<Context>
+    automationTriggersData$: (id: BigNumber) => Observable<TriggersData>
+    readPositionCreatedEvents$: (wallet: string) => Observable<PositionCreated[]>
+  },
   aaveProtocolData$: (
     collateralToken: string,
     debtToken: string,
     address: string,
   ) => Observable<AaveProtocolData>,
   getAaveAssetsPrices$: (args: AaveAssetsPricesParameters) => Observable<BigNumber[]>,
-  tickerPrices$: (tokens: string[]) => Observable<Tickers>,
   wrappedGetAaveReserveData$: (token: string) => Observable<PreparedAaveReserveData>,
-  context$: Observable<Context>,
-  readPositionCreatedEvents$: (wallet: string) => Observable<PositionCreated[]>,
   aaveAvailableLiquidityInUSDC$: (reserveDataParameters: {
     token: string
   }) => Observable<BigNumber>,
   getStrategyConfig$: (positionId: PositionId) => Observable<IStrategyConfig>,
   walletAddress: string,
 ): Observable<AavePosition[]> {
+  const {
+    context$,
+    tickerPrices$,
+    readPositionCreatedEvents$,
+    automationTriggersData$,
+  } = environment
   return combineLatest(
     proxyAddresses.userDpmProxies$(walletAddress),
     proxyAddresses.dsProxy$(walletAddress),
@@ -280,12 +302,14 @@ export function createAavePosition$(
               if (!userProxy) {
                 throw new Error('nope')
               }
+
               return buildPosition(pce, userProxy.vaultId, context, walletAddress, {
                 aaveProtocolData$,
                 getAaveAssetsPrices$,
                 tickerPrices$,
                 wrappedGetAaveReserveData$,
                 aaveAvailableLiquidityInUSDC$,
+                automationTriggersData$,
               })
             }),
           )

--- a/features/vaultsOverview/vaultsOverview.ts
+++ b/features/vaultsOverview/vaultsOverview.ts
@@ -7,6 +7,8 @@ import {
   PositionVM,
 } from 'components/dumb/PositionList'
 import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
+import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
+import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { formatCryptoBalance, formatFiatBalance, formatPercent } from 'helpers/formatters/format'
 import { calculatePNL } from 'helpers/multiply/calculations'
 import { zero } from 'helpers/zero'
@@ -153,7 +155,13 @@ function mapAavePositions(position: AavePosition[]): PositionVM[] {
           precision: 2,
         }),
         collateralLocked: `${formatCryptoBalance(position.lockedCollateral)} ${position.token}`,
-        automationEnabled: false,
+        automationEnabled: isAutomationEnabled(position),
+        protectionAmount: getProtectionAmount(position),
+        automationLinkProps: {
+          href: `/aave/${position.id}`,
+          hash: VaultViewMode.Protection,
+          internalInNewTab: false,
+        },
         editLinkProps: {
           href: position.url,
           hash: VaultViewMode.Overview,
@@ -194,16 +202,21 @@ function getPnl(vault: MakerPositionDetails): BigNumber {
   return calculatePNL(history, netValueUSD)
 }
 
-function isAutomationEnabled(position: MakerPositionDetails): boolean {
-  return position.stopLossData.isStopLossEnabled || position.autoSellData.isTriggerEnabled
+interface PositionWithProtection {
+  stopLossData?: StopLossTriggerData
+  autoSellData?: AutoBSTriggerData
 }
 
-function getProtectionAmount(position: MakerPositionDetails): string {
+function isAutomationEnabled(position: PositionWithProtection): boolean {
+  return !!(position.stopLossData?.isStopLossEnabled || position.autoSellData?.isTriggerEnabled)
+}
+
+function getProtectionAmount(position: PositionWithProtection): string {
   let protectionAmount = zero
 
-  if (position.stopLossData.stopLossLevel.gt(zero))
+  if (position.stopLossData?.stopLossLevel.gt(zero))
     protectionAmount = position.stopLossData.stopLossLevel.times(100)
-  else if (position.autoSellData.execCollRatio.gt(zero))
+  else if (position.autoSellData?.execCollRatio.gt(zero))
     protectionAmount = position.autoSellData.execCollRatio
 
   return formatPercent(protectionAmount)


### PR DESCRIPTION
# [Aave protection indication owner page](https://app.shortcut.com/oazo-apps/story/7565/handle-aave-protection-indicator-on-owner-page)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added handling of protection indication for aave multiply positions on owner page
  
## How to test 🧪
  <Please explain how to test your changes>

- `AaveProtection` feature toggle on, local instance of hardhat and cache, manually deploy automation v2 using hardhat commands
- create Aave multiply postion, add / remove stop loss trigger and verify if it's handled properly on owner page
