### PR TITLE
[SC-7574] Collecting fee in the library (package version bump)

### DIFF
--- a/features/aave/oasisActionsLibWrapper.ts
+++ b/features/aave/oasisActionsLibWrapper.ts
@@ -338,11 +338,9 @@ export async function getManageAaveParameters(
       case ManageCollateralActionsEnum.DEPOSIT_COLLATERAL:
         const borrowDepositStratArgs: Parameters<typeof strategies.aave.depositBorrow>[0] = {
           slippage,
-          collectFeeFrom: 'sourceToken',
         }
         if (manageTokenInput?.manageTokenAction === ManageDebtActionsEnum.BORROW_DEBT) {
           borrowDepositStratArgs.borrowAmount = debt || ZERO
-          borrowDepositStratArgs.collectFeeFrom = 'targetToken'
         }
         if (
           manageTokenInput?.manageTokenAction === ManageCollateralActionsEnum.DEPOSIT_COLLATERAL

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.2.5",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.1.8",
+    "@oasisdex/oasis-actions": "0.1.12",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.8.tgz#dad106c9244af65a70adf07afa7148af5b408ac9"
-  integrity sha512-gQ47FRaVsd11ooYtCXxXqU07M2QLLhLiEW81IMS1SDh0kBDXaPXNmD59kQ0lJnTqay6eTcdgIP7PVB9kCsIQxQ==
+"@oasisdex/oasis-actions@0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.1.12.tgz#a330f6f5d3b27bb70c39ead844aade009111716f"
+  integrity sha512-0FA8ZdKoC8CqBYYtS+MZMSH78JB1D+9dx4/xEX2KuTVZtIFXsfC6IYOxa8e/QZZk0m9Z7EHSDKBMyD2bekBW0w==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
## Changes
- Collecting fee is calculated in the library
- In the library (done in [PR](https://github.com/OasisDEX/oasis-earn-sc/pull/168)) we have a hierarchy in which token we want to get a fee. In that order: `USDC`, `DAI`, `WETH`, `ETH`, `STETH`, `WBTC`. 

How to test:

- Ensure on the FE in its current state multiply fee should always be in USDC, for earn in ETH.