### PR TITLE
Spike for using Xstate component with RXJS or like separated views.

### DIFF
--- a/pages/_example/dpm/components/containerDPM.tsx
+++ b/pages/_example/dpm/components/containerDPM.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react'
+import { map } from 'rxjs/operators'
+import { Box, Container, Grid } from 'theme-ui'
+
+import { DetailsSection } from '../../../../components/DetailsSection'
+import { TabBar } from '../../../../components/TabBar'
+import { CreateDPMAccountView } from '../../../../features/stateMachines/dpmAccount'
+import { useObservable } from '../../../../helpers/observableHook'
+import { useDpmContext } from './dpmProvider'
+export function DPMLog() {
+  const { states$, dpmAccounts$ } = useDpmContext()
+  const onlyEvents = states$.pipe(map((state) => state.event))
+  const [state] = useObservable(onlyEvents)
+  const [dpms] = useObservable(dpmAccounts$)
+  const [content, setContent] = useState<string[]>([])
+  useEffect(() => {
+    setContent([...content, state?.type || ''])
+  }, [state])
+  return (
+    <DetailsSection
+      title={'LOG'}
+      content={
+        <Box>
+          {content.map((c, index) => (
+            <Box key={index}>{c}</Box>
+          ))}
+          <Box>{`Created DPM: ${dpms?.vaultId}, Proxy Address: ${dpms?.proxy}`}</Box>
+        </Box>
+      }
+    ></DetailsSection>
+  )
+}
+
+export function ContainerDPM() {
+  const { stateMachine } = useDpmContext()
+
+  return (
+    <Container>
+      <TabBar
+        sections={[
+          {
+            value: 'simulate',
+            label: 'Test',
+            content: (
+              <Grid variant="vaultContainer">
+                <Box>
+                  <DPMLog></DPMLog>
+                </Box>
+                <Box>
+                  <CreateDPMAccountView machine={stateMachine} />
+                </Box>
+              </Grid>
+            ),
+          },
+        ]}
+        variant={'underline'}
+      />
+    </Container>
+  )
+}

--- a/pages/_example/dpm/components/dpmProvider.tsx
+++ b/pages/_example/dpm/components/dpmProvider.tsx
@@ -1,0 +1,69 @@
+import { useInterpret } from '@xstate/react'
+import React from 'react'
+import { from, Subject } from 'rxjs'
+import { createMachine, send } from 'xstate'
+
+import { UserDpmAccount } from '../../../../blockchain/userDpmProxies'
+import { useAaveContext } from '../../../../features/aave/AaveContextProvider'
+import { DPMAccountStateMachine } from '../../../../features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
+
+const dpmContext = React.createContext<ReturnType<typeof setupDpmContext> | undefined>(undefined)
+
+// This is the easiest solution to deal with `sendParent` in machines.
+// We create a dummy parent machine that will send all events from the child machine.
+// We can subscribe to the events and react to them.
+// Another Solution:
+//  1. Change `sendParent` to send and:.
+//    a. in `getOpenAaveStateMachine.ts` override the sendResultToParent function to `sendParent` instead of `send`
+//    b. don't use `spawn` and pass a service (using for example: useInterpret) to getOpenStateMachine and react to `DPM_ACCOUNT_CREATED` event
+const dummyParent = createMachine({
+  schema: {
+    events: {} as any,
+    context: {} as {},
+  },
+  id: 'parent',
+  initial: 'idle',
+  states: {
+    idle: {},
+  },
+  on: {
+    '*': {
+      actions: (context, event) => send({ ...event }),
+    },
+  },
+})
+
+function setupDpmContext(machine: DPMAccountStateMachine) {
+  const createdDpmAccount = new Subject<UserDpmAccount>()
+  const parentService = useInterpret(dummyParent)
+    .start()
+    .onEvent((event) => {
+      if (event.type === 'DPM_ACCOUNT_CREATED') {
+        // @ts-ignore
+        createdDpmAccount.next(event.userDpmAccount)
+      }
+    })
+
+  const service = useInterpret(machine, { parent: parentService }).start()
+
+  const states$ = from(service)
+  return {
+    stateMachine: service,
+    states$,
+    dpmAccounts$: createdDpmAccount.asObservable(),
+  }
+}
+
+export function useDpmContext(): ReturnType<typeof setupDpmContext> {
+  const ac = React.useContext(dpmContext)
+  if (!ac) {
+    throw new Error('DpmContext not available!')
+  }
+  return ac
+}
+
+export function DpmContextProvider({ children }: React.PropsWithChildren<any>) {
+  const { dpmAccountStateMachine } = useAaveContext()
+  const context = setupDpmContext(dpmAccountStateMachine)
+  return <dpmContext.Provider value={context}>{children}</dpmContext.Provider>
+}

--- a/pages/_example/dpm/index.tsx
+++ b/pages/_example/dpm/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { BackgroundLight } from 'theme/BackgroundLight'
+
+import { WithWalletConnection } from '../../../components/connectWallet/ConnectWallet'
+import { AppLayout } from '../../../components/Layouts'
+import { AaveContextProvider } from '../../../features/aave/AaveContextProvider'
+import { WithTermsOfService } from '../../../features/termsOfService/TermsOfService'
+import { ContainerDPM } from './components/containerDPM'
+import { DpmContextProvider } from './components/dpmProvider'
+
+export async function getServerSideProps() {
+  return {
+    props: {},
+  }
+}
+
+function DpmPage() {
+  return (
+    <AaveContextProvider>
+      <WithWalletConnection>
+        <WithTermsOfService>
+          <DpmContextProvider>
+            <BackgroundLight />
+            <ContainerDPM />
+          </DpmContextProvider>
+        </WithTermsOfService>
+      </WithWalletConnection>
+    </AaveContextProvider>
+  )
+}
+DpmPage.layout = AppLayout
+
+export default DpmPage


### PR DESCRIPTION
# How to test?
- Go to http://localhost:3000/_example/dpm?network=hardhat
- Try to create a DPM Account. 

# Funcionallity
- We can use CreateDPMAccountView without a machine for the whole flow.
- We can subscribe to events from the machine Proxy View
- We can subscribe to only results. In that case: `UserDpmAccount`

# Problems
- It's not easy to deal with machines with `sendParent`. 
- I created a dummy parent to send all events.
- It can be fixed. I propose solutions in the code. 