### PR TITLE
Ades/aave/baron chris fixes

### DIFF
--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -212,6 +212,7 @@ export function setupAaveContext({
     allowanceForAccount$,
     unconsumedDpmProxyForConnectedAccount$,
     proxyConsumed$,
+    aaveReserveConfigurationData$,
   )
 
   const manageAaveStateMachineServices = getManageAavePositionStateMachineServices(

--- a/features/aave/common/BaseAaveContext.ts
+++ b/features/aave/common/BaseAaveContext.ts
@@ -120,6 +120,7 @@ export interface BaseAaveContext {
   effectiveProxyAddress?: string
   refAllowanceStateMachine?: ActorRefFrom<AllowanceStateMachine>
   transactionToken?: string
+  defaultRiskRatio?: IRiskRatio
 }
 
 export type BaseViewProps<AaveEvent extends EventObject> = {

--- a/features/aave/common/StrategyConfigTypes.ts
+++ b/features/aave/common/StrategyConfigTypes.ts
@@ -35,7 +35,7 @@ export interface IStrategyConfig {
   }
   riskRatios: {
     minimum: IRiskRatio
-    default: IRiskRatio
+    default: IRiskRatio | 'slightlyLessThanMaxRisk'
   }
   type: 'Multiply' | 'Earn'
   featureToggle: Feature

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -70,7 +70,7 @@ export type AdjustRiskViewConfig = {
   }
   riskRatios: {
     minimum: IRiskRatio
-    default: IRiskRatio
+    default: IRiskRatio | 'slightlyLessThanMaxRisk'
   }
 }
 
@@ -93,9 +93,8 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
     const simulation = state.context.strategy?.simulation
     const targetPosition = simulation?.position
 
-    const maxRisk = targetPosition
-      ? targetPosition?.category.maxLoanToValue
-      : onChainPosition?.category.maxLoanToValue
+    const maxRisk =
+      targetPosition?.category.maxLoanToValue || onChainPosition?.category.maxLoanToValue || zero
 
     const minRisk =
       (simulation?.minConfigurableRiskRatio &&
@@ -137,7 +136,9 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
     )
 
     const sliderValue =
-      state.context.userInput.riskRatio?.loanToValue || onChainPosition?.riskRatio.loanToValue
+      state.context.userInput.riskRatio?.loanToValue ||
+      onChainPosition?.riskRatio.loanToValue ||
+      state.context.defaultRiskRatio?.loanToValue
 
     const sidebarContent = (
       <Grid gap={3}>
@@ -178,8 +179,8 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
             send({ type: 'SET_RISK_RATIO', riskRatio: new RiskRatio(ltv, RiskRatio.TYPE.LTV) })
           }}
           minBoundry={minRisk}
-          maxBoundry={maxRisk || zero}
-          lastValue={sliderValue || viewConfig.riskRatios.default.loanToValue}
+          maxBoundry={maxRisk}
+          lastValue={sliderValue || zero}
           disabled={viewLocked || !maxRisk}
           disabledVisually={viewLocked || !maxRisk}
           step={0.01}

--- a/features/aave/open/services/getOpenAaveStateMachine.ts
+++ b/features/aave/open/services/getOpenAaveStateMachine.ts
@@ -7,6 +7,7 @@ import { isEqual } from 'lodash'
 import { combineLatest, iif, Observable, of } from 'rxjs'
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators'
 
+import { AaveReserveConfigurationData } from '../../../../blockchain/calls/aave/aaveProtocolDataProvider'
 import { TransactionDef } from '../../../../blockchain/calls/callsHelpers'
 import { OperationExecutorTxMeta } from '../../../../blockchain/calls/operationExecutor'
 import { Context } from '../../../../blockchain/network'
@@ -31,7 +32,6 @@ import { ProxyType } from '../../common/StrategyConfigTypes'
 import { AaveProtocolData } from '../../manage/services'
 import { OpenAaveParameters } from '../../oasisActionsLibWrapper'
 import { createOpenAaveStateMachine, OpenAaveStateMachineServices } from '../state'
-import { AaveReserveConfigurationData } from '../../../../blockchain/calls/aave/aaveProtocolDataProvider'
 
 export function getOpenAavePositionStateMachineServices(
   context$: Observable<Context>,

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -35,6 +35,8 @@ import {
 } from '../../common/BaseAaveContext'
 import { IStrategyConfig, ProxyType } from '../../common/StrategyConfigTypes'
 import { OpenAaveParameters } from '../../oasisActionsLibWrapper'
+import { IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
+import { AaveReserveConfigurationData } from '../../../../blockchain/calls/aave/aaveProtocolDataProvider'
 
 export const totalStepsMap = {
   base: 2,
@@ -51,6 +53,7 @@ export interface OpenAaveContext extends BaseAaveContext {
   strategyConfig: IStrategyConfig
   positionRelativeAddress?: string
   blockSettingCalculatedAddresses?: boolean
+  reserveConfig?: AaveReserveConfigurationData
 }
 
 function getTransactionDef(context: OpenAaveContext): TransactionDef<OperationExecutorTxMeta> {
@@ -67,6 +70,7 @@ export type OpenAaveEvent =
   | { type: 'SET_AMOUNT'; amount?: BigNumber }
   | { type: 'NEXT_STEP' }
   | { type: 'UPDATE_META_INFO'; hasOpenedPosition: boolean }
+  | { type: 'RESERVE_CONFIG_UPDATED'; reserveConfig: AaveReserveConfigurationData }
   | BaseAaveEvent
   | ProxyResultEvent
   | DMPAccountStateMachineResultEvents
@@ -129,6 +133,10 @@ export function createOpenAaveStateMachine(
         {
           src: 'allowance$',
           id: 'allowance$',
+        },
+        {
+          src: 'aaveReserveConfiguration$',
+          id: 'aaveReserveConfiguration$',
         },
       ],
       id: 'openAaveStateMachine',
@@ -315,6 +323,9 @@ export function createOpenAaveStateMachine(
         DPM_PROXY_RECEIVED: {
           actions: ['updateContext', 'calculateEffectiveProxyAddress', 'setTotalSteps'],
         },
+        RESERVE_CONFIG_UPDATED: {
+          actions: ['updateContext', 'setDefaultRiskRatio'],
+        },
       },
     },
     {
@@ -343,8 +354,18 @@ export function createOpenAaveStateMachine(
           return {
             userInput: {
               ...context.userInput,
-              riskRatio: context.strategyConfig.riskRatios.default,
+              riskRatio: context.defaultRiskRatio,
             },
+          }
+        }),
+        setDefaultRiskRatio: assign((context) => {
+          const defaultRiskRatio =
+            context.strategyConfig.riskRatios.default === 'slightlyLessThanMaxRisk'
+              ? new RiskRatio(context.reserveConfig?.ltv.times('0.999') || zero, RiskRatio.TYPE.LTV)
+              : context.strategyConfig.riskRatios.default
+
+          return {
+            defaultRiskRatio,
           }
         }),
         setTotalSteps: assign((context) => {
@@ -441,7 +462,10 @@ export function createOpenAaveStateMachine(
               type: 'VARIABLES_RECEIVED',
               parameters: {
                 amount: context.userInput.amount!,
-                riskRatio: context.userInput.riskRatio || context.strategyConfig.riskRatios.default,
+                riskRatio:
+                  context.userInput.riskRatio ||
+                  context.defaultRiskRatio ||
+                  new RiskRatio(zero, RiskRatio.TYPE.LTV),
                 // ethNullAddress just for the simulation, theres a guard for that
                 proxyAddress: context.effectiveProxyAddress! || ethNullAddress,
                 collateralToken: context.strategyConfig.tokens.collateral,

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -1,3 +1,4 @@
+import { RiskRatio } from '@oasisdex/oasis-actions'
 import { trackingEvents } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
 import { ethNullAddress } from 'blockchain/config'
@@ -6,6 +7,7 @@ import { ActorRefFrom, assign, createMachine, send, spawn } from 'xstate'
 import { pure } from 'xstate/lib/actions'
 import { MachineOptionsFrom } from 'xstate/lib/types'
 
+import { AaveReserveConfigurationData } from '../../../../blockchain/calls/aave/aaveProtocolDataProvider'
 import { TransactionDef } from '../../../../blockchain/calls/callsHelpers'
 import {
   callOperationExecutorWithDpmProxy,
@@ -35,8 +37,6 @@ import {
 } from '../../common/BaseAaveContext'
 import { IStrategyConfig, ProxyType } from '../../common/StrategyConfigTypes'
 import { OpenAaveParameters } from '../../oasisActionsLibWrapper'
-import { IRiskRatio, RiskRatio } from '@oasisdex/oasis-actions'
-import { AaveReserveConfigurationData } from '../../../../blockchain/calls/aave/aaveProtocolDataProvider'
 
 export const totalStepsMap = {
   base: 2,

--- a/features/earn/EarnView.tsx
+++ b/features/earn/EarnView.tsx
@@ -49,13 +49,13 @@ export function EarnView() {
         <WithLoadingIndicator value={[productCardsIlksData]} customLoader={<ProductCardsLoader />}>
           {([_productCardsIlksData]) => (
             <ProductCardsWrapper>
+              {aaveEarnStrategies.map((cardData) => (
+                <ProductCardEarnAave key={cardData.symbol} cardData={cardData} />
+              ))}
               {/* TODO move logic regarding dsr to productCardsData$ */}
               {daiSavingsRate && <ProductCardEarnDsr />}
               {_productCardsIlksData.map((cardData) => (
                 <ProductCardEarnMaker key={cardData.ilk} cardData={cardData} />
-              ))}
-              {aaveEarnStrategies.map((cardData) => (
-                <ProductCardEarnAave key={cardData.symbol} cardData={cardData} />
               ))}
             </ProductCardsWrapper>
           )}

--- a/features/earn/aave/riskSliderConfig.tsx
+++ b/features/earn/aave/riskSliderConfig.tsx
@@ -23,7 +23,7 @@ export const adjustRiskSliderConfig: AdjustRiskViewConfig = {
     textTranslationKey: 'open-earn.aave.vault-form.configure-multiple.historical-ratio',
   },
   riskRatios: {
-    minimum: new RiskRatio(new BigNumber(1.1), RiskRatio.TYPE.MULITPLE),
-    default: new RiskRatio(new BigNumber(2.01), RiskRatio.TYPE.MULITPLE),
+    minimum: new RiskRatio(new BigNumber('1.1'), RiskRatio.TYPE.MULITPLE),
+    default: new RiskRatio(new BigNumber('0.70'), RiskRatio.TYPE.LTV),
   },
 }

--- a/features/earn/aave/riskSliderConfig.tsx
+++ b/features/earn/aave/riskSliderConfig.tsx
@@ -24,6 +24,6 @@ export const adjustRiskSliderConfig: AdjustRiskViewConfig = {
   },
   riskRatios: {
     minimum: new RiskRatio(new BigNumber('1.1'), RiskRatio.TYPE.MULITPLE),
-    default: new RiskRatio(new BigNumber('0.70'), RiskRatio.TYPE.LTV),
+    default: 'slightlyLessThanMaxRisk',
   },
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -683,7 +683,7 @@
     "earnings-to-date-modal": "The earnings to date of the position. Calculated as the current net value of the position, minus the cumulative deposits, plus the cumulative withdrawals, and not accounting for the Oasis fees. The 'After fees' value is accounting for the earnings including the Oasis fee, and the Ethereum Gas fees.",
     "net-apy": "Net APY",
     "net-apy-modal": "The annual percentage yield, accounting for fees.  Calculated as the percentage price increase of the {{ token }} token over the last 7 days, annualised, and subtracting the variable annual fee.",
-    "net-apy-modal-aave": "The annual percentage yield, accounting for fees. Calculated as the yield on the stETH token over the last 7 days, annualised, and subtracting the variable annual fee paid in AAVE for the ETH.",
+    "net-apy-modal-aave": "The annual percentage yield, accounting for fees. Calculated as the yield on the stETH token over the last 7 days, annualised, and subtracting the variable annual fee paid in Aave for the ETH.",
     "eth-value": "ETH Value",
     "collateral-value-in-vault": "Collateral value in vault",
     "debt-value-in-vault": "Debt value in vault",
@@ -696,7 +696,7 @@
     "below-current-ratio": "({{percentage}} below current ratio)",
     "below-current-price": "{{percentage}} below current price",
     "liquidation-threshold": "Liq Threshold: {{percentage}}",
-    "has-asset-already": "There is an active AAVE position open in this address. Therefore, you cannot open a stETH earn position. Close your AAVE position first to continue.",
+    "has-asset-already": "There is an active Aave position open in this address. Therefore, you cannot open a stETH earn position. Close your Aave position first to continue.",
     "net-value-modal": "Net Value",
     "net-value-calculation": "The current net value is calculated based on the oracle price of {{stETHPrice}} stETH/ETH."
   },
@@ -1080,7 +1080,7 @@
   "vault": {
     "current-price": "Current {{token}}/USD Price in {{time}}",
     "header": "{{ilk}} Vault {{id}}",
-    "header-aave-open": "Open {{collateral}}/{{debt}} AAVE position",
+    "header-aave-open": "Open {{collateral}}/{{debt}} Aave position",
     "header-aave-view": "Aave {{collateral}}/{{debt}}",
     "header-aave-view-id": "Aave {{collateral}}/{{debt}} Vault {{vaultId}}",
     "insti-header": "Institutional {{ilk}} Vault {{id}}",
@@ -1284,8 +1284,8 @@
       "subheader": "The current loan to value of {{loanToValue}} is higher than the maximum loan to value of {{maxLoanToValue}} allowed by the protocol. Therefore this position can only be de-risked. If the loan to value of the position reaches {{liquidationThreshold}} the position will be available for liquidation."
     },
     "aave-multi-position": {
-      "header": "This position is affected by other assets on AAVE",
-      "subheader": "This position is not reflecting the entire position on AAVE, as there are other assets put up as collateral or debt on this same DS-Proxy. Contact us to see what you can do."
+      "header": "This position is affected by other assets on Aave",
+      "subheader": "This position is not reflecting the entire position on Aave, as there are other assets put up as collateral or debt on this same DS-Proxy. Contact us to see what you can do."
     }
   },
   "vault-banners": {
@@ -1545,8 +1545,8 @@
     },
     "aave": {
       "stETHeth": {
-        "title": "stETH/ETH AAVE",
-        "description": "Earn on your ETH with increased staking rewards. Borrow ETH on AAVE to get more exposure to stETH."
+        "title": "stETH/ETH Aave",
+        "description": "Earn on your ETH with increased staking rewards. Borrow ETH on Aave to get more exposure to stETH."
       },
       "stETHusdc": {
         "title": "Highest stETH multiple option",
@@ -1557,7 +1557,7 @@
         "description": "Maximise your ETH exposure with Aave and USDC."
       },
       "wBTCusdc": {
-        "title": "Highest WBTC multiple option",
+        "title": "High wBTC multiple option",
         "description": "The biggest possible Multiple to maximize your exposure to WBTC"
       }
     },
@@ -1588,7 +1588,7 @@
     "ETH-B": "High ETH multiple with liquidation delay",
     "ETH-C": "Lowest ETH borrowing cost",
     "WBTC-A": "wBTC with medium cost and multiple",
-    "WBTC-B": "Highest wBTC multiple option",
+    "WBTC-B": "High wBTC multiple with liquidation delay",
     "WBTC-C": "Lowest wBTC borrowing cost",
     "RENBTC-A": "Ren Bitcoin (RenBTC)",
     "WSTETH-A": "StETH with medium cost and multiple",
@@ -2107,7 +2107,7 @@
     "aave": {
       "product-header": {
         "token-pair-list": {
-          "aave-steth-eth": "AAVE stETH yield multiple"
+          "aave-steth-eth": "Aave stETH yield multiple"
         },
         "current-yield": "Current yield",
         "90-day-avg-yield": "90 Day Avg",
@@ -2129,8 +2129,8 @@
           "back-to-enter-eth": "Back to enter ETH",
           "increase-risk": "Increase risk",
           "decrease-risk": "Decrease risk",
-          "vault-message-ok": "At the chosen risk level, the price of {{collateralToken}} needs to move over {{priceMovement}} with respect to {{debtToken}} for this position to be available for liquidation. AAVE's liquidations penalty is at least {{liquidationPenalty}}.",
-          "vault-message-warning": "At the chosen risk level, if the price of {{collateralToken}} moves over {{priceMovement}} with respect to {{debtToken}} this Earn position could be liquidated. AAVE's liquidations penalty is at least {{liquidationPenalty}}."
+          "vault-message-ok": "At the chosen risk level, the price of {{collateralToken}} needs to move over {{priceMovement}} with respect to {{debtToken}} for this position to be available for liquidation. Aave's liquidations penalty is at least {{liquidationPenalty}}.",
+          "vault-message-warning": "At the chosen risk level, if the price of {{collateralToken}} moves over {{priceMovement}} with respect to {{debtToken}} this Earn position could be liquidated. Aave's liquidations penalty is at least {{liquidationPenalty}}."
         }
       }
     }


### PR DESCRIPTION
[story](https://app.shortcut.com/oazo-apps/story/7592/copy-feedback-product-order-feedback-new-default-from-barron-chris)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- Copy updated of Aave WTBC to: High wBTC Multiple Option
- Copy updated of wBTC-B to: High wBTC multiple with liquidation delay
- update order of Earn positions on /earn, so that stETH product is top left.
- new default position risk of `slightlyLessThanMaxRisk`.  this is applied to the steth/eth earn position only
  
## How to test 🧪

For both earn and multiply:

- opening position
    - form opens with correct default risk
    - risk resets to default risk
    - position created with correct risk
- managing position
    - form opens with onchain risk
    - reset goes back to onchain risk
    - position saved with correct risk