### PR TITLE
Follow vault buttons on discover table

### DIFF
--- a/components/vault/DefaultVaultHeadline.tsx
+++ b/components/vault/DefaultVaultHeadline.tsx
@@ -1,4 +1,4 @@
-import { FollowButtonProps } from 'features/follow/common/FollowButtonControl'
+import { FollowButtonControlProps } from 'features/follow/common/FollowButtonControl'
 import { PriceInfo } from 'features/shared/priceInfo'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { moreMinutes } from 'helpers/time'
@@ -14,13 +14,13 @@ export function DefaultVaultHeadline({
   token,
   priceInfo,
   colRatio,
-  followButtonProps,
+  followButton,
 }: {
   header: VaultHeadlineProps['header']
   token: VaultHeadlineProps['token']
   priceInfo: PriceInfo
   colRatio?: string
-  followButtonProps?: FollowButtonProps
+  followButton?: FollowButtonControlProps
 }) {
   const { t } = useTranslation()
   const {
@@ -73,7 +73,7 @@ export function DefaultVaultHeadline({
       header={header}
       token={token}
       details={detailsList}
-      followButtonProps={followButtonProps}
+      followButton={followButton}
     />
   )
 }

--- a/components/vault/EarnVaultHeadline.tsx
+++ b/components/vault/EarnVaultHeadline.tsx
@@ -6,14 +6,14 @@ export function EarnVaultHeadline({
   header,
   token,
   details,
-  followButtonProps,
+  followButton,
 }: VaultHeadlineProps) {
   return (
     <VaultHeadline
       header={header}
       token={token}
       details={details}
-      followButtonProps={followButtonProps}
+      followButton={followButton}
     />
   )
 }

--- a/components/vault/EarnVaultHeadline.tsx
+++ b/components/vault/EarnVaultHeadline.tsx
@@ -2,18 +2,8 @@ import React from 'react'
 
 import { VaultHeadline, VaultHeadlineProps } from './VaultHeadline'
 
-export function EarnVaultHeadline({
-  header,
-  token,
-  details,
-  followButton,
-}: VaultHeadlineProps) {
+export function EarnVaultHeadline({ header, token, details, followButton }: VaultHeadlineProps) {
   return (
-    <VaultHeadline
-      header={header}
-      token={token}
-      details={details}
-      followButton={followButton}
-    />
+    <VaultHeadline header={header} token={token} details={details} followButton={followButton} />
   )
 }

--- a/components/vault/GeneralManageControl.tsx
+++ b/components/vault/GeneralManageControl.tsx
@@ -39,7 +39,7 @@ export function GeneralManageControl({ id }: GeneralManageControlProps) {
           <MakerAutomationContext generalManageVault={generalManageVault}>
             <GeneralManageLayout
               generalManageVault={generalManageVault}
-              followButtonProps={
+              followButton={
                 chainId
                   ? {
                       followerAddress: account,

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -31,11 +31,7 @@ export function GeneralManageLayout({
 
   const headlineElement =
     generalManageVault.type === VaultType.Earn ? (
-      <GuniVaultHeader
-        token={ilkData.token}
-        ilk={ilkData.ilk}
-        followButton={followButton}
-      />
+      <GuniVaultHeader token={ilkData.token} ilk={ilkData.ilk} followButton={followButton} />
     ) : (
       <DefaultVaultHeadline
         header={t('vault.header', { ilk: vault.ilk, id: vault.id })}

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -2,7 +2,7 @@ import { getNetworkName } from '@oasisdex/web3-context'
 import { isSupportedAutomationIlk } from 'blockchain/tokensMetadata'
 import { guniFaq } from 'features/content/faqs/guni'
 import { GuniVaultHeader } from 'features/earn/guni/common/GuniVaultHeader'
-import { FollowButtonProps } from 'features/follow/common/FollowButtonControl'
+import { FollowButtonControlProps } from 'features/follow/common/FollowButtonControl'
 import { GeneralManageVaultState } from 'features/generalManageVault/generalManageVault'
 import { VaultType } from 'features/generalManageVault/vaultType'
 import { VaultNoticesView } from 'features/notices/VaultsNoticesView'
@@ -15,12 +15,12 @@ import { GeneralManageTabBar } from './GeneralManageTabBar'
 
 interface GeneralManageLayoutProps {
   generalManageVault: GeneralManageVaultState
-  followButtonProps: FollowButtonProps | undefined
+  followButton?: FollowButtonControlProps
 }
 
 export function GeneralManageLayout({
   generalManageVault,
-  followButtonProps,
+  followButton,
 }: GeneralManageLayoutProps) {
   const { t } = useTranslation()
   const { ilkData, vault, priceInfo } = generalManageVault.state
@@ -34,7 +34,7 @@ export function GeneralManageLayout({
       <GuniVaultHeader
         token={ilkData.token}
         ilk={ilkData.ilk}
-        followButtonProps={followButtonProps}
+        followButton={followButton}
       />
     ) : (
       <DefaultVaultHeadline
@@ -42,7 +42,7 @@ export function GeneralManageLayout({
         token={[vault.token]}
         priceInfo={priceInfo}
         colRatio={colRatioPercnentage}
-        followButtonProps={followButtonProps}
+        followButton={followButton}
       />
     )
 

--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -1,7 +1,10 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Heading } from '@theme-ui/components'
 import { getTokens } from 'blockchain/tokensMetadata'
-import { FollowButtonControl, FollowButtonProps } from 'features/follow/common/FollowButtonControl'
+import {
+  FollowButtonControl,
+  FollowButtonControlProps,
+} from 'features/follow/common/FollowButtonControl'
 import { AppSpinner } from 'helpers/AppSpinner'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
@@ -12,7 +15,7 @@ import { HeadlineDetailsProp, VaultHeadlineDetails } from './VaultHeadlineDetail
 
 export type VaultHeadlineProps = {
   details: HeadlineDetailsProp[]
-  followButtonProps?: FollowButtonProps
+  followButton?: FollowButtonControlProps
   header: string
   label?: string
   loading?: boolean
@@ -25,7 +28,7 @@ export type VaultHeadlineProps = {
 
 export function VaultHeadline({
   details,
-  followButtonProps,
+  followButton,
   header,
   label,
   loading = false,
@@ -85,12 +88,8 @@ export function VaultHeadline({
         )}
         {header}
         {label && <Image src={staticFilesRuntimeUrl(label)} sx={{ ml: 3 }} />}
-        {followVaultEnabled && followButtonProps && (
-          <FollowButtonControl
-            followerAddress={followButtonProps.followerAddress}
-            vaultId={followButtonProps.vaultId}
-            chainId={followButtonProps.chainId}
-          />
+        {followVaultEnabled && followButton && (
+          <FollowButtonControl {...followButton} sx={{ ml: 3 }} />
         )}
       </Heading>
       <Flex

--- a/features/discover/common/DiscoverCards.tsx
+++ b/features/discover/common/DiscoverCards.tsx
@@ -1,8 +1,9 @@
+import { DiscoverTableProps } from 'features/discover/common/DiscoverTable'
 import { DiscoverTableBanner } from 'features/discover/common/DiscoverTableBanner'
 import { DiscoverTableDataCellContent } from 'features/discover/common/DiscoverTableDataCellContent'
 import { getRowKey } from 'features/discover/helpers'
-import { DiscoverBanner } from 'features/discover/meta'
-import { DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
+import { DiscoverFollow } from 'features/discover/meta'
+import { DiscoverTableRowData } from 'features/discover/types'
 import { kebabCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React, { Fragment } from 'react'
@@ -12,21 +13,14 @@ const fullWidthColumns = ['asset', 'cdpId']
 
 export function DiscoverCards({
   banner,
-  isLoading,
+  follow,
+  isLoading = false,
   kind,
   rows = [],
   skip = [],
   onBannerClick,
   onPositionClick,
-}: {
-  banner?: DiscoverBanner
-  isLoading: boolean
-  kind?: DiscoverPages
-  rows: DiscoverTableRowData[]
-  skip?: string[]
-  onBannerClick?: (link: string) => void
-  onPositionClick?: (cdpId: string) => void
-}) {
+}: Omit<DiscoverTableProps, 'isSticky' | 'tooltips'>) {
   const rowsForBanner = Math.min(rows.length - 1, 9)
 
   return (
@@ -47,14 +41,14 @@ export function DiscoverCards({
           opacity: isLoading ? 0.5 : 1,
           pointerEvents: isLoading ? 'none' : 'auto',
           transition: '200ms opacity',
-          button: {
+          '.discover-action': {
             width: '100%',
           },
         }}
       >
         {rows.map((row, i) => (
           <Fragment key={getRowKey(i, row)}>
-            <DiscoverCard row={row} skip={skip} onPositionClick={onPositionClick} />
+            <DiscoverCard follow={follow} row={row} skip={skip} onPositionClick={onPositionClick} />
             {kind && banner && i === Math.floor(rowsForBanner / 2) && (
               <Box as="li">
                 <DiscoverTableBanner kind={kind} onBannerClick={onBannerClick} {...banner} />
@@ -68,10 +62,12 @@ export function DiscoverCards({
 }
 
 export function DiscoverCard({
+  follow,
   row,
   skip,
   onPositionClick,
 }: {
+  follow?: DiscoverFollow
   row: DiscoverTableRowData
   skip: string[]
   onPositionClick?: (cdpId: string) => void
@@ -109,6 +105,7 @@ export function DiscoverCard({
               </Box>
             )}
             <DiscoverTableDataCellContent
+              follow={follow}
               label={label}
               row={row}
               onPositionClick={onPositionClick}

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -1,10 +1,12 @@
 import { MixpanelUserContext, trackingEvents } from 'analytics/analytics'
+import { NetworkIds } from 'blockchain/network'
 import { DiscoverDataResponse } from 'features/discover/api'
 import { DiscoverError } from 'features/discover/common/DiscoverError'
 import { DiscoverPreloader } from 'features/discover/common/DiscoverPreloader'
 import { DiscoverResponsiveTable } from 'features/discover/common/DiscoverResponsiveTable'
 import { DiscoverBanner } from 'features/discover/meta'
 import { DiscoverPages } from 'features/discover/types'
+import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 import { Box } from 'theme-ui'
 
@@ -25,6 +27,8 @@ export function DiscoverData({
   response,
   userContext,
 }: DiscoverDataProps) {
+  const { walletAddress } = useAccount()
+
   return (
     <Box sx={{ position: 'relative' }}>
       {response?.rows ? (
@@ -36,6 +40,9 @@ export function DiscoverData({
             isSticky={isSticky}
             kind={kind}
             rows={response.rows}
+            {...(!!walletAddress && {
+              follow: { followerAddress: walletAddress, chainId: NetworkIds.MAINNET },
+            })}
             onBannerClick={(link) => {
               trackingEvents.discover.clickedTableBanner(kind, link, userContext)
             }}

--- a/features/discover/common/DiscoverResponsiveTable.tsx
+++ b/features/discover/common/DiscoverResponsiveTable.tsx
@@ -1,13 +1,12 @@
 import { DiscoverCards } from 'features/discover/common/DiscoverCards'
-import { DiscoverTable } from 'features/discover/common/DiscoverTable'
-import { DiscoverBanner } from 'features/discover/meta'
-import { DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
+import { DiscoverTable, DiscoverTableProps } from 'features/discover/common/DiscoverTable'
 import React from 'react'
 import { theme } from 'theme'
 import { useMediaQuery } from 'usehooks-ts'
 
 export function DiscoverResponsiveTable({
   banner,
+  follow,
   isLoading = false,
   isSticky = false,
   kind,
@@ -16,22 +15,13 @@ export function DiscoverResponsiveTable({
   tooltips = [],
   onPositionClick,
   onBannerClick,
-}: {
-  banner?: DiscoverBanner
-  isLoading?: boolean
-  isSticky?: boolean
-  kind?: DiscoverPages
-  rows: DiscoverTableRowData[]
-  skip?: string[]
-  tooltips?: string[]
-  onBannerClick?: (link: string) => void
-  onPositionClick?: (cdpId: string) => void
-}) {
+}: DiscoverTableProps) {
   const isSmallerScreen = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`)
 
   return isSmallerScreen ? (
     <DiscoverCards
       banner={banner}
+      follow={follow}
       isLoading={isLoading}
       kind={kind}
       rows={rows}
@@ -42,14 +32,15 @@ export function DiscoverResponsiveTable({
   ) : (
     <DiscoverTable
       banner={banner}
+      follow={follow}
       isLoading={isLoading}
       isSticky={isSticky}
       kind={kind}
+      onBannerClick={onBannerClick}
+      onPositionClick={onPositionClick}
       rows={rows}
       skip={skip}
       tooltips={tooltips}
-      onBannerClick={onBannerClick}
-      onPositionClick={onPositionClick}
     />
   )
 }

--- a/features/discover/common/DiscoverTable.tsx
+++ b/features/discover/common/DiscoverTable.tsx
@@ -3,15 +3,29 @@ import { StatefulTooltip } from 'components/Tooltip'
 import { DiscoverTableBanner } from 'features/discover/common/DiscoverTableBanner'
 import { DiscoverTableDataCellContent } from 'features/discover/common/DiscoverTableDataCellContent'
 import { getRowKey } from 'features/discover/helpers'
-import { DiscoverBanner } from 'features/discover/meta'
+import { DiscoverBanner, DiscoverFollow } from 'features/discover/meta'
 import { DiscoverPages, DiscoverTableRowData } from 'features/discover/types'
 import { kebabCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React, { Fragment } from 'react'
 import { Box, Flex } from 'theme-ui'
 
+export interface DiscoverTableProps {
+  banner?: DiscoverBanner
+  follow?: DiscoverFollow
+  isLoading?: boolean
+  isSticky?: boolean
+  kind?: DiscoverPages
+  rows: DiscoverTableRowData[]
+  skip?: string[]
+  tooltips?: string[]
+  onBannerClick?: (link: string) => void
+  onPositionClick?: (cdpId: string) => void
+}
+
 export function DiscoverTable({
   banner,
+  follow,
   isLoading = false,
   isSticky = false,
   kind,
@@ -20,17 +34,7 @@ export function DiscoverTable({
   tooltips = [],
   onPositionClick,
   onBannerClick,
-}: {
-  banner?: DiscoverBanner
-  isLoading?: boolean
-  isSticky?: boolean
-  kind?: DiscoverPages
-  rows: DiscoverTableRowData[]
-  tooltips?: string[]
-  skip?: string[]
-  onBannerClick?: (link: string) => void
-  onPositionClick?: (cdpId: string) => void
-}) {
+}: DiscoverTableProps) {
   const filteredRowKeys = Object.keys(rows[0]).filter((key) => !skip.includes(key))
   const rowsForBanner = Math.min(rows.length - 1, 9)
 
@@ -65,8 +69,9 @@ export function DiscoverTable({
               <DiscoverTableHeaderCell
                 key={getRowKey(i, rows[0])}
                 first={i === 0}
-                last={i + 1 === filteredRowKeys.length}
+                follow={follow}
                 label={label}
+                last={i + 1 === filteredRowKeys.length}
                 tooltip={tooltips.includes(label)}
               />
             ))}
@@ -84,6 +89,7 @@ export function DiscoverTable({
             <Fragment key={getRowKey(i, row)}>
               <DiscoverTableDataRow
                 filteredRowKeys={filteredRowKeys}
+                follow={follow}
                 row={row}
                 onPositionClick={onPositionClick}
               />
@@ -104,13 +110,15 @@ export function DiscoverTable({
 
 export function DiscoverTableHeaderCell({
   first,
-  last,
+  follow,
   label,
+  last,
   tooltip,
 }: {
   first: boolean
-  last: boolean
+  follow?: DiscoverFollow
   label: string
+  last: boolean
   tooltip: boolean
 }) {
   const { t } = useTranslation()
@@ -122,6 +130,7 @@ export function DiscoverTableHeaderCell({
         position: 'relative',
         px: '12px',
         py: '20px',
+        ...(first && follow && { pl: '80px' }),
         fontSize: 1,
         fontWeight: 'semiBold',
         color: 'neutral80',
@@ -188,10 +197,12 @@ export function DiscoverTableHeaderCell({
 export function DiscoverTableDataRow({
   row,
   filteredRowKeys,
+  follow,
   onPositionClick,
 }: {
-  row: DiscoverTableRowData
   filteredRowKeys: string[]
+  follow?: DiscoverFollow
+  row: DiscoverTableRowData
   onPositionClick?: (cdpId: string) => void
 }) {
   return (
@@ -208,6 +219,7 @@ export function DiscoverTableDataRow({
       {filteredRowKeys.map((label, i) => (
         <DiscoverTableDataCell
           key={getRowKey(i, row)}
+          follow={follow}
           label={label}
           row={row}
           onPositionClick={onPositionClick}
@@ -218,10 +230,12 @@ export function DiscoverTableDataRow({
 }
 
 export function DiscoverTableDataCell({
+  follow,
   label,
   row,
   onPositionClick,
 }: {
+  follow?: DiscoverFollow
   label: string
   row: DiscoverTableRowData
   onPositionClick?: (cdpId: string) => void
@@ -238,7 +252,12 @@ export function DiscoverTableDataCell({
         },
       }}
     >
-      <DiscoverTableDataCellContent label={label} row={row} onPositionClick={onPositionClick} />
+      <DiscoverTableDataCellContent
+        label={label}
+        follow={follow}
+        row={row}
+        onPositionClick={onPositionClick}
+      />
     </Box>
   )
 }

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -5,17 +5,21 @@ import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
 import { DiscoverTableDataCellPill } from 'features/discover/common/DiscoverTableDataCellPill'
 import { discoverFiltersAssetItems } from 'features/discover/filters'
 import { parsePillAdditionalData } from 'features/discover/helpers'
+import { DiscoverFollow } from 'features/discover/meta'
 import { DiscoverTableRowData } from 'features/discover/types'
+import { FollowButtonControl } from 'features/follow/common/FollowButtonControl'
 import { formatCryptoBalance, formatFiatBalance, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Button, Flex, Text } from 'theme-ui'
 
 export function DiscoverTableDataCellContent({
+  follow,
   label,
   row,
   onPositionClick,
 }: {
+  follow?: DiscoverFollow
   label: string
   row: DiscoverTableRowData
   onPositionClick?: (cdpId: string) => void
@@ -36,6 +40,19 @@ export function DiscoverTableDataCellContent({
 
       return (
         <Flex sx={{ alignItems: 'center' }}>
+          {follow && primitives.cdpId && (
+            <FollowButtonControl
+              chainId={follow.chainId}
+              followerAddress={follow.followerAddress}
+              vaultId={new BigNumber(primitives.cdpId)}
+              short
+              sx={{
+                position: ['absolute', null, null, 'relative'],
+                right: [0, null, null, 'auto'],
+                mr: ['24px', null, null, 4],
+              }}
+            />
+          )}
           {(primitives.icon || (asset && asset.icon)) && (
             <Icon size={44} name={(primitives.icon || asset.icon) as string} />
           )}
@@ -77,7 +94,9 @@ export function DiscoverTableDataCellContent({
             onPositionClick && onPositionClick(String(row.url || row.cdpId))
           }}
         >
-          <Button variant="tertiary">{t('discover.table.view-position')}</Button>
+          <Button className="discover-action" variant="tertiary">
+            {t('discover.table.view-position')}
+          </Button>
         </AppLink>
       )
     case 'collateralValue':
@@ -150,7 +169,10 @@ export function DiscoverTableDataCellContent({
               hash={VaultViewMode.Overview}
               internalInNewTab={true}
             >
-              <Button variant={primitives[label] > 0 ? 'actionActiveGreen' : 'action'}>
+              <Button
+                className="discover-action"
+                variant={primitives[label] > 0 ? 'actionActiveGreen' : 'action'}
+              >
                 {primitives[label] > 0
                   ? t('discover.table.protection-value', { protection: primitives[label] })
                   : t('discover.table.activate')}

--- a/features/discover/filters.ts
+++ b/features/discover/filters.ts
@@ -23,6 +23,7 @@ export const discoverFiltersAssetItems: { [key: string]: DiscoverFiltersListOpti
   link: { value: 'LINK', label: 'LINK', icon: getToken('LINK').iconCircle },
   mana: { value: 'MANA', label: 'MANA', icon: getToken('MANA').iconCircle },
   matic: { value: 'MATIC', label: 'MATIC', icon: getToken('MATIC').iconCircle },
+  uni: { value: 'UNI', label: 'UNI', icon: getToken('UNI').iconCircle },
   wbtc: { value: 'WBTC', label: 'WBTC', icon: getToken('WBTC').iconCircle },
   wsteth: { value: 'WSTETH', label: 'WSTETH', icon: getToken('WSTETH').iconCircle },
   yfi: { value: 'YFI', label: 'YFI', icon: getToken('YFI').iconCircle },

--- a/features/discover/meta.tsx
+++ b/features/discover/meta.tsx
@@ -21,6 +21,10 @@ export interface DiscoverFiltersListItem {
 export interface DiscoverFiltersList {
   [key: string]: DiscoverFiltersListItem
 }
+export interface DiscoverFollow {
+  followerAddress: string
+  chainId: number
+}
 export interface DiscoverBanner {
   icon: JSX.Element
   link: string

--- a/features/earn/guni/common/GuniVaultHeader.tsx
+++ b/features/earn/guni/common/GuniVaultHeader.tsx
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { HeadlineDetailsProp } from 'components/vault/VaultHeadlineDetails'
-import { FollowButtonProps } from 'features/follow/common/FollowButtonControl'
+import { FollowButtonControlProps } from 'features/follow/common/FollowButtonControl'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
 import { YieldChange } from 'helpers/earn/calculations'
 import moment from 'moment'
@@ -17,13 +17,13 @@ import { zero } from '../../../../helpers/zero'
 export interface EarnVaultHeaderProps {
   ilk: string
   token: string
-  followButtonProps?: FollowButtonProps
+  followButton?: FollowButtonControlProps
 }
 
 const currentDate = moment().startOf('day')
 const previousDate = currentDate.clone().subtract(1, 'day')
 
-export function GuniVaultHeader({ ilk, token, followButtonProps }: EarnVaultHeaderProps) {
+export function GuniVaultHeader({ ilk, token, followButton }: EarnVaultHeaderProps) {
   const { yieldsChange$, totalValueLocked$ } = useAppContext()
   const [yieldChanges, changesError] = useObservable(yieldsChange$(currentDate, previousDate, ilk))
   const [totalValueLocked, totalValueLockedError] = useObservable(totalValueLocked$(ilk))
@@ -48,7 +48,7 @@ export function GuniVaultHeader({ ilk, token, followButtonProps }: EarnVaultHead
               header={ilk}
               token={[token]}
               details={details}
-              followButtonProps={followButtonProps}
+              followButton={followButton}
             />
           )
         }}

--- a/features/follow/common/FollowButton.tsx
+++ b/features/follow/common/FollowButton.tsx
@@ -2,15 +2,21 @@ import { Icon } from '@makerdao/dai-ui-icons'
 import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
 import React from 'react'
-import { Box, Button, Spinner } from 'theme-ui'
+import { Box, Button, Spinner, SxStyleProp } from 'theme-ui'
 
 interface FollowButtonProps {
-  isProcessing: boolean
-  isFollowing: boolean
   buttonClickHandler: () => void
+  isFollowing: boolean
+  isProcessing: boolean
+  sx?: SxStyleProp
 }
 
-export function FollowButton(props: FollowButtonProps) {
+export function FollowButton({
+  buttonClickHandler,
+  isFollowing,
+  isProcessing,
+  sx,
+}: FollowButtonProps) {
   const { t } = useTranslation()
   const [isHovering, setIsHovering] = useState(false)
 
@@ -24,57 +30,64 @@ export function FollowButton(props: FollowButtonProps) {
 
   return (
     <Button
-      disabled={props.isProcessing}
-      onClick={props.buttonClickHandler}
+      disabled={isProcessing}
+      onClick={buttonClickHandler}
       sx={{
         position: 'relative',
         p: '0 12px 0 30px',
+        fontSize: 1,
+        lineHeight: '26px',
+        color: isFollowing ? 'primary100' : 'primary60',
         border: '1px solid',
         borderColor: 'neutral20',
         borderRadius: 'large',
-        marginLeft: '16px',
         backgroundColor: 'neutral10',
+        boxShadow: 'surface',
+        transition: 'border-color 200ms, background-color 200ms, color 200ms',
         '&:hover': {
           backgroundColor: 'neutral10',
           borderColor: 'primary100',
-          color: 'primary60',
-          '.star': { color: '#878BFC', fill: '#878BFC' },
-          '.star_empty': { color: '#EAEAEA', fill: 'white', stroke: '#25273D' },
+          color: isFollowing ? 'primary60' : 'primary100',
+          '.star': {
+            fill: isFollowing ? 'interactive50' : 'neutral10',
+            stroke: isFollowing ? 'interactive50' : 'primary100',
+            strokeWidth: isFollowing ? '1px' : '1.5px',
+          },
         },
         '&:disabled': {
           backgroundColor: 'neutral10',
           color: 'primary60',
         },
-        fontSize: 1,
-        lineHeight: '26px',
-        color: 'primary100',
-        boxShadow: 'surface',
-        transition: 'border-color 200ms, background-color 200ms, color 200ms',
-        '.star': { color: '#575CFE', fill: '#575CFE' },
-        '.star_empty': { fill: 'white', stroke: '#EAEAEA' },
+        '.star': {
+          fill: isFollowing ? 'interactive100' : 'neutral10',
+          stroke: isFollowing ? 'interactive100' : 'primary60',
+          strokeWidth: '1px',
+          transition: 'stroke 200ms, stroke-width 200ms, fill 200ms',
+        },
+        ...sx,
       }}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
     >
       <Box sx={{ position: 'absolute', top: '2px', left: '13px', margin: 'auto' }}>
-        {props.isProcessing ? (
+        {isProcessing ? (
           <Spinner
             size={15}
             color="#878BFC"
             sx={{ position: 'relative', top: '1px', left: '-3px' }}
           />
         ) : (
-          <Box className={props.isFollowing ? 'star_empty' : 'star'}>
+          <Box className="star">
             <Icon name="star" size={12} />
           </Box>
         )}
       </Box>
 
-      {props.isProcessing
+      {isProcessing
         ? t('loading')
-        : isHovering && props.isFollowing
+        : isHovering && isFollowing
         ? t('unfollow')
-        : props.isFollowing
+        : isFollowing
         ? t('following')
         : t('follow')}
     </Button>

--- a/features/follow/common/FollowButton.tsx
+++ b/features/follow/common/FollowButton.tsx
@@ -2,12 +2,15 @@ import { Icon } from '@makerdao/dai-ui-icons'
 import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
 import React from 'react'
+import { theme } from 'theme'
 import { Box, Button, Spinner, SxStyleProp } from 'theme-ui'
+import { useMediaQuery } from 'usehooks-ts'
 
 interface FollowButtonProps {
   buttonClickHandler: () => void
   isFollowing: boolean
   isProcessing: boolean
+  short?: boolean
   sx?: SxStyleProp
 }
 
@@ -15,10 +18,12 @@ export function FollowButton({
   buttonClickHandler,
   isFollowing,
   isProcessing,
+  short,
   sx,
 }: FollowButtonProps) {
   const { t } = useTranslation()
   const [isHovering, setIsHovering] = useState(false)
+  const isShort = useMediaQuery(`(max-width: ${theme.breakpoints[2]})`) || short
 
   const handleMouseOver = () => {
     setIsHovering(true)
@@ -34,15 +39,19 @@ export function FollowButton({
       onClick={buttonClickHandler}
       sx={{
         position: 'relative',
-        p: '0 12px 0 30px',
+        py: 0,
+        pr: isShort ? 0 : '12px',
+        pl: isShort ? 0 : '30px',
         fontSize: 1,
+        width: isShort ? ['32px', null, null, '36px'] : 'auto',
+        height: isShort ? ['32px', null, null, '36px'] : 'auto',
         lineHeight: '26px',
         color: isFollowing ? 'primary100' : 'primary60',
         border: '1px solid',
         borderColor: 'neutral20',
-        borderRadius: 'large',
+        borderRadius: isShort ? 'ellipse' : 'large',
         backgroundColor: 'neutral10',
-        boxShadow: 'surface',
+        boxShadow: isShort ? 'none' : 'surface',
         transition: 'border-color 200ms, background-color 200ms, color 200ms',
         '&:hover': {
           backgroundColor: 'neutral10',
@@ -51,7 +60,7 @@ export function FollowButton({
           '.star': {
             fill: isFollowing ? 'interactive50' : 'neutral10',
             stroke: isFollowing ? 'interactive50' : 'primary100',
-            strokeWidth: isFollowing ? '1px' : '1.5px',
+            strokeWidth: isFollowing ? 0 : '1.5px',
           },
         },
         '&:disabled': {
@@ -61,7 +70,7 @@ export function FollowButton({
         '.star': {
           fill: isFollowing ? 'interactive100' : 'neutral10',
           stroke: isFollowing ? 'interactive100' : 'primary60',
-          strokeWidth: '1px',
+          strokeWidth: isFollowing ? 0 : '1px',
           transition: 'stroke 200ms, stroke-width 200ms, fill 200ms',
         },
         ...sx,
@@ -69,27 +78,37 @@ export function FollowButton({
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
     >
-      <Box sx={{ position: 'absolute', top: '2px', left: '13px', margin: 'auto' }}>
+      <Box
+        sx={{
+          position: 'absolute',
+          top: isShort ? ['5px', null, null, '7px'] : '2px',
+          left: isShort ? ['8px', null, null, '10px'] : '13px',
+          margin: 'auto',
+        }}
+      >
         {isProcessing ? (
           <Spinner
-            size={15}
+            size={isShort ? 20 : 15}
             color="#878BFC"
-            sx={{ position: 'relative', top: '1px', left: '-3px' }}
+            sx={{ position: 'relative', top: isShort ? 0 : '1px', left: '-3px' }}
           />
         ) : (
           <Box className="star">
-            <Icon name="star" size={12} />
+            <Icon name="star" size={isShort ? 14 : 12} />
           </Box>
         )}
       </Box>
-
-      {isProcessing
-        ? t('loading')
-        : isHovering && isFollowing
-        ? t('unfollow')
-        : isFollowing
-        ? t('following')
-        : t('follow')}
+      {!isShort && (
+        <>
+          {isProcessing
+            ? t('loading')
+            : isHovering && isFollowing
+            ? t('unfollow')
+            : isFollowing
+            ? t('following')
+            : t('follow')}
+        </>
+      )}
     </Button>
   )
 }

--- a/features/follow/common/FollowButtonControl.tsx
+++ b/features/follow/common/FollowButtonControl.tsx
@@ -13,11 +13,18 @@ import { SxStyleProp } from 'theme-ui'
 export type FollowButtonControlProps = {
   chainId: number
   followerAddress: string
+  short?: boolean
   sx?: SxStyleProp
   vaultId: BigNumber
 }
 
-export function FollowButtonControl({ chainId, followerAddress, sx, vaultId }: FollowButtonControlProps) {
+export function FollowButtonControl({
+  chainId,
+  followerAddress,
+  short,
+  sx,
+  vaultId,
+}: FollowButtonControlProps) {
   const [isFollowing, setIsFollowing] = useState(false)
   const [isProcessing, setProcessing] = useState(true)
 
@@ -57,6 +64,7 @@ export function FollowButtonControl({ chainId, followerAddress, sx, vaultId }: F
       isProcessing={isProcessing}
       isFollowing={isFollowing}
       buttonClickHandler={buttonClickHandler}
+      short={short}
       sx={sx}
     />
   )

--- a/features/follow/common/FollowButtonControl.tsx
+++ b/features/follow/common/FollowButtonControl.tsx
@@ -8,14 +8,16 @@ import {
 } from 'features/shared/followApi'
 import { jwtAuthGetToken } from 'features/shared/jwt'
 import React, { useEffect, useState } from 'react'
+import { SxStyleProp } from 'theme-ui'
 
-export type FollowButtonProps = {
-  followerAddress: string
-  vaultId: BigNumber
+export type FollowButtonControlProps = {
   chainId: number
+  followerAddress: string
+  sx?: SxStyleProp
+  vaultId: BigNumber
 }
 
-export function FollowButtonControl({ followerAddress, vaultId, chainId }: FollowButtonProps) {
+export function FollowButtonControl({ chainId, followerAddress, sx, vaultId }: FollowButtonControlProps) {
   const [isFollowing, setIsFollowing] = useState(false)
   const [isProcessing, setProcessing] = useState(true)
 
@@ -55,6 +57,7 @@ export function FollowButtonControl({ followerAddress, vaultId, chainId }: Follo
       isProcessing={isProcessing}
       isFollowing={isFollowing}
       buttonClickHandler={buttonClickHandler}
+      sx={sx}
     />
   )
 

--- a/features/vaultsOverview/containers/FollowedTable.tsx
+++ b/features/vaultsOverview/containers/FollowedTable.tsx
@@ -24,16 +24,17 @@ import React from 'react'
 export function FollowedTable({ address }: { address: string }) {
   const { t } = useTranslation()
   const checksumAddress = getAddress(address.toLocaleLowerCase())
-  const { followedList$ } = useAppContext()
+  const { context$, followedList$ } = useAppContext()
   const { walletAddress } = useAccount()
+  const [contextData, contextError] = useObservable(context$)
   const [followedListData, followedListError] = useObservable(followedList$(checksumAddress))
 
   const isOwner = address === walletAddress
 
   return (
-    <WithErrorHandler error={[followedListError]}>
-      <WithLoadingIndicator value={[followedListData]} customLoader={<PositionTableLoadingState />}>
-        {([followedList]) => {
+    <WithErrorHandler error={[contextError, followedListError]}>
+      <WithLoadingIndicator value={[contextData, followedListData]} customLoader={<PositionTableLoadingState />}>
+        {([context, followedList]) => {
           const borrowPositions = getMakerBorrowPositions(followedList)
           const multiplyPositions = getMakerMultiplyPositions(followedList)
           const earnPositions = getMakerEarnPositions(followedList)
@@ -53,6 +54,9 @@ export function FollowedTable({ address }: { address: string }) {
                     rows={borrowPositions}
                     skip={followTableSkippedHeaders}
                     tooltips={positionsTableTooltips}
+                    {...(!!walletAddress && {
+                      follow: { followerAddress: walletAddress, chainId: context.chainId },
+                    })}
                   />
                 </>
               )}
@@ -65,6 +69,9 @@ export function FollowedTable({ address }: { address: string }) {
                     rows={multiplyPositions}
                     skip={followTableSkippedHeaders}
                     tooltips={positionsTableTooltips}
+                    {...(!!walletAddress && {
+                      follow: { followerAddress: walletAddress, chainId: context.chainId },
+                    })}
                   />
                 </>
               )}
@@ -77,6 +84,9 @@ export function FollowedTable({ address }: { address: string }) {
                     rows={earnPositions}
                     skip={followTableSkippedHeaders}
                     tooltips={positionsTableTooltips}
+                    {...(!!walletAddress && {
+                      follow: { followerAddress: walletAddress, chainId: context.chainId },
+                    })}
                   />
                 </>
               )}

--- a/features/vaultsOverview/containers/FollowedTable.tsx
+++ b/features/vaultsOverview/containers/FollowedTable.tsx
@@ -33,7 +33,10 @@ export function FollowedTable({ address }: { address: string }) {
 
   return (
     <WithErrorHandler error={[contextError, followedListError]}>
-      <WithLoadingIndicator value={[contextData, followedListData]} customLoader={<PositionTableLoadingState />}>
+      <WithLoadingIndicator
+        value={[contextData, followedListData]}
+        customLoader={<PositionTableLoadingState />}
+      >
         {([context, followedList]) => {
           const borrowPositions = getMakerBorrowPositions(followedList)
           const multiplyPositions = getMakerMultiplyPositions(followedList)

--- a/pages/discover/[slug].tsx
+++ b/pages/discover/[slug].tsx
@@ -1,3 +1,4 @@
+import { WithConnection } from 'components/connectWallet/ConnectWallet'
 import {
   discoverPageLayout,
   discoverPageLayoutProps,
@@ -11,7 +12,11 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
 
 function DiscoverPage({ kind }: { kind: DiscoverPages }) {
-  return <DiscoverView kind={kind} />
+  return (
+    <WithConnection>
+      <DiscoverView kind={kind} />
+    </WithConnection>
+  )
 }
 
 DiscoverPage.layout = discoverPageLayout


### PR DESCRIPTION
# Follow vault buttons on discover table

Covers:
https://app.shortcut.com/oazo-apps/story/7598/add-follow-unfollow-button-to-followed-vaults-list
https://app.shortcut.com/oazo-apps/story/7597/add-follow-unfollow-button-to-discover-oasis-table
  
## Changes 👷‍♀️

- Added props to discover table component for vault following support,
- added short and mobile versions for follow vault button,
- added follow vault buttons to discover table,
- added follow vault buttons to table with positions that user is already following.
  
## How to test 🧪

- Check if follow vault button in short version is available in two tables mentioned above.

Additional notes:
- Discover has `chainId` hardcoded to mainnet, since it doesn't support any other chain.
- Table with users followed vault does not automatically remove record when you decide to unfollow, that will happen only on reload. I've tested both version and that way we are protecting user from accidental unfollowing and losing vault forever.