### PR TITLE
Add Aave product cards to multiply page, featured cards

### DIFF
--- a/components/productCards/ProductCardsFilter.tsx
+++ b/components/productCards/ProductCardsFilter.tsx
@@ -119,11 +119,13 @@ export function ProductCardsFilter({
             {([_productCardsData]) => (
               <ProductCardsWrapper>
                 {otherStrategies
-                  .filter(
-                    ({ protocol, name }) =>
+                  .filter(({ protocol, name }) => {
+                    return (
                       protocol === 'aave' &&
-                      name.toLocaleUpperCase().includes(currentFilter.toLocaleUpperCase()),
-                  )
+                      (name.toLocaleUpperCase().includes(currentFilter.toLocaleUpperCase()) ||
+                        currentFilter.toLocaleUpperCase() === 'FEATURED')
+                    )
+                  })
                   .map((cardData) => (
                     <ProductCardMultiplyAave key={cardData.symbol} cardData={cardData} />
                   ))}


### PR DESCRIPTION
[shortcut](https://app.shortcut.com/oazo-apps/story/7596/update-the-featured-product-cards-on-multiply-in-line-with-the-homepage)

## Changes 👷‍♀️

- added the cards
  
## How to test 🧪

- ensure the cards appear under /multiply#featured
