### PR TITLE
Remove AAVE Multiply feature flags and add AAVE Borrow flag

### DIFF
--- a/features/aave/common/StrategyConfigTypes.ts
+++ b/features/aave/common/StrategyConfigTypes.ts
@@ -38,7 +38,7 @@ export interface IStrategyConfig {
     default: IRiskRatio
   }
   type: 'Multiply' | 'Earn'
-  featureToggle: Feature
+  featureToggle?: Feature
 }
 
 export type AaveHeaderProps = {

--- a/features/aave/open/containers/AaveOpenStateMachineContext.tsx
+++ b/features/aave/open/containers/AaveOpenStateMachineContext.tsx
@@ -1,7 +1,6 @@
 import { useInterpret } from '@xstate/react'
 import React from 'react'
 
-import { useFeatureToggle } from '../../../../helpers/useFeatureToggle'
 import { IStrategyConfig, ProxyType } from '../../common/StrategyConfigTypes'
 import { getEmptyPosition } from '../../oasisActionsLibWrapper'
 import { OpenAaveStateMachine } from '../state'
@@ -13,10 +12,9 @@ function setupOpenAaveStateContext({
   machine: OpenAaveStateMachine
   config: IStrategyConfig
 }) {
-  const useDpmProxy = useFeatureToggle('AaveUseDpmProxy')
   const effectiveStrategy = {
     ...config,
-    proxyType: useDpmProxy ? ProxyType.DpmProxy : ProxyType.DsProxy,
+    proxyType: ProxyType.DpmProxy,
   }
   const stateMachine = useInterpret(
     machine.withContext({

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -52,9 +52,7 @@ export const strategies: Array<IStrategyConfig> = [
     },
     riskRatios: earnAdjustRiskSliderConfig.riskRatios,
     type: 'Earn',
-    featureToggle: 'AaveEarnSTETHETH',
   },
-
   {
     name: 'ethusdc',
     urlSlug: 'ethusdc',
@@ -77,10 +75,8 @@ export const strategies: Array<IStrategyConfig> = [
       deposit: 'ETH',
     },
     riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
-    featureToggle: 'AaveMultiplyETHUSDC',
     type: 'Multiply',
   },
-
   {
     name: 'stETHusdc',
     urlSlug: 'stETHusdc',
@@ -103,10 +99,8 @@ export const strategies: Array<IStrategyConfig> = [
       deposit: 'STETH',
     },
     riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
-    featureToggle: 'AaveMultiplySTETHUSDC',
     type: 'Multiply',
   },
-
   {
     name: 'wBTCusdc',
     urlSlug: 'wBTCusdc',
@@ -129,14 +123,13 @@ export const strategies: Array<IStrategyConfig> = [
       deposit: 'WBTC',
     },
     riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
-    featureToggle: 'AaveMultiplyWBTCUSDC',
     type: 'Multiply',
   },
 ]
 
 export function aaveStrategiesList(filterProduct?: IStrategyConfig['type']): IStrategyConfig[] {
   return Object.values(strategies)
-    .filter(({ featureToggle }) => getFeatureToggle(featureToggle))
+    .filter(({ featureToggle }) => (featureToggle ? getFeatureToggle(featureToggle) : true))
     .filter(({ type }) => (filterProduct ? type === filterProduct : true))
 }
 

--- a/features/asset/AssetView.tsx
+++ b/features/asset/AssetView.tsx
@@ -17,16 +17,11 @@ import {
 const aaveAssets = {
   // not putting this to ASSETS_PAGES cause we need feature toggles
   eth: {
-    multiply: getAaveEnabledStrategies([
-      { strategy: 'ethusdc', featureToggle: 'AaveMultiplyETHUSDC' },
-      { strategy: 'stETHusdc', featureToggle: 'AaveMultiplySTETHUSDC' },
-    ]),
-    earn: getAaveEnabledStrategies([{ strategy: 'stETHeth', featureToggle: 'AaveEarnSTETHETH' }]),
+    multiply: getAaveEnabledStrategies([{ strategy: 'ethusdc' }, { strategy: 'stETHusdc' }]),
+    earn: getAaveEnabledStrategies([{ strategy: 'stETHeth' }]),
   },
   btc: {
-    multiply: getAaveEnabledStrategies([
-      { strategy: 'wBTCusdc', featureToggle: 'AaveMultiplyWBTCUSDC' },
-    ]),
+    multiply: getAaveEnabledStrategies([{ strategy: 'wBTCusdc' }]),
     earn: [],
   },
 }

--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -63,6 +63,7 @@ function Pill(props: PillProps) {
     </AppLink>
   )
 }
+
 function Pills({ sx }: { sx?: SxProps }) {
   return (
     <Flex sx={{ width: '100%', justifyContent: 'center', flexWrap: 'wrap', ...sx }}>
@@ -122,7 +123,6 @@ export function HomepageView() {
 
   const referralsEnabled = useFeatureToggle('Referrals')
   const notificationsEnabled = useFeatureToggle('Notifications')
-  const dpmEnabled = useFeatureToggle('AaveUseDpmProxy')
   const { context$, checkReferralLocal$, userReferral$ } = useAppContext()
   const [context] = useObservable(context$)
   const [checkReferralLocal] = useObservable(checkReferralLocal$)
@@ -152,20 +152,18 @@ export function HomepageView() {
         animationTimingFunction: 'cubic-bezier(0.7, 0.01, 0.6, 1)',
       }}
     >
-      {dpmEnabled && (
-        <Flex
-          sx={{
-            justifyContent: 'center',
-            mt: '80px',
-            mb: 0,
-          }}
-        >
-          <HomePageBanner
-            heading={t('ref.banner')}
-            link="https://blog.oasis.app/introducing-oasis-multiply-for-aave/"
-          />
-        </Flex>
-      )}
+      <Flex
+        sx={{
+          justifyContent: 'center',
+          mt: '80px',
+          mb: 0,
+        }}
+      >
+        <HomePageBanner
+          heading={t('ref.banner')}
+          link="https://blog.oasis.app/introducing-oasis-multiply-for-aave/"
+        />
+      </Flex>
       {referralsEnabled && landedWithRef && context?.status === 'connectedReadonly' && (
         <NewReferralModal />
       )}
@@ -211,17 +209,15 @@ export function HomepageView() {
                       <AppLink href="/multiply" variant="inText">
                         {t('landing.tabs.maker.multiply.tabParaLinkContent')}
                       </AppLink>
-                      {dpmEnabled && (
-                        <Box sx={{ mt: 3 }}>
-                          {t('landing.tabs.maker.multiply.aaveTabParaContent')}{' '}
-                          <AppLink
-                            href="https://blog.oasis.app/introducing-oasis-multiply-for-aave/"
-                            variant="inText"
-                          >
-                            {t('landing.tabs.maker.multiply.aaveTabParaLinkContent')}
-                          </AppLink>
-                        </Box>
-                      )}
+                      <Box sx={{ mt: 3 }}>
+                        {t('landing.tabs.maker.multiply.aaveTabParaContent')}{' '}
+                        <AppLink
+                          href="https://blog.oasis.app/introducing-oasis-multiply-for-aave/"
+                          variant="inText"
+                        >
+                          {t('landing.tabs.maker.multiply.aaveTabParaLinkContent')}
+                        </AppLink>
+                      </Box>
                     </>
                   }
                   cards={

--- a/features/multiply/MultiplyView.tsx
+++ b/features/multiply/MultiplyView.tsx
@@ -9,13 +9,12 @@ import { ProductCardMultiplyMaker } from '../../components/productCards/ProductC
 import { ProductCardsFilter } from '../../components/productCards/ProductCardsFilter'
 import { ProductHeader } from '../../components/ProductHeader'
 import { multiplyPageCardsData, productCardsConfig } from '../../helpers/productCards'
-import { useFeatureToggle } from '../../helpers/useFeatureToggle'
 
 export function MultiplyView() {
   const { t } = useTranslation()
   const tab = window.location.hash.replace(/^#/, '')
   const aaveMultiplyStrategies = getTokens(aaveStrategiesList('Multiply').map(({ name }) => name))
-  const dpmEnabled = useFeatureToggle('AaveUseDpmProxy')
+
   return (
     <Grid
       sx={{
@@ -33,24 +32,24 @@ export function MultiplyView() {
         }}
         scrollToId={tab}
       />
-      {dpmEnabled && (
-        <Text
-          variant="paragraph1"
-          sx={{
-            color: 'neutral80',
-            mt: '-50px',
-            textAlign: 'center',
-          }}
+
+      <Text
+        variant="paragraph1"
+        sx={{
+          color: 'neutral80',
+          mt: '-50px',
+          textAlign: 'center',
+        }}
+      >
+        {t('product-page.multiply.aaveDescription')}{' '}
+        <AppLink
+          href="https://blog.oasis.app/introducing-oasis-multiply-for-aave/"
+          sx={{ fontSize: 4, fontWeight: 'body' }}
         >
-          {t('product-page.multiply.aaveDescription')}{' '}
-          <AppLink
-            href="https://blog.oasis.app/introducing-oasis-multiply-for-aave/"
-            sx={{ fontSize: 4, fontWeight: 'body' }}
-          >
-            {t('product-page.multiply.aaveLink')}
-          </AppLink>
-        </Text>
-      )}
+          {t('product-page.multiply.aaveLink')}
+        </AppLink>
+      </Text>
+
       <ProductCardsFilter
         filters={productCardsConfig.multiply.cardsFilters}
         selectedFilter={tab}

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -191,10 +191,10 @@ export function mapTokenToFilter(token: string) {
 }
 
 export function getAaveEnabledStrategies(
-  strategies: { strategy: string; featureToggle: Feature }[],
+  strategies: { strategy: string; featureToggle?: Feature }[],
 ) {
   return strategies
-    .filter(({ featureToggle }) => getFeatureToggle(featureToggle))
+    .filter(({ featureToggle }) => (featureToggle ? getFeatureToggle(featureToggle) : true))
     .map((item) => item.strategy)
 }
 
@@ -288,11 +288,11 @@ export const productCardsConfig: {
     featuredAaveCards: {
       borrow: [],
       multiply: getAaveEnabledStrategies([
-        { strategy: 'ethusdc', featureToggle: 'AaveMultiplyETHUSDC' },
-        { strategy: 'stETHusdc', featureToggle: 'AaveMultiplySTETHUSDC' },
-        { strategy: 'wBTCusdc', featureToggle: 'AaveMultiplyWBTCUSDC' },
+        { strategy: 'ethusdc' },
+        { strategy: 'stETHusdc' },
+        { strategy: 'wBTCusdc' },
       ]),
-      earn: getAaveEnabledStrategies([{ strategy: 'stETHeth', featureToggle: 'AaveEarnSTETHETH' }]),
+      earn: getAaveEnabledStrategies([{ strategy: 'stETHeth' }]),
     },
   },
   descriptionCustomKeys: {

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -20,14 +20,10 @@ export type Feature =
   | 'UpdatedPnL'
   | 'ReadOnlyAutoTakeProfit'
   | 'DiscoverOasis'
-  | 'AaveEarnSTETHETH'
-  | 'AaveMultiplySTETHUSDC'
-  | 'AaveMultiplyETHUSDC'
-  | 'AaveMultiplyWBTCUSDC'
+  | 'AaveBorrow'
   | 'FollowVaults'
   | 'AaveProtection'
   | 'Ajna'
-  | 'AaveUseDpmProxy'
   | 'DaiSavingsRate'
 
 const configuredFeatures: Record<Feature, boolean> = {
@@ -47,16 +43,11 @@ const configuredFeatures: Record<Feature, boolean> = {
   UpdatedPnL: false,
   ReadOnlyAutoTakeProfit: false,
   DiscoverOasis: true,
-  AaveEarnSTETHETH: true,
-  AaveMultiplySTETHUSDC: true,
-  AaveMultiplyETHUSDC: true,
-  AaveMultiplyWBTCUSDC: true,
+  AaveBorrow: false,
   FollowVaults: false,
   AaveProtection: false,
   Ajna: false,
-  AaveUseDpmProxy: true,
   DaiSavingsRate: true,
-  // your feature here....
 }
 
 export function configureLocalStorageForTests(data: { [feature in Feature]?: boolean }) {


### PR DESCRIPTION
# [Remove AAVE Multiply feature flags and add AAVE Borrow flag](https://app.shortcut.com/oazo-apps/story/7487/open-feature-toggle-for-aave-borrowing-in-the-product-cards)
  
## Changes 👷‍♀️
- Remove AAVE Multiply and DPM Proxy feature flags
- Add AAVE Borrow flag
- Ensure all helpers connected with strategy config continue work correctly when no feature flag is specified
  
## How to test 🧪
- step 1 ...
