### PR TITLE
Auto-buy override banner

### DIFF
--- a/features/automation/common/consts.ts
+++ b/features/automation/common/consts.ts
@@ -74,3 +74,13 @@ export const protocolAutomations = {
 }
 
 export const aaveTokenPairsAllowedAutomation = [['ETH', 'USDC']]
+
+export const vaultIdsThatAutoBuyTriggerShouldBeRecreated = [
+  10804,
+  29568,
+  29186,
+  30084,
+  29628,
+  29928,
+  29574,
+]

--- a/features/automation/common/state/autoBSTxHandlers.ts
+++ b/features/automation/common/state/autoBSTxHandlers.ts
@@ -1,7 +1,9 @@
+import { TriggerType } from '@oasisdex/automation'
 import { TxStatus } from '@oasisdex/transactions'
 import BigNumber from 'bignumber.js'
 import { AutomationBotAddTriggerData } from 'blockchain/calls/automationBot'
 import { useAppContext } from 'components/AppContextProvider'
+import { maxUint256 } from 'features/automation/common/consts'
 import { AutoBSFormChange } from 'features/automation/common/state/autoBSFormChange'
 import { prepareAddAutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
 import { AutoBSTriggerTypes, AutomationBSPublishType } from 'features/automation/common/types'
@@ -35,6 +37,8 @@ export function getAutoBSTxHandlers({
 }: GetAutoBSTxHandlersParams): AutoBSTxHandlers {
   const { uiChanges } = useAppContext()
 
+  const unlimitedMaxMinPrice = triggerType === TriggerType.BasicSell ? zero : maxUint256
+
   const addTxData = useMemo(
     () =>
       prepareAddAutoBSTriggerData({
@@ -45,7 +49,7 @@ export function getAutoBSTxHandlers({
         targetCollRatio: autoBSState.targetCollRatio,
         maxBuyOrMinSellPrice: autoBSState.withThreshold
           ? autoBSState.maxBuyOrMinSellPrice || zero
-          : zero,
+          : unlimitedMaxMinPrice,
         continuous: autoBSState.continuous,
         deviation: autoBSState.deviation,
         replacedTriggerId: autoBSState.triggerId,

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1170,7 +1170,8 @@
     "auto-take-profit-trigger-lower-than-constant-multiple-buy-trigger": "Setting your Target Price at this level may result in your Constant Multiple Buy Trigger not executing. Find out more <0>here</0>.",
     "auto-buy-trigger-greater-than-auto-take-profit": "Setting your trigger ratio at this level may result in your Auto-Buy Trigger not executing. Find out more <0>here</0>.",
     "constant-multiple-buy-trigger-greater-than-auto-take-profit": "Setting your buy trigger ratio at this level may result in your Constant Multiple Buy Trigger not executing. Find out more <0>here</0>.",
-    "existing-take-profit-trigger-after-vault-reopen": "You have an existing Take Profit Trigger, it will remain active after you reopen this vault."
+    "existing-take-profit-trigger-after-vault-reopen": "You have an existing Take Profit Trigger, it will remain active after you reopen this vault.",
+    "auto-buy-override":"We have updated our Auto-Buy Feature. In order for your Auto-Buy automation to trigger, please cancel your existing Auto-Buy and create a new one. Oasis.app will refund any gas costs associated with these transaction, just contact oasis.app support."
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Auto-buy override banner](https://app.shortcut.com/oazo-apps/story/7713/bug-users-auto-buy-is-not-executing-because-it-is-setting-the-max-buy-price-to-0-instead-of-unlimited)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added banner to vaults for which auto buy trigger should be recreated
- fixed issue with unlimited value when adding auto buy trigger
  
## How to test 🧪
  <Please explain how to test your changes>

- use results from query from story and verify whether given vaults displays warning banner in the overview
- using your vault try to add auto buy trigger with unlimited threshold and check using console.logs whether added trigger indeed has maxUint256 as maxBuyOrSellPrice
- test unlimited threshold for auto sell as logic change was done in common place
