### PR TITLE
Fixed aave earn default APY

### DIFF
--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -3,6 +3,7 @@ import { trackingEvents } from 'analytics/analytics'
 import BigNumber from 'bignumber.js'
 import { ethNullAddress } from 'blockchain/config'
 import { isUserWalletConnected } from 'features/aave/helpers/isUserWalletConnected'
+import { convertDefaultRiskRatioToActualRiskRatio } from 'features/aave/strategyConfig'
 import { ActorRefFrom, assign, createMachine, send, spawn } from 'xstate'
 import { pure } from 'xstate/lib/actions'
 import { MachineOptionsFrom } from 'xstate/lib/types'
@@ -359,13 +360,11 @@ export function createOpenAaveStateMachine(
           }
         }),
         setDefaultRiskRatio: assign((context) => {
-          const defaultRiskRatio =
-            context.strategyConfig.riskRatios.default === 'slightlyLessThanMaxRisk'
-              ? new RiskRatio(context.reserveConfig?.ltv.times('0.999') || zero, RiskRatio.TYPE.LTV)
-              : context.strategyConfig.riskRatios.default
-
           return {
-            defaultRiskRatio,
+            defaultRiskRatio: convertDefaultRiskRatioToActualRiskRatio(
+              context.strategyConfig.riskRatios.default,
+              context.reserveConfig?.ltv,
+            ),
           }
         }),
         setTotalSteps: assign((context) => {

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -1,5 +1,8 @@
+import { RiskRatio } from '@oasisdex/oasis-actions'
+import BigNumber from 'bignumber.js'
 import { ViewPositionSectionComponent } from 'features/earn/aave/components/ViewPositionSectionComponent'
 import { Feature, getFeatureToggle } from 'helpers/useFeatureToggle'
+import { zero } from 'helpers/zero'
 
 import { AaveEarnFaq } from '../content/faqs/aave/earn'
 import { AaveMultiplyFaq } from '../content/faqs/aave/multiply'
@@ -196,3 +199,12 @@ export const supportedTokens = Array.from(
       .flatMap((tokens) => tokens),
   ),
 )
+
+export function convertDefaultRiskRatioToActualRiskRatio(
+  defaultRiskRatio: IStrategyConfig['riskRatios']['default'],
+  ltv?: BigNumber,
+) {
+  return defaultRiskRatio === 'slightlyLessThanMaxRisk'
+    ? new RiskRatio(ltv?.times('0.999') || zero, RiskRatio.TYPE.LTV)
+    : defaultRiskRatio
+}

--- a/features/earn/aave/components/SimulateSectionComponent.tsx
+++ b/features/earn/aave/components/SimulateSectionComponent.tsx
@@ -2,6 +2,7 @@ import { IPositionTransition, IRiskRatio } from '@oasisdex/oasis-actions'
 import { useSelector } from '@xstate/react'
 import BigNumber from 'bignumber.js'
 import { useAaveContext } from 'features/aave/AaveContextProvider'
+import { convertDefaultRiskRatioToActualRiskRatio } from 'features/aave/strategyConfig'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect, useState } from 'react'
 import { Box } from 'theme-ui'
@@ -37,13 +38,13 @@ function SimulationSection({
   token,
   userInputAmount,
   gasPrice,
-  minRiskRatio,
+  defaultRiskRatio,
 }: {
   strategy?: IPositionTransition
   token: string
   userInputAmount?: BigNumber
   gasPrice?: HasGasEstimation
-  minRiskRatio: IRiskRatio
+  defaultRiskRatio: IRiskRatio
 }) {
   const { t } = useTranslation()
   const [, setHash] = useHash<string>()
@@ -54,7 +55,7 @@ function SimulationSection({
   const swapFee = (strategy?.simulation.swap && getFee(strategy?.simulation.swap)) || zero
   const gasFee = gasPrice?.gasEstimationEth || zero
   const fees = swapFee.plus(gasFee)
-  const riskRatio = strategy?.simulation.position.riskRatio || minRiskRatio
+  const riskRatio = strategy?.simulation.position.riskRatio || defaultRiskRatio
 
   useEffect(() => {
     aaveSthEthYieldsQuery(riskRatio, ['7Days', '30Days', '90Days', '1Year'])
@@ -127,7 +128,10 @@ export function SimulateSectionComponent() {
       token: state.context.tokens.debt,
       userInputAmount: state.context.userInput.amount,
       gasPrice: state.context.estimatedGasPrice,
-      minRiskRatio: state.context.strategyConfig.riskRatios.minimum,
+      defaultRiskRatio: convertDefaultRiskRatioToActualRiskRatio(
+        state.context.strategyConfig.riskRatios.default,
+        state.context.reserveConfig?.ltv,
+      ),
     }
   })
 


### PR DESCRIPTION
## Changes 👷‍♀️
- the default value for the Aave Earn APY is based on the maximum risk possible (same as default simulation)
