### PR TITLE
aave borrow base page

### DIFF
--- a/features/aave/common/StrategyConfigTypes.ts
+++ b/features/aave/common/StrategyConfigTypes.ts
@@ -12,6 +12,8 @@ export enum ProxyType {
   DpmProxy = 'DpmProxy',
 }
 
+export type ProductType = 'Multiply' | 'Earn' | 'Borrow'
+
 export interface IStrategyConfig {
   name: string
   urlSlug: string
@@ -37,7 +39,7 @@ export interface IStrategyConfig {
     minimum: IRiskRatio
     default: IRiskRatio | 'slightlyLessThanMaxRisk'
   }
-  type: 'Multiply' | 'Earn'
+  type: ProductType
   featureToggle: Feature
 }
 

--- a/features/aave/common/components/AaveHeader.tsx
+++ b/features/aave/common/components/AaveHeader.tsx
@@ -9,7 +9,7 @@ import { useObservable } from 'helpers/observableHook'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-function AaveMultiplyHeader({
+function AaveHeader({
   strategyConfig,
   headerLabelString,
 }: {
@@ -58,20 +58,10 @@ function AaveMultiplyHeader({
   )
 }
 
-export function AaveMultiplyOpenHeader({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
-  return (
-    <AaveMultiplyHeader
-      strategyConfig={strategyConfig}
-      headerLabelString={'vault.header-aave-open'}
-    />
-  )
+export function AaveOpenHeader({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
+  return <AaveHeader strategyConfig={strategyConfig} headerLabelString={'vault.header-aave-open'} />
 }
 
-export function AaveMultiplyManageHeader({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
-  return (
-    <AaveMultiplyHeader
-      strategyConfig={strategyConfig}
-      headerLabelString={'vault.header-aave-view'}
-    />
-  )
+export function AaveManageHeader({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
+  return <AaveHeader strategyConfig={strategyConfig} headerLabelString={'vault.header-aave-view'} />
 }

--- a/features/aave/services/readPositionCreatedEvents.ts
+++ b/features/aave/services/readPositionCreatedEvents.ts
@@ -20,7 +20,7 @@ type PositionCreatedChainEvent = {
 export type PositionCreated = {
   collateralTokenSymbol: string
   debtTokenSymbol: string
-  positionType: 'Multiply' | 'Earn'
+  positionType: 'Borrow' | 'Multiply' | 'Earn'
   protocol: string
   proxyAddress: string
 }

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -1,5 +1,5 @@
 import { ViewPositionSectionComponent } from 'features/earn/aave/components/ViewPositionSectionComponent'
-import { getFeatureToggle } from 'helpers/useFeatureToggle'
+import { Feature, getFeatureToggle } from 'helpers/useFeatureToggle'
 
 import { AaveEarnFaq } from '../content/faqs/aave/earn'
 import { AaveMultiplyFaq } from '../content/faqs/aave/multiply'
@@ -10,14 +10,11 @@ import {
 import { ManageSectionComponent } from '../earn/aave/components/ManageSectionComponent'
 import { SimulateSectionComponent } from '../earn/aave/components/SimulateSectionComponent'
 import { adjustRiskSliderConfig as earnAdjustRiskSliderConfig } from '../earn/aave/riskSliderConfig'
-import {
-  AaveMultiplyManageHeader,
-  AaveMultiplyOpenHeader,
-} from '../multiply/aave/components/AaveMultiplyHeader'
 import { AaveMultiplyManageComponent } from '../multiply/aave/components/AaveMultiplyManageComponent'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from '../multiply/aave/riskSliderConfig'
+import { AaveManageHeader, AaveOpenHeader } from './common/components/AaveHeader'
 import { adjustRiskView } from './common/components/SidebarAdjustRiskView'
-import { IStrategyConfig, ProxyType } from './common/StrategyConfigTypes'
+import { IStrategyConfig, ProductType, ProxyType } from './common/StrategyConfigTypes'
 
 export enum ManageCollateralActionsEnum {
   DEPOSIT_COLLATERAL = 'deposit-collateral',
@@ -27,6 +24,8 @@ export enum ManageDebtActionsEnum {
   BORROW_DEBT = 'borrow-debt',
   PAYBACK_DEBT = 'payback-debt',
 }
+
+const supportedAaveBorrowCollateralTokens = ['ETH']
 
 export const strategies: Array<IStrategyConfig> = [
   {
@@ -60,9 +59,9 @@ export const strategies: Array<IStrategyConfig> = [
     urlSlug: 'ethusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
-      headerOpen: AaveMultiplyOpenHeader,
-      headerManage: AaveMultiplyManageHeader,
-      headerView: AaveMultiplyManageHeader,
+      headerOpen: AaveOpenHeader,
+      headerManage: AaveManageHeader,
+      headerView: AaveManageHeader,
       simulateSection: AaveMultiplyManageComponent,
       vaultDetailsManage: AaveMultiplyManageComponent,
       vaultDetailsView: AaveMultiplyManageComponent,
@@ -86,9 +85,9 @@ export const strategies: Array<IStrategyConfig> = [
     urlSlug: 'stETHusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
-      headerOpen: AaveMultiplyOpenHeader,
-      headerManage: AaveMultiplyManageHeader,
-      headerView: AaveMultiplyManageHeader,
+      headerOpen: AaveOpenHeader,
+      headerManage: AaveManageHeader,
+      headerView: AaveManageHeader,
       simulateSection: AaveMultiplyManageComponent,
       vaultDetailsManage: AaveMultiplyManageComponent,
       vaultDetailsView: AaveMultiplyManageComponent,
@@ -112,9 +111,9 @@ export const strategies: Array<IStrategyConfig> = [
     urlSlug: 'wBTCusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
-      headerOpen: AaveMultiplyOpenHeader,
-      headerManage: AaveMultiplyManageHeader,
-      headerView: AaveMultiplyManageHeader,
+      headerOpen: AaveOpenHeader,
+      headerManage: AaveManageHeader,
+      headerView: AaveManageHeader,
       simulateSection: AaveMultiplyManageComponent,
       vaultDetailsManage: AaveMultiplyManageComponent,
       vaultDetailsView: AaveMultiplyManageComponent,
@@ -132,6 +131,34 @@ export const strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveMultiplyWBTCUSDC',
     type: 'Multiply',
   },
+
+  ...supportedAaveBorrowCollateralTokens.map((collateral) => {
+    return {
+      name: `borrow-${collateral}`,
+      urlSlug: collateral,
+      proxyType: ProxyType.DpmProxy,
+      viewComponents: {
+        headerOpen: AaveOpenHeader,
+        headerManage: AaveManageHeader,
+        headerView: AaveManageHeader,
+        simulateSection: AaveMultiplyManageComponent,
+        vaultDetailsManage: AaveMultiplyManageComponent,
+        vaultDetailsView: AaveMultiplyManageComponent,
+        adjustRiskView: adjustRiskView(multiplyAdjustRiskSliderConfig),
+        positionInfo: AaveMultiplyFaq,
+        sidebarTitle: 'open-multiply.sidebar.title',
+        sidebarButton: 'open-multiply.sidebar.open-btn',
+      },
+      tokens: {
+        collateral: collateral,
+        debt: 'USDC',
+        deposit: collateral,
+      },
+      riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
+      featureToggle: 'AaveMultiplyWBTCUSDC' as Feature, // this will get set optional with https://github.com/OasisDEX/oasis-borrow/pull/1928
+      type: 'Borrow' as ProductType,
+    }
+  }),
 ]
 
 export function aaveStrategiesList(filterProduct?: IStrategyConfig['type']): IStrategyConfig[] {
@@ -144,8 +171,12 @@ export function getAaveStrategy(strategyName: IStrategyConfig['name']) {
   return Object.values(strategies).filter(({ name }) => strategyName === name)
 }
 
-export function loadStrategyFromSlug(slug: string): IStrategyConfig {
-  const strategy = strategies.find((s) => s.urlSlug === slug)
+export function loadStrategyFromUrl(slug: string, positionType: string): IStrategyConfig {
+  const strategy = strategies.find(
+    (s) =>
+      s.urlSlug.toUpperCase() === slug.toUpperCase() &&
+      s.type.toUpperCase() === positionType.toUpperCase(),
+  )
   if (!strategy) {
     throw new Error(`Strategy not found for slug: ${slug}`)
   }

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -148,7 +148,7 @@ export const strategies: Array<IStrategyConfig> = [
         deposit: collateral,
       },
       riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
-      featureToggle: 'AaveMultiplyWBTCUSDC' as Feature, // this will get set optional with https://github.com/OasisDEX/oasis-borrow/pull/1928
+      featureToggle: 'AaveBorrow' as Feature,
       type: 'Borrow' as ProductType,
     }
   }),

--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -95,7 +95,7 @@ export type AavePosition = Position & {
   id: string
   multiple: BigNumber
   isOwner: boolean
-  type: 'multiply' | 'earn'
+  type: 'borrow' | 'multiply' | 'earn'
   liquidity: BigNumber
 }
 
@@ -297,6 +297,7 @@ export function createAavePosition$(
 }
 
 const mappymap = {
+  Borrow: 'borrow',
   Multiply: 'multiply',
   Earn: 'earn',
 } as const

--- a/next.config.js
+++ b/next.config.js
@@ -132,11 +132,6 @@ const conf = withBundleAnalyzer(
       async redirects() {
         return [
           {
-            source: '/borrow/:slug(.{1,})', // wildcard redirect `:slug*` was causing an infinite redirect loop
-            destination: '/:slug',
-            permanent: true,
-          },
-          {
             source: '/dashboard',
             destination: '/daiwallet/dashboard',
             permanent: true,

--- a/pages/borrow/[protocol]/open/[collateralToken].tsx
+++ b/pages/borrow/[protocol]/open/[collateralToken].tsx
@@ -13,20 +13,19 @@ import { aaveContext, AaveContextProvider } from '../../../../features/aave/Aave
 import { loadStrategyFromUrl } from '../../../../features/aave/strategyConfig'
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  const strategy = ctx.query.strategy as string
+  const collateralToken = ctx.query.collateralToken as string
   try {
-    loadStrategyFromUrl(strategy, 'multiply')
+    loadStrategyFromUrl(collateralToken, 'Borrow')
   } catch (e) {
-    console.log(`could not load strategy '${strategy}' for route '${ctx.resolvedUrl}'`)
+    console.log(`could not load strategy '${collateralToken}' for route '${ctx.resolvedUrl}'`)
     return {
       notFound: true,
     }
   }
-
   return {
     props: {
       ...(await serverSideTranslations(ctx.locale!, ['common'])),
-      strategy: strategy,
+      strategy: collateralToken,
     },
   }
 }
@@ -38,7 +37,7 @@ function OpenVault({ strategy }: { strategy: string }) {
         <WithTermsOfService>
           <BackgroundLight />
           <DeferedContextProvider context={aaveContext}>
-            <AaveOpenView config={loadStrategyFromUrl(strategy, 'multiply')} />
+            <AaveOpenView config={loadStrategyFromUrl(strategy, 'Borrow')} />
           </DeferedContextProvider>
           <Survey for="earn" />
         </WithTermsOfService>

--- a/pages/earn/[protocol]/open/[strategy].tsx
+++ b/pages/earn/[protocol]/open/[strategy].tsx
@@ -10,12 +10,12 @@ import React from 'react'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
 import { aaveContext, AaveContextProvider } from '../../../../features/aave/AaveContextProvider'
-import { loadStrategyFromSlug } from '../../../../features/aave/strategyConfig'
+import { loadStrategyFromUrl } from '../../../../features/aave/strategyConfig'
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const strategy = ctx.query.strategy as string
   try {
-    loadStrategyFromSlug(strategy)
+    loadStrategyFromUrl(strategy, 'earn')
   } catch (e) {
     console.log(`could not load strategy '${strategy}' for route '${ctx.resolvedUrl}'`)
     return {
@@ -37,7 +37,7 @@ function OpenVault({ strategy }: { strategy: string }) {
         <WithTermsOfService>
           <BackgroundLight />
           <DeferedContextProvider context={aaveContext}>
-            <AaveOpenView config={loadStrategyFromSlug(strategy)} />
+            <AaveOpenView config={loadStrategyFromUrl(strategy, 'earn')} />
           </DeferedContextProvider>
           <Survey for="earn" />
         </WithTermsOfService>


### PR DESCRIPTION
# [Shortcut](https://app.shortcut.com/oazo-apps/story/7645/open-aave-borrow-base-position-page)
  
## Changes 👷‍♀️

- adds base page for Aave borrow
- includes list of allowed collaterals (only eth for now)
- adds borrow strategy config
  
## How to test 🧪
- open, manage, close Earn and Multiply positions to ensure no regression.
