### PR TITLE
deleted unique constraint so now one can follow any vaults not only o…

### DIFF
--- a/server/database/migrations/018-drop-constraint.sql
+++ b/server/database/migrations/018-drop-constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users_who_follow_vaults" DROP CONSTRAINT "users_who_follow_vaults_vault_id_vault_chain_id_fkey";

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -33,7 +33,6 @@ model Vault {
     type          VaultType
     owner_address String
     chain_id      Int?
-    users         UsersWhoFollowVaults[]
 
     @@unique([vault_id, chain_id], name: "vault_vault_id_chain_id_unique_constraint")
     @@map("vault")
@@ -217,7 +216,6 @@ model LargestDebt {
 
 model UsersWhoFollowVaults {
     user_address    String
-    vault           Vault       @relation(fields: [vault_id, vault_chain_id], references: [vault_id, chain_id])
     vault_id        Int // relation scalar field (used in the `@relation` attribute above)
     vault_chain_id  Int
 


### PR DESCRIPTION
…asis ones

# [Removed constraint](https://app.shortcut.com/oazo-apps/story/7714/db-remove-relation-allow-to-follow-non-oasis-vaults)

  
## Changes 👷‍♀️
- removed relation with vault table
  
## How to test 🧪
- Follow any Maker vaults not only ones that exist in db
