### PR TITLE
Auto-buy override banner in AB details section

### DIFF
--- a/features/automation/common/consts.ts
+++ b/features/automation/common/consts.ts
@@ -83,4 +83,5 @@ export const vaultIdsThatAutoBuyTriggerShouldBeRecreated = [
   29628,
   29928,
   29574,
+  29643,
 ]

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1171,7 +1171,7 @@
     "auto-buy-trigger-greater-than-auto-take-profit": "Setting your trigger ratio at this level may result in your Auto-Buy Trigger not executing. Find out more <0>here</0>.",
     "constant-multiple-buy-trigger-greater-than-auto-take-profit": "Setting your buy trigger ratio at this level may result in your Constant Multiple Buy Trigger not executing. Find out more <0>here</0>.",
     "existing-take-profit-trigger-after-vault-reopen": "You have an existing Take Profit Trigger, it will remain active after you reopen this vault.",
-    "auto-buy-override":"We have updated our Auto-Buy Feature. In order for your Auto-Buy automation to trigger, please cancel your existing Auto-Buy and create a new one. Oasis.app will refund any gas costs associated with these transaction, just contact oasis.app support."
+    "auto-buy-override": "We recently discovered an issue with Auto-Buy which prevents it from executing and affects your current Auto-Buy setup. It only affects execution and no funds are at risk. Please cancel your existing Auto-Buy from the Optimisation Tab and re-enable it. Oasis.app will refund any gas costs associated with cancelling and re-enabling. If you have any questions, you can contact us at support@oasis.app"
   },
   "vault-info-messages": {
     "earn-overview": "This {{token}} position is earning trading fees in Uniswap V3. The supplied DAI is multiplied by using the Maker protocol, giving the user a bigger exposure to the Uniswap pool. Currently the only actions you can take is to <1>close this Vault</1>.",


### PR DESCRIPTION
# [Auto-buy override banner in AB details section](https://app.shortcut.com/oazo-apps/story/7713/bug-users-auto-buy-is-not-executing-because-it-is-setting-the-max-buy-price-to-0-instead-of-unlimited)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted banner copy
- banner is visible in auto-buy details section 
  
## How to test 🧪
  <Please explain how to test your changes>

- visit one of the vaults from story, banner should be visible in overview and auto-buy details section
- copy should be updated