### PR TITLE
AutoBS tx handlers dependency array fix

### DIFF
--- a/features/automation/common/state/autoBSTxHandlers.ts
+++ b/features/automation/common/state/autoBSTxHandlers.ts
@@ -56,6 +56,7 @@ export function getAutoBSTxHandlers({
         maxBaseFeeInGwei: autoBSState.maxBaseFeeInGwei,
       }),
     [
+      autoBSState.withThreshold,
       autoBSState.execCollRatio.toNumber(),
       autoBSState.targetCollRatio.toNumber(),
       autoBSState.maxBuyOrMinSellPrice?.toNumber(),


### PR DESCRIPTION
# [AutoBS tx handlers dependency array fix](https://app.shortcut.com/oazo-apps/story/7713/bug-users-auto-buy-is-not-executing-because-it-is-setting-the-max-buy-price-to-0-instead-of-unlimited)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added missing item to dependency array
  
## How to test 🧪
  <Please explain how to test your changes>

- click on `Set Threshold` `Set No Threshold` button in auto buy or sell form should refresh tx data
