### PR TITLE
Share button on demand

### DIFF
--- a/components/vault/DefaultVaultHeadline.tsx
+++ b/components/vault/DefaultVaultHeadline.tsx
@@ -15,12 +15,14 @@ export function DefaultVaultHeadline({
   priceInfo,
   colRatio,
   followButton,
+  shareButton,
 }: {
   header: VaultHeadlineProps['header']
   token: VaultHeadlineProps['token']
   priceInfo: PriceInfo
   colRatio?: string
   followButton?: FollowButtonControlProps
+  shareButton?: boolean
 }) {
   const { t } = useTranslation()
   const {
@@ -74,6 +76,7 @@ export function DefaultVaultHeadline({
       token={token}
       details={detailsList}
       followButton={followButton}
+      shareButton={shareButton}
     />
   )
 }

--- a/components/vault/EarnVaultHeadline.tsx
+++ b/components/vault/EarnVaultHeadline.tsx
@@ -2,8 +2,20 @@ import React from 'react'
 
 import { VaultHeadline, VaultHeadlineProps } from './VaultHeadline'
 
-export function EarnVaultHeadline({ header, token, details, followButton }: VaultHeadlineProps) {
+export function EarnVaultHeadline({
+  header,
+  token,
+  details,
+  followButton,
+  shareButton,
+}: VaultHeadlineProps) {
   return (
-    <VaultHeadline header={header} token={token} details={details} followButton={followButton} />
+    <VaultHeadline
+      header={header}
+      token={token}
+      details={details}
+      followButton={followButton}
+      shareButton={shareButton}
+    />
   )
 }

--- a/components/vault/GeneralManageLayout.tsx
+++ b/components/vault/GeneralManageLayout.tsx
@@ -31,7 +31,12 @@ export function GeneralManageLayout({
 
   const headlineElement =
     generalManageVault.type === VaultType.Earn ? (
-      <GuniVaultHeader token={ilkData.token} ilk={ilkData.ilk} followButton={followButton} />
+      <GuniVaultHeader
+        token={ilkData.token}
+        ilk={ilkData.ilk}
+        followButton={followButton}
+        shareButton
+      />
     ) : (
       <DefaultVaultHeadline
         header={t('vault.header', { ilk: vault.ilk, id: vault.id })}
@@ -39,6 +44,7 @@ export function GeneralManageLayout({
         priceInfo={priceInfo}
         colRatio={colRatioPercnentage}
         followButton={followButton}
+        shareButton
       />
     )
 

--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -28,6 +28,7 @@ export type VaultHeadlineProps = {
     color: string
     size: number
   }
+  shareButton?: boolean
   token: string[]
 }
 
@@ -38,6 +39,7 @@ export function VaultHeadline({
   label,
   loading = false,
   outline,
+  shareButton,
   token,
 }: VaultHeadlineProps) {
   const tokenData = getTokens(token)
@@ -97,11 +99,13 @@ export function VaultHeadline({
         {followVaultEnabled && (
           <Flex sx={{ alignItems: 'center', columnGap: 2, ml: 3 }}>
             {followButton && <FollowButtonControl {...followButton} />}
-            <ShareButton
-              text={twitterSharePositionText}
-              url={document.location.href.replace(document.location.hash, '')}
-              via={twitterSharePositionVia}
-            />
+            {shareButton && (
+              <ShareButton
+                text={twitterSharePositionText}
+                url={document.location.href.replace(document.location.hash, '')}
+                via={twitterSharePositionVia}
+              />
+            )}
           </Flex>
         )}
       </Heading>

--- a/features/aave/common/components/AaveHeader.tsx
+++ b/features/aave/common/components/AaveHeader.tsx
@@ -12,9 +12,11 @@ import React from 'react'
 function AaveHeader({
   strategyConfig,
   headerLabelString,
+  shareButton,
 }: {
   strategyConfig: IStrategyConfig
   headerLabelString: string
+  shareButton?: boolean
 }) {
   const { t } = useTranslation()
   const { getAaveAssetsPrices$, chainlinkUSDCUSDOraclePrice$ } = useAaveContext()
@@ -53,6 +55,7 @@ function AaveHeader({
         token={[strategyConfig.tokens.collateral, strategyConfig.tokens.debt]}
         loading={!positionTokenPrices}
         details={detailsList}
+        shareButton={shareButton}
       />
     </WithErrorHandler>
   )
@@ -63,5 +66,11 @@ export function AaveOpenHeader({ strategyConfig }: { strategyConfig: IStrategyCo
 }
 
 export function AaveManageHeader({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
-  return <AaveHeader strategyConfig={strategyConfig} headerLabelString={'vault.header-aave-view'} />
+  return (
+    <AaveHeader
+      strategyConfig={strategyConfig}
+      headerLabelString={'vault.header-aave-view'}
+      shareButton
+    />
+  )
 }

--- a/features/dsr/containers/DsrView.tsx
+++ b/features/dsr/containers/DsrView.tsx
@@ -77,6 +77,7 @@ export function DsrView({
             value: potTotalValueLocked ? formatCryptoBalance(potTotalValueLocked) : 'n/a',
           },
         ]}
+        shareButton={netValue.gt(zero)}
       />
       <TabBar
         variant="underline"

--- a/features/earn/aave/components/AavePositionHeader.tsx
+++ b/features/earn/aave/components/AavePositionHeader.tsx
@@ -154,6 +154,11 @@ export function AavePositionHeaderNoDetails({ strategyConfig }: AaveHeaderProps)
   const { t } = useTranslation()
   const tokenData = tokenPairList[strategyConfig.name]
   return (
-    <VaultHeadline header={t(tokenData.translationKey)} token={tokenData.tokenList} details={[]} />
+    <VaultHeadline
+      header={t(tokenData.translationKey)}
+      token={tokenData.tokenList}
+      details={[]}
+      shareButton
+    />
   )
 }

--- a/features/earn/guni/common/GuniVaultHeader.tsx
+++ b/features/earn/guni/common/GuniVaultHeader.tsx
@@ -18,12 +18,13 @@ export interface EarnVaultHeaderProps {
   ilk: string
   token: string
   followButton?: FollowButtonControlProps
+  shareButton?: boolean
 }
 
 const currentDate = moment().startOf('day')
 const previousDate = currentDate.clone().subtract(1, 'day')
 
-export function GuniVaultHeader({ ilk, token, followButton }: EarnVaultHeaderProps) {
+export function GuniVaultHeader({ ilk, token, followButton, shareButton }: EarnVaultHeaderProps) {
   const { yieldsChange$, totalValueLocked$ } = useAppContext()
   const [yieldChanges, changesError] = useObservable(yieldsChange$(currentDate, previousDate, ilk))
   const [totalValueLocked, totalValueLockedError] = useObservable(totalValueLocked$(ilk))
@@ -49,6 +50,7 @@ export function GuniVaultHeader({ ilk, token, followButton }: EarnVaultHeaderPro
               token={[token]}
               details={details}
               followButton={followButton}
+              shareButton={shareButton}
             />
           )
         }}


### PR DESCRIPTION
# Share button on demand

Share to twitter button was mistakenly visible not just on existing positions, but also in opening flow.
  
## Changes 👷‍♀️

- Added `shareButton` prop to `vaultHeadline` so it's possible to turn it on and off,
- set `shareButton` to true on all manage positions pages.
  
## How to test 🧪

Visit every type of position (borrow, multiply and earn for maker, multiply and earn for aave and dsr) and see if share button is not visible in open flow, just in manage.