### PR TITLE
Component for creating DPM and Allowance flow

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -107,7 +107,7 @@ import {
   createBalance$,
   createCollateralTokens$,
 } from 'blockchain/tokens'
-import { getUserDpmProxies$, getUserDpmProxy$, UserDpmAccount } from 'blockchain/userDpmProxies'
+import { getUserDpmProxies$, getUserDpmProxy$ } from 'blockchain/userDpmProxies'
 import {
   createStandardCdps$,
   createVault$,

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -231,6 +231,7 @@ import { createCheckOasisCDPType$ } from 'features/shared/checkOasisCDPType'
 import { jwtAuthSetupToken$ } from 'features/shared/jwt'
 import { createPriceInfo$ } from 'features/shared/priceInfo'
 import { checkVaultTypeUsingApi$, saveVaultUsingApi$ } from 'features/shared/vaultApi'
+import { getAllowanceStateMachine } from 'features/stateMachines/allowance'
 import {
   getCreateDPMAccountTransactionMachine,
   getDPMAccountStateMachine,
@@ -1322,6 +1323,12 @@ export function setupAppContext() {
     [LendingProtocol.AaveV2]: aaveV2,
     [LendingProtocol.AaveV3]: aaveV3,
   }
+
+  const allowanceStateMachine = getAllowanceStateMachine(
+    txHelpers$,
+    connectedContext$,
+    commonTransactionServices,
+  )
 
   return {
     web3Context$,

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -1330,6 +1330,12 @@ export function setupAppContext() {
     commonTransactionServices,
   )
 
+  const allowanceForAccount$: (token: string, spender: string) => Observable<BigNumber> = memoize(
+    (token: string, spender: string) =>
+      contextForAddress$.pipe(switchMap(({ account }) => allowance$(token, account, spender))),
+    (token, spender) => `${token}-${spender}`,
+  )
+
   return {
     web3Context$,
     web3ContextConnected$,

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -107,7 +107,7 @@ import {
   createBalance$,
   createCollateralTokens$,
 } from 'blockchain/tokens'
-import { getUserDpmProxies$, getUserDpmProxy$ } from 'blockchain/userDpmProxies'
+import { getUserDpmProxies$, getUserDpmProxy$, UserDpmAccount } from 'blockchain/userDpmProxies'
 import {
   createStandardCdps$,
   createVault$,
@@ -231,6 +231,12 @@ import { createCheckOasisCDPType$ } from 'features/shared/checkOasisCDPType'
 import { jwtAuthSetupToken$ } from 'features/shared/jwt'
 import { createPriceInfo$ } from 'features/shared/priceInfo'
 import { checkVaultTypeUsingApi$, saveVaultUsingApi$ } from 'features/shared/vaultApi'
+import {
+  getCreateDPMAccountTransactionMachine,
+  getDPMAccountStateMachine,
+} from 'features/stateMachines/dpmAccount'
+import { getGasEstimation$ } from 'features/stateMachines/proxy/pipelines'
+import { transactionContextService } from 'features/stateMachines/transaction'
 import { createTermsAcceptance$ } from 'features/termsOfService/termsAcceptance'
 import {
   checkAcceptanceFromApi$,

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -1,11 +1,6 @@
 import { useActor } from '@xstate/react'
 import { AllowanceView } from 'features/stateMachines/allowance'
 import { CreateDPMAccountViewConsumed } from 'features/stateMachines/dpmAccount/CreateDPMAccountView'
-import {
-  DPMAccountStateMachine,
-  DPMAccountStateMachineEvents,
-} from 'features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
-import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useFlowState } from 'helpers/useFlowState'
 import { useTranslation } from 'next-i18next'
 import React from 'react'

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -1,0 +1,224 @@
+import { useActor } from '@xstate/react'
+import {
+  DPMAccountStateMachine,
+  DPMAccountStateMachineEvents,
+} from 'features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
+import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
+import { Trans, useTranslation } from 'next-i18next'
+import React from 'react'
+import { Grid, Image, Text } from 'theme-ui'
+import { ActorRefFrom, Sender, StateFrom } from 'xstate'
+
+import { AppLink } from './Links'
+import { ListWithIcon } from './ListWithIcon'
+import { SidebarSection, SidebarSectionProps } from './sidebar/SidebarSection'
+import { SidebarSectionFooterButtonSettings } from './sidebar/SidebarSectionFooter'
+import {
+  getEstimatedGasFeeTextOld,
+  VaultChangesInformationContainer,
+  VaultChangesInformationItem,
+} from './vault/VaultChangesInformation'
+
+export interface CreateDPMAccountViewProps {
+  machine: ActorRefFrom<DPMAccountStateMachine>
+  isConnected?: boolean
+  noConnectionContent?: JSX.Element
+}
+
+interface InternalViewsProps {
+  state: StateFrom<DPMAccountStateMachine>
+  send: Sender<DPMAccountStateMachineEvents>
+}
+
+function buttonInfoSettings({
+  state,
+  send,
+}: InternalViewsProps): Pick<SidebarSectionFooterButtonSettings, 'label' | 'action'> {
+  const { t } = useTranslation()
+
+  const isRetry = state.matches('txFailure')
+
+  return {
+    label: isRetry
+      ? t('dpm.create-flow.welcome-screen.retry-create-button')
+      : t('dpm.create-flow.welcome-screen.create-button'),
+    action: isRetry ? () => send('RETRY') : () => send('START'),
+  }
+}
+
+function NoConnectionStateView({
+  noConnectionContent,
+}: {
+  noConnectionContent?: CreateDPMAccountViewProps['noConnectionContent']
+}) {
+  const { t } = useTranslation()
+  const sidebarSectionProps: SidebarSectionProps = {
+    title: t('dpm.create-flow.welcome-screen.header'),
+    content: (
+      <Grid gap={3}>
+        {noConnectionContent || (
+          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
+            {t('vaults-overview.headers.not-connected-suggestions')}
+          </Text>
+        )}
+      </Grid>
+    ),
+    primaryButton: {
+      isLoading: false,
+      disabled: false,
+      label: t('connect-wallet'),
+      url: '/connect',
+    },
+  }
+
+  return <SidebarSection {...sidebarSectionProps} />
+}
+
+function InfoStateView({ state, send }: InternalViewsProps) {
+  const { t } = useTranslation()
+
+  const sidebarSectionProps: SidebarSectionProps = {
+    title: t('dpm.create-flow.welcome-screen.header'),
+    content: (
+      <Grid gap={3}>
+        <>
+          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
+            <Trans
+              i18nKey={'dpm.create-flow.welcome-screen.paragraph'}
+              components={{
+                1: (
+                  <AppLink
+                    href="https://kb.oasis.app/help/what-is-a-smart-defi-account"
+                    sx={{ fontSize: 2 }}
+                  />
+                ),
+              }}
+            />
+          </Text>
+          <>
+            <ListWithIcon
+              icon="checkmark"
+              iconSize="14px"
+              iconColor="primary100"
+              items={t<string, string[]>('dpm.create-flow.bullet-points', {
+                returnObjects: true,
+              })}
+              listStyle={{ my: 2 }}
+            />
+            <VaultChangesInformationContainer
+              title={t('dpm.create-flow.welcome-screen.create-order-summary-heading')}
+            >
+              <VaultChangesInformationItem
+                label={t('transaction-fee')}
+                value={getEstimatedGasFeeTextOld(state.context.gasData)}
+              />
+            </VaultChangesInformationContainer>
+          </>
+        </>
+      </Grid>
+    ),
+    primaryButton: {
+      isLoading: false,
+      disabled: false,
+      ...buttonInfoSettings({ state, send }),
+    },
+  }
+
+  return <SidebarSection {...sidebarSectionProps} />
+}
+
+function InProgressView(_: InternalViewsProps) {
+  const { t } = useTranslation()
+  const sidebarSectionProps: SidebarSectionProps = {
+    title: t('dpm.create-flow.proxy-creating-screen.header'),
+    content: (
+      <Grid gap={3}>
+        <>
+          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
+            <Trans
+              i18nKey={'dpm.create-flow.proxy-creating-screen.paragraph'}
+              components={{
+                1: (
+                  <AppLink
+                    href="https://kb.oasis.app/help/what-is-a-smart-defi-account"
+                    sx={{ fontSize: 2 }}
+                  />
+                ),
+              }}
+            />
+          </Text>
+          <Image
+            src={staticFilesRuntimeUrl('/static/img/proxy_complete.gif')}
+            sx={{ display: 'block', maxWidth: '210px', mx: 'auto' }}
+          />
+        </>
+      </Grid>
+    ),
+    primaryButton: {
+      isLoading: true,
+      disabled: true,
+      label: t('dpm.create-flow.proxy-creating-screen.button'),
+    },
+  }
+  return <SidebarSection {...sidebarSectionProps} />
+}
+
+function SuccessStateView({ send }: InternalViewsProps) {
+  const { t } = useTranslation()
+
+  const sidebarSectionProps: SidebarSectionProps = {
+    title: t('dpm.create-flow.proxy-created-screen.header'),
+    content: (
+      <Grid gap={3}>
+        <>
+          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
+            <Trans
+              i18nKey={'dpm.create-flow.proxy-created-screen.paragraph'}
+              components={{
+                1: (
+                  <AppLink
+                    href="https://kb.oasis.app/help/what-is-a-smart-defi-account"
+                    sx={{ fontSize: 2 }}
+                  />
+                ),
+              }}
+            />
+          </Text>
+          <Image
+            src={staticFilesRuntimeUrl('/static/img/proxy_complete.gif')}
+            sx={{ display: 'block', maxWidth: '210px', mx: 'auto' }}
+          />
+        </>
+      </Grid>
+    ),
+    primaryButton: {
+      isLoading: false,
+      disabled: false,
+      label: t('continue'),
+      action: () => send('CONTINUE'),
+    },
+  }
+  return <SidebarSection {...sidebarSectionProps} />
+}
+
+export function FlowSidebar({
+  machine,
+  isConnected = false,
+  noConnectionContent,
+}: CreateDPMAccountViewProps) {
+  const [state, send] = useActor(machine)
+
+  switch (true) {
+    case !isConnected:
+      return <NoConnectionStateView noConnectionContent={noConnectionContent} />
+    case state.matches('idle'):
+    case state.matches('txFailure'):
+      return <InfoStateView state={state} send={send} />
+    case state.matches('txInProgress'):
+      return <InProgressView state={state} send={send} />
+    case state.matches('txSuccess'):
+      return <SuccessStateView state={state} send={send} />
+    default:
+      return <></>
+  }
+}

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -7,45 +7,15 @@ import {
 } from 'features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useFlowState } from 'helpers/useFlowState'
-import { Trans, useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Grid, Image, Text } from 'theme-ui'
-import { Sender, StateFrom } from 'xstate'
+import { Grid, Text } from 'theme-ui'
 
-import { AppLink } from './Links'
-import { ListWithIcon } from './ListWithIcon'
 import { SidebarSection, SidebarSectionProps } from './sidebar/SidebarSection'
-import { SidebarSectionFooterButtonSettings } from './sidebar/SidebarSectionFooter'
-import {
-  getEstimatedGasFeeTextOld,
-  VaultChangesInformationContainer,
-  VaultChangesInformationItem,
-} from './vault/VaultChangesInformation'
 
 export type CreateDPMAccountViewProps = {
   noConnectionContent?: JSX.Element
 } & ReturnType<typeof useFlowState>
-
-interface InternalViewsProps {
-  state: StateFrom<DPMAccountStateMachine>
-  send: Sender<DPMAccountStateMachineEvents>
-}
-
-function buttonInfoSettings({
-  state,
-  send,
-}: InternalViewsProps): Pick<SidebarSectionFooterButtonSettings, 'label' | 'action'> {
-  const { t } = useTranslation()
-
-  const isRetry = state.matches('txFailure')
-
-  return {
-    label: isRetry
-      ? t('dpm.create-flow.welcome-screen.retry-create-button')
-      : t('dpm.create-flow.welcome-screen.create-button'),
-    action: isRetry ? () => send('RETRY') : () => send('START'),
-  }
-}
 
 function NoConnectionStateView({
   noConnectionContent,
@@ -99,7 +69,9 @@ export function FlowSidebar({
       case dpmState.matches('txFailure'):
       case dpmState.matches('txInProgress'):
       case dpmState.matches('txSuccess'):
-        return <CreateDPMAccountViewConsumed state={dpmState} send={dpmSend} />
+        return (
+          <CreateDPMAccountViewConsumed state={dpmState} send={dpmSend} backButtonOnFirstStep />
+        )
       default:
         return <></>
     }
@@ -110,7 +82,13 @@ export function FlowSidebar({
       case allowanceState.matches('txFailure'):
       case allowanceState.matches('txInProgress'):
       case allowanceState.matches('txSuccess'):
-        return <AllowanceView allowanceMachine={allowanceMachine} isLoading={isLoading} />
+        return (
+          <AllowanceView
+            allowanceMachine={allowanceMachine}
+            isLoading={isLoading}
+            backButtonOnFirstStep
+          />
+        )
       default:
         return <></>
     }

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -1,5 +1,6 @@
 import { useActor } from '@xstate/react'
 import { AllowanceView } from 'features/stateMachines/allowance'
+import { CreateDPMAccountViewConsumed } from 'features/stateMachines/dpmAccount/CreateDPMAccountView'
 import {
   DPMAccountStateMachine,
   DPMAccountStateMachineEvents,
@@ -74,133 +75,6 @@ function NoConnectionStateView({
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-function DPMInfoStateView({ state, send }: InternalViewsProps) {
-  const { t } = useTranslation()
-
-  const sidebarSectionProps: SidebarSectionProps = {
-    title: t('dpm.create-flow.welcome-screen.header'),
-    content: (
-      <Grid gap={3}>
-        <>
-          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-            <Trans
-              i18nKey={'dpm.create-flow.welcome-screen.paragraph'}
-              components={{
-                1: (
-                  <AppLink
-                    href="https://kb.oasis.app/help/what-is-a-smart-defi-account"
-                    sx={{ fontSize: 2 }}
-                  />
-                ),
-              }}
-            />
-          </Text>
-          <>
-            <ListWithIcon
-              icon="checkmark"
-              iconSize="14px"
-              iconColor="primary100"
-              items={t<string, string[]>('dpm.create-flow.bullet-points', {
-                returnObjects: true,
-              })}
-              listStyle={{ my: 2 }}
-            />
-            <VaultChangesInformationContainer
-              title={t('dpm.create-flow.welcome-screen.create-order-summary-heading')}
-            >
-              <VaultChangesInformationItem
-                label={t('transaction-fee')}
-                value={getEstimatedGasFeeTextOld(state.context.gasData)}
-              />
-            </VaultChangesInformationContainer>
-          </>
-        </>
-      </Grid>
-    ),
-    primaryButton: {
-      isLoading: false,
-      disabled: false,
-      ...buttonInfoSettings({ state, send }),
-    },
-  }
-
-  return <SidebarSection {...sidebarSectionProps} />
-}
-
-function DPMInProgressView(_: InternalViewsProps) {
-  const { t } = useTranslation()
-  const sidebarSectionProps: SidebarSectionProps = {
-    title: t('dpm.create-flow.proxy-creating-screen.header'),
-    content: (
-      <Grid gap={3}>
-        <>
-          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-            <Trans
-              i18nKey={'dpm.create-flow.proxy-creating-screen.paragraph'}
-              components={{
-                1: (
-                  <AppLink
-                    href="https://kb.oasis.app/help/what-is-a-smart-defi-account"
-                    sx={{ fontSize: 2 }}
-                  />
-                ),
-              }}
-            />
-          </Text>
-          <Image
-            src={staticFilesRuntimeUrl('/static/img/proxy_complete.gif')}
-            sx={{ display: 'block', maxWidth: '210px', mx: 'auto' }}
-          />
-        </>
-      </Grid>
-    ),
-    primaryButton: {
-      isLoading: true,
-      disabled: true,
-      label: t('dpm.create-flow.proxy-creating-screen.button'),
-    },
-  }
-  return <SidebarSection {...sidebarSectionProps} />
-}
-
-function DPMSuccessStateView({ send }: InternalViewsProps) {
-  const { t } = useTranslation()
-
-  const sidebarSectionProps: SidebarSectionProps = {
-    title: t('dpm.create-flow.proxy-created-screen.header'),
-    content: (
-      <Grid gap={3}>
-        <>
-          <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
-            <Trans
-              i18nKey={'dpm.create-flow.proxy-created-screen.paragraph'}
-              components={{
-                1: (
-                  <AppLink
-                    href="https://kb.oasis.app/help/what-is-a-smart-defi-account"
-                    sx={{ fontSize: 2 }}
-                  />
-                ),
-              }}
-            />
-          </Text>
-          <Image
-            src={staticFilesRuntimeUrl('/static/img/proxy_complete.gif')}
-            sx={{ display: 'block', maxWidth: '210px', mx: 'auto' }}
-          />
-        </>
-      </Grid>
-    ),
-    primaryButton: {
-      isLoading: false,
-      disabled: false,
-      label: t('continue'),
-      action: () => send('CONTINUE'),
-    },
-  }
-  return <SidebarSection {...sidebarSectionProps} />
-}
-
 export function FlowSidebar({
   noConnectionContent,
   dpmMachine,
@@ -223,11 +97,11 @@ export function FlowSidebar({
     switch (true) {
       case dpmState.matches('idle'):
       case dpmState.matches('txFailure'):
-        return <DPMInfoStateView state={dpmState} send={dpmSend} />
       case dpmState.matches('txInProgress'):
-        return <DPMInProgressView state={dpmState} send={dpmSend} />
       case dpmState.matches('txSuccess'):
-        return <DPMSuccessStateView state={dpmState} send={dpmSend} />
+        return <CreateDPMAccountViewConsumed state={dpmState} send={dpmSend} />
+      default:
+        return <></>
     }
   }
   if (isProxyReady && !isAllowanceReady && allowanceConsidered) {

--- a/components/forms/Radio.tsx
+++ b/components/forms/Radio.tsx
@@ -18,8 +18,8 @@ export function Radio({ children, checked, onChange, name }: React.PropsWithChil
         boxSizing: 'border-box',
         cursor: 'pointer',
         transition: `
-          border-color ease-in 0.2s,
-          box-shadow ease-in 0.2s`,
+          border-color 0.2s,
+          box-shadow 0.2s`,
         '&:hover': {
           borderColor: 'primary100',
           boxShadow: 'medium',

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -177,7 +177,6 @@ export function setupAaveV2Context(appContext: AppContext) {
     convertToAaveOracleAssetPrice$,
     getAaveReserveData$,
     dpmAccountStateMachine,
-    unconsumedDpmProxyForConnectedAccount$,
   }
 }
 

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -11,7 +11,6 @@ import { AppContext } from '../../components/AppContext'
 import { LendingProtocol } from '../../lendingProtocols'
 import { prepareAaveTotalValueLocked$ } from '../../lendingProtocols/aave-v2/pipelines'
 import { getAaveStEthYield } from './common'
-import { getAvailableDPMProxy$ } from './common/services/getAvailableDPMProxy'
 import {
   getAdjustAaveParametersMachine,
   getCloseAaveParametersMachine,

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -177,6 +177,7 @@ export function setupAaveV2Context(appContext: AppContext) {
     convertToAaveOracleAssetPrice$,
     getAaveReserveData$,
     dpmAccountStateMachine,
+    unconsumedDpmProxyForConnectedAccount$,
   }
 }
 

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -159,16 +159,6 @@ export function setupAaveV2Context(appContext: AppContext) {
     getAaveAssetsPrices$({ tokens: ['USDC', 'STETH'] }), //this needs to be fixed in OasisDEX/transactions -> CallDef
   )
 
-  const getAvailableDPMProxy: (
-    walletAddress: string,
-  ) => Observable<UserDpmAccount | undefined> = memoize(
-    curry(getAvailableDPMProxy$)(userDpmProxies$, proxyConsumed$),
-  )
-
-  const unconsumedDpmProxyForConnectedAccount$ = contextForAddress$.pipe(
-    switchMap(({ account }) => getAvailableDPMProxy(account)),
-  )
-
   return {
     aaveStateMachine,
     aaveManageStateMachine,

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -11,6 +11,7 @@ import { AppContext } from '../../components/AppContext'
 import { LendingProtocol } from '../../lendingProtocols'
 import { prepareAaveTotalValueLocked$ } from '../../lendingProtocols/aave-v2/pipelines'
 import { getAaveStEthYield } from './common'
+import { getAvailableDPMProxy$ } from './common/services/getAvailableDPMProxy'
 import {
   getAdjustAaveParametersMachine,
   getCloseAaveParametersMachine,
@@ -156,6 +157,16 @@ export function setupAaveV2Context(appContext: AppContext) {
     getAaveReserveData$({ token: 'ETH' }),
     // @ts-expect-error
     getAaveAssetsPrices$({ tokens: ['USDC', 'STETH'] }), //this needs to be fixed in OasisDEX/transactions -> CallDef
+  )
+
+  const getAvailableDPMProxy: (
+    walletAddress: string,
+  ) => Observable<UserDpmAccount | undefined> = memoize(
+    curry(getAvailableDPMProxy$)(userDpmProxies$, proxyConsumed$),
+  )
+
+  const unconsumedDpmProxyForConnectedAccount$ = contextForAddress$.pipe(
+    switchMap(({ account }) => getAvailableDPMProxy(account)),
   )
 
   return {

--- a/features/aave/getCommonPartsFromAppContext.ts
+++ b/features/aave/getCommonPartsFromAppContext.ts
@@ -3,7 +3,7 @@ import { GraphQLClient } from 'graphql-request'
 import { memoize } from 'lodash'
 import { curry } from 'ramda'
 import { Observable } from 'rxjs'
-import { distinctUntilKeyChanged, map, shareReplay, switchMap } from 'rxjs/operators'
+import { distinctUntilKeyChanged, map, switchMap } from 'rxjs/operators'
 
 import { getChainlinkOraclePrice } from '../../blockchain/calls/chainlink/chainlinkPriceOracle'
 import { observe } from '../../blockchain/calls/observe'

--- a/features/aave/getCommonPartsFromAppContext.ts
+++ b/features/aave/getCommonPartsFromAppContext.ts
@@ -10,12 +10,7 @@ import { observe } from '../../blockchain/calls/observe'
 import { UserDpmAccount } from '../../blockchain/userDpmProxies'
 import { AppContext } from '../../components/AppContext'
 import { getAllowanceStateMachine } from '../stateMachines/allowance'
-import {
-  getCreateDPMAccountTransactionMachine,
-  getDPMAccountStateMachine,
-} from '../stateMachines/dpmAccount'
-import { getGasEstimation$, getOpenProxyStateMachine } from '../stateMachines/proxy/pipelines'
-import { transactionContextService } from '../stateMachines/transaction'
+import { getOpenProxyStateMachine } from '../stateMachines/proxy/pipelines'
 import { getAvailableDPMProxy$ } from './common/services/getAvailableDPMProxy'
 import { getOperationExecutorTransactionMachine } from './common/services/getTransactionMachine'
 import { getProxiesRelatedWithPosition$ } from './helpers/getProxiesRelatedWithPosition'
@@ -25,19 +20,17 @@ export function getCommonPartsFromAppContext({
   onEveryBlock$,
   connectedContext$,
   context$,
-  gasPrice$,
-  daiEthTokenPrice$,
+  gasEstimation$,
   proxyAddress$,
   userDpmProxy$,
   allowance$,
   txHelpers$,
   proxyConsumed$,
   userDpmProxies$,
+  commonTransactionServices,
+  dpmAccountStateMachine,
+  contextForAddress$,
 }: AppContext) {
-  const contextForAddress$ = connectedContext$.pipe(
-    distinctUntilKeyChanged('account'),
-    shareReplay(1),
-  )
   const disconnectedGraphQLClient$ = context$.pipe(
     distinctUntilKeyChanged('cacheApi'),
     map(({ cacheApi }) => new GraphQLClient(cacheApi)),
@@ -46,8 +39,6 @@ export function getCommonPartsFromAppContext({
   const proxyForAccount$: Observable<string | undefined> = contextForAddress$.pipe(
     switchMap(({ account }) => proxyAddress$(account)),
   )
-
-  const gasEstimation$ = curry(getGasEstimation$)(gasPrice$, daiEthTokenPrice$)
 
   const proxiesRelatedWithPosition$ = memoize(
     curry(getProxiesRelatedWithPosition$)(proxyAddress$, userDpmProxy$),
@@ -60,8 +51,6 @@ export function getCommonPartsFromAppContext({
     (token, spender) => `${token}-${spender}`,
   )
 
-  const commonTransactionServices = transactionContextService(context$)
-
   const allowanceStateMachine = getAllowanceStateMachine(
     txHelpers$,
     connectedContext$,
@@ -73,17 +62,6 @@ export function getCommonPartsFromAppContext({
     txHelpers$,
     proxyForAccount$,
     gasEstimation$,
-  )
-
-  const dpmAccountTransactionMachine = getCreateDPMAccountTransactionMachine(
-    txHelpers$,
-    connectedContext$,
-    commonTransactionServices,
-  )
-  const dpmAccountStateMachine = getDPMAccountStateMachine(
-    txHelpers$,
-    gasEstimation$,
-    dpmAccountTransactionMachine,
   )
 
   const operationExecutorTransactionMachine = curry(getOperationExecutorTransactionMachine)(

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -2,6 +2,7 @@ import { useActor } from '@xstate/react'
 import { TabBar } from 'components/TabBar'
 import { hasUserInteracted } from 'features/aave/helpers/hasUserInteracted'
 import { Survey } from 'features/survey'
+import { useFlowState } from 'helpers/useFlowState'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Card, Container, Grid } from 'theme-ui'
@@ -49,6 +50,13 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
 function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
   const { t } = useTranslation()
   const { stateMachine } = useOpenAaveStateMachineContext()
+  const { freeProxyAddress, dpmMachine, isConnected } = useFlowState({
+    onProxyReady: (freeProxyAddress) => {
+      console.log('wow onProxyReady', freeProxyAddress)
+    },
+  })
+
+  console.log('===============', { freeProxyAddress, dpmMachine, isConnected })
   const [, send] = useActor(stateMachine)
   const PositionInfo = strategyConfig.viewComponents.positionInfo
   return (

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -1,4 +1,5 @@
 import { useActor } from '@xstate/react'
+import { FlowSidebar } from 'components/FlowSidebar'
 import { TabBar } from 'components/TabBar'
 import { hasUserInteracted } from 'features/aave/helpers/hasUserInteracted'
 import { Survey } from 'features/survey'
@@ -50,15 +51,13 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
 function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
   const { t } = useTranslation()
   const { stateMachine } = useOpenAaveStateMachineContext()
-  const { freeProxyAddress, dpmMachine, isConnected } = useFlowState({
-    onProxyReady: (freeProxyAddress) => {
-      console.log('wow onProxyReady', freeProxyAddress)
-    },
+  const [state, send] = useActor(stateMachine)
+  const PositionInfo = strategyConfig.viewComponents.positionInfo
+  const flowState = useFlowState({
+    amount: state.context.userInput.amount,
+    token: state.context.tokens.collateral,
   })
 
-  console.log('===============', { freeProxyAddress, dpmMachine, isConnected })
-  const [, send] = useActor(stateMachine)
-  const PositionInfo = strategyConfig.viewComponents.positionInfo
   return (
     <TabBar
       variant="underline"
@@ -70,6 +69,9 @@ function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConf
             <Grid variant="vaultContainer">
               <Box>
                 <SimulateSectionComponent config={strategyConfig} />
+                <Box sx={{ mt: 5 }}>
+                  <FlowSidebar {...flowState} />
+                </Box>
               </Box>
               <Box>{<SidebarOpenAaveVault />}</Box>
             </Grid>

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -56,6 +56,18 @@ function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConf
   const flowState = useFlowState({
     amount: state.context.userInput.amount,
     token: state.context.tokens.collateral,
+    onEverythingReady(params) {
+      // console.log('onEverythingReady', params)
+    },
+  })
+
+  console.log('flowState', {
+    availableProxies: flowState.availableProxies,
+    isAllowanceReady: flowState.isAllowanceReady,
+    isProxyReady: flowState.isProxyReady,
+    isWalletConnected: flowState.isWalletConnected,
+    token: flowState.token,
+    walletAddress: flowState.walletAddress,
   })
 
   return (

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -1,9 +1,7 @@
 import { useActor } from '@xstate/react'
-import { FlowSidebar } from 'components/FlowSidebar'
 import { TabBar } from 'components/TabBar'
 import { hasUserInteracted } from 'features/aave/helpers/hasUserInteracted'
 import { Survey } from 'features/survey'
-import { useFlowState } from 'helpers/useFlowState'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Card, Container, Grid } from 'theme-ui'
@@ -51,24 +49,8 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
 function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConfig }) {
   const { t } = useTranslation()
   const { stateMachine } = useOpenAaveStateMachineContext()
-  const [state, send] = useActor(stateMachine)
+  const [, send] = useActor(stateMachine)
   const PositionInfo = strategyConfig.viewComponents.positionInfo
-  const flowState = useFlowState({
-    amount: state.context.userInput.amount,
-    token: state.context.tokens.collateral,
-    onEverythingReady(params) {
-      // console.log('onEverythingReady', params)
-    },
-  })
-
-  console.log('flowState', {
-    availableProxies: flowState.availableProxies,
-    isAllowanceReady: flowState.isAllowanceReady,
-    isProxyReady: flowState.isProxyReady,
-    isWalletConnected: flowState.isWalletConnected,
-    token: flowState.token,
-    walletAddress: flowState.walletAddress,
-  })
 
   return (
     <TabBar
@@ -81,9 +63,7 @@ function TabSectionComponent({ strategyConfig }: { strategyConfig: IStrategyConf
             <Grid variant="vaultContainer">
               <Box>
                 <SimulateSectionComponent config={strategyConfig} />
-                <Box sx={{ mt: 5 }}>
-                  <FlowSidebar {...flowState} />
-                </Box>
+                <Box sx={{ mt: 5 }}></Box>
               </Box>
               <Box>{<SidebarOpenAaveVault />}</Box>
             </Grid>

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -8,7 +8,6 @@ import { ActorRefFrom, Sender, StateFrom } from 'xstate'
 import { getToken } from '../../../blockchain/tokensMetadata'
 import { Radio } from '../../../components/forms/Radio'
 import { SidebarSection, SidebarSectionProps } from '../../../components/sidebar/SidebarSection'
-import { TxStatusCardProgress, TxStatusCardSuccess } from '../../../components/vault/TxStatusCard'
 import { BigNumberInput } from '../../../helpers/BigNumberInput'
 import { formatAmount, formatCryptoBalance } from '../../../helpers/formatters/format'
 import { handleNumericInput } from '../../../helpers/input'
@@ -40,6 +39,7 @@ function AllowanceInfoStateViewContent({
   const isUnlimited = allowanceType === 'unlimited'
   const isMinimum = allowanceType === 'minimum'
   const isCustom = allowanceType === 'custom'
+
   return (
     <Grid gap={3}>
       <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
@@ -54,7 +54,6 @@ function AllowanceInfoStateViewContent({
           {t('unlimited-allowance')}
         </Text>
       </Radio>
-
       <Radio
         onChange={() => send({ type: 'SET_ALLOWANCE', allowanceType: 'minimum' })}
         name="allowance-open-form"
@@ -115,30 +114,28 @@ function AllowanceInfoStateView({ state, send, steps, isLoading }: AllowanceView
       action: () => send('NEXT_STEP'),
     },
   }
+
   return <SidebarSection {...sidebarSectionProps} />
 }
 
 function AllowanceInProgressStateViewContent({ state }: Pick<AllowanceViewStateProps, 'state'>) {
   const { t } = useTranslation()
-  const [transactionState] = useActor(state.context.refTransactionMachine!)
   const { token } = state.context
-  const { txHash, etherscanUrl } = transactionState.context
+
   return (
     <Grid gap={3}>
       <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
         {t('vault-form.subtext.commonAllowance', { token })}
       </Text>
-      <TxStatusCardProgress
-        text={t('setting-allowance-for', { token })}
-        txHash={txHash!}
-        etherscan={etherscanUrl || ''}
-      />
     </Grid>
   )
 }
 
 function AllowanceInProgressStateView({ state, steps }: AllowanceViewStateProps) {
   const { t } = useTranslation()
+  const { token } = state.context
+  const [transactionState] = useActor(state.context.refTransactionMachine!)
+  const { txHash, etherscanUrl } = transactionState.context
 
   const sidebarSectionProps: SidebarSectionProps = {
     title: t('vault-form.header.allowance', { token: state.context.token }),
@@ -149,7 +146,16 @@ function AllowanceInProgressStateView({ state, steps }: AllowanceViewStateProps)
       disabled: true,
       label: t('approving-allowance'),
     },
+    status: [
+      {
+        type: 'progress',
+        text: t('setting-allowance-for', { token }),
+        etherscan: etherscanUrl || '',
+        txHash: txHash!,
+      },
+    ],
   }
+
   return <SidebarSection {...sidebarSectionProps} />
 }
 
@@ -166,11 +172,6 @@ function AllowanceSuccessStateView({ state, send, steps }: AllowanceViewStatePro
         <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
           {t('vault-form.subtext.commonAllowance', { token })}
         </Text>
-        <TxStatusCardSuccess
-          text={t('setting-allowance-for', { token })}
-          txHash={txHash!}
-          etherscan={etherscanUrl || ''}
-        />
       </Grid>
     ),
     primaryButton: {
@@ -180,7 +181,16 @@ function AllowanceSuccessStateView({ state, send, steps }: AllowanceViewStatePro
       label: t('continue'),
       action: () => send('CONTINUE'),
     },
+    status: [
+      {
+        type: 'success',
+        text: t('setting-allowance-for', { token }),
+        etherscan: etherscanUrl || '',
+        txHash: txHash!,
+      },
+    ],
   }
+
   return <SidebarSection {...sidebarSectionProps} />
 }
 
@@ -208,6 +218,7 @@ function AllowanceRetryStateView({ state, send }: AllowanceViewStateProps) {
       action: () => send('BACK'),
     },
   }
+
   return <SidebarSection {...sidebarSectionProps} />
 }
 

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -19,13 +19,13 @@ import {
 
 interface AllowanceViewProps {
   allowanceMachine: ActorRefFrom<AllowanceStateMachine>
-  steps: [number, number]
+  steps?: [number, number]
 }
 
 interface AllowanceViewStateProps {
   state: StateFrom<AllowanceStateMachine>
   send: Sender<AllowanceStateMachineEvent>
-  steps: [number, number]
+  steps?: [number, number]
 }
 
 function AllowanceInfoStateViewContent({

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -1,4 +1,5 @@
 import { useActor } from '@xstate/react'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { createNumberMask } from 'text-mask-addons'
@@ -40,10 +41,14 @@ function AllowanceInfoStateViewContent({
   const isMinimum = allowanceType === 'minimum'
   const isCustom = allowanceType === 'custom'
 
+  const allowanceAmountInfo = isUnlimited
+    ? t('unlimited-allowance')
+    : `${formatAmount(isMinimum ? minimumAmount : amount || zero, token)} ${token}`
+
   return (
     <Grid gap={3}>
       <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-        {t('vault-form.subtext.commonAllowance', { token })}
+        {t('vault-form.subtext.commonAllowance', { allowanceAmountInfo })}
       </Text>
       <Radio
         onChange={() => send({ type: 'SET_ALLOWANCE', allowanceType: 'unlimited' })}

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -125,12 +125,19 @@ function AllowanceInfoStateView({ state, send, steps, isLoading }: AllowanceView
 
 function AllowanceInProgressStateViewContent({ state }: Pick<AllowanceViewStateProps, 'state'>) {
   const { t } = useTranslation()
-  const { token } = state.context
+  const { token, minimumAmount, allowanceType, amount } = state.context
+
+  const isUnlimited = allowanceType === 'unlimited'
+  const isMinimum = allowanceType === 'minimum'
+
+  const allowanceAmountInfo = isUnlimited
+    ? t('unlimited-allowance')
+    : `${formatAmount(isMinimum ? minimumAmount : amount || zero, token)} ${token}`
 
   return (
     <Grid gap={3}>
       <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-        {t('vault-form.subtext.commonAllowance', { token })}
+        {t('vault-form.subtext.commonAllowance', { allowanceAmountInfo })}
       </Text>
     </Grid>
   )
@@ -167,15 +174,22 @@ function AllowanceInProgressStateView({ state, steps }: AllowanceViewStateProps)
 function AllowanceSuccessStateView({ state, send, steps }: AllowanceViewStateProps) {
   const { t } = useTranslation()
   const [transactionState] = useActor(state.context.refTransactionMachine!)
-  const { token } = state.context
+  const { token, minimumAmount, allowanceType, amount } = state.context
   const { txHash, etherscanUrl } = transactionState.context
+
+  const isUnlimited = allowanceType === 'unlimited'
+  const isMinimum = allowanceType === 'minimum'
+
+  const allowanceAmountInfo = isUnlimited
+    ? t('unlimited-allowance')
+    : `${formatAmount(isMinimum ? minimumAmount : amount || zero, token)} ${token}`
 
   const sidebarSectionProps: SidebarSectionProps = {
     title: t('vault-form.header.allowance', { token: state.context.token }),
     content: (
       <Grid gap={3}>
         <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-          {t('vault-form.subtext.commonAllowance', { token })}
+          {t('vault-form.subtext.commonAllowance', { allowanceAmountInfo })}
         </Text>
       </Grid>
     ),
@@ -201,14 +215,21 @@ function AllowanceSuccessStateView({ state, send, steps }: AllowanceViewStatePro
 
 function AllowanceRetryStateView({ state, send }: AllowanceViewStateProps) {
   const { t } = useTranslation()
-  const { token } = state.context
+  const { token, minimumAmount, allowanceType, amount } = state.context
+
+  const isUnlimited = allowanceType === 'unlimited'
+  const isMinimum = allowanceType === 'minimum'
+
+  const allowanceAmountInfo = isUnlimited
+    ? t('unlimited-allowance')
+    : `${formatAmount(isMinimum ? minimumAmount : amount || zero, token)} ${token}`
 
   const sidebarSectionProps: SidebarSectionProps = {
     title: t('vault-form.header.allowance', { token: state.context.token }),
     content: (
       <Grid gap={3}>
         <Text variant="paragraph3" sx={{ color: 'neutral80', lineHeight: '22px' }}>
-          {t('vault-form.subtext.commonAllowance', { token })}
+          {t('vault-form.subtext.commonAllowance', { allowanceAmountInfo })}
         </Text>
       </Grid>
     ),

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -20,12 +20,14 @@ import {
 interface AllowanceViewProps {
   allowanceMachine: ActorRefFrom<AllowanceStateMachine>
   steps?: [number, number]
+  isLoading?: boolean
 }
 
 interface AllowanceViewStateProps {
   state: StateFrom<AllowanceStateMachine>
   send: Sender<AllowanceStateMachineEvent>
   steps?: [number, number]
+  isLoading?: boolean
 }
 
 function AllowanceInfoStateViewContent({
@@ -99,7 +101,7 @@ function AllowanceInfoStateViewContent({
   )
 }
 
-function AllowanceInfoStateView({ state, send, steps }: AllowanceViewStateProps) {
+function AllowanceInfoStateView({ state, send, steps, isLoading }: AllowanceViewStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -107,7 +109,7 @@ function AllowanceInfoStateView({ state, send, steps }: AllowanceViewStateProps)
     content: <AllowanceInfoStateViewContent state={state} send={send} />,
     primaryButton: {
       steps: steps,
-      isLoading: false,
+      isLoading,
       disabled: !state.can('NEXT_STEP'),
       label: t('approve-allowance'),
       action: () => send('NEXT_STEP'),
@@ -209,12 +211,14 @@ function AllowanceRetryStateView({ state, send }: AllowanceViewStateProps) {
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-export function AllowanceView({ allowanceMachine, steps }: AllowanceViewProps) {
+export function AllowanceView({ allowanceMachine, steps, isLoading }: AllowanceViewProps) {
   const [state, send] = useActor(allowanceMachine)
 
   switch (true) {
     case state.matches('idle'):
-      return <AllowanceInfoStateView state={state} send={send} steps={steps} />
+      return (
+        <AllowanceInfoStateView state={state} send={send} steps={steps} isLoading={isLoading} />
+      )
     case state.matches('txFailure'):
       return <AllowanceRetryStateView state={state} send={send} steps={steps} />
     case state.matches('txInProgress'):

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -21,6 +21,7 @@ interface AllowanceViewProps {
   allowanceMachine: ActorRefFrom<AllowanceStateMachine>
   steps?: [number, number]
   isLoading?: boolean
+  backButtonOnFirstStep?: boolean
 }
 
 interface AllowanceViewStateProps {
@@ -28,6 +29,7 @@ interface AllowanceViewStateProps {
   send: Sender<AllowanceStateMachineEvent>
   steps?: [number, number]
   isLoading?: boolean
+  backButtonOnFirstStep?: boolean
 }
 
 function AllowanceInfoStateViewContent({
@@ -105,7 +107,13 @@ function AllowanceInfoStateViewContent({
   )
 }
 
-function AllowanceInfoStateView({ state, send, steps, isLoading }: AllowanceViewStateProps) {
+function AllowanceInfoStateView({
+  state,
+  send,
+  steps,
+  isLoading,
+  backButtonOnFirstStep,
+}: AllowanceViewStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -118,6 +126,14 @@ function AllowanceInfoStateView({ state, send, steps, isLoading }: AllowanceView
       label: t('approve-allowance'),
       action: () => send('NEXT_STEP'),
     },
+    textButton: backButtonOnFirstStep
+      ? {
+          action: () => {
+            send('BACK')
+          },
+          label: t('go-back'),
+        }
+      : undefined,
   }
 
   return <SidebarSection {...sidebarSectionProps} />
@@ -248,13 +264,24 @@ function AllowanceRetryStateView({ state, send }: AllowanceViewStateProps) {
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-export function AllowanceView({ allowanceMachine, steps, isLoading }: AllowanceViewProps) {
+export function AllowanceView({
+  allowanceMachine,
+  steps,
+  isLoading,
+  backButtonOnFirstStep,
+}: AllowanceViewProps) {
   const [state, send] = useActor(allowanceMachine)
 
   switch (true) {
     case state.matches('idle'):
       return (
-        <AllowanceInfoStateView state={state} send={send} steps={steps} isLoading={isLoading} />
+        <AllowanceInfoStateView
+          state={state}
+          send={send}
+          steps={steps}
+          isLoading={isLoading}
+          backButtonOnFirstStep={backButtonOnFirstStep}
+        />
       )
     case state.matches('txFailure'):
       return <AllowanceRetryStateView state={state} send={send} steps={steps} />

--- a/features/stateMachines/allowance/state/createAllowanceStateMachine.ts
+++ b/features/stateMachines/allowance/state/createAllowanceStateMachine.ts
@@ -57,6 +57,7 @@ export type AllowanceStateMachineEvent =
   | { type: 'BACK' }
   | { type: 'CONTINUE' }
   | { type: 'SET_ALLOWANCE'; amount?: BigNumber; allowanceType: AllowanceType }
+  | { type: 'SET_ALLOWANCE_CONTEXT'; minimumAmount: BigNumber; token: string; spender: string }
   | TransactionStateMachineResultEvents
 
 export function createAllowanceStateMachine(
@@ -83,6 +84,9 @@ export function createAllowanceStateMachine(
               target: 'txInProgress',
             },
             SET_ALLOWANCE: {
+              actions: ['updateContext'],
+            },
+            SET_ALLOWANCE_CONTEXT: {
               actions: ['updateContext'],
             },
           },

--- a/features/stateMachines/allowance/state/createAllowanceStateMachine.ts
+++ b/features/stateMachines/allowance/state/createAllowanceStateMachine.ts
@@ -57,7 +57,13 @@ export type AllowanceStateMachineEvent =
   | { type: 'BACK' }
   | { type: 'CONTINUE' }
   | { type: 'SET_ALLOWANCE'; amount?: BigNumber; allowanceType: AllowanceType }
-  | { type: 'SET_ALLOWANCE_CONTEXT'; minimumAmount: BigNumber; token: string; spender: string }
+  | {
+      type: 'SET_ALLOWANCE_CONTEXT'
+      minimumAmount: BigNumber
+      token: string
+      spender: string
+      allowanceType: AllowanceType
+    }
   | TransactionStateMachineResultEvents
 
 export function createAllowanceStateMachine(

--- a/features/stateMachines/dpmAccount/CreateDPMAccountView.tsx
+++ b/features/stateMachines/dpmAccount/CreateDPMAccountView.tsx
@@ -2,7 +2,7 @@ import { useActor } from '@xstate/react'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid, Image, Text } from 'theme-ui'
-import { ActorRefFrom, Sender, StateFrom } from 'xstate'
+import { ActorRefFrom, Sender, State, StateFrom } from 'xstate'
 
 import { AppLink } from '../../../components/Links'
 import { ListWithIcon } from '../../../components/ListWithIcon'
@@ -15,6 +15,7 @@ import {
 } from '../../../components/vault/VaultChangesInformation'
 import { staticFilesRuntimeUrl } from '../../../helpers/staticPaths'
 import {
+  DMPAccountStateMachineContext,
   DPMAccountStateMachine,
   DPMAccountStateMachineEvents,
 } from './state/createDPMAccountStateMachine'
@@ -174,6 +175,11 @@ function SuccessStateView({ send }: InternalViewsProps) {
 export function CreateDPMAccountView({ machine }: CreateDPMAccountViewProps) {
   const [state, send] = useActor(machine)
 
+  return <CreateDPMAccountViewConsumed state={state} send={send} />
+}
+
+export function CreateDPMAccountViewConsumed({ state, send }: InternalViewsProps) {
+  // proxy component so I can use the below ones outside of the normal xstate flow
   switch (true) {
     case state.matches('idle'):
     case state.matches('txFailure'):

--- a/features/stateMachines/dpmAccount/CreateDPMAccountView.tsx
+++ b/features/stateMachines/dpmAccount/CreateDPMAccountView.tsx
@@ -27,6 +27,7 @@ export interface CreateDPMAccountViewProps {
 interface InternalViewsProps {
   state: StateFrom<DPMAccountStateMachine>
   send: Sender<DPMAccountStateMachineEvents>
+  backButtonOnFirstStep?: boolean
 }
 
 function buttonInfoSettings({
@@ -45,7 +46,7 @@ function buttonInfoSettings({
   }
 }
 
-function InfoStateView({ state, send }: InternalViewsProps) {
+function InfoStateView({ state, send, backButtonOnFirstStep }: InternalViewsProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -93,6 +94,14 @@ function InfoStateView({ state, send }: InternalViewsProps) {
       disabled: false,
       ...buttonInfoSettings({ state, send }),
     },
+    textButton: backButtonOnFirstStep
+      ? {
+          action: () => {
+            send('GO_BACK')
+          },
+          label: t('go-back'),
+        }
+      : undefined,
   }
 
   return <SidebarSection {...sidebarSectionProps} />
@@ -178,12 +187,18 @@ export function CreateDPMAccountView({ machine }: CreateDPMAccountViewProps) {
   return <CreateDPMAccountViewConsumed state={state} send={send} />
 }
 
-export function CreateDPMAccountViewConsumed({ state, send }: InternalViewsProps) {
+export function CreateDPMAccountViewConsumed({
+  state,
+  send,
+  backButtonOnFirstStep,
+}: InternalViewsProps) {
   // proxy component so I can use the below ones outside of the normal xstate flow
   switch (true) {
     case state.matches('idle'):
     case state.matches('txFailure'):
-      return <InfoStateView state={state} send={send} />
+      return (
+        <InfoStateView state={state} send={send} backButtonOnFirstStep={backButtonOnFirstStep} />
+      )
     case state.matches('txInProgress'):
       return <InProgressView state={state} send={send} />
     case state.matches('txSuccess'):

--- a/features/stateMachines/dpmAccount/CreateDPMAccountView.tsx
+++ b/features/stateMachines/dpmAccount/CreateDPMAccountView.tsx
@@ -2,7 +2,7 @@ import { useActor } from '@xstate/react'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid, Image, Text } from 'theme-ui'
-import { ActorRefFrom, Sender, State, StateFrom } from 'xstate'
+import { ActorRefFrom, Sender, StateFrom } from 'xstate'
 
 import { AppLink } from '../../../components/Links'
 import { ListWithIcon } from '../../../components/ListWithIcon'
@@ -15,7 +15,6 @@ import {
 } from '../../../components/vault/VaultChangesInformation'
 import { staticFilesRuntimeUrl } from '../../../helpers/staticPaths'
 import {
-  DMPAccountStateMachineContext,
   DPMAccountStateMachine,
   DPMAccountStateMachineEvents,
 } from './state/createDPMAccountStateMachine'

--- a/features/stateMachines/dpmAccount/state/createDPMAccountStateMachine.ts
+++ b/features/stateMachines/dpmAccount/state/createDPMAccountStateMachine.ts
@@ -29,6 +29,7 @@ export type DPMAccountStateMachineEvents =
   | { type: 'START' }
   | { type: 'RETRY' }
   | { type: 'CONTINUE' }
+  | { type: 'GO_BACK' }
   | { type: 'GAS_COST_ESTIMATION'; gasData: HasGasEstimation }
 
 export function createDPMAccountStateMachine(

--- a/helpers/dummyStateMachine.ts
+++ b/helpers/dummyStateMachine.ts
@@ -36,11 +36,8 @@ export function setupDpmContext(machine: DPMAccountStateMachine) {
     })
 
   const service = useInterpret(machine, { parent: parentService }).start()
-
-  const states$ = from(service)
   return {
     stateMachine: service,
-    states$,
     dpmAccounts$: createdDpmAccount.asObservable(),
   }
 }
@@ -51,9 +48,7 @@ export function setupAllowanceContext(machine: AllowanceStateMachine) {
     parent: parentService,
     context: { minimumAmount: zero, token: 'ETH' },
   }).start()
-  const states$ = from(service)
   return {
     stateMachine: service,
-    states$,
   }
 }

--- a/helpers/dummyStateMachine.ts
+++ b/helpers/dummyStateMachine.ts
@@ -2,7 +2,7 @@ import { useInterpret } from '@xstate/react'
 import { UserDpmAccount } from 'blockchain/userDpmProxies'
 import { AllowanceStateMachine } from 'features/stateMachines/allowance'
 import { DPMAccountStateMachine } from 'features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
-import { from, Subject } from 'rxjs'
+import { Subject } from 'rxjs'
 import { createMachine, send } from 'xstate'
 
 import { zero } from './zero'

--- a/helpers/dummyStateMachine.ts
+++ b/helpers/dummyStateMachine.ts
@@ -1,0 +1,43 @@
+import { useInterpret } from '@xstate/react'
+import { UserDpmAccount } from 'blockchain/userDpmProxies'
+import { DPMAccountStateMachine } from 'features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
+import { from, Subject } from 'rxjs'
+import { createMachine, send } from 'xstate'
+
+export const dummyParent = createMachine({
+  schema: {
+    events: {} as any,
+    context: {} as {},
+  },
+  id: 'parent',
+  initial: 'idle',
+  states: {
+    idle: {},
+  },
+  on: {
+    '*': {
+      actions: (context, event) => send({ ...event }),
+    },
+  },
+})
+
+export function setupDpmContext(machine: DPMAccountStateMachine) {
+  const createdDpmAccount = new Subject<UserDpmAccount>()
+  const parentService = useInterpret(dummyParent)
+    .start()
+    .onEvent((event) => {
+      if (event.type === 'DPM_ACCOUNT_CREATED') {
+        // @ts-ignore
+        createdDpmAccount.next(event.userDpmAccount)
+      }
+    })
+
+  const service = useInterpret(machine, { parent: parentService }).start()
+
+  const states$ = from(service)
+  return {
+    stateMachine: service,
+    states$,
+    dpmAccounts$: createdDpmAccount.asObservable(),
+  }
+}

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -1,0 +1,59 @@
+import { useAppContext } from 'components/AppContextProvider'
+import { useAaveContext } from 'features/aave/AaveContextProvider'
+import { useEffect, useState } from 'react'
+
+import { setupDpmContext } from './dummyStateMachine'
+
+type useFlowStateProps = {
+  onProxyReady?: (onProxyReady: string) => void
+}
+
+export function useFlowState({ onProxyReady }: useFlowStateProps) {
+  const [isConnected, setIsConnected] = useState<boolean>()
+  const [freeProxyAddress, setFreeProxyAddress] = useState<string>()
+  const { dpmAccountStateMachine, unconsumedDpmProxyForConnectedAccount$ } = useAaveContext()
+  const { context$ } = useAppContext()
+  const { stateMachine } = setupDpmContext(dpmAccountStateMachine)
+
+  function updateProxyValues(proxy: string) {
+    setFreeProxyAddress(proxy)
+    typeof onProxyReady === 'function' && onProxyReady(proxy)
+  }
+
+  useEffect(() => {
+    const walletConnectionSubscription = context$.subscribe(({ status }) => {
+      setIsConnected(status === 'connected')
+    })
+    const proxyMachineSubscription = stateMachine.subscribe((state) => {
+      if (
+        state.value === 'txSuccess' &&
+        state.context.result?.proxy &&
+        freeProxyAddress !== state.context.result?.proxy
+      ) {
+        // new proxy created
+        updateProxyValues(state.context.result.proxy)
+      }
+    })
+    const currentFreeProxySubscription = unconsumedDpmProxyForConnectedAccount$.subscribe(
+      (...data) => {
+        console.log('data', data)
+        return
+        // unused proxy found
+        if (data?.proxy) {
+          updateProxyValues(data?.proxy)
+        }
+      },
+    )
+    return () => {
+      proxyMachineSubscription.unsubscribe()
+      walletConnectionSubscription.unsubscribe()
+      currentFreeProxySubscription.unsubscribe()
+    }
+  }, [])
+
+  return {
+    dpmMachine: stateMachine,
+    freeProxyAddress,
+    isConnected,
+  }
+}

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -145,7 +145,7 @@ export function useFlowState({
     })
     const allowanceSubscription = allowanceForAccount$(token!, spender).subscribe(
       (allowanceData) => {
-        if (allowanceData) {
+        if (allowanceData && allowanceMachineSubscription) {
           setLoading(false)
           if (allowanceData.gt(zero) && allowanceData.gte(amount!)) {
             setAllowanceReady(true)
@@ -166,6 +166,10 @@ export function useFlowState({
           isWalletConnected,
           isAllowanceReady,
         })
+      }
+      if (value !== 'idle') {
+        // do not update isAllowanceReady in the background if user started the allowance flow in the machine
+        allowanceSubscription.unsubscribe()
       }
       if (value === 'txSuccess' && context.allowanceType && event.type === 'CONTINUE') {
         setAllowanceReady(true)

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -10,20 +10,21 @@ import { setupAllowanceContext, setupDpmContext } from './dummyStateMachine'
 import { zero } from './zero'
 
 type UserFlowStateReturnType = ReturnType<typeof useFlowState>
+type FinalCallbackType = (params: {
+  availableProxies: UserFlowStateReturnType['availableProxies']
+  walletAddress: UserFlowStateReturnType['walletAddress']
+  amount: UserFlowStateReturnType['amount']
+  token: UserFlowStateReturnType['token']
+  isProxyReady: UserFlowStateReturnType['isProxyReady']
+  isWalletConnected: UserFlowStateReturnType['isWalletConnected']
+  isAllowanceReady: UserFlowStateReturnType['isAllowanceReady']
+}) => void
 
 type UseFlowStateProps = {
   amount?: BigNumber
   token?: string
   existingProxy?: string
-  onEverythingReady?: (params: {
-    availableProxies: UserFlowStateReturnType['availableProxies']
-    walletAddress: UserFlowStateReturnType['walletAddress']
-    amount: UserFlowStateReturnType['amount']
-    token: UserFlowStateReturnType['token']
-    isProxyReady: UserFlowStateReturnType['isProxyReady']
-    isWalletConnected: UserFlowStateReturnType['isWalletConnected']
-    isAllowanceReady: UserFlowStateReturnType['isAllowanceReady']
-  }) => void
+  onEverythingReady?: FinalCallbackType
 }
 
 export function useFlowState({

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -35,8 +35,6 @@ export function useFlowState({
   onEverythingReady,
   onGoBack,
 }: UseFlowStateProps) {
-  console.log('amount.toString()', amount?.toString())
-
   const [isWalletConnected, setWalletConnected] = useState<boolean>(false)
   const [walletAddress, setWalletAddress] = useState<string>()
   const [userProxyList, setUserProxyList] = useState<UserDpmAccount[]>([])
@@ -177,7 +175,7 @@ export function useFlowState({
       allowanceMachineSubscription.unsubscribe()
       allowanceSubscription.unsubscribe()
     }
-  }, [walletAddress, availableProxies, amount, token])
+  }, [walletAddress, availableProxies, amount?.toString(), token])
 
   // wrapping up
   useEffect(() => {
@@ -198,13 +196,13 @@ export function useFlowState({
         isAllowanceReady,
       })
     }
-  }, [isAllowanceReady, availableProxies, amount])
+  }, [isAllowanceReady, availableProxies, amount?.toString()])
 
   useEffect(() => {
     if (isProxyReady && allDefined(amount, token)) {
       setLoading(true)
     }
-  }, [amount])
+  }, [amount?.toString()])
 
   return {
     dpmMachine,

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -1,5 +1,4 @@
 import { useAppContext } from 'components/AppContextProvider'
-import { useAaveContext } from 'features/aave/AaveContextProvider'
 import { useEffect, useState } from 'react'
 
 import { setupDpmContext } from './dummyStateMachine'
@@ -11,7 +10,7 @@ type useFlowStateProps = {
 export function useFlowState({ onProxyReady }: useFlowStateProps) {
   const [isConnected, setIsConnected] = useState<boolean>()
   const [freeProxyAddress, setFreeProxyAddress] = useState<string>()
-  const { dpmAccountStateMachine, unconsumedDpmProxyForConnectedAccount$ } = useAaveContext()
+  const { dpmAccountStateMachine, unconsumedDpmProxyForConnectedAccount$ } = useAppContext()
   const { context$ } = useAppContext()
   const { stateMachine } = setupDpmContext(dpmAccountStateMachine)
 
@@ -35,9 +34,7 @@ export function useFlowState({ onProxyReady }: useFlowStateProps) {
       }
     })
     const currentFreeProxySubscription = unconsumedDpmProxyForConnectedAccount$.subscribe(
-      (...data) => {
-        console.log('data', data)
-        return
+      (data) => {
         // unused proxy found
         if (data?.proxy) {
           updateProxyValues(data?.proxy)

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -134,7 +134,7 @@ export function useFlowState({
       (allowanceData) => {
         if (allowanceData) {
           setLoading(false)
-          if (allowanceData.gt(zero) && allowanceData.gt(amount!)) {
+          if (allowanceData.gt(zero) && allowanceData.gte(amount!)) {
             setAllowanceReady(true)
           } else {
             setAllowanceReady(false)

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -44,6 +44,7 @@
   "approve-allowance": "Approve Allowance",
   "approving-allowance": "Approving Allowance",
   "back": "Back",
+  "go-back": "Go back",
   "ok": "OK",
   "back-to-editing": "Back to editing",
   "view-vault-link": "<0>View Vault -></0>",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1370,7 +1370,7 @@
       "proxy-progress": "Read more on smart proxy in the <1>Knowledge Base</1>.",
       "allowance": "Specify an allowance to set a maximum on the amount of tokens the vault contracts can interact with.",
       "daiAllowance": "Specify an allowance to set a maximum on the amount of tokens the vault contracts can interact with.",
-      "commonAllowance": "Select a maximum allowance amount for your Smart DeFi Account. Your Smart Defi Account will be able to interact with up to:",
+      "commonAllowance": "Select a maximum allowance amount for your Smart DeFi Account. Your Smart Defi Account will be able to interact with up to: {{allowanceAmountInfo}}",
       "confirm": "This will update your vault to a multiply vault. It does not require a transaction. You will be able to switch it back to the Borrow view.",
       "review-manage": "Here you can review the details of the changes to your vault.",
       "confirm-in-progress": "Your Vault is currently being created.",


### PR DESCRIPTION
# Component + hook for creating DPM and Allowance flow

  
## Changes 👷‍♀️
- added new hook - `useFlowState`. The purpose of this hook is to provide access to internals of handling flow states: creating DPM proxy and allowance.
- added new component `FlowSideBar` which can consume `flowState` from the hook above. This provides UI needed for proxy and allowance states.

## How to use it? 🔧 
Typical use case:
```
  const flowState = useFlowState({
    amount: yourDataSource.amount,
    token: yourDataSource.collateral,
    onEverythingReady(params) {
      // we have everything we need, pick the first
      // DPM proxy from "availableProxies" and proceed with your flow
      console.log('onEverythingReady', params)
    },
  })
```
```
  <FlowSidebar {...flowState} />
```
If you don't want to use `onEverythingReady` for whatever reason you can react to the hook changes:
```
{
    dpmMachine, // internals
    allowanceMachine, // internals
    availableProxies, // list of available proxies ⭐
    walletAddress, // just for convenience
    amount, // just for convenience
    token, // just for convenience
    isProxyReady, // self explanatory
    isWalletConnected, // self explanatory
    isAllowanceReady, // self explanatory
    isLoading, // just for the allowance loading state
    isEverythingReady, // self explanatory
  }
```
⭐ internals use first (`[0]`) for allowance and so should you for your flow

For manage flows - everything stays the same, just provide `existingProxy` to the hook and it will be available in `availableProxies`, the hook will ignore getting the list of proxies. This is helpful for the allowance flow (which might need to be updated if user picked minimum allowance for example).
  

  
## How to test 🧪
- use it, tell me what you think and how you feel 💡 
