### PR TITLE
[SC-7756] Set allowance with transaction result, zero fee 

### DIFF
--- a/features/aave/common/components/informationContainer/FeesInformation.tsx
+++ b/features/aave/common/components/informationContainer/FeesInformation.tsx
@@ -22,10 +22,13 @@ export function FeesInformation({ estimatedGasPrice, swap }: FeesInformationProp
   const { t } = useTranslation()
   const [showBreakdown, setShowBreakdown] = React.useState(false)
 
-  const oasisFeeDisplayInDebtToken = formatAmount(
-    amountFromWei(swap.tokenFee, swap[swap.collectFeeFrom].symbol),
-    swap[swap.collectFeeFrom].symbol,
-  )
+  const oasisFeeDisplayInDebtToken = swap.tokenFee.isZero()
+    ? '0'
+    : formatAmount(
+        amountFromWei(swap.tokenFee, swap[swap.collectFeeFrom].symbol),
+        swap[swap.collectFeeFrom].symbol,
+      )
+
   return (
     <>
       <VaultChangesInformationItem

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -273,6 +273,7 @@ export function createManageAaveStateMachine(
               exit: ['killAllowanceMachine'],
               on: {
                 ALLOWANCE_SUCCESS: {
+                  actions: ['updateAllowance'],
                   target: ['reviewingAdjusting', '#manageAaveStateMachine.background.debouncing'],
                 },
               },
@@ -282,6 +283,7 @@ export function createManageAaveStateMachine(
               exit: ['killAllowanceMachine'],
               on: {
                 ALLOWANCE_SUCCESS: {
+                  actions: ['updateAllowance'],
                   target: ['manageDebt', '#manageAaveStateMachine.background.debouncingManage'],
                 },
               },
@@ -291,6 +293,7 @@ export function createManageAaveStateMachine(
               exit: ['killAllowanceMachine'],
               on: {
                 ALLOWANCE_SUCCESS: {
+                  actions: ['updateAllowance'],
                   target: [
                     'manageCollateral',
                     '#manageAaveStateMachine.background.debouncingManage',
@@ -618,6 +621,31 @@ export function createManageAaveStateMachine(
           return {
             tokenBalance: event.balance.deposit.balance,
             tokenPrice: event.balance.deposit.price,
+          }
+        }),
+        updateAllowance: assign((context, event) => {
+          const result = Object.entries(context.tokens).find(([_, token]) => event.token === token)
+          if (result === undefined) {
+            return {}
+          }
+
+          const [type] = result
+
+          if (context.allowance === undefined) {
+            return {
+              allowance: {
+                collateral: zero,
+                debt: zero,
+                deposit: zero,
+                [type]: event.amount,
+              },
+            }
+          }
+          return {
+            allowance: {
+              ...context.allowance,
+              [type]: event.amount,
+            },
           }
         }),
       },

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -239,6 +239,7 @@ export function createOpenAaveStateMachine(
               exit: ['killAllowanceMachine'],
               on: {
                 ALLOWANCE_SUCCESS: {
+                  actions: ['updateAllowance'],
                   target: 'editing',
                 },
               },
@@ -551,6 +552,31 @@ export function createOpenAaveStateMachine(
         disableChangingAddresses: assign((_) => {
           return {
             blockSettingCalculatedAddresses: true,
+          }
+        }),
+        updateAllowance: assign((context, event) => {
+          const result = Object.entries(context.tokens).find(([_, token]) => event.token === token)
+          if (result === undefined) {
+            return {}
+          }
+
+          const [type] = result
+
+          if (context.allowance === undefined) {
+            return {
+              allowance: {
+                collateral: zero,
+                debt: zero,
+                deposit: zero,
+                [type]: event.amount,
+              },
+            }
+          }
+          return {
+            allowance: {
+              ...context.allowance,
+              [type]: event.amount,
+            },
           }
         }),
       },

--- a/features/stateMachines/allowance/state/createAllowanceStateMachine.ts
+++ b/features/stateMachines/allowance/state/createAllowanceStateMachine.ts
@@ -43,7 +43,12 @@ export interface AllowanceTxMeta extends TxMeta {
   amount: BigNumber
 }
 
-export type AllowanceStateMachineResponseEvent = { type: 'ALLOWANCE_SUCCESS' }
+export type AllowanceStateMachineResponseEvent = {
+  type: 'ALLOWANCE_SUCCESS'
+  amount: BigNumber
+  token: string
+  spender: string
+}
 
 export type AllowanceStateMachineEvent =
   | AllowanceStateMachineResponseEvent
@@ -138,7 +143,12 @@ export function createAllowanceStateMachine(
           }
           return undefined
         }),
-        sendAllowanceSetEvent: sendParent({ type: 'ALLOWANCE_SUCCESS' }),
+        sendAllowanceSetEvent: sendParent((context) => ({
+          type: 'ALLOWANCE_SUCCESS',
+          amount: getEffectiveAllowanceAmount(context),
+          token: context.token,
+          spender: context.spender,
+        })),
       },
     },
   )


### PR DESCRIPTION
# changes
- Now allowance machine returns the result of the transaction
- State machines update the allowance just after the transaction
- Fee information displays 0 if a token fee is zero. 
