### PR TITLE
disable follow button when wallet not connected

### DIFF
--- a/features/follow/common/FollowButton.tsx
+++ b/features/follow/common/FollowButton.tsx
@@ -12,6 +12,7 @@ interface FollowButtonProps {
   isProcessing: boolean
   short?: boolean
   sx?: SxStyleProp
+  isWalletConnected?: boolean
 }
 
 export function FollowButton({
@@ -20,6 +21,7 @@ export function FollowButton({
   isProcessing,
   short,
   sx,
+  isWalletConnected,
 }: FollowButtonProps) {
   const { t } = useTranslation()
   const [isHovering, setIsHovering] = useState(false)
@@ -35,7 +37,7 @@ export function FollowButton({
 
   return (
     <Button
-      disabled={isProcessing}
+      disabled={isProcessing || !isWalletConnected}
       onClick={buttonClickHandler}
       sx={{
         position: 'relative',

--- a/features/follow/common/FollowButtonControl.tsx
+++ b/features/follow/common/FollowButtonControl.tsx
@@ -1,6 +1,7 @@
 import { UsersWhoFollowVaults } from '@prisma/client'
 import BigNumber from 'bignumber.js'
 import { FollowButton } from 'features/follow/common/FollowButton'
+import { accountIsConnectedValidator } from 'features/form/commonValidators'
 import {
   followVaultUsingApi,
   getFollowFromApi,
@@ -59,6 +60,7 @@ export function FollowButtonControl({
       }
     }
   }
+  const isWalletConnected = accountIsConnectedValidator({ account: followerAddress })
   return (
     <FollowButton
       isProcessing={isProcessing}
@@ -66,6 +68,7 @@ export function FollowButtonControl({
       buttonClickHandler={buttonClickHandler}
       short={short}
       sx={sx}
+      isWalletConnected={isWalletConnected}
     />
   )
 


### PR DESCRIPTION
# [Disabled follow button when wallet not connected](https://app.shortcut.com/oazo-apps/story/7751/disable-follow-button-when-wallet-not-connected)

  
## Changes 👷‍♀️
- Disabled follow button when wallet not connected
  
## How to test 🧪
- Follow button on vault overview should be disabled when wallet not connected, and enabled when wallet is connected and limitof followed vaults is not reached, and is not progressing
- Also check GUNI

![image](https://user-images.githubusercontent.com/6871923/215735043-691f7de5-d40d-477c-86a9-ffe5d5828d03.png)
