### PR TITLE
DPM/Allowance flow helpers - fixes

### DIFF
--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -53,7 +53,7 @@ export function FlowSidebar({
 }: CreateDPMAccountViewProps) {
   const [dpmState, dpmSend] = useActor(dpmMachine)
   const [allowanceState] = useActor(allowanceMachine)
-  const allowanceConsidered = token !== 'ETH' && amount
+  const allowanceConsidered = !!token && token !== 'ETH' && amount
 
   if (!isWalletConnected) {
     return <NoConnectionStateView noConnectionContent={noConnectionContent} />

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -141,15 +141,19 @@ export function useFlowState({
     }
   }, [walletAddress, userProxyList])
 
-  // allowance machine
+  // a case when proxy is ready and amount/token is not provided (skipping allowance)
   useEffect(() => {
     if (!isProxyReady || !allDefined(walletAddress, amount, token)) return
-    if (!!token || !!amount || new BigNumber(amount || NaN).isNaN()) {
+    if (!token || !amount || new BigNumber(amount || NaN).isNaN()) {
       setLoading(false)
       setAllowanceReady(false)
       callBackIfDefined(onEverythingReady)
-      return
     }
+  }, [token, amount?.toString(), isProxyReady])
+
+  // allowance machine
+  useEffect(() => {
+    if (!isProxyReady || !allDefined(walletAddress, amount, token)) return
     if (token === 'ETH') {
       setLoading(false)
       setAllowanceReady(true)
@@ -193,14 +197,14 @@ export function useFlowState({
       allowanceMachineSubscription.unsubscribe()
       allowanceSubscription.unsubscribe()
     }
-  }, [walletAddress, availableProxies, amount?.toString(), token, onEverythingReady, onGoBack])
+  }, [walletAddress, availableProxies, amount?.toString(), token, onGoBack])
 
   // wrapping up
   useEffect(() => {
     if (isAllowanceReady && amount && token && availableProxies.length) {
       callBackIfDefined(onEverythingReady)
     }
-  }, [isAllowanceReady, availableProxies, amount?.toString(), onEverythingReady])
+  }, [isAllowanceReady, availableProxies, amount?.toString()])
 
   useEffect(() => {
     if (isProxyReady && allDefined(amount, token)) {

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -58,7 +58,7 @@ export function useFlowState({
 
   const isProxyReady = !!availableProxies.length
 
-  const callBackIfDefined = (callback: CallbacksType) => {
+  function callBackIfDefined(callback: CallbacksType) {
     if (typeof callback === 'function') {
       callback({
         availableProxies,

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -100,7 +100,7 @@ export function useFlowState({
       walletConnectionSubscription.unsubscribe()
       proxyMachineSubscription.unsubscribe()
     }
-  }, [])
+  }, [onGoBack])
 
   // list of (all) DPM proxies
   useEffect(() => {
@@ -185,14 +185,14 @@ export function useFlowState({
       allowanceMachineSubscription.unsubscribe()
       allowanceSubscription.unsubscribe()
     }
-  }, [walletAddress, availableProxies, amount?.toString(), token])
+  }, [walletAddress, availableProxies, amount?.toString(), token, onEverythingReady, onGoBack])
 
   // wrapping up
   useEffect(() => {
     if (isAllowanceReady && amount && token && availableProxies.length) {
       callBackIfDefined(onEverythingReady)
     }
-  }, [isAllowanceReady, availableProxies, amount?.toString()])
+  }, [isAllowanceReady, availableProxies, amount?.toString(), onEverythingReady])
 
   useEffect(() => {
     if (isProxyReady && allDefined(amount, token)) {


### PR DESCRIPTION
# [DPM/Allowance flow helpers - fixes](https://app.shortcut.com/oazo-apps/story/7707/create-a-component-for-creating-dpm-and-allowance-flow)

Fixes for above.
  
## Changes 👷‍♀️
- proper handling of the `''` (empty string) token as well as wrong or not provided amount
- in the above situation allowance flow is skipped and `onEverythingReady` callback is fired, but with `isAllowanceReady` set to `false`
- fixes callback handling
- added `asUserAction` to callbacks (true if user action, false if done automatically)
  
## How to test 🧪
- I know who you are, you can test it better than me 👽 
