### PR TITLE
🧿 Ajna form without wallet connection

### DIFF
--- a/components/sidebar/SidebarSectionFooterButton.tsx
+++ b/components/sidebar/SidebarSectionFooterButton.tsx
@@ -1,4 +1,4 @@
-import { useRedirect } from 'helpers/useRedirect'
+import { AppLink } from 'components/Links'
 import React from 'react'
 import { Button, Spinner } from 'theme-ui'
 
@@ -14,37 +14,48 @@ export interface SidebarSectionFooterButtonProps {
 }
 
 export function SidebarSectionFooterButton({
+  hidden,
+  url,
+  ...rest
+}: SidebarSectionFooterButtonProps) {
+  return (
+    <>
+      {!hidden &&
+        (url ? (
+          <AppLink href={url} sx={{ display: 'block' }}>
+            <SidebarSectionFooterButtonIner {...rest} />
+          </AppLink>
+        ) : (
+          <SidebarSectionFooterButtonIner {...rest} />
+        ))}
+    </>
+  )
+}
+
+export function SidebarSectionFooterButtonIner({
   variant = 'primary',
   label,
   steps,
   disabled,
-  hidden,
   isLoading,
   action,
-  url,
-}: SidebarSectionFooterButtonProps) {
-  const { replace } = useRedirect()
-
+}: Omit<SidebarSectionFooterButtonProps, 'hidden' | 'url'>) {
   return (
-    <>
-      {!hidden && (
-        <Button
-          disabled={disabled}
-          variant={variant}
-          onClick={() => {
-            if (action) action()
-            if (url) replace(url)
-          }}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          {isLoading && <Spinner size={24} color="neutral10" sx={{ mr: 2, mb: '2px' }} />}
-          {label} {steps && `(${steps[0]}/${steps[1]})`}
-        </Button>
-      )}
-    </>
+    <Button
+      disabled={disabled}
+      variant={variant}
+      onClick={() => {
+        if (action) action()
+      }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+      }}
+    >
+      {isLoading && <Spinner size={24} color="neutral10" sx={{ mr: 2, mb: '2px' }} />}
+      {label} {steps && `(${steps[0]}/${steps[1]})`}
+    </Button>
   )
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -7,18 +7,32 @@ import { AjnaBorrowFormContentTransaction } from 'features/ajna/borrow/sidebars/
 import { getPrimaryButtonLabelKey, getTextButtonLabelKey } from 'features/ajna/common/helpers'
 import { AjnaBorrowPanel } from 'features/ajna/common/types'
 import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAccount } from 'helpers/useAccount'
 import { useTranslation } from 'next-i18next'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid } from 'theme-ui'
 
 export function AjnaBorrowFormContent() {
   const { t } = useTranslation()
+  const { walletAddress } = useAccount()
   const {
     environment: { collateralToken, flow, product, quoteToken },
-    steps: { currentStep, isStepValid, isStepWithBack, setNextStep, setPrevStep },
+    steps: {
+      currentStep,
+      editingStep,
+      isStepValid,
+      isStepWithBack,
+      setNextStep,
+      setPrevStep,
+      setStep,
+    },
   } = useAjnaBorrowContext()
 
   const [panel, setPanel] = useState<AjnaBorrowPanel>('collateral')
+
+  useEffect(() => {
+    if (!walletAddress && currentStep !== 'risk') setStep(editingStep)
+  }, [walletAddress])
 
   const sidebarSectionProps: SidebarSectionProps = {
     title: t(`ajna.${product}.common.form.title.${currentStep}`),
@@ -50,9 +64,13 @@ export function AjnaBorrowFormContent() {
       </Grid>
     ),
     primaryButton: {
-      label: t(getPrimaryButtonLabelKey({ currentStep, product })),
-      disabled: !isStepValid,
-      action: setNextStep,
+      label: t(getPrimaryButtonLabelKey({ currentStep, product, walletAddress })),
+      disabled: !!walletAddress && !isStepValid,
+      ...(!walletAddress && currentStep === editingStep
+        ? {
+            url: '/connect',
+          }
+        : { action: setNextStep }),
     },
     ...(isStepWithBack && {
       textButton: {

--- a/features/ajna/common/helpers.tsx
+++ b/features/ajna/common/helpers.tsx
@@ -14,12 +14,15 @@ export function getAjnaWithArrowColorScheme(): SxStyleProp {
   }
 }
 
-export function getPrimaryButtonLabelKey({ currentStep }: GetKeyMethodParams): string {
+export function getPrimaryButtonLabelKey({
+  currentStep,
+  walletAddress,
+}: GetKeyMethodParams & { walletAddress?: string }): string {
   switch (currentStep) {
     case 'risk':
       return 'i-understand'
     default:
-      return 'confirm'
+      return walletAddress ? 'confirm' : 'connect-wallet-button'
   }
 }
 

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -41,6 +41,7 @@ interface AjnaBorrowPosition {
 
 interface AjnaBorrowSteps {
   currentStep: AjnaStatusStep
+  editingStep: Extract<AjnaStatusStep, 'setup' | 'manage'>
   isExternalStep: boolean
   isStepWithBack: boolean
   isStepWithTransaction: boolean
@@ -106,10 +107,11 @@ export function AjnaBorrowContextProvider({
     else throw new Error(`A step with index ${i} does not exist in form flow.`)
   }
 
-  const setupStepManager = () => {
+  const setupStepManager = (): AjnaBorrowSteps => {
     return {
       currentStep,
       steps,
+      editingStep: props.flow === 'open' ? 'setup' : 'manage',
       isExternalStep: isExternalStep({ currentStep }),
       isStepWithBack: isStepWithBack({ currentStep }),
       isStepWithTransaction: isStepWithTransaction({ currentStep }),
@@ -120,7 +122,7 @@ export function AjnaBorrowContextProvider({
     }
   }
 
-  const setupTxManager = () => {
+  const setupTxManager = (): AjnaBorrowTx => {
     return {
       txStatus,
       setTxStatus,

--- a/features/ajna/controls/AjnaProductController.tsx
+++ b/features/ajna/controls/AjnaProductController.tsx
@@ -66,8 +66,8 @@ export function AjnaProductController({
   const [balancesInfoArrayData, balancesInfoArrayError] = useObservable(
     useMemo(
       () =>
-        collateralTokenData && quoteTokenData && walletAddress
-          ? balancesInfoArray$([collateralTokenData, quoteTokenData], walletAddress)
+        collateralTokenData && quoteTokenData
+          ? balancesInfoArray$([collateralTokenData, quoteTokenData], walletAddress || '')
           : EMPTY,
       [collateralTokenData, walletAddress],
     ),


### PR DESCRIPTION
🧿 Ajna form without wallet connection

You can simulate if no wallet is connected. On setup or manage steps, if wallet is disconnected, primary button will take user to `/connect` page. If users disconnects wallet while on any later step, he is going to be taken back to setup.
![image](https://user-images.githubusercontent.com/16230404/216553525-26a866b3-4946-4f62-9093-7d6a95ab37ee.png)
  
## Changes 👷‍♀️

- Added disconnected wallet handling.
  
## How to test 🧪

Play with form with wallet connected and disconnected and compare it it behaves like it is in description above.
