### PR TITLE
Flow state components changes

### DIFF
--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -42,8 +42,7 @@ function NoConnectionStateView({
 
 export function FlowSidebar({
   noConnectionContent,
-  dpmMachine,
-  allowanceMachine,
+  internals,
   isWalletConnected = false,
   token,
   amount,
@@ -51,8 +50,8 @@ export function FlowSidebar({
   isAllowanceReady,
   isLoading,
 }: CreateDPMAccountViewProps) {
-  const [dpmState, dpmSend] = useActor(dpmMachine)
-  const [allowanceState] = useActor(allowanceMachine)
+  const [dpmState, dpmSend] = useActor(internals.dpmMachine)
+  const [allowanceState] = useActor(internals.allowanceMachine)
   const allowanceConsidered = !!token && token !== 'ETH' && amount
 
   if (!isWalletConnected) {
@@ -79,7 +78,7 @@ export function FlowSidebar({
       case allowanceState.matches('txSuccess'):
         return (
           <AllowanceView
-            allowanceMachine={allowanceMachine}
+            allowanceMachine={internals.allowanceMachine}
             isLoading={isLoading}
             backButtonOnFirstStep
           />

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -1,9 +1,12 @@
 import { useActor } from '@xstate/react'
+import BigNumber from 'bignumber.js'
 import { AllowanceView } from 'features/stateMachines/allowance'
 import { CreateDPMAccountViewConsumed } from 'features/stateMachines/dpmAccount/CreateDPMAccountView'
-import { useFlowState } from 'helpers/useFlowState'
+import { allDefined } from 'helpers/allDefined'
+import { callBackIfDefined } from 'helpers/callBackIfDefined'
+import { useFlowState, UseFlowStateCBParamsType, UseFlowStateCBType } from 'helpers/useFlowState'
 import { useTranslation } from 'next-i18next'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Grid, Text } from 'theme-ui'
 
 import { SidebarSection, SidebarSectionProps } from './sidebar/SidebarSection'
@@ -49,10 +52,46 @@ export function FlowSidebar({
   isProxyReady,
   isAllowanceReady,
   isLoading,
+  walletAddress,
+  availableProxies,
+  asUserAction,
+  onEverythingReady,
 }: CreateDPMAccountViewProps) {
   const [dpmState, dpmSend] = useActor(internals.dpmMachine)
   const [allowanceState] = useActor(internals.allowanceMachine)
   const allowanceConsidered = !!token && token !== 'ETH' && amount
+
+  const callbackParams = {
+    availableProxies,
+    walletAddress,
+    amount,
+    token,
+    isProxyReady,
+    isWalletConnected,
+    isAllowanceReady,
+    asUserAction,
+  }
+
+  // a case when proxy is ready and amount/token is not provided (skipping allowance)
+  useEffect(() => {
+    if (!isProxyReady || !allDefined(walletAddress, amount, token)) return
+    if (!token || !amount || new BigNumber(amount || NaN).isNaN()) {
+      callBackIfDefined<UseFlowStateCBType, UseFlowStateCBParamsType>(
+        callbackParams,
+        onEverythingReady,
+      )
+    }
+  }, [token, amount?.toString(), isProxyReady])
+
+  // wrapping up
+  useEffect(() => {
+    if (isAllowanceReady && amount && token && availableProxies.length) {
+      callBackIfDefined<UseFlowStateCBType, UseFlowStateCBParamsType>(
+        callbackParams,
+        onEverythingReady,
+      )
+    }
+  }, [isAllowanceReady, availableProxies, amount?.toString()])
 
   if (!isWalletConnected) {
     return <NoConnectionStateView noConnectionContent={noConnectionContent} />

--- a/helpers/callBackIfDefined.ts
+++ b/helpers/callBackIfDefined.ts
@@ -1,0 +1,5 @@
+export function callBackIfDefined<CallbackType, DataType>(data: DataType, callback?: CallbackType) {
+  if (typeof callback === 'function') {
+    callback(data)
+  }
+}

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -213,8 +213,10 @@ export function useFlowState({
   }, [amount?.toString()])
 
   return {
-    dpmMachine,
-    allowanceMachine,
+    internals: {
+      dpmMachine,
+      allowanceMachine,
+    },
     availableProxies,
     walletAddress,
     amount,


### PR DESCRIPTION
# Flow state components changes

If you have any questions regarding how this works - consult the ADR.
  
## Changes 👷‍♀️
- `onEverythingReady` has been moved to the UI component - preventing it from executing until 100% necessary
- exported `callBackIfDefined` for reusability
- machines provided by the hook are now inside `internals` (since they're not really that useful for the user; minimizing the noise)
  
## How to test 🧪
🤷 
