### PR TITLE
[FE] Create Product card with feature toggle

### DIFF
--- a/blockchain/aave-v3/aaveV3Oracle.ts
+++ b/blockchain/aave-v3/aaveV3Oracle.ts
@@ -1,18 +1,24 @@
 import BigNumber from 'bignumber.js'
+import { CallDef } from 'blockchain/calls/callsHelpers'
 import { amountFromWei } from 'blockchain/utils'
 import { AaveV3Oracle } from 'types/web3-v1-contracts/aave-v3-oracle'
-
-import { CallDef } from '../calls/callsHelpers'
 export interface AaveV3AssetsPricesParameters {
   tokens: string[]
+}
+
+export const getAaveV3OracleBaseCurrencyUnit: CallDef<void, BigNumber> = {
+  call: (_, { contract, aaveV3Oracle }) =>
+    contract<AaveV3Oracle>(aaveV3Oracle).methods.BASE_CURRENCY_UNIT,
+  prepareArgs: () => [],
+  postprocess: (baseCurrencyUnit) => new BigNumber(baseCurrencyUnit),
 }
 
 export const getAaveV3AssetsPrices: CallDef<AaveV3AssetsPricesParameters, BigNumber[]> = {
   call: (_, { contract, aaveV3Oracle }) =>
     contract<AaveV3Oracle>(aaveV3Oracle).methods.getAssetsPrices,
   prepareArgs: ({ tokens }, context) => [tokens.map((token) => context.tokens[token].address)],
-  postprocess: (tokenPrices) =>
-    tokenPrices.map((tokenPriceInEth) => amountFromWei(new BigNumber(tokenPriceInEth), 'ETH')),
+  // tokenPrice needs BASE_CURRENCY_UNIT
+  postprocess: (tokenPrices) => tokenPrices.map((tokenPrice) => new BigNumber(tokenPrice)),
 }
 
 export const getAaveV3OracleAssetPriceData$: CallDef<{ token: string }, BigNumber> = {

--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -28,7 +28,7 @@ export interface TokenConfig {
   background: string
   digitsInstant?: number
   safeCollRatio?: number
-  protocol: 'maker' | 'aave'
+  protocol: 'maker' | 'aaveV2' | 'aaveV3'
 }
 
 export const COIN_TAGS = ['stablecoin', 'lp-token'] as const
@@ -36,7 +36,8 @@ export type CoinTag = ElementOf<typeof COIN_TAGS>
 
 export enum ProtocolLongNames {
   maker = 'Maker',
-  aave = 'Aave V2',
+  aaveV2 = 'Aave V2',
+  aaveV3 = 'Aave V3',
 }
 
 export const tokens: TokenConfig[] = [
@@ -704,7 +705,7 @@ export const tokens: TokenConfig[] = [
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/Aave_stETH.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v2.gif'),
     tags: [],
-    protocol: 'aave',
+    protocol: 'aaveV2',
   },
   {
     symbol: 'stETHusdc',
@@ -721,7 +722,7 @@ export const tokens: TokenConfig[] = [
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/Aave_stETH.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v2.gif'),
     tags: [],
-    protocol: 'aave',
+    protocol: 'aaveV2',
   },
   {
     symbol: 'ethusdc',
@@ -737,7 +738,7 @@ export const tokens: TokenConfig[] = [
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/Aave_ETH.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_ETH_v2.gif'),
     tags: [],
-    protocol: 'aave',
+    protocol: 'aaveV2',
   },
   {
     symbol: 'wBTCusdc',
@@ -754,7 +755,24 @@ export const tokens: TokenConfig[] = [
     bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/Aave_WBTC.png'),
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_WBTC_v2.gif'),
     tags: [],
-    protocol: 'aave',
+    protocol: 'aaveV2',
+  },
+  {
+    symbol: 'wstETHeth',
+    // copied from above, used as a placeholder for now
+    precision: 18,
+    digits: 5,
+    digitsInstant: 2,
+    name: 'WSTETH / USDC',
+    icon: 'aave_wsteth_usdc',
+    iconCircle: 'aave_wsteth_usdc',
+    iconColor: 'aave_wsteth_usdc',
+    color: '#E2F7F9',
+    background: 'linear-gradient(160.47deg, #E2F7F9 0.35%, #D3F3F5 99.18%), #000000',
+    bannerIcon: staticFilesRuntimeUrl('/static/img/tokens/Aave_STETH.png'),
+    bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_STETH_v2.gif'),
+    tags: [],
+    protocol: 'aaveV3',
   },
   {
     symbol: 'RETH',

--- a/components/productCards/ProductCardEarnAave.tsx
+++ b/components/productCards/ProductCardEarnAave.tsx
@@ -2,6 +2,7 @@ import { RiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { TokenMetadataType } from 'blockchain/tokensMetadata'
 import { useAaveContext } from 'features/aave/AaveContextProvider'
+import { IStrategyConfig } from 'features/aave/common/StrategyConfigTypes'
 import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { displayMultiple } from 'helpers/display-multiple'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
@@ -11,8 +12,6 @@ import { useSimulationYields } from 'helpers/useSimulationYields'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { IStrategyConfig } from '../../features/aave/common/StrategyConfigTypes'
-import { LendingProtocol } from '../../lendingProtocols'
 import { ProductCard, ProductCardProtocolLink } from './ProductCard'
 import { ProductCardsLoader } from './ProductCardsWrapper'
 
@@ -28,8 +27,9 @@ const aaveEarnCalcValueBasis = {
 
 export function ProductCardEarnAave({ cardData, strategy }: ProductCardEarnAaveProps) {
   const { t } = useTranslation()
+
   const { earnCollateralsReserveData, aaveAvailableLiquidityInUSDC$ } = useAaveContext(
-    LendingProtocol.AaveV2,
+    strategy.protocol,
   )
   const [aaveReserveState, aaveReserveStateError] = useObservable(
     earnCollateralsReserveData[strategy.tokens.collateral],

--- a/components/productCards/ProductCardsContainer.tsx
+++ b/components/productCards/ProductCardsContainer.tsx
@@ -1,4 +1,5 @@
 import { getTokens } from 'blockchain/tokensMetadata'
+import { useAppContext } from 'components/AppContextProvider'
 import { ProductCardEarnDsr } from 'components/productCards/ProductCardEarnDsr'
 import { getAaveStrategy } from 'features/aave/strategyConfig'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
@@ -8,7 +9,6 @@ import { ProductCardData } from 'helpers/productCards'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
 
-import { useAppContext } from '../AppContextProvider'
 import { ProductCardBorrow } from './ProductCardBorrow'
 import { ProductCardEarnAave } from './ProductCardEarnAave'
 import { ProductCardEarnMaker } from './ProductCardEarnMaker'

--- a/components/productCards/ProductCardsFilter.tsx
+++ b/components/productCards/ProductCardsFilter.tsx
@@ -1,12 +1,10 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { TokenConfig } from 'blockchain/tokensMetadata'
+import { useAppContext } from 'components/AppContextProvider'
 import { AaveContextProvider, isAaveContextAvailable } from 'features/aave/AaveContextProvider'
-import React, { useState } from 'react'
-import { Box, Button, Flex, Text } from 'theme-ui'
-
-import { WithLoadingIndicator } from '../../helpers/AppSpinner'
-import { WithErrorHandler } from '../../helpers/errorHandlers/WithErrorHandler'
-import { useObservable } from '../../helpers/observableHook'
+import { WithLoadingIndicator } from 'helpers/AppSpinner'
+import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
+import { useObservable } from 'helpers/observableHook'
 import {
   ilkToEntryToken,
   IlkTokenMap,
@@ -14,8 +12,10 @@ import {
   ProductCardData,
   ProductLandingPagesFilter,
   ProductLandingPagesFiltersKeys,
-} from '../../helpers/productCards'
-import { useAppContext } from '../AppContextProvider'
+} from 'helpers/productCards'
+import React, { useState } from 'react'
+import { Box, Button, Flex, Text } from 'theme-ui'
+
 import { ProductCardMultiplyAave } from './ProductCardMultiplyAave'
 import { ProductCardsSelect } from './ProductCardsSelect'
 import { ProductCardsLoader, ProductCardsWrapper } from './ProductCardsWrapper'
@@ -121,7 +121,7 @@ export function ProductCardsFilter({
                 {otherStrategies
                   .filter(({ protocol, name }) => {
                     return (
-                      protocol === 'aave' &&
+                      protocol === 'aaveV2' &&
                       (name.toLocaleUpperCase().includes(currentFilter.toLocaleUpperCase()) ||
                         currentFilter.toLocaleUpperCase() === 'FEATURED')
                     )

--- a/features/aave/AaveContext.ts
+++ b/features/aave/AaveContext.ts
@@ -1,15 +1,15 @@
+import { getAaveV2AssetsPrices } from 'blockchain/aave'
+import { observe } from 'blockchain/calls/observe'
+import { TokenBalances } from 'blockchain/tokens'
+import { AppContext } from 'components/AppContext'
+import { LendingProtocol } from 'lendingProtocols'
+import { prepareAaveTotalValueLocked$ } from 'lendingProtocols/aave-v2/pipelines'
 import { memoize } from 'lodash'
 import moment from 'moment'
 import { curry } from 'ramda'
 import { Observable, of } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 
-import { getAaveV2AssetsPrices } from '../../blockchain/aave'
-import { observe } from '../../blockchain/calls/observe'
-import { TokenBalances } from '../../blockchain/tokens'
-import { AppContext } from '../../components/AppContext'
-import { LendingProtocol } from '../../lendingProtocols'
-import { prepareAaveTotalValueLocked$ } from '../../lendingProtocols/aave-v2/pipelines'
 import { getAaveStEthYield } from './common'
 import {
   getAdjustAaveParametersMachine,

--- a/features/aave/AaveContextProvider.tsx
+++ b/features/aave/AaveContextProvider.tsx
@@ -1,8 +1,8 @@
+import { useAppContext } from 'components/AppContextProvider'
+import { WithChildren } from 'helpers/types'
+import { LendingProtocol } from 'lendingProtocols'
 import React, { useContext, useEffect, useState } from 'react'
 
-import { useAppContext } from '../../components/AppContextProvider'
-import { WithChildren } from '../../helpers/types'
-import { LendingProtocol } from '../../lendingProtocols'
 import { AaveContext, setupAaveV2Context } from './AaveContext'
 import { setupAaveV3Context } from './SetupAaveV3Context'
 

--- a/features/aave/SetupAaveV3Context.ts
+++ b/features/aave/SetupAaveV3Context.ts
@@ -1,15 +1,15 @@
+import { getAaveV3AssetsPrices } from 'blockchain/aave-v3'
+import { observe } from 'blockchain/calls/observe'
+import { TokenBalances } from 'blockchain/tokens'
+import { AppContext } from 'components/AppContext'
+import { LendingProtocol } from 'lendingProtocols'
+import { prepareAaveTotalValueLocked$ } from 'lendingProtocols/aave-v3/pipelines'
 import { memoize } from 'lodash'
 import moment from 'moment/moment'
 import { curry } from 'ramda'
 import { Observable, of } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 
-import { getAaveV3AssetsPrices } from '../../blockchain/aave-v3'
-import { observe } from '../../blockchain/calls/observe'
-import { TokenBalances } from '../../blockchain/tokens'
-import { AppContext } from '../../components/AppContext'
-import { LendingProtocol } from '../../lendingProtocols'
-import { prepareAaveTotalValueLocked$ } from '../../lendingProtocols/aave-v3/pipelines'
 import { getAaveStEthYield } from './common'
 import {
   getAdjustAaveParametersMachine,

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -1,21 +1,21 @@
 import { RiskRatio } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
-import { ViewPositionSectionComponent } from 'features/earn/aave/components/ViewPositionSectionComponent'
-import { getFeatureToggle } from 'helpers/useFeatureToggle'
-import { zero } from 'helpers/zero'
-
-import { LendingProtocol } from '../../lendingProtocols'
-import { AaveEarnFaq } from '../content/faqs/aave/earn'
-import { AaveMultiplyFaq } from '../content/faqs/aave/multiply'
+import { AaveEarnFaq } from 'features/content/faqs/aave/earn'
+import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
 import {
   AavePositionHeaderNoDetails,
   headerWithDetails,
-} from '../earn/aave/components/AavePositionHeader'
-import { ManageSectionComponent } from '../earn/aave/components/ManageSectionComponent'
-import { SimulateSectionComponent } from '../earn/aave/components/SimulateSectionComponent'
-import { adjustRiskSliders } from '../earn/aave/riskSliderConfig'
-import { AaveMultiplyManageComponent } from '../multiply/aave/components/AaveMultiplyManageComponent'
-import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from '../multiply/aave/riskSliderConfig'
+} from 'features/earn/aave/components/AavePositionHeader'
+import { ManageSectionComponent } from 'features/earn/aave/components/ManageSectionComponent'
+import { SimulateSectionComponent } from 'features/earn/aave/components/SimulateSectionComponent'
+import { ViewPositionSectionComponent } from 'features/earn/aave/components/ViewPositionSectionComponent'
+import { adjustRiskSliders } from 'features/earn/aave/riskSliderConfig'
+import { AaveMultiplyManageComponent } from 'features/multiply/aave/components/AaveMultiplyManageComponent'
+import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/multiply/aave/riskSliderConfig'
+import { getFeatureToggle } from 'helpers/useFeatureToggle'
+import { zero } from 'helpers/zero'
+import { LendingProtocol } from 'lendingProtocols'
+
 import { AaveManageHeader, AaveOpenHeader } from './common/components/AaveHeader'
 import { adjustRiskView } from './common/components/SidebarAdjustRiskView'
 import { IStrategyConfig, ProxyType } from './common/StrategyConfigTypes'
@@ -56,6 +56,7 @@ export const strategies: Array<IStrategyConfig> = [
     riskRatios: adjustRiskSliders.wstethEth.riskRatios,
     type: 'Earn',
     protocol: LendingProtocol.AaveV3,
+    featureToggle: 'AaveV3EarnWSTETH' as const,
   },
   {
     urlSlug: 'stETHeth',

--- a/features/asset/AssetView.tsx
+++ b/features/asset/AssetView.tsx
@@ -1,5 +1,10 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { AppLink } from 'components/Links'
+import {
+  BorrowProductCardsContainer,
+  EarnProductCardsContainer,
+  MultiplyProductCardsContainer,
+} from 'components/productCards/ProductCardsContainer'
 import { TabBar, TabSection } from 'components/TabBar'
 import { WithArrow } from 'components/WithArrow'
 import { AssetPageContent } from 'content/assets'
@@ -7,12 +12,6 @@ import { getAaveEnabledStrategies } from 'helpers/productCards'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Flex, Grid, Heading, Text } from 'theme-ui'
-
-import {
-  BorrowProductCardsContainer,
-  EarnProductCardsContainer,
-  MultiplyProductCardsContainer,
-} from '../../components/productCards/ProductCardsContainer'
 
 const aaveAssets = {
   // not putting this to ASSETS_PAGES cause we need feature toggles

--- a/features/earn/EarnView.tsx
+++ b/features/earn/EarnView.tsx
@@ -1,4 +1,3 @@
-import { getTokens } from 'blockchain/tokensMetadata'
 import { useAppContext } from 'components/AppContextProvider'
 import { ProductCardEarnAave } from 'components/productCards/ProductCardEarnAave'
 import { ProductCardEarnDsr } from 'components/productCards/ProductCardEarnDsr'
@@ -8,17 +7,17 @@ import {
   ProductCardsWrapper,
 } from 'components/productCards/ProductCardsWrapper'
 import { ProductHeader } from 'components/ProductHeader'
+import { aaveStrategiesList } from 'features/aave/strategyConfig'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
+import { mapStrategyToToken } from 'helpers/mapStrategyToToken'
 import { useObservable } from 'helpers/observableHook'
 import { supportedEarnIlks } from 'helpers/productCards'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
+import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
-
-import { LendingProtocol } from '../../lendingProtocols'
-import { aaveStrategiesList } from '../aave/strategyConfig'
 
 export function EarnView() {
   const { t } = useTranslation()
@@ -28,13 +27,12 @@ export function EarnView() {
   )
   const daiSavingsRate = useFeatureToggle('DaiSavingsRate')
 
-  const aaveEarnStrategies = aaveStrategiesList('Earn', LendingProtocol.AaveV2).map((strategy) => {
-    const tokenConfig = getTokens([strategy.name])[0]
-    return {
-      tokenConfig,
-      strategy,
-    }
-  })
+  const aaveEarnV2Strategies = aaveStrategiesList('Earn', LendingProtocol.AaveV2).map(
+    mapStrategyToToken,
+  )
+  const aaveEarnV3Strategies = aaveStrategiesList('Earn', LendingProtocol.AaveV3).map(
+    mapStrategyToToken,
+  )
   return (
     <Grid
       sx={{
@@ -56,13 +54,15 @@ export function EarnView() {
         <WithLoadingIndicator value={[productCardsIlksData]} customLoader={<ProductCardsLoader />}>
           {([_productCardsIlksData]) => (
             <ProductCardsWrapper>
-              {aaveEarnStrategies.map(({ strategy, tokenConfig }) => (
-                <ProductCardEarnAave
-                  key={tokenConfig.symbol}
-                  cardData={tokenConfig}
-                  strategy={strategy}
-                />
-              ))}
+              {[...aaveEarnV3Strategies, ...aaveEarnV2Strategies].map(
+                ({ strategy, tokenConfig }) => (
+                  <ProductCardEarnAave
+                    key={tokenConfig.symbol}
+                    cardData={tokenConfig}
+                    strategy={strategy}
+                  />
+                ),
+              )}
               {/* TODO move logic regarding dsr to productCardsData$ */}
               {daiSavingsRate && <ProductCardEarnDsr />}
               {_productCardsIlksData.map((cardData) => (

--- a/helpers/mapStrategyToToken.ts
+++ b/helpers/mapStrategyToToken.ts
@@ -1,0 +1,10 @@
+import { getTokens } from 'blockchain/tokensMetadata'
+import { IStrategyConfig } from 'features/aave/common/StrategyConfigTypes'
+
+export function mapStrategyToToken(strategy: IStrategyConfig) {
+  const tokenConfig = getTokens([strategy.name])[0]
+  return {
+    tokenConfig,
+    strategy,
+  }
+}

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -292,7 +292,10 @@ export const productCardsConfig: {
         { strategy: 'stETHusdc' },
         { strategy: 'wBTCusdc' },
       ]),
-      earn: getAaveEnabledStrategies([{ strategy: 'wstETHeth' }, { strategy: 'stETHeth' }]),
+      earn: getAaveEnabledStrategies([
+        { strategy: 'wstETHeth', featureToggle: 'AaveV3EarnWSTETH' },
+        { strategy: 'stETHeth' },
+      ]),
     },
   },
   descriptionCustomKeys: {

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -1,13 +1,7 @@
 import { BigNumber } from 'bignumber.js'
-import { IlkWithBalance } from 'features/ilks/ilksWithBalances'
-import { Feature, getFeatureToggle } from 'helpers/useFeatureToggle'
-import _, { keyBy, sortBy } from 'lodash'
-import { combineLatest, Observable, of } from 'rxjs'
-import { map, startWith, switchMap } from 'rxjs/operators'
-
-import { supportedIlks } from '../blockchain/config'
-import { IlkData } from '../blockchain/ilks'
-import { OraclePriceData, OraclePriceDataArgs } from '../blockchain/prices'
+import { supportedIlks } from 'blockchain/config'
+import { IlkData } from 'blockchain/ilks'
+import { OraclePriceData, OraclePriceDataArgs } from 'blockchain/prices'
 import {
   BTC_TOKENS,
   ETH_TOKENS,
@@ -15,7 +9,13 @@ import {
   LP_TOKENS,
   ONLY_MULTIPLY_TOKENS,
   TokenMetadataType,
-} from '../blockchain/tokensMetadata'
+} from 'blockchain/tokensMetadata'
+import { IlkWithBalance } from 'features/ilks/ilksWithBalances'
+import { Feature, getFeatureToggle } from 'helpers/useFeatureToggle'
+import _, { keyBy, sortBy } from 'lodash'
+import { combineLatest, Observable, of } from 'rxjs'
+import { map, startWith, switchMap } from 'rxjs/operators'
+
 import { zero } from './zero'
 
 export interface ProductCardData {
@@ -292,7 +292,7 @@ export const productCardsConfig: {
         { strategy: 'stETHusdc' },
         { strategy: 'wBTCusdc' },
       ]),
-      earn: getAaveEnabledStrategies([{ strategy: 'stETHeth' }]),
+      earn: getAaveEnabledStrategies([{ strategy: 'wstETHeth' }, { strategy: 'stETHeth' }]),
     },
   },
   descriptionCustomKeys: {

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -21,6 +21,7 @@ export type Feature =
   | 'ReadOnlyAutoTakeProfit'
   | 'DiscoverOasis'
   | 'AaveBorrow'
+  | 'AaveV3EarnWSTETH'
   | 'FollowVaults'
   | 'AaveProtection'
   | 'Ajna'
@@ -44,6 +45,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   ReadOnlyAutoTakeProfit: false,
   DiscoverOasis: true,
   AaveBorrow: false,
+  AaveV3EarnWSTETH: false,
   FollowVaults: false,
   AaveProtection: false,
   Ajna: false,

--- a/lendingProtocols/aave-v2/pipelines/aavePrepareAvailableLiquidity.ts
+++ b/lendingProtocols/aave-v2/pipelines/aavePrepareAvailableLiquidity.ts
@@ -4,10 +4,9 @@ import {
   AaveV2ReserveDataReply,
 } from 'blockchain/aave/aaveV2ProtocolDataProvider'
 import { amountFromWei } from 'blockchain/utils'
+import { zero } from 'helpers/zero'
 import { combineLatest, Observable, of } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
-
-import { zero } from '../../../helpers/zero'
 
 type PrepareAaveAvailableLiquidityProps = [AaveV2ReserveDataReply, BigNumber[]]
 
@@ -26,7 +25,7 @@ export function prepareAaveAvailableLiquidityInUSDC$(
       return availableLiquidityInETH.times(ETH_USDC_price)
     }),
     catchError((error) => {
-      console.log(`Can't get Aave available liquidity for ${reserveDataToken}`, error)
+      console.log(`Can't get Aave V2 available liquidity for ${reserveDataToken}`, error)
       return of(zero)
     }),
   )

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1558,6 +1558,10 @@
         "title": "stETH/ETH Aave",
         "description": "Earn on your ETH with increased staking rewards. Borrow ETH on Aave to get more exposure to stETH."
       },
+      "wstETHeth": {
+        "title": "wstETH/ETH Aave",
+        "description": "Earn on your ETH with increased staking rewards. Borrow ETH on Aave to get more exposure to wstETH."
+      },
       "stETHusdc": {
         "title": "Highest stETH multiple option",
         "description": "Maximise your stETH exposure with Aave and USDC."
@@ -1590,7 +1594,8 @@
       "GUNIV3DAIUSDC1-A": "Get up to {{value}} exposure to the DAI/USDC UNI V3 5bps pool"
     },
     "aave": {
-      "stETHeth": "Get up to {{value}} ETH exposure to stETH"
+      "stETHeth": "Get up to {{value}} ETH exposure to stETH",
+      "wstETHeth": "Get up to {{value}} ETH exposure to wstETH"
     }
   },
   "product-card-title": {


### PR DESCRIPTION
# [[FE] Create Product card with feature toggle](https://app.shortcut.com/oazo-apps/story/7736/fe-create-product-card-with-feature-toggle)

  
## Changes 👷‍♀️
- new product card for wstETH Aave V3
- since Aave V3 oracles report prices in USD there are some changes to the current liquidity available data
- new observable called `getAaveV3OracleBaseCurrencyUnit` which gives you `BASE_CURRENCY_UNIT` (to deal with the new oracle data format)
  
## How to test 🧪
- turn on the feature flag - `AaveV3EarnWSTETH`
- there should be a wstETH/ETH earn card on: 
- home page, Earn tab
- Products -> Earn page
