### PR TITLE
DPM/Allowance flow fixes

### DIFF
--- a/helpers/dummyStateMachine.ts
+++ b/helpers/dummyStateMachine.ts
@@ -1,8 +1,6 @@
 import { useInterpret } from '@xstate/react'
-import { UserDpmAccount } from 'blockchain/userDpmProxies'
 import { AllowanceStateMachine } from 'features/stateMachines/allowance'
 import { DPMAccountStateMachine } from 'features/stateMachines/dpmAccount/state/createDPMAccountStateMachine'
-import { Subject } from 'rxjs'
 import { createMachine, send } from 'xstate'
 
 import { zero } from './zero'
@@ -25,20 +23,10 @@ export const dummyParent = createMachine({
 })
 
 export function setupDpmContext(machine: DPMAccountStateMachine) {
-  const createdDpmAccount = new Subject<UserDpmAccount>()
-  const parentService = useInterpret(dummyParent)
-    .start()
-    .onEvent((event) => {
-      if (event.type === 'DPM_ACCOUNT_CREATED') {
-        // @ts-ignore
-        createdDpmAccount.next(event.userDpmAccount)
-      }
-    })
-
+  const parentService = useInterpret(dummyParent).start()
   const service = useInterpret(machine, { parent: parentService }).start()
   return {
     stateMachine: service,
-    dpmAccounts$: createdDpmAccount.asObservable(),
   }
 }
 

--- a/helpers/useFlowState.ts
+++ b/helpers/useFlowState.ts
@@ -70,6 +70,12 @@ export function useFlowState({
     asUserAction,
   }
 
+  const baseAllowanceContext = {
+    minimumAmount: amount,
+    allowanceType: 'unlimited',
+    token,
+  }
+
   // wallet connection + DPM proxy machine
   useEffect(() => {
     const walletConnectionSubscription = context$.subscribe(({ status, account }) => {
@@ -156,9 +162,7 @@ export function useFlowState({
     }
     const spender = availableProxies[0] // probably needs further thoguht
     allowanceMachine.send('SET_ALLOWANCE_CONTEXT', {
-      minimumAmount: amount,
-      allowanceType: 'unlimited',
-      token,
+      ...baseAllowanceContext,
       spender,
     })
     const allowanceSubscription = allowanceForAccount$(token!, spender).subscribe(
@@ -186,6 +190,10 @@ export function useFlowState({
       if (value === 'txSuccess' && context.allowanceType && event.type === 'CONTINUE') {
         setAsUserAction(true)
         setAllowanceReady(true)
+        allowanceMachine.send('RESET_ALLOWANCE_CONTEXT', {
+          ...baseAllowanceContext,
+          spender,
+        })
       }
     })
     return () => {


### PR DESCRIPTION
# [DPM/Allowance flow - can't set allowance twice in the same process](https://app.shortcut.com/oazo-apps/story/7826/dpm-allowance-flow-can-t-set-allowance-twice-in-the-same-process)
# [DPM/Allowance flow - allowance form resets itself to default value](https://app.shortcut.com/oazo-apps/story/7827/dpm-allowance-flow-allowance-form-resets-itself-to-default-value)
# [DPM/Allowance flow - back button on retry](https://app.shortcut.com/oazo-apps/story/7826/dpm-allowance-flow-can-t-set-allowance-twice-in-the-same-process](https://app.shortcut.com/oazo-apps/story/7863/dpm-allowance-flow-back-button-on-retry))

  
## Changes 👷‍♀️
- added proper resetting of the allowance machine context (fixes two or more allowances in one flow)
- fixed internal state handling when going back after initial allowance is set
- fixed how back button works on failed allowance transaction screen
  
## How to test 🧪
- read above changes
- test them 🧛 
