### PR TITLE
🧿 Always pass data to allowance

### DIFF
--- a/features/ajna/borrow/ajnaBorrowStepManager.ts
+++ b/features/ajna/borrow/ajnaBorrowStepManager.ts
@@ -5,11 +5,18 @@ interface StepManagerWithBorrowForm extends GeneralStepManager {
   formState: AjnaBorrowFormState
 }
 
-export function isBorrowStepValid({ currentStep, formState }: StepManagerWithBorrowForm) {
-  switch (currentStep) {
-    case 'setup':
+export function isBorrowStepValid({ formState }: StepManagerWithBorrowForm) {
+  switch (formState.action) {
+    case 'open':
+    case 'deposit':
       return !!formState.depositAmount?.gt(0)
+    case 'withdraw':
+      return !!formState.withdrawAmount?.gt(0)
+    case 'generate':
+      return !!formState.generateAmount?.gt(0)
+    case 'payback':
+      return !!formState.paybackAmount?.gt(0)
     default:
-      return true
+      return false
   }
 }

--- a/features/ajna/borrow/ajnaBorrowStepManager.ts
+++ b/features/ajna/borrow/ajnaBorrowStepManager.ts
@@ -5,18 +5,24 @@ interface StepManagerWithBorrowForm extends GeneralStepManager {
   formState: AjnaBorrowFormState
 }
 
-export function isBorrowStepValid({ formState }: StepManagerWithBorrowForm) {
-  switch (formState.action) {
-    case 'open':
-    case 'deposit':
-      return !!formState.depositAmount?.gt(0)
-    case 'withdraw':
-      return !!formState.withdrawAmount?.gt(0)
-    case 'generate':
-      return !!formState.generateAmount?.gt(0)
-    case 'payback':
-      return !!formState.paybackAmount?.gt(0)
+export function isBorrowStepValid({ currentStep, formState }: StepManagerWithBorrowForm) {
+  switch (currentStep) {
+    case 'setup':
+    case 'manage':
+      switch (formState.action) {
+        case 'open':
+        case 'deposit':
+          return !!formState.depositAmount?.gt(0)
+        case 'withdraw':
+          return !!formState.withdrawAmount?.gt(0)
+        case 'generate':
+          return !!formState.generateAmount?.gt(0)
+        case 'payback':
+          return !!formState.paybackAmount?.gt(0)
+        default:
+          return false
+      }
     default:
-      return false
+      return true
   }
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormWrapper.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormWrapper.tsx
@@ -3,6 +3,7 @@ import { AjnaBorrowFormContent } from 'features/ajna/borrow/sidebars/AjnaBorrowF
 import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useAccount } from 'helpers/useAccount'
 import { useFlowState } from 'helpers/useFlowState'
+import { zero } from 'helpers/zero'
 import React, { useEffect } from 'react'
 
 export function AjnaBorrowFormWrapper() {
@@ -17,14 +18,14 @@ export function AjnaBorrowFormWrapper() {
   } = useAjnaBorrowContext()
 
   const flowState = useFlowState({
-    ...((action === 'open' || action === 'deposit') && {
-      amount: depositAmount,
-      token: collateralToken,
-    }),
-    ...(action === 'payback' && {
-      amount: paybackAmount,
-      token: quoteToken,
-    }),
+    token: ['open', 'deposit', 'withdraw'].includes(action as string)
+      ? collateralToken
+      : quoteToken,
+    amount: ['open', 'deposit'].includes(action as string)
+      ? depositAmount
+      : action === 'payback'
+      ? paybackAmount
+      : zero,
     onEverythingReady: () => setNextStep(),
     onGoBack: () => setStep(editingStep),
   })


### PR DESCRIPTION
# 🧿 Always pass data to allowance

Temporary workaround, `useFlowState` require `token` and `amount` in all cases.
  
## Changes 👷‍♀️
- updated `useFlowState` handling,
- updated `isBorrowStepValid` method to disable primary button in manage flow.
  
## How to test 🧪

See if allowance component doesn't break on of the actions in manage position.
