### PR TITLE
turned follow vaults on to make it turned on on staging

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -47,7 +47,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   DiscoverOasis: true,
   AaveBorrow: false,
   AaveV3EarnWSTETH: false,
-  FollowVaults: false,
+  FollowVaults: true,
   AaveProtection: false,
   AaveProtectionWrite: false,
   Ajna: false,


### PR DESCRIPTION
# [Turned follow vaults feature flag on just for staging](https://app.shortcut.com/oazo-apps/epic/4960/follow-vaults?group_by=none&vc_group_by=day&ct_workflow=all&cf_workflow=500000053)

  
## Changes 👷‍♀️
- Turned Follow Vaults feature flag on
  
## How to test 🧪
Point is to make Follow Vaults turned on for everybody on staging before next release
- Turning Follow Vaults feature flag turns the follow vault feature on for Maker vaults
