### PR TITLE
fixed wrapping text for disabled follow button on vault overview

### DIFF
--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -84,7 +84,20 @@ export function VaultHeadline({
         {header}
         {label && <Image src={staticFilesRuntimeUrl(label)} sx={{ ml: 3 }} />}
         {followVaultEnabled && (
-          <Flex sx={{ flexWrap: 'wrap', flexShrink: 0, alignItems: 'center', columnGap: 2, ml: 3 }}>
+          <Flex
+            sx={{
+              flexWrap: 'wrap',
+              flexShrink: 0,
+              alignItems: 'center',
+              columnGap: 2,
+              ml: 3,
+              '&:hover': {
+                '.tooltip': {
+                  whiteSpace: 'nowrap',
+                },
+              },
+            }}
+          >
             {followButton && <FollowButtonControl {...followButton} />}
             {shareButton && (
               <ShareButton


### PR DESCRIPTION
# [fixed wrapping text for the tooltip that appears when one attempts to click the disabled follow button on vault overview page  on a mobile device or in a narrow window](https://app.shortcut.com/oazo-apps/story/7960/bug-responsive-design-on-validation)
  
## Changes 👷‍♀️
- Added no wrapping on follow button when disabled in Vault Headline 
  
## How to test 🧪
- Make sure it fixes the issue on the vault overview page
![image](https://user-images.githubusercontent.com/6871923/217804644-97e62c47-63f7-4514-ac65-0abf32357b14.png)

- Make sure it doesn't break it on the discovery page (attempting to apply it everywhere would break it)

![image](https://user-images.githubusercontent.com/6871923/217804726-3e24326c-22ae-448d-982d-25761526c630.png)

