### PR TITLE
🧿 Ajna empty position

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -131,7 +131,7 @@ import {
 import { PositionId } from 'features/aave/types'
 import { createAccountData } from 'features/account/AccountData'
 import { createTransactionManager } from 'features/account/transactionManager'
-import { getAjnaPosition$ } from 'features/ajna/common/observables/getAjnaPosition'
+import { getAjnaPosition$, GetAjnaPositionIdentification } from 'features/ajna/common/observables/getAjnaPosition'
 import { getDpmPositionData$ } from 'features/ajna/common/observables/getDpmPositionData'
 import { createAutomationTriggersData } from 'features/automation/api/automationTriggersData'
 import {
@@ -1398,7 +1398,7 @@ export function setupAppContext() {
 
   const ajnaPosition$ = memoize(
     curry(getAjnaPosition$)(context$, dpmPositionData$),
-    (positionId: PositionId) => `${positionId.walletAddress}-${positionId.vaultId}`,
+    (ajnaPositionIdentification: GetAjnaPositionIdentification) => ajnaPositionIdentification,
   )
 
   return {

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -131,7 +131,10 @@ import {
 import { PositionId } from 'features/aave/types'
 import { createAccountData } from 'features/account/AccountData'
 import { createTransactionManager } from 'features/account/transactionManager'
-import { getAjnaPosition$, GetAjnaPositionIdentification } from 'features/ajna/common/observables/getAjnaPosition'
+import {
+  getAjnaPosition$,
+  GetAjnaPositionIdentification,
+} from 'features/ajna/common/observables/getAjnaPosition'
 import { getDpmPositionData$ } from 'features/ajna/common/observables/getDpmPositionData'
 import { createAutomationTriggersData } from 'features/automation/api/automationTriggersData'
 import {

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormWrapper.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormWrapper.tsx
@@ -10,7 +10,7 @@ import React, { useEffect } from 'react'
 export function AjnaBorrowFormWrapper() {
   const { walletAddress } = useAccount()
   const {
-    environment: { collateralToken, quoteToken },
+    environment: { dpmProxy, collateralToken, quoteToken },
     form: {
       state: { action, depositAmount, paybackAmount },
       updateState,
@@ -20,6 +20,7 @@ export function AjnaBorrowFormWrapper() {
   const txHandler = useAjnaTxHandler()
 
   const flowState = useFlowState({
+    ...(dpmProxy && { existingProxy: dpmProxy }),
     token: ['open', 'deposit', 'withdraw'].includes(action as string)
       ? collateralToken
       : quoteToken,

--- a/features/ajna/common/observables/getAjnaPosition.ts
+++ b/features/ajna/common/observables/getAjnaPosition.ts
@@ -42,14 +42,14 @@ export function getAjnaPosition$(
     switchMap(async ([context, dpmPositionData]) => {
       if (dpmPositionData && dpmPositionData.protocol !== 'Ajna') return null
 
-      const meta: DpmPositionData = positionId
+      const meta = positionId
         ? (dpmPositionData as DpmPositionData)
         : {
-            collateralToken: collateralToken,
-            product: product,
+            collateralToken,
+            product,
             protocol: 'Ajna',
             proxy: '0x0000000000000000000000000000000000000000',
-            quoteToken: quoteToken,
+            quoteToken,
             user: '0x0000000000000000000000000000000000000000',
             vaultId: '0',
           }
@@ -70,7 +70,7 @@ export function getAjnaPosition$(
         ),
         meta: {
           ...meta,
-          product: meta.product.toLowerCase() as AjnaProduct,
+          product: (meta.product as string).toLowerCase() as AjnaProduct,
         },
       }
     }),

--- a/features/ajna/common/observables/getAjnaPosition.ts
+++ b/features/ajna/common/observables/getAjnaPosition.ts
@@ -2,42 +2,77 @@ import { views } from '@oasisdex/oasis-actions'
 import { Context } from 'blockchain/network'
 import { PositionId } from 'features/aave/types'
 import { DpmPositionData } from 'features/ajna/common/observables/getDpmPositionData'
+import { AjnaProduct } from 'features/ajna/common/types'
 import { isEqual } from 'lodash'
-import { combineLatest, Observable } from 'rxjs'
+import { combineLatest, Observable, of } from 'rxjs'
 import { distinctUntilChanged, shareReplay, switchMap } from 'rxjs/operators'
 
 import { AjnaPosition } from '@oasisdex/oasis-actions/lib/src/helpers/ajna'
 
-export interface AjnaPositionWithMeta {
+interface AjnaMeta extends Omit<DpmPositionData, 'product'> {
+  product: AjnaProduct
+}
+interface GetAjnaPositionIdentificationWithPosition {
+  positionId: PositionId
+  collateralToken?: never
+  product?: never
+  quoteToken?: never
+}
+interface GetAjnaPositionIdentificationWithoutPosition {
+  collateralToken: string
+  product: string
+  quoteToken: string
+  positionId?: never
+}
+export type GetAjnaPositionIdentification =
+  | GetAjnaPositionIdentificationWithPosition
+  | GetAjnaPositionIdentificationWithoutPosition
+
+interface AjnaPositionWithMeta {
   position: AjnaPosition
-  meta: DpmPositionData
+  meta: AjnaMeta
 }
 
 export function getAjnaPosition$(
   context$: Observable<Context>,
   dpmPositionData$: (positionId: PositionId) => Observable<DpmPositionData | null>,
-  positionId: PositionId,
+  { collateralToken, positionId, product, quoteToken }: GetAjnaPositionIdentification,
 ): Observable<AjnaPositionWithMeta | null> {
-  return combineLatest(context$, dpmPositionData$(positionId)).pipe(
+  return combineLatest(context$, positionId ? dpmPositionData$(positionId) : of(undefined)).pipe(
     switchMap(async ([context, dpmPositionData]) => {
-      return dpmPositionData
-        ? {
-            position: await views.ajna.getPosition(
-              {
-                proxyAddress: dpmPositionData.proxy,
-                poolAddress:
-                  context.ajnaPoolPairs[
-                    `${dpmPositionData.collateralToken}-${dpmPositionData.quoteToken}` as keyof typeof context.ajnaPoolPairs
-                  ].address,
-              },
-              {
-                poolInfoAddress: context.ajnaPoolInfo.address,
-                provider: context.rpcProvider,
-              },
-            ),
-            meta: dpmPositionData,
+      if (dpmPositionData && dpmPositionData.protocol !== 'Ajna') return null
+
+      const meta: DpmPositionData = positionId
+        ? (dpmPositionData as DpmPositionData)
+        : {
+            collateralToken: collateralToken,
+            product: product,
+            protocol: 'Ajna',
+            proxy: '0x0000000000000000000000000000000000000000',
+            quoteToken: quoteToken,
+            user: '0x0000000000000000000000000000000000000000',
+            vaultId: '0',
           }
-        : null
+
+      return {
+        position: await views.ajna.getPosition(
+          {
+            proxyAddress: meta.proxy,
+            poolAddress:
+              context.ajnaPoolPairs[
+                `${meta.collateralToken}-${meta.quoteToken}` as keyof typeof context.ajnaPoolPairs
+              ].address,
+          },
+          {
+            poolInfoAddress: context.ajnaPoolInfo.address,
+            provider: context.rpcProvider,
+          },
+        ),
+        meta: {
+          ...meta,
+          product: meta.product.toLowerCase() as AjnaProduct,
+        },
+      }
     }),
     distinctUntilChanged(isEqual),
     shareReplay(1),

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -25,13 +25,14 @@ interface AjnaBorrowContextProviderProps {
   collateralBalance: BigNumber
   collateralPrice: BigNumber
   collateralToken: string
+  dpmProxy?: string
   ethPrice: BigNumber
   flow: AjnaFlow
   product: AjnaProduct
   quoteBalance: BigNumber
   quotePrice: BigNumber
   quoteToken: string
-  owner?: string
+  owner: string
   position: AjnaBorrowPosition
   steps: AjnaStatusStep[]
 }


### PR DESCRIPTION
# 🧿 Ajna empty position

Loads empty position state from library on open flow. Note: this breaks any Ajna position page on mainnet since there are no contacts deployed on it.
  
## Changes 👷‍♀️

- Modified `getAjnaPosition$` observable in a way that it can return existing position when passed ID or empty position when collateral and quote tokens passed,
- fixed an issue where user was asked for DPM proxy during manage flow.
  
## How to test 🧪

Just see if both open and manage flow views loads properly.
