### PR TITLE
🧿 Refresh pool selector

### DIFF
--- a/features/ajna/controls/AjnaSelectorController.tsx
+++ b/features/ajna/controls/AjnaSelectorController.tsx
@@ -33,23 +33,31 @@ export function AjnaSelectorController({ product }: AjnaSelectorControllerProps)
   const { context$ } = useAppContext()
   const [context] = useObservable(context$)
   const [hash] = useHash()
-  const defaultOptionValue = hash.length ? hash.replace('#', '') : DEFAULT_SELECTED_TOKEN
   const ref = useRef<HTMLDivElement>(null)
-  const options = uniq(
-    [...(context ? Object.keys(context.ajnaPoolPairs) : []), ...ajnaComingSoonPools].map(
-      (pool) => pool.split('-')[0],
-    ),
-  )
-    .sort()
-    .map((token) => ({
-      label: token,
-      value: token,
-      icon: getToken(token).iconCircle,
-    }))
+  const [options, setOptions] = useState<HeaderSelectorOption[]>(getOptions())
+  const defaultOptionValue = hash.length ? hash.replace('#', '') : DEFAULT_SELECTED_TOKEN
   const defaultOption = options.filter((option) => option.value === defaultOptionValue)[0]
   const [selected, setSelected] = useState<HeaderSelectorOption>(defaultOption)
   // TODO: to be replaced with real data coming from observable
   const [rows, setRows] = useState<DiscoverTableRowData[]>([])
+
+  function getOptions(): HeaderSelectorOption[] {
+    return uniq(
+      [...(context ? Object.keys(context.ajnaPoolPairs) : []), ...ajnaComingSoonPools].map(
+        (pool) => pool.split('-')[0],
+      ),
+    )
+      .sort()
+      .map((token) => ({
+        label: token,
+        value: token,
+        icon: getToken(token).iconCircle,
+      }))
+  }
+
+  useEffect(() => {
+    setOptions(getOptions())
+  }, [context?.ajnaPoolPairs])
 
   useEffect(() => {
     setRows([
@@ -107,7 +115,7 @@ export function AjnaSelectorController({ product }: AjnaSelectorControllerProps)
           ),
         })),
     ])
-  }, [selected])
+  }, [selected, context?.ajnaPoolPairs])
 
   return (
     <WithConnection>


### PR DESCRIPTION
🧿 Refresh pool selector

On initial load pool selector wasn't showing pools that are available in context config, just items that are coming soon.
  
## Changes 👷‍♀️

- Fixed issue above.
  
## How to test 🧪

Go to page with pool selector and see if pair ETH/USDC is available to select from the beginning.
