### PR TITLE
🧿 Ajna flow refinements

### DIFF
--- a/features/ajna/borrow/overview/AjnaBorrowOverviewWrapper.tsx
+++ b/features/ajna/borrow/overview/AjnaBorrowOverviewWrapper.tsx
@@ -58,7 +58,6 @@ export function AjnaBorrowOverviewWrapper() {
               collateralToken={collateralToken}
               quoteToken={quoteToken}
               cost={currentPosition.pool.rate}
-              afterCost={simulation?.pool.rate}
               availableToBorrow={currentPosition.debtAvailable}
               afterAvailableToBorrow={simulation?.debtAvailable}
               availableToWithdraw={currentPosition.collateralAvailable}

--- a/features/ajna/borrow/overview/ContentCardLiquidationPrice.tsx
+++ b/features/ajna/borrow/overview/ContentCardLiquidationPrice.tsx
@@ -47,7 +47,7 @@ export function ContentCardLiquidationPrice({
 
   if (afterLiquidationPrice !== undefined)
     contentCardSettings.change = {
-      value: `${formatted.afterLiquidationPrice} ${t('system.cards.common.after')}`,
+      value: `${formatted.afterLiquidationPrice} ${collateralToken}/${quoteToken} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     }
 

--- a/features/ajna/borrow/overview/ContentCardLiquidationPrice.tsx
+++ b/features/ajna/borrow/overview/ContentCardLiquidationPrice.tsx
@@ -47,7 +47,9 @@ export function ContentCardLiquidationPrice({
 
   if (afterLiquidationPrice !== undefined)
     contentCardSettings.change = {
-      value: `${formatted.afterLiquidationPrice} ${collateralToken}/${quoteToken} ${t('system.cards.common.after')}`,
+      value: `${formatted.afterLiquidationPrice} ${collateralToken}/${quoteToken} ${t(
+        'system.cards.common.after',
+      )}`,
       variant: changeVariant,
     }
 

--- a/features/ajna/borrow/overview/ContentCardLiquidationPrice.tsx
+++ b/features/ajna/borrow/overview/ContentCardLiquidationPrice.tsx
@@ -39,17 +39,17 @@ export function ContentCardLiquidationPrice({
     unit: `${collateralToken}/${quoteToken}`,
   }
 
+  if (!liquidationPrice.isZero()) {
+    contentCardSettings.footnote = t('ajna.borrow.common.overview.below-current-price', {
+      belowCurrentPrice: formatted.belowCurrentPrice,
+    })
+  }
+
   if (afterLiquidationPrice !== undefined)
     contentCardSettings.change = {
       value: `${formatted.afterLiquidationPrice} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     }
-
-  if (liquidationPrice.isZero()) {
-    contentCardSettings.footnote = t('ajna.borrow.common.overview.below-current-price', {
-      belowCurrentPrice: formatted.belowCurrentPrice,
-    })
-  }
 
   return <DetailsSectionContentCard {...contentCardSettings} />
 }

--- a/features/ajna/borrow/overview/ContentFooterItemsBorrow.tsx
+++ b/features/ajna/borrow/overview/ContentFooterItemsBorrow.tsx
@@ -9,7 +9,6 @@ interface ContentFooterItemsBorrowProps {
   collateralToken: string
   quoteToken: string
   cost: BigNumber
-  afterCost?: BigNumber
   availableToBorrow: BigNumber
   afterAvailableToBorrow?: BigNumber
   availableToWithdraw: BigNumber
@@ -21,7 +20,6 @@ export function ContentFooterItemsBorrow({
   collateralToken,
   quoteToken,
   cost,
-  afterCost,
   availableToBorrow,
   afterAvailableToBorrow,
   availableToWithdraw,
@@ -32,7 +30,6 @@ export function ContentFooterItemsBorrow({
 
   const formatted = {
     cost: formatDecimalAsPercent(cost),
-    afterCost: afterCost && formatDecimalAsPercent(afterCost),
     availableToBorrow: `${formatAmount(availableToBorrow, collateralToken)}`,
     afterAvailableToBorrow:
       afterAvailableToBorrow && `${formatAmount(afterAvailableToBorrow, collateralToken)}`,
@@ -46,12 +43,6 @@ export function ContentFooterItemsBorrow({
       <DetailsSectionFooterItem
         title={t('ajna.borrow.common.footer.annual-net-borrow-cost')}
         value={formatted.cost}
-        {...(afterCost && {
-          change: {
-            value: `${formatted.afterCost} ${t('system.cards.common.after')}`,
-            variant: changeVariant,
-          },
-        })}
       />
       <DetailsSectionFooterItem
         title={t('ajna.borrow.common.footer.available-to-borrow')}

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -5,11 +5,10 @@ import { AjnaBorrowFormContentManage } from 'features/ajna/borrow/sidebars/AjnaB
 import { AjnaBorrowFormContentRisk } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentRisk'
 import { AjnaBorrowFormContentTransaction } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentTransaction'
 import { getPrimaryButtonLabelKey } from 'features/ajna/common/helpers'
-import { AjnaBorrowPanel } from 'features/ajna/common/types'
 import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useAccount } from 'helpers/useAccount'
 import { useTranslation } from 'next-i18next'
-import React, { useState } from 'react'
+import React from 'react'
 import { Grid } from 'theme-ui'
 
 interface AjnaBorrowFormContentProps {
@@ -26,36 +25,44 @@ export function AjnaBorrowFormContent({
   const {
     environment: { collateralToken, isOwner, flow, product, quoteToken },
     form: {
-      state: { dpmAddress },
+      state: { dpmAddress, uiDropdown },
+      updateState,
     },
     steps: { currentStep, editingStep, isStepValid, setNextStep, setStep, isStepWithTransaction },
     tx: { isTxStarted, isTxError, isTxWaitingForApproval, isTxSuccess, isTxInProgress },
     position: { isSimulationLoading, id },
   } = useAjnaBorrowContext()
 
-  const [panel, setPanel] = useState<AjnaBorrowPanel>('collateral')
-
   const sidebarSectionProps: SidebarSectionProps = {
     title: t(`ajna.${product}.common.form.title.${currentStep}`),
     ...(flow === 'manage' && {
       dropdown: {
+        forcePanel: uiDropdown,
         disabled: currentStep !== 'manage',
         items: [
           {
             label: t('system.manage-collateral-token', {
               token: collateralToken,
             }),
+            panel: 'collateral',
             shortLabel: collateralToken,
             icon: getToken(collateralToken).iconCircle,
-            action: () => setPanel('collateral'),
+            action: () => {
+              updateState('uiDropdown', 'collateral')
+              updateState('uiPill', 'deposit')
+            },
           },
           {
             label: t('system.manage-debt-token', {
               token: quoteToken,
             }),
+            panel: 'quote',
             shortLabel: quoteToken,
             icon: getToken(quoteToken).iconCircle,
-            action: () => setPanel('quote'),
+            action: () => {
+              updateState('uiDropdown', 'quote')
+              updateState('uiPill', 'generate')
+            },
           },
         ],
       },
@@ -64,7 +71,7 @@ export function AjnaBorrowFormContent({
       <Grid gap={3}>
         {currentStep === 'risk' && <AjnaBorrowFormContentRisk />}
         {currentStep === 'setup' && <AjnaBorrowFormContentDeposit />}
-        {currentStep === 'manage' && <AjnaBorrowFormContentManage panel={panel} />}
+        {currentStep === 'manage' && <AjnaBorrowFormContentManage />}
         {currentStep === 'transaction' && <AjnaBorrowFormContentTransaction />}
       </Grid>
     ),

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -25,6 +25,7 @@ export function AjnaBorrowFormContent({
   const {
     environment: { collateralToken, isOwner, flow, product, quoteToken },
     form: {
+      dispatch,
       state: { dpmAddress, uiDropdown },
       updateState,
     },
@@ -48,6 +49,7 @@ export function AjnaBorrowFormContent({
             shortLabel: collateralToken,
             icon: getToken(collateralToken).iconCircle,
             action: () => {
+              dispatch({ type: 'reset' })
               updateState('uiDropdown', 'collateral')
               updateState('uiPill', 'deposit')
             },
@@ -60,6 +62,7 @@ export function AjnaBorrowFormContent({
             shortLabel: quoteToken,
             icon: getToken(quoteToken).iconCircle,
             action: () => {
+              dispatch({ type: 'reset' })
               updateState('uiDropdown', 'quote')
               updateState('uiPill', 'generate')
             },

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentManage.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentManage.tsx
@@ -11,6 +11,7 @@ export function AjnaBorrowFormContentManage() {
   const { t } = useTranslation()
   const {
     form: {
+      dispatch,
       state: { uiDropdown, uiPill },
       updateState,
     },
@@ -26,12 +27,18 @@ export function AjnaBorrowFormContentManage() {
                 {
                   id: 'deposit',
                   label: t('vault-actions.deposit'),
-                  action: () => updateState('uiPill', 'deposit'),
+                  action: () => {
+                    dispatch({ type: 'reset' })
+                    updateState('uiPill', 'deposit')
+                  },
                 },
                 {
                   id: 'withdraw',
                   label: t('vault-actions.withdraw'),
-                  action: () => updateState('uiPill', 'withdraw'),
+                  action: () => {
+                    dispatch({ type: 'reset' })
+                    updateState('uiPill', 'withdraw')
+                  },
                 },
               ],
             }
@@ -40,12 +47,18 @@ export function AjnaBorrowFormContentManage() {
                 {
                   id: 'generate',
                   label: t('vault-actions.generate'),
-                  action: () => updateState('uiPill', 'generate'),
+                  action: () => {
+                    dispatch({ type: 'reset' })
+                    updateState('uiPill', 'generate')
+                  },
                 },
                 {
                   id: 'payback',
                   label: t('vault-actions.payback'),
-                  action: () => updateState('uiPill', 'payback'),
+                  action: () => {
+                    dispatch({ type: 'reset' })
+                    updateState('uiPill', 'payback')
+                  },
                 },
               ],
             })}

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentManage.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentManage.tsx
@@ -3,43 +3,35 @@ import { AjnaBorrowFormContentDeposit } from 'features/ajna/borrow/sidebars/Ajna
 import { AjnaBorrowFormContentGenerate } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentGenerate'
 import { AjnaBorrowFormContentPayback } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentPayback'
 import { AjnaBorrowFormContentWithdraw } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentWithdraw'
-import { AjnaBorrowAction, AjnaBorrowPanel } from 'features/ajna/common/types'
 import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
-interface AjnaBorrowFormContentManageProps {
-  panel: AjnaBorrowPanel
-}
-
-export function AjnaBorrowFormContentManage({ panel }: AjnaBorrowFormContentManageProps) {
+export function AjnaBorrowFormContentManage() {
   const { t } = useTranslation()
   const {
-    form: { updateState },
+    form: {
+      state: { uiDropdown, uiPill },
+      updateState,
+    },
   } = useAjnaBorrowContext()
-  const [active, setActive] = useState<Exclude<AjnaBorrowAction, 'open'>>('deposit')
-
-  useEffect(() => {
-    setActive(panel === 'collateral' ? 'deposit' : 'generate')
-  }, [panel])
-  useEffect(() => updateState('action', active), [active])
 
   return (
     <>
       <ActionPills
-        active={active}
-        {...(panel === 'collateral'
+        active={uiPill}
+        {...(uiDropdown === 'collateral'
           ? {
               items: [
                 {
                   id: 'deposit',
                   label: t('vault-actions.deposit'),
-                  action: () => setActive('deposit'),
+                  action: () => updateState('uiPill', 'deposit'),
                 },
                 {
                   id: 'withdraw',
                   label: t('vault-actions.withdraw'),
-                  action: () => setActive('withdraw'),
+                  action: () => updateState('uiPill', 'withdraw'),
                 },
               ],
             }
@@ -48,12 +40,12 @@ export function AjnaBorrowFormContentManage({ panel }: AjnaBorrowFormContentMana
                 {
                   id: 'generate',
                   label: t('vault-actions.generate'),
-                  action: () => setActive('generate'),
+                  action: () => updateState('uiPill', 'generate'),
                 },
                 {
                   id: 'payback',
                   label: t('vault-actions.payback'),
-                  action: () => setActive('payback'),
+                  action: () => updateState('uiPill', 'payback'),
                 },
               ],
             })}
@@ -64,7 +56,7 @@ export function AjnaBorrowFormContentManage({ panel }: AjnaBorrowFormContentMana
           withdraw: <AjnaBorrowFormContentWithdraw />,
           generate: <AjnaBorrowFormContentGenerate />,
           payback: <AjnaBorrowFormContentPayback />,
-        }[active]
+        }[uiPill]
       }
     </>
   )

--- a/features/ajna/borrow/state/ajnaBorrowFormReducto.ts
+++ b/features/ajna/borrow/state/ajnaBorrowFormReducto.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { AjnaBorrowAction } from 'features/ajna/common/types'
+import { AjnaBorrowAction, AjnaBorrowPanel } from 'features/ajna/common/types'
 import { ReductoActions, useReducto } from 'helpers/useReducto'
 
 export interface AjnaBorrowFormState {
@@ -13,6 +13,8 @@ export interface AjnaBorrowFormState {
   paybackAmountUSD?: BigNumber
   withdrawAmount?: BigNumber
   withdrawAmountUSD?: BigNumber
+  uiDropdown: AjnaBorrowPanel
+  uiPill: Exclude<AjnaBorrowAction, 'open'>
 }
 
 interface AjnaBorrowFormActionsUpdateDeposit {
@@ -57,6 +59,8 @@ export const ajnaBorrowDefault: AjnaBorrowFormState = {
   paybackAmountUSD: undefined,
   withdrawAmount: undefined,
   withdrawAmountUSD: undefined,
+  uiDropdown: 'collateral',
+  uiPill: 'deposit',
 }
 
 export function useAjnaBorrowFormReducto({ ...rest }: Partial<AjnaBorrowFormState>) {

--- a/features/ajna/borrow/state/ajnaBorrowFormReducto.ts
+++ b/features/ajna/borrow/state/ajnaBorrowFormReducto.ts
@@ -50,7 +50,7 @@ type AjnaBorrowFormAction = ReductoActions<
   | AjnaBorrowFormActionsReset
 >
 
-export const ajnaBorrowDefault: AjnaBorrowFormState = {
+export const ajnaBorrowReset = {
   depositAmount: undefined,
   depositAmountUSD: undefined,
   generateAmount: undefined,
@@ -59,6 +59,10 @@ export const ajnaBorrowDefault: AjnaBorrowFormState = {
   paybackAmountUSD: undefined,
   withdrawAmount: undefined,
   withdrawAmountUSD: undefined,
+}
+
+export const ajnaBorrowDefault: AjnaBorrowFormState = {
+  ...ajnaBorrowReset,
   uiDropdown: 'collateral',
   uiPill: 'deposit',
 }
@@ -97,7 +101,7 @@ export function useAjnaBorrowFormReducto({ ...rest }: Partial<AjnaBorrowFormStat
             paybackAmountUSD: action.paybackAmountUSD,
           }
         case 'reset':
-          return { ...state, ...ajnaBorrowDefault }
+          return { ...state, ...ajnaBorrowReset }
         default:
           return state
       }

--- a/features/ajna/borrow/views/AjnaBorrowView.tsx
+++ b/features/ajna/borrow/views/AjnaBorrowView.tsx
@@ -14,24 +14,15 @@ import { Box, Card, Container, Flex, Grid, Heading, Image, Text } from 'theme-ui
 
 export function AjnaBorrowView() {
   const { t } = useTranslation()
-  const { walletAddress } = useAccount()
+  const { contextIsLoaded, walletAddress } = useAccount()
   const {
-    environment: {
-      collateralPrice,
-      collateralToken,
-      flow,
-      isOwner,
-      owner,
-      product,
-      quotePrice,
-      quoteToken,
-    },
+    environment: { collateralPrice, collateralToken, flow, owner, product, quotePrice, quoteToken },
     position: { id },
   } = useAjnaBorrowContext()
 
   return (
     <Container variant="vaultPageContainerStatic">
-      {!isOwner && (
+      {contextIsLoaded && owner !== walletAddress && flow === 'manage' && (
         <Box sx={{ mb: 4 }}>
           <VaultOwnershipBanner controller={owner} account={walletAddress} />
         </Box>

--- a/features/ajna/controls/AjnaSelectorController.tsx
+++ b/features/ajna/controls/AjnaSelectorController.tsx
@@ -100,9 +100,11 @@ export function AjnaSelectorController({ product }: AjnaSelectorControllerProps)
           liquidityAvaliable: <DiscoverTableDataCellInactive>n/a</DiscoverTableDataCellInactive>,
           annualFee: <DiscoverTableDataCellInactive>n/a</DiscoverTableDataCellInactive>,
           protocol: (
-            <DiscoverTableDataCellProtocol color={['#f154db', '#974eea']}>
-              Ajna
-            </DiscoverTableDataCellProtocol>
+            <DiscoverTableDataCellInactive>
+              <DiscoverTableDataCellProtocol color={['#f154db', '#974eea']}>
+                Ajna
+              </DiscoverTableDataCellProtocol>
+            </DiscoverTableDataCellInactive>
           ),
           action: (
             <Button className="discover-action" variant="tertiary" disabled={true}>

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -19,7 +19,7 @@ import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import getConfig from 'next/config'
 import React, { PropsWithChildren } from 'react'
-import { Button, Flex, Text } from 'theme-ui'
+import { Box, Button, Flex, Text } from 'theme-ui'
 
 const basePath = getConfig()?.publicRuntimeConfig?.basePath
 
@@ -270,20 +270,17 @@ export function DiscoverTableDataCellProtocol({
   color,
 }: PropsWithChildren<{ color: string | [string, string] }>) {
   return (
-    <Text
-      as="span"
-      sx={{
-        display: 'inline-block',
-        lineHeight: '26px',
-        px: '12px',
-        fontSize: 2,
-        fontWeight: 'regular',
-        color: 'neutral10',
-        borderRadius: 'mediumLarge',
-        background: getPillColor(color),
-      }}
-    >
+    <Flex sx={{ alignItems: 'center', justifyContent: 'flex-end' }}>
+      <Box
+        sx={{
+          width: '10px',
+          height: '10px',
+          mr: 2,
+          borderRadius: 'ellipse',
+          background: getPillColor(color),
+        }}
+      />
       {children}
-    </Text>
+    </Flex>
   )
 }

--- a/helpers/useAccount.ts
+++ b/helpers/useAccount.ts
@@ -2,6 +2,7 @@ import { useAppContext } from 'components/AppContextProvider'
 import { useObservable } from 'helpers/observableHook'
 
 interface AccountState {
+  contextIsLoaded: boolean
   amountOfPositions?: number
   isConnected: boolean
   walletAddress?: string
@@ -13,6 +14,7 @@ export function useAccount(): AccountState {
   const [accountData] = useObservable(accountData$)
 
   return {
+    contextIsLoaded: context !== undefined,
     amountOfPositions: accountData?.numberOfVaults,
     isConnected: context?.status === 'connected',
     walletAddress: context?.account,


### PR DESCRIPTION
# 🧿 Ajna flow refinements

A package will small fixes for bugs found while testing open and manage flow.
  
## Changes 👷‍♀️

- A change in manage form dropdown or pill will reset form state,
- selecting "Back to editing" won't reset selected dropdown and pill in manage form,
- removed footer in `ContentCardLiquidationPrice` when main value is equal to zero,
- added unit to `ContentCardLiquidationPrice` afterpill,
- ownership banner on manage view no longer shows for a second on users own position,
- removed afterpill in footer for "Annual net borrow cost" as it is always the same,
- updated protocol column in pool selector according to Oasis Create design.
  
## How to test 🧪

See all changes from the above.
