### PR TITLE
Stop-Loss form action change fix

### DIFF
--- a/features/automation/protection/stopLoss/state/useStopLossStateInitialization.ts
+++ b/features/automation/protection/stopLoss/state/useStopLossStateInitialization.ts
@@ -29,10 +29,6 @@ export function useStopLossStateInitialization({
       type: 'stop-loss-level',
       stopLossLevel: initialSlRatioWhenTriggerDoesntExist,
     })
-    uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
-      type: 'current-form',
-      currentForm: 'add',
-    })
   }, [triggerId.toNumber(), positionRatio.toNumber()])
 
   useEffect(() => {
@@ -43,6 +39,10 @@ export function useStopLossStateInitialization({
     uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
       type: 'is-awaiting-confirmation',
       isAwaitingConfirmation: false,
+    })
+    uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
+      type: 'current-form',
+      currentForm: 'add',
     })
   }, [positionRatio.toNumber()])
 


### PR DESCRIPTION
# [Stop-Loss form action change fix](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue when during stop loss trigger removal, form action was switching to `add`
  
## How to test 🧪
  <Please explain how to test your changes>

- remove stop loss trigger, form action should remail `remove`
