### PR TITLE
fix show no icon when it's missing

### DIFF
--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -48,7 +48,6 @@ export function DiscoverTableDataCellContent({
       const asset = Object.values(discoverFiltersAssetItems).filter(
         (item) => item.value === primitives.asset,
       )[0]
-
       return (
         <DiscoverTableDataCellAsset
           asset={
@@ -56,7 +55,7 @@ export function DiscoverTableDataCellContent({
           }
           cdpId={primitives.cdpId as number}
           follow={follow}
-          icon={(primitives.icon || asset.icon) as string}
+          icon={(primitives?.icon || asset?.icon || '') as string}
         />
       )
     case 'status':
@@ -68,6 +67,9 @@ export function DiscoverTableDataCellContent({
         </DiscoverTableDataCellPill>
       )
     case 'activity':
+      console.log('row.activity', row.activity)
+      console.log('parsePillAdditionalData(i18n.language, row.activity)')
+      console.log(parsePillAdditionalData(i18n.language, row.activity))
       return (
         <DiscoverTableDataCellPill activity={row.activity}>
           {t(`discover.table.activity.${row.activity?.kind}`, {

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -67,9 +67,6 @@ export function DiscoverTableDataCellContent({
         </DiscoverTableDataCellPill>
       )
     case 'activity':
-      console.log('row.activity', row.activity)
-      console.log('parsePillAdditionalData(i18n.language, row.activity)')
-      console.log(parsePillAdditionalData(i18n.language, row.activity))
       return (
         <DiscoverTableDataCellPill activity={row.activity}>
           {t(`discover.table.activity.${row.activity?.kind}`, {

--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -55,7 +55,7 @@ export function DiscoverTableDataCellContent({
           }
           cdpId={primitives.cdpId as number}
           follow={follow}
-          icon={(primitives?.icon || asset?.icon || '') as string}
+          icon={(primitives?.icon || asset?.icon) as string}
         />
       )
     case 'status':


### PR DESCRIPTION
# [Fix discovery table for assets with missing contents](https://app.shortcut.com/oazo-apps/story/7997/error-when-follow-vaults-table-contain-corrupted-data)
  
## Changes 👷‍♀️
- Modified discovery table to display no icon when it's missing in both `asset` and `primitives`
  
## How to test 🧪
- In `tokensMetadata` find tokens with missing `bannerIcon` for example `GNO`, `PAXUSD` etc.
- In https://tracker-vaults.makerdao.network/ find a vault with token with missing icon as a collateral for example 
- View one of vaults with missing icon, for example GNO http://localhost:3000/29954 , PAXUSD http://localhost:3000/14896 , UNIV2DAIUSDC-A http://localhost:3000/28539
- Follow that vault
- Go to my positions page
- Page should open correctly, vaults with missing icon will just have no icon displayed in DiscoverTableDataCellContent

![image](https://user-images.githubusercontent.com/6871923/218470285-b547db72-423c-4bae-962c-cccd89c0ea89.png)

