### PR TITLE
🧿 Fix Ajna simulation on manage flow

### DIFF
--- a/features/ajna/borrow/state/ajnaBorrowFormReducto.ts
+++ b/features/ajna/borrow/state/ajnaBorrowFormReducto.ts
@@ -72,7 +72,6 @@ export const ajnaBorrowDefault: AjnaBorrowFormState = {
 export function useAjnaBorrowFormReducto({ ...rest }: Partial<AjnaBorrowFormState>) {
   const { dispatch, state, updateState } = useReducto<AjnaBorrowFormState, AjnaBorrowFormAction>({
     defaults: {
-      action: 'open',
       ...ajnaBorrowDefault,
       ...rest,
     },

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -107,7 +107,7 @@ export function AjnaBorrowContextProvider({
   if (!isAppContextAvailable()) return null
 
   const form = useAjnaBorrowFormReducto({
-    action: props.flow === 'open' ? 'open' : 'deposit'
+    action: props.flow === 'open' ? 'open' : 'deposit',
   })
   const { walletAddress } = useAccount()
   const [currentStep, setCurrentStep] = useState<AjnaStatusStep>(steps[0])

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -106,7 +106,9 @@ export function AjnaBorrowContextProvider({
 }: PropsWithChildren<AjnaBorrowContextProviderProps>) {
   if (!isAppContextAvailable()) return null
 
-  const form = useAjnaBorrowFormReducto({})
+  const form = useAjnaBorrowFormReducto({
+    action: props.flow === 'open' ? 'open' : 'deposit'
+  })
   const { walletAddress } = useAccount()
   const [currentStep, setCurrentStep] = useState<AjnaStatusStep>(steps[0])
   const [txDetails, setTxDetails] = useState<TxDetails>()


### PR DESCRIPTION
# 🧿 Fix Ajna simulation on manage flow

Due to the `open` state being default action, unless user didn't select something in dropdown or switched pill, simulation wasn't working.
  
## Changes 👷‍♀️

- Default action is set depending on context `flow`.
  
## How to test 🧪

See if simulation works on Ajna manage position page.
