### PR TITLE
Close to collateral/debt on Aave v3

### DIFF
--- a/actions/aave/types/closeAaveParameters.ts
+++ b/actions/aave/types/closeAaveParameters.ts
@@ -2,6 +2,7 @@ import { IPosition } from '@oasisdex/oasis-actions'
 import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
 import { ProxyType } from 'features/aave/common'
+import { LendingProtocol } from 'lendingProtocols'
 
 export interface CloseAaveParameters {
   context: Context
@@ -12,4 +13,5 @@ export interface CloseAaveParameters {
   amount: BigNumber
   proxyType: ProxyType
   shouldCloseToCollateral: boolean
+  protocol: LendingProtocol
 }

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -524,6 +524,7 @@ export function createManageAaveStateMachine(
               currentPosition: context.currentPosition!,
               manageTokenInput: context.manageTokenInput,
               proxyType: context.positionCreatedBy,
+              protocol: context.strategyConfig.protocol,
               shouldCloseToCollateral:
                 context.manageTokenInput?.closingToken === context.tokens.collateral,
               positionType: context.strategyConfig.type,
@@ -532,7 +533,9 @@ export function createManageAaveStateMachine(
           { to: (context) => context.refParametersMachine! },
         ),
         requestManageParameters: send(
-          (context): TransactionParametersStateMachineEvent<ManageAaveParameters> => {
+          (
+            context,
+          ): TransactionParametersStateMachineEvent<ManageAaveParameters | CloseAaveParameters> => {
             const { token, amount } = getTxTokenAndAmount(context)
             return {
               type: 'VARIABLES_RECEIVED',
@@ -545,6 +548,7 @@ export function createManageAaveStateMachine(
                 proxyType: context.positionCreatedBy,
                 token,
                 amount,
+                protocol: context.strategyConfig.protocol,
                 shouldCloseToCollateral:
                   context.manageTokenInput?.closingToken === context.tokens.collateral,
               },


### PR DESCRIPTION
# [[Aave V3] Integrate close to collateral/debt](https://app.shortcut.com/oazo-apps/story/8016/aave-v3-integrate-close-to-collateral-debt)

  
## Changes 👷‍♀️
- used `strategies.aave.v2.close`/`strategies.aave.v3.close` separately
  
## How to test 🧪
