### PR TITLE
Aave SL trigger value adjustment

### DIFF
--- a/features/automation/protection/stopLoss/state/stopLossTriggerData.ts
+++ b/features/automation/protection/stopLoss/state/stopLossTriggerData.ts
@@ -24,19 +24,31 @@ function pickTriggerWithHighestStopLossLevel(stopLossTriggersData: TriggerDataTy
 
     const triggerTypeAsNumber = new BigNumber(triggerType).toNumber()
 
+    const isAutomationV2Trigger = [
+      TriggerType.AaveStopLossToDebt,
+      TriggerType.AaveStopLossToCollateral,
+    ].includes(triggerTypeAsNumber)
+
+    const resolvedDiv = isAutomationV2Trigger ? 10 ** 6 : 100
+    const stopLossLevel = new BigNumber((ltv || collRatio).toString()).div(resolvedDiv)
+
     return {
       triggerId: new BigNumber(trigger.triggerId),
       isStopLossEnabled: true,
-      stopLossLevel: new BigNumber((ltv || collRatio).toString()).div(100),
+      stopLossLevel,
       isToCollateral:
         triggerTypeAsNumber === TriggerType.StopLossToCollateral ||
         triggerTypeAsNumber === TriggerType.AaveStopLossToCollateral,
       executionParams: trigger.executionParams,
+      triggerType: triggerTypeAsNumber,
     }
   })
 
   return mappedStopLossTriggers.reduce((acc, obj) => {
-    if (TriggerType.AaveStopLossToDebt || TriggerType.AaveStopLossToCollateral) {
+    if (
+      obj.triggerType === TriggerType.AaveStopLossToDebt ||
+      obj.triggerType === TriggerType.AaveStopLossToCollateral
+    ) {
       return acc.stopLossLevel.lt(obj.stopLossLevel) ? acc : obj
     }
     return acc.stopLossLevel.gt(obj.stopLossLevel) ? acc : obj
@@ -131,7 +143,7 @@ export function prepareStopLossTriggerDataV2(
     triggerType, // triggerType
     tokenAddress, // collateralToken
     debtTokenAddress, // debtToken
-    stopLossLevel.toString(), // stop loss level
+    stopLossLevel.times(10 ** 6).toString(), // stop loss level
     DEFAULT_MAX_BASE_FEE_IN_GWEI.toString(), // max gas fee
   ])
 

--- a/features/automation/protection/stopLoss/state/stopLossTriggerData.ts
+++ b/features/automation/protection/stopLoss/state/stopLossTriggerData.ts
@@ -30,12 +30,11 @@ function pickTriggerWithHighestStopLossLevel(stopLossTriggersData: TriggerDataTy
     ].includes(triggerTypeAsNumber)
 
     const resolvedDiv = isAutomationV2Trigger ? 10 ** 6 : 100
-    const stopLossLevel = new BigNumber((ltv || collRatio).toString()).div(resolvedDiv)
 
     return {
       triggerId: new BigNumber(trigger.triggerId),
       isStopLossEnabled: true,
-      stopLossLevel,
+      stopLossLevel: new BigNumber((ltv || collRatio).toString()).div(resolvedDiv),
       isToCollateral:
         triggerTypeAsNumber === TriggerType.StopLossToCollateral ||
         triggerTypeAsNumber === TriggerType.AaveStopLossToCollateral,


### PR DESCRIPTION
# Aave SL trigger value adjustment

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- stop loss value for auto v2 needs to be multiplied by `10 ** 6` (so `76 * 10 ** 6` or `0.76 * 10 ** 8`) and divided by this value during decoding
  
## How to test 🧪
  <Please explain how to test your changes>

- triggers data should contain correct sl value format
- when adding and removing, on UI user should see correct numbers
