### PR TITLE
🧿 Ajna sidebar refinements, part II

### DIFF
--- a/features/ajna/borrow/helpers.tsx
+++ b/features/ajna/borrow/helpers.tsx
@@ -29,29 +29,29 @@ export function getAjnaBorrowHeadlineProps({
 }
 
 export function getAjnaBorrowStatus({
-  isStepValid,
-  isAllowanceLoading,
-  isTxInProgress,
-  isTxWaitingForApproval,
-  isTxStarted,
-  isTxError,
-  isOwner,
   currentStep,
   editingStep,
-  walletAddress,
+  isAllowanceLoading,
+  isOwner,
   isSimulationLoading,
+  isStepValid,
+  isTxError,
+  isTxInProgress,
+  isTxStarted,
+  isTxWaitingForApproval,
+  walletAddress,
 }: {
-  isStepValid: boolean
-  isAllowanceLoading: boolean
-  isTxInProgress: boolean
-  isTxWaitingForApproval: boolean
-  isTxStarted: boolean
-  isTxError: boolean
-  isOwner: boolean
   currentStep: AjnaStatusStep
   editingStep: AjnaEditingStep
-  walletAddress?: string
+  isAllowanceLoading: boolean
+  isOwner: boolean
   isSimulationLoading?: boolean
+  isStepValid: boolean
+  isTxError: boolean
+  isTxInProgress: boolean
+  isTxStarted: boolean
+  isTxWaitingForApproval: boolean
+  walletAddress?: string
 }) {
   const isPrimaryButtonDisabled =
     !!walletAddress &&
@@ -66,8 +66,7 @@ export function getAjnaBorrowStatus({
     (isAllowanceLoading || isSimulationLoading || isTxInProgress || isTxWaitingForApproval)
 
   const isPrimaryButtonHidden = !!(walletAddress && !isOwner && currentStep === editingStep)
-  const isTextButtonHidden =
-    currentStep === 'transaction' && (!isTxStarted || isTxWaitingForApproval || isTxError)
+  const isTextButtonHidden = !(currentStep === 'transaction' && (!isTxStarted || isTxError))
 
   return {
     isPrimaryButtonLoading,

--- a/features/ajna/borrow/helpers.tsx
+++ b/features/ajna/borrow/helpers.tsx
@@ -28,7 +28,7 @@ export function getAjnaBorrowHeadlineProps({
   }
 }
 
-export function getAjnaBorrowStatus({
+export function getAjnaSidebarButtonsStatus({
   currentStep,
   editingStep,
   isAllowanceLoading,
@@ -69,42 +69,36 @@ export function getAjnaBorrowStatus({
   const isTextButtonHidden = !(currentStep === 'transaction' && (!isTxStarted || isTxError))
 
   return {
-    isPrimaryButtonLoading,
     isPrimaryButtonDisabled,
     isPrimaryButtonHidden,
+    isPrimaryButtonLoading,
     isTextButtonHidden,
   }
 }
 
-export function getPrimaryButtonAction({
-  walletAddress,
+export function getAjnaSidebarPrimaryButtonActions({
   currentStep,
+  defaultAction,
   editingStep,
-  isTxSuccess,
   flow,
   id,
-  buttonDefaultAction,
+  isTxSuccess,
+  walletAddress,
 }: {
-  walletAddress?: string
   currentStep: string
+  defaultAction: () => void
   editingStep: string
-  isTxSuccess: boolean
   flow: AjnaFlow
-  buttonDefaultAction: () => void
   id?: string
+  isTxSuccess: boolean
+  walletAddress?: string
 }) {
   switch (true) {
     case !walletAddress && currentStep === editingStep:
-      return {
-        url: '/connect',
-      }
+      return { url: '/connect' }
     case isTxSuccess && flow === 'open':
-      return {
-        url: `/ajna/position/${id}`,
-      }
+      return { url: `/ajna/position/${id}` }
     default:
-      return {
-        action: () => buttonDefaultAction(),
-      }
+      return { action: defaultAction }
   }
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -42,22 +42,22 @@ export function AjnaBorrowFormContent({
   }
 
   const {
-    isPrimaryButtonLoading,
     isPrimaryButtonDisabled,
     isPrimaryButtonHidden,
+    isPrimaryButtonLoading,
     isTextButtonHidden,
   } = getAjnaBorrowStatus({
-    walletAddress,
-    isStepValid,
-    isAllowanceLoading,
-    isSimulationLoading,
-    isTxInProgress,
-    isTxWaitingForApproval,
-    isTxError,
-    isTxStarted,
     currentStep,
     editingStep,
+    isAllowanceLoading,
     isOwner,
+    isSimulationLoading,
+    isStepValid,
+    isTxError,
+    isTxInProgress,
+    isTxStarted,
+    isTxWaitingForApproval,
+    walletAddress,
   })
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -128,12 +128,11 @@ export function AjnaBorrowFormContent({
         buttonDefaultAction,
       }),
     },
-    ...(!isTextButtonHidden && {
-      textButton: {
-        label: t('back-to-editing'),
-        action: () => setStep(editingStep),
-      },
-    }),
+    textButton: {
+      label: t('back-to-editing'),
+      action: () => setStep(editingStep),
+      hidden: isTextButtonHidden,
+    },
   }
 
   return <SidebarSection {...sidebarSectionProps} />

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -1,6 +1,9 @@
 import { getToken } from 'blockchain/tokensMetadata'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
-import { getAjnaBorrowStatus, getPrimaryButtonAction } from 'features/ajna/borrow/helpers'
+import {
+  getAjnaSidebarButtonsStatus,
+  getAjnaSidebarPrimaryButtonActions,
+} from 'features/ajna/borrow/helpers'
 import { AjnaBorrowFormContentDeposit } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentDeposit'
 import { AjnaBorrowFormContentManage } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentManage'
 import { AjnaBorrowFormContentRisk } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentRisk'
@@ -31,23 +34,23 @@ export function AjnaBorrowFormContent({
       updateState,
     },
     steps: { currentStep, editingStep, setNextStep, setStep, isStepWithTransaction, isStepValid },
-    tx: { isTxError, isTxSuccess, isTxWaitingForApproval, isTxStarted, isTxInProgress },
+    tx: {
+      isTxError,
+      isTxSuccess,
+      isTxWaitingForApproval,
+      isTxStarted,
+      isTxInProgress,
+      setTxDetails,
+    },
     position: { id, isSimulationLoading },
   } = useAjnaBorrowContext()
-
-  async function buttonDefaultAction() {
-    if (isStepWithTransaction) {
-      if (isTxSuccess) setStep(editingStep)
-      else txHandler()
-    } else setNextStep()
-  }
 
   const {
     isPrimaryButtonDisabled,
     isPrimaryButtonHidden,
     isPrimaryButtonLoading,
     isTextButtonHidden,
-  } = getAjnaBorrowStatus({
+  } = getAjnaSidebarButtonsStatus({
     currentStep,
     editingStep,
     isAllowanceLoading,
@@ -58,6 +61,31 @@ export function AjnaBorrowFormContent({
     isTxInProgress,
     isTxStarted,
     isTxWaitingForApproval,
+    walletAddress,
+  })
+  const primaryButtonLabel = getPrimaryButtonLabelKey({
+    flow,
+    currentStep,
+    product,
+    dpmAddress,
+    walletAddress,
+    isTxSuccess,
+    isTxError,
+  })
+  const primaryButtonActions = getAjnaSidebarPrimaryButtonActions({
+    defaultAction: async () => {
+      if (isStepWithTransaction) {
+        if (isTxSuccess) {
+          setTxDetails(undefined)
+          setStep(editingStep)
+        } else txHandler()
+      } else setNextStep()
+    },
+    currentStep,
+    editingStep,
+    flow,
+    id,
+    isTxSuccess,
     walletAddress,
   })
 
@@ -106,29 +134,11 @@ export function AjnaBorrowFormContent({
       </Grid>
     ),
     primaryButton: {
-      label: t(
-        getPrimaryButtonLabelKey({
-          flow,
-          currentStep,
-          product,
-          dpmAddress,
-          walletAddress,
-          isTxSuccess,
-          isTxError,
-        }),
-      ),
+      label: t(primaryButtonLabel),
       disabled: isPrimaryButtonDisabled,
       isLoading: isPrimaryButtonLoading,
       hidden: isPrimaryButtonHidden,
-      ...getPrimaryButtonAction({
-        walletAddress,
-        currentStep,
-        editingStep,
-        isTxSuccess,
-        flow,
-        id,
-        buttonDefaultAction,
-      }),
+      ...primaryButtonActions,
     },
     textButton: {
       label: t('back-to-editing'),

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -37,7 +37,8 @@ export function AjnaBorrowFormContent({
 
   async function buttonDefaultAction() {
     if (isStepWithTransaction) {
-      txHandler()
+      if (isTxSuccess) setStep(editingStep)
+      else txHandler()
     } else setNextStep()
   }
 
@@ -107,6 +108,7 @@ export function AjnaBorrowFormContent({
     primaryButton: {
       label: t(
         getPrimaryButtonLabelKey({
+          flow,
           currentStep,
           product,
           dpmAddress,

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentTransaction.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentTransaction.tsx
@@ -33,7 +33,7 @@ export function AjnaBorrowFormContentTransaction() {
       )}
       {isTxSuccess && (
         <>
-          <AjnaBorrowFormOrder />
+          <AjnaBorrowFormOrder cached />
           <VaultChangesWithADelayCard />
         </>
       )}

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -9,33 +9,37 @@ import {
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-export function AjnaBorrowFormOrder() {
+export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
   const { t } = useTranslation()
 
   const {
     environment: { collateralToken, quoteToken },
-    position: { currentPosition, simulation },
+    position: { currentPosition, simulation, cachedPosition },
   } = useAjnaBorrowContext()
 
-  const isLoading = simulation === undefined
+  const positionData = cached && cachedPosition ? cachedPosition.currentPosition : currentPosition
+  const simulationData = cached && cachedPosition ? cachedPosition.simulation : simulation
+
+  const isLoading = !cached && simulation === undefined
   const formatted = {
-    collateralLocked: formatCryptoBalance(currentPosition.collateralAmount),
-    debt: formatCryptoBalance(currentPosition.debtAmount),
-    ltv: formatDecimalAsPercent(currentPosition.riskRatio.loanToValue),
-    liquidationPrice: formatCryptoBalance(currentPosition.liquidationPrice),
-    availableToBorrow: formatAmount(currentPosition.debtAvailable, quoteToken),
-    availableToWithdraw: formatAmount(currentPosition.collateralAvailable, collateralToken),
+    collateralLocked: formatCryptoBalance(positionData.collateralAmount),
+    debt: formatCryptoBalance(positionData.debtAmount),
+    ltv: formatDecimalAsPercent(positionData.riskRatio.loanToValue),
+    liquidationPrice: formatCryptoBalance(positionData.liquidationPrice),
+    availableToBorrow: formatAmount(positionData.debtAvailable, quoteToken),
+    availableToWithdraw: formatAmount(positionData.collateralAvailable, collateralToken),
     afterLiquidationPrice:
-      simulation?.liquidationPrice && formatCryptoBalance(simulation.liquidationPrice),
-    afterLtv: simulation?.riskRatio && formatDecimalAsPercent(simulation.riskRatio.loanToValue),
-    afterDebt: simulation?.debtAmount && formatCryptoBalance(simulation.debtAmount),
+      simulationData?.liquidationPrice && formatCryptoBalance(simulationData.liquidationPrice),
+    afterLtv:
+      simulationData?.riskRatio && formatDecimalAsPercent(simulationData.riskRatio.loanToValue),
+    afterDebt: simulationData?.debtAmount && formatCryptoBalance(simulationData.debtAmount),
     afterCollateralLocked:
-      simulation?.collateralAmount && formatCryptoBalance(simulation.collateralAmount),
+      simulationData?.collateralAmount && formatCryptoBalance(simulationData.collateralAmount),
     afterAvailableToBorrow:
-      simulation?.debtAvailable && formatAmount(simulation?.debtAvailable, quoteToken),
+      simulationData?.debtAvailable && formatAmount(simulationData?.debtAvailable, quoteToken),
     afterAvailableToWithdraw:
-      simulation?.collateralAvailable &&
-      formatAmount(simulation?.collateralAvailable, collateralToken),
+      simulationData?.collateralAvailable &&
+      formatAmount(simulationData?.collateralAvailable, collateralToken),
   }
 
   return (

--- a/features/ajna/common/helpers.tsx
+++ b/features/ajna/common/helpers.tsx
@@ -1,12 +1,5 @@
-import { AjnaProduct, AjnaStatusStep } from 'features/ajna/common/types'
+import { AjnaFlow, AjnaProduct, AjnaStatusStep } from 'features/ajna/common/types'
 import { SxStyleProp } from 'theme-ui'
-
-interface GetKeyMethodParams {
-  currentStep: AjnaStatusStep
-  product: AjnaProduct
-  isTxSuccess: boolean
-  isTxError: boolean
-}
 
 export function getAjnaWithArrowColorScheme(): SxStyleProp {
   return {
@@ -19,27 +12,29 @@ export function getAjnaWithArrowColorScheme(): SxStyleProp {
 export function getPrimaryButtonLabelKey({
   currentStep,
   dpmAddress,
-  walletAddress,
-  isTxSuccess,
+  flow,
   isTxError,
-}: GetKeyMethodParams & { dpmAddress?: string; walletAddress?: string }): string {
+  isTxSuccess,
+  walletAddress,
+}: {
+  currentStep: AjnaStatusStep
+  dpmAddress?: string
+  flow: AjnaFlow
+  isTxError: boolean
+  isTxSuccess: boolean
+  product: AjnaProduct
+  walletAddress?: string
+}): string {
   switch (currentStep) {
     case 'risk':
       return 'i-understand'
     case 'transaction':
-      if (isTxSuccess) return 'system.go-to-position'
+      if (isTxSuccess && flow === 'open') return 'system.go-to-position'
       else if (isTxError) return 'retry'
       else return 'confirm'
     default:
       if (walletAddress && dpmAddress) return 'confirm'
       else if (walletAddress) return 'dpm.create-flow.welcome-screen.create-button'
       else return 'connect-wallet-button'
-  }
-}
-
-export function getTextButtonLabelKey({ currentStep }: GetKeyMethodParams): string {
-  switch (currentStep) {
-    default:
-      return 'back-to-editing'
   }
 }

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -43,14 +43,20 @@ interface AjnaBorrowContextProviderProps {
 }
 
 type AjnaBorrowEnvironment = Omit<AjnaBorrowContextProviderProps, 'currentPosition' | 'steps'>
+type AjnaCachedPosition = {
+  currentPosition: AjnaPosition
+  simulation: AjnaPosition
+}
 
 export interface AjnaBorrowPosition {
-  id?: string
+  cachedPosition?: AjnaCachedPosition
   currentPosition: AjnaPosition
-  setSimulation: Dispatch<SetStateAction<AjnaPosition | undefined>>
-  setIsLoadingSimulation: Dispatch<SetStateAction<boolean>>
-  simulation?: AjnaPosition
+  id?: string
   isSimulationLoading?: boolean
+  setCachedPosition: Dispatch<SetStateAction<AjnaCachedPosition | undefined>>
+  setIsLoadingSimulation: Dispatch<SetStateAction<boolean>>
+  setSimulation: Dispatch<SetStateAction<AjnaPosition | undefined>>
+  simulation?: AjnaPosition
 }
 
 interface AjnaBorrowSteps {
@@ -124,6 +130,7 @@ export function AjnaBorrowContextProvider({
   const [txDetails, setTxDetails] = useState<TxDetails>()
   const [simulation, setSimulation] = useState<AjnaPosition>()
   const [isSimulationLoading, setIsLoadingSimulation] = useState(false)
+  const [cachedPosition, setCachedPosition] = useState<AjnaCachedPosition>()
 
   const setStep = (step: AjnaStatusStep) => {
     if (
@@ -170,6 +177,7 @@ export function AjnaBorrowContextProvider({
       currentPosition,
       setIsLoadingSimulation,
       setSimulation,
+      setCachedPosition,
     },
     steps: setupStepManager(),
     tx: setupTxManager(),
@@ -187,6 +195,7 @@ export function AjnaBorrowContextProvider({
       position: {
         ...prev.position,
         id: resolvedId,
+        cachedPosition,
         currentPosition,
         simulation,
         isSimulationLoading,
@@ -198,13 +207,14 @@ export function AjnaBorrowContextProvider({
   }, [
     props.collateralBalance,
     props.quoteBalance,
+    resolvedId,
+    cachedPosition,
+    currentPosition,
+    simulation,
+    isSimulationLoading,
     form.state,
     currentStep,
     txDetails,
-    simulation,
-    currentPosition,
-    resolvedId,
-    isSimulationLoading,
   ])
 
   return <ajnaBorrowContext.Provider value={context}>{children}</ajnaBorrowContext.Provider>


### PR DESCRIPTION
# 🧿 Ajna sidebar refinements, part II

Second iteration of bugfixes and refinements to Ajna form sidebars.
  
## Changes 👷‍♀️

- Refined and updated structure in methods related to handling sidebar statuses,
- fixed an issue where "Back to editing" button was shown on risk and form steps, but wasn't on confirmation,
- fixed an issue where afterpills and simulation stayed after transaction was finished with success,
- fixed an issue where it was impossible to trigger one transaction after another on manage flow without refreshing page,
- fixed an issue where order information on success screen was constantly updating and wasn't showing data that actually was changed.
  
## How to test 🧪

See if issues mentioned above are still occuring.
