### PR TITLE
fix closing

### DIFF
--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -327,7 +327,13 @@ export function createManageAaveStateMachine(
               },
             },
             reviewingClosing: {
-              entry: ['closePositionEvent'],
+              entry: [
+                'closePositionEvent',
+                'reset',
+                'killCurrentParametersMachine',
+                'spawnCloseParametersMachine',
+                'requestParameters',
+              ],
               on: {
                 NEXT_STEP: {
                   cond: 'validClosingTransactionParameters',

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -203,6 +203,12 @@ export function createManageAaveStateMachine(
                 CLOSE_POSITION: {
                   cond: 'canChangePosition',
                   target: 'reviewingClosing',
+                  actions: [
+                    'reset',
+                    'killCurrentParametersMachine',
+                    'spawnCloseParametersMachine',
+                    'requestParameters',
+                  ],
                 },
                 SET_RISK_RATIO: {
                   cond: 'canChangePosition',
@@ -324,7 +330,7 @@ export function createManageAaveStateMachine(
               entry: [
                 'closePositionEvent',
                 'reset',
-                'killCurrentParametersMachine',
+                // 'killCurrentParametersMachine', -> including this breaks machine when selecting close from drop-down
                 'spawnCloseParametersMachine',
                 'requestParameters',
               ],

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -203,12 +203,6 @@ export function createManageAaveStateMachine(
                 CLOSE_POSITION: {
                   cond: 'canChangePosition',
                   target: 'reviewingClosing',
-                  actions: [
-                    'reset',
-                    'killCurrentParametersMachine',
-                    'spawnCloseParametersMachine',
-                    'requestParameters',
-                  ],
                 },
                 SET_RISK_RATIO: {
                   cond: 'canChangePosition',


### PR DESCRIPTION
# [fix closing](https://app.shortcut.com/oazo-apps/story/8065/close-to-eth-on-wsteth-eth-aave-v3-doesen-t-seem-to-load-yet)
  
## Changes 👷‍♀️

- call actions when entering the closing state instead of on the transition itself

