### PR TITLE
[SC-8085] Default slippage in strategy

### DIFF
--- a/features/aave/common/StrategyConfigTypes.ts
+++ b/features/aave/common/StrategyConfigTypes.ts
@@ -1,4 +1,5 @@
 import { IRiskRatio } from '@oasisdex/oasis-actions'
+import { BigNumber } from 'bignumber.js'
 import { AaveV2ReserveConfigurationData } from 'blockchain/aave'
 import { ViewPositionSectionComponentProps } from 'features/earn/aave/components/ViewPositionSectionComponent'
 import { AaveMultiplyManageComponentProps } from 'features/multiply/aave/components/AaveMultiplyManageComponent'
@@ -50,6 +51,7 @@ export interface IStrategyConfig {
   type: ProductType
   protocol: LendingProtocol
   featureToggle?: Feature
+  defaultSlippage?: BigNumber
 }
 
 export type AaveHeaderProps = {

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -7,11 +7,10 @@ import { SidebarSectionFooterButtonSettings } from 'components/sidebar/SidebarSe
 import { SidebarSectionHeaderDropdown } from 'components/sidebar/SidebarSectionHeader'
 import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
 import { WithArrow } from 'components/WithArrow'
-import { BaseViewProps } from 'features/aave/common/BaseAaveContext'
+import { BaseAaveEvent, BaseViewProps } from 'features/aave/common/BaseAaveContext'
 import { hasUserInteracted } from 'features/aave/helpers/hasUserInteracted'
 import { StopLossAaveErrorMessage } from 'features/aave/manage/components/StopLossAaveErrorMessage'
 import { ManageAaveAutomation } from 'features/aave/manage/sidebars/SidebarManageAaveVault'
-import { ManageAaveEvent } from 'features/aave/manage/state'
 import { getLiquidationPriceAccountingForPrecision } from 'features/shared/liquidationPrice'
 import { formatPercent } from 'helpers/formatters/format'
 import { one, zero } from 'helpers/zero'
@@ -23,9 +22,12 @@ import { StrategyInformationContainer } from './informationContainer'
 
 type RaisedEvents =
   | { type: 'SET_RISK_RATIO'; riskRatio: IRiskRatio }
-  | ({
-      type: 'RESET_RISK_RATIO'
-    } & ManageAaveEvent)
+  | (
+      | {
+          type: 'RESET_RISK_RATIO'
+        }
+      | BaseAaveEvent
+    )
 
 export type AdjustRiskViewProps = BaseViewProps<RaisedEvents> & {
   primaryButton: SidebarSectionFooterButtonSettings
@@ -273,7 +275,14 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
             />
           )
         )}
-        {hasUserInteracted(state) && <StrategyInformationContainer state={state} />}
+        {hasUserInteracted(state) && (
+          <StrategyInformationContainer
+            state={state}
+            changeSlippageSource={(from) => {
+              send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+            }}
+          />
+        )}
       </Grid>
     )
     if (noSidebar) {

--- a/features/aave/common/components/informationContainer/OrderInformationTooltipAction.tsx
+++ b/features/aave/common/components/informationContainer/OrderInformationTooltipAction.tsx
@@ -1,0 +1,43 @@
+import { Icon } from '@makerdao/dai-ui-icons'
+import { WithChildren } from 'helpers/types'
+import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
+import React, { useState } from 'react'
+import { Box, Flex } from 'theme-ui'
+
+export function OrderInformationTooltipAction({ children }: WithChildren) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const componentRef = useOutsideElementClickHandler(() => setIsOpen(false))
+
+  return (
+    <Flex ref={componentRef} sx={{ position: 'relative' }}>
+      <Icon
+        name="question_o"
+        size="20px"
+        sx={{ ml: 1 }}
+        onClick={() => {
+          setIsOpen(!isOpen)
+        }}
+      />
+      <Box
+        sx={{
+          transform: 'translateY(-100%)',
+          top: '-15px',
+          display: isOpen ? 'block' : 'none',
+          p: 0,
+          position: 'absolute',
+          right: 0,
+          width: '300px',
+          bg: 'neutral10',
+          boxShadow: 'elevation',
+          borderRadius: 'mediumLarge',
+          border: 'none',
+          overflow: 'hidden',
+          zIndex: 2,
+        }}
+      >
+        {children}
+      </Box>
+    </Flex>
+  )
+}

--- a/features/aave/common/components/informationContainer/SlippageInformation.tsx
+++ b/features/aave/common/components/informationContainer/SlippageInformation.tsx
@@ -1,15 +1,43 @@
 import BigNumber from 'bignumber.js'
+import { SidebarSectionFooterButton } from 'components/sidebar/SidebarSectionFooterButton'
+import { VaultChangesInformationItem } from 'components/vault/VaultChangesInformation'
+import { formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { Box, Flex, Text } from 'theme-ui'
 
-import { VaultChangesInformationItem } from '../../../../../components/vault/VaultChangesInformation'
-import { formatPercent } from '../../../../../helpers/formatters/format'
+import { OrderInformationTooltipAction } from './OrderInformationTooltipAction'
 
-interface LtvInformationProps {
+interface SlippageInformationProps {
   slippage: BigNumber
+  isStrategyHasSlippage: boolean
+  getSlippageFrom: 'userSettings' | 'strategyConfig'
+  changeSlippage: (from: 'userSettings' | 'strategyConfig') => void
 }
 
-export function SlippageInformation({ slippage }: LtvInformationProps) {
+function ChangeSlippageToUserSettings({
+  changeSlippage,
+  buttonLabel,
+}: {
+  changeSlippage: () => void
+  buttonLabel: string
+}) {
+  const { t } = useTranslation()
+  return (
+    <Box sx={{ p: 3 }}>
+      {t('vault-changes.slippage-info')}
+      <SidebarSectionFooterButton
+        variant="textual"
+        action={() => {
+          changeSlippage()
+        }}
+        label={buttonLabel}
+      />
+    </Box>
+  )
+}
+
+function BasicSlippageInformation({ slippage }: SlippageInformationProps) {
   const { t } = useTranslation()
   return (
     <VaultChangesInformationItem
@@ -17,4 +45,55 @@ export function SlippageInformation({ slippage }: LtvInformationProps) {
       value={formatPercent(slippage.times(100), { precision: 2 })}
     />
   )
+}
+
+function SlippageFromStrategyWithTooltip({ slippage, changeSlippage }: SlippageInformationProps) {
+  const { t } = useTranslation()
+  return (
+    <VaultChangesInformationItem
+      label={t('vault-changes.slippage-limit')}
+      value={
+        <Flex>
+          <Text color={'primary100'}>{formatPercent(slippage.times(100), { precision: 2 })}</Text>{' '}
+          <OrderInformationTooltipAction>
+            <ChangeSlippageToUserSettings
+              buttonLabel={t('vault-changes.slippage-from-settings')}
+              changeSlippage={() => {
+                changeSlippage('userSettings')
+              }}
+            />
+          </OrderInformationTooltipAction>
+        </Flex>
+      }
+    />
+  )
+}
+
+function SlippageFromSettingsWithTooltip({ slippage, changeSlippage }: SlippageInformationProps) {
+  const { t } = useTranslation()
+  return (
+    <VaultChangesInformationItem
+      label={t('vault-changes.slippage-limit')}
+      value={
+        <Flex>
+          <Text color={'warning100'}>{formatPercent(slippage.times(100), { precision: 2 })}</Text>
+          <OrderInformationTooltipAction>
+            <ChangeSlippageToUserSettings
+              buttonLabel={t('vault-changes.slippage-from-strategy')}
+              changeSlippage={() => {
+                changeSlippage('strategyConfig')
+              }}
+            />
+          </OrderInformationTooltipAction>
+        </Flex>
+      }
+    />
+  )
+}
+
+export function SlippageInformation(props: SlippageInformationProps) {
+  if (!props.isStrategyHasSlippage) return <BasicSlippageInformation {...props} />
+  if (props.getSlippageFrom === 'strategyConfig')
+    return <SlippageFromStrategyWithTooltip {...props} />
+  return <SlippageFromSettingsWithTooltip {...props} />
 }

--- a/features/aave/common/components/informationContainer/StrategyInformationContainer.tsx
+++ b/features/aave/common/components/informationContainer/StrategyInformationContainer.tsx
@@ -1,6 +1,7 @@
 import { IPosition, IPositionTransition } from '@oasisdex/oasis-actions'
 import { VaultChangesInformationContainer } from 'components/vault/VaultChangesInformation'
-import { StrategyTokenBalance } from 'features/aave/common/BaseAaveContext'
+import { getSlippage, StrategyTokenBalance } from 'features/aave/common/BaseAaveContext'
+import { IStrategyConfig } from 'features/aave/common/StrategyConfigTypes'
 import { UserSettingsState } from 'features/userSettings/userSettings'
 import { HasGasEstimation } from 'helpers/form'
 import { zero } from 'helpers/zero'
@@ -31,11 +32,17 @@ type OpenAaveInformationContainerProps = {
       transition?: IPositionTransition
       userSettings?: UserSettingsState
       currentPosition?: IPosition
+      strategyConfig: IStrategyConfig
+      getSlippageFrom: 'strategyConfig' | 'userSettings'
     }
   }
+  changeSlippageSource: (from: 'strategyConfig' | 'userSettings') => void
 }
 
-export function StrategyInformationContainer({ state }: OpenAaveInformationContainerProps) {
+export function StrategyInformationContainer({
+  state,
+  changeSlippageSource,
+}: OpenAaveInformationContainerProps) {
   const { t } = useTranslation()
 
   const { transition, currentPosition, balance } = state.context
@@ -54,7 +61,14 @@ export function StrategyInformationContainer({ state }: OpenAaveInformationConta
       {simulationHasSwap && balance && (
         <PriceImpact {...state.context} transactionParameters={transition} balance={balance} />
       )}
-      {simulationHasSwap && <SlippageInformation {...state.context.userSettings!} />}
+      {simulationHasSwap && (
+        <SlippageInformation
+          slippage={getSlippage(state.context)}
+          isStrategyHasSlippage={state.context.strategyConfig.defaultSlippage !== undefined}
+          getSlippageFrom={state.context.getSlippageFrom}
+          changeSlippage={changeSlippageSource}
+        />
+      )}
       <MultiplyInformation
         {...state.context}
         transactionParameters={transition}

--- a/features/aave/manage/containers/AaveManageStateMachineContext.tsx
+++ b/features/aave/manage/containers/AaveManageStateMachineContext.tsx
@@ -34,6 +34,7 @@ function setupManageAaveStateContext({
       manageTokenInput: defaultManageTokenInputValues,
       positionCreatedBy: positionCreatedBy,
       positionId: positionId,
+      getSlippageFrom: strategy.defaultSlippage !== undefined ? 'strategyConfig' : 'userSettings',
     }),
     { devTools: env.NODE_ENV !== 'production' },
   ).start()

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -134,7 +134,7 @@ function BalanceAfterClose({ state, token }: ManageAaveStateProps & { token: str
   )
 }
 
-function ManageAaveTransactionInProgressStateView({ state }: ManageAaveStateProps) {
+function ManageAaveTransactionInProgressStateView({ state, send }: ManageAaveStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -142,7 +142,12 @@ function ManageAaveTransactionInProgressStateView({ state }: ManageAaveStateProp
     content: (
       <Grid gap={3}>
         <OpenVaultAnimation />
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton: {
@@ -238,7 +243,14 @@ function GetReviewingSidebarProps({
               {t('manage-earn.aave.vault-form.close-description', { closeToToken })}
             </Text>
             {closeToToken && <BalanceAfterClose state={state} send={send} token={closeToToken} />}
-            {closeToToken && <StrategyInformationContainer state={state} />}
+            {closeToToken && (
+              <StrategyInformationContainer
+                state={state}
+                changeSlippageSource={(from) => {
+                  send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+                }}
+              />
+            )}
           </Grid>
         ),
       }
@@ -293,7 +305,12 @@ function GetReviewingSidebarProps({
                 type="error"
               />
             )}
-            <StrategyInformationContainer state={state} />
+            <StrategyInformationContainer
+              state={state}
+              changeSlippageSource={(from) => {
+                send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+              }}
+            />
           </Grid>
         ),
       }
@@ -353,7 +370,12 @@ function GetReviewingSidebarProps({
                 type="error"
               />
             )}
-            <StrategyInformationContainer state={state} />
+            <StrategyInformationContainer
+              state={state}
+              changeSlippageSource={(from) => {
+                send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+              }}
+            />
           </Grid>
         ),
       }
@@ -365,7 +387,12 @@ function GetReviewingSidebarProps({
             <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
               {t('manage-earn.aave.vault-form.adjust-description')}
             </Text>
-            <StrategyInformationContainer state={state} />
+            <StrategyInformationContainer
+              state={state}
+              changeSlippageSource={(from) => {
+                send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+              }}
+            />
           </Grid>
         ),
       }
@@ -424,7 +451,7 @@ function ManageAaveFailureStateView({ state, send }: ManageAaveStateProps) {
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-function ManageAaveSuccessAdjustPositionStateView({ state }: ManageAaveStateProps) {
+function ManageAaveSuccessAdjustPositionStateView({ state, send }: ManageAaveStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -436,7 +463,12 @@ function ManageAaveSuccessAdjustPositionStateView({ state }: ManageAaveStateProp
             <Image src={staticFilesRuntimeUrl('/static/img/protection_complete_v2.svg')} />
           </Flex>
         </Box>
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton: {
@@ -448,7 +480,7 @@ function ManageAaveSuccessAdjustPositionStateView({ state }: ManageAaveStateProp
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-function ManageAaveSuccessClosePositionStateView({ state }: ManageAaveStateProps) {
+function ManageAaveSuccessClosePositionStateView({ state, send }: ManageAaveStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -460,7 +492,12 @@ function ManageAaveSuccessClosePositionStateView({ state }: ManageAaveStateProps
             <Image src={staticFilesRuntimeUrl('/static/img/protection_complete_v2.svg')} />
           </Flex>
         </Box>
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton: {

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -11,8 +11,8 @@ import {
   BaseAaveContext,
   BaseAaveEvent,
   contextToTransactionParameters,
+  getSlippage,
   isAllowanceNeeded,
-  IStrategyConfig,
   ManageTokenInput,
   ProxyType,
 } from 'features/aave/common'
@@ -40,7 +40,6 @@ type ActorFromTransactionParametersStateMachine =
 export interface ManageAaveContext extends BaseAaveContext {
   refTransactionMachine?: ActorRefFrom<TransactionStateMachine<OperationExecutorTxMeta>>
   refParametersMachine?: ActorFromTransactionParametersStateMachine
-  strategyConfig: IStrategyConfig
   positionId: PositionId
   proxyAddress?: string
   ownerAddress?: string
@@ -254,6 +253,10 @@ export function createManageAaveStateMachine(
                   target: 'reviewingClosing',
                   actions: ['reset', 'killCurrentParametersMachine', 'spawnCloseParametersMachine'],
                 },
+                USE_SLIPPAGE: {
+                  target: ['#manageAaveStateMachine.background.debouncingManage'],
+                  actions: 'updateContext',
+                },
               },
             },
             manageDebt: {
@@ -277,6 +280,10 @@ export function createManageAaveStateMachine(
                   cond: 'canChangePosition',
                   target: 'reviewingClosing',
                   actions: ['reset', 'killCurrentParametersMachine', 'spawnCloseParametersMachine'],
+                },
+                USE_SLIPPAGE: {
+                  target: ['#manageAaveStateMachine.background.debouncingManage'],
+                  actions: 'updateContext',
                 },
               },
             },
@@ -465,6 +472,10 @@ export function createManageAaveStateMachine(
           target: '#manageAaveStateMachine.background.debouncingManage',
           actions: ['updateTokenActionValue'],
         },
+        USE_SLIPPAGE: {
+          target: ['background.debouncing'],
+          actions: 'updateContext',
+        },
       },
     },
     {
@@ -558,7 +569,7 @@ export function createManageAaveStateMachine(
               proxyAddress: context.proxyAddress!,
               token: context.tokens.deposit,
               context: context.web3Context!,
-              slippage: context.userSettings!.slippage,
+              slippage: getSlippage(context),
               currentPosition: context.currentPosition!,
               manageTokenInput: context.manageTokenInput,
               proxyType: context.positionCreatedBy,
@@ -580,7 +591,7 @@ export function createManageAaveStateMachine(
               parameters: {
                 proxyAddress: context.proxyAddress!,
                 context: context.web3Context!,
-                slippage: context.userSettings!.slippage,
+                slippage: getSlippage(context),
                 currentPosition: context.currentPosition!,
                 manageTokenInput: context.manageTokenInput,
                 proxyType: context.positionCreatedBy,

--- a/features/aave/open/containers/AaveOpenStateMachineContext.tsx
+++ b/features/aave/open/containers/AaveOpenStateMachineContext.tsx
@@ -23,6 +23,8 @@ function setupOpenAaveStateContext({
       currentStep: 1,
       totalSteps: 4,
       currentPosition: getEmptyPosition(config.tokens.collateral, config.tokens.debt),
+      getSlippageFrom:
+        effectiveStrategy.defaultSlippage !== undefined ? 'strategyConfig' : 'userSettings',
     }),
     { devTools: process.env.NODE_ENV !== 'production' },
   ).start()

--- a/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -52,7 +52,7 @@ interface OpenAaveStateProps {
   isLoading: () => boolean
 }
 
-function OpenAaveTransactionInProgressStateView({ state }: OpenAaveStateProps) {
+function OpenAaveTransactionInProgressStateView({ state, send }: OpenAaveStateProps) {
   const { t } = useTranslation()
   const { stopLossSkipped, stopLossLevel } = state.context
 
@@ -67,7 +67,12 @@ function OpenAaveTransactionInProgressStateView({ state }: OpenAaveStateProps) {
       <Grid gap={3}>
         {withStopLoss && <StopLossTwoTxRequirement typeKey="position" />}
         <OpenVaultAnimation />
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton: {
@@ -199,7 +204,12 @@ function OpenAaveReviewingStateView({ state, send, isLoading }: OpenAaveStatePro
     content: (
       <Grid gap={3}>
         {withStopLoss && <StopLossTwoTxRequirement typeKey="position" />}
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton,
@@ -223,7 +233,12 @@ function OpenAaveFailureStateView({ state, send }: OpenAaveStateProps) {
     title: t(state.context.strategyConfig.viewComponents.sidebarTitle),
     content: (
       <Grid gap={3}>
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton: {
@@ -343,7 +358,7 @@ function OpenAaveEditingStateView({ state, send, isLoading }: OpenAaveStateProps
   return <SidebarSection {...sidebarSectionProps} />
 }
 
-function OpenAaveSuccessStateView({ state }: OpenAaveStateProps) {
+function OpenAaveSuccessStateView({ state, send }: OpenAaveStateProps) {
   const { t } = useTranslation()
 
   const sidebarSectionProps: SidebarSectionProps = {
@@ -351,7 +366,12 @@ function OpenAaveSuccessStateView({ state }: OpenAaveStateProps) {
     content: (
       <Grid gap={3}>
         <CompleteBanner />
-        <StrategyInformationContainer state={state} />
+        <StrategyInformationContainer
+          state={state}
+          changeSlippageSource={(from) => {
+            send({ type: 'USE_SLIPPAGE', getSlippageFrom: from })
+          }}
+        />
       </Grid>
     ),
     primaryButton: {

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -19,9 +19,10 @@ import {
   BaseAaveContext,
   BaseAaveEvent,
   contextToTransactionParameters,
+  getSlippage,
   isAllowanceNeeded,
 } from 'features/aave/common/BaseAaveContext'
-import { IStrategyConfig, ProxyType } from 'features/aave/common/StrategyConfigTypes'
+import { ProxyType } from 'features/aave/common/StrategyConfigTypes'
 import { isUserWalletConnected } from 'features/aave/helpers'
 import { convertDefaultRiskRatioToActualRiskRatio } from 'features/aave/strategyConfig'
 import {
@@ -65,7 +66,6 @@ export interface OpenAaveContext extends BaseAaveContext {
   refParametersMachine?: ActorRefFrom<TransactionParametersStateMachine<OpenAaveParameters>>
   refStopLossMachine?: ActorRefFrom<TransactionStateMachine<AutomationTxData>>
   hasOpenedPosition?: boolean
-  strategyConfig: IStrategyConfig
   positionRelativeAddress?: string
   blockSettingCalculatedAddresses?: boolean
   reserveConfig?: AaveV2ReserveConfigurationData
@@ -395,6 +395,10 @@ export function createOpenAaveStateMachine(
         GAS_PRICE_ESTIMATION_RECEIVED: {
           actions: 'updateContext',
         },
+        USE_SLIPPAGE: {
+          target: ['background.debouncing'],
+          actions: 'updateContext',
+        },
         UPDATE_STRATEGY_INFO: {
           actions: 'updateContext',
         },
@@ -600,7 +604,7 @@ export function createOpenAaveStateMachine(
                 depositToken: context.tokens.deposit,
                 token: context.tokens.deposit,
                 context: context.web3Context!,
-                slippage: context.userSettings!.slippage,
+                slippage: getSlippage(context),
                 proxyType: context.strategyConfig.proxyType,
                 positionType: context.strategyConfig.type,
                 protocol: context.strategyConfig.protocol,

--- a/features/aave/strategyConfig.ts
+++ b/features/aave/strategyConfig.ts
@@ -65,6 +65,7 @@ export const strategies: Array<IStrategyConfig> = [
     protocol: LendingProtocol.AaveV3,
     featureToggle: 'AaveV3EarnWSTETH' as const,
     availableActions: ['close'],
+    defaultSlippage: new BigNumber(0.001),
   },
   {
     urlSlug: 'stETHeth',

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -1300,7 +1300,10 @@
     "third-party-fees": "第三方协议手续费",
     "oasis-fee": "Oasis 手续费",
     "ltv": "LTV",
-    "outstanding-debt": "Outstanding debt"
+    "outstanding-debt": "Outstanding debt",
+    "slippage-info": "Slippage Limit sets the percentage you are willing to slip below the above shown buy/sell price. Lower slippage decreases potential losses, but increases chances of transaction failure. ",
+    "slippage-from-settings": "Use slippage from settings",
+    "slippage-from-strategy": "Use slippage from strategy"
   },
   "vault-information": "金库信息",
   "vault-banners": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1210,7 +1210,10 @@
     "oasis-fee": "Oasis fee",
     "ltv": "LTV",
     "outstanding-debt": "Outstanding debt",
-    "loan-to-value": "Loan to Value"
+    "loan-to-value": "Loan to Value",
+    "slippage-info": "Slippage Limit sets the percentage you are willing to slip below the above shown buy/sell price. Lower slippage decreases potential losses, but increases chances of transaction failure. ",
+    "slippage-from-settings": "Use slippage from settings",
+    "slippage-from-strategy": "Use slippage from strategy"
   },
   "vault-actions": {
     "deposit": "Deposit",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -785,7 +785,10 @@
     "third-party-fees": "Tasas de protocolos de terceros",
     "oasis-fee": "Tasa de Oasis",
     "ltv": "LTV",
-    "outstanding-debt": "Outstanding debt"
+    "outstanding-debt": "Outstanding debt",
+    "slippage-info": "Slippage Limit sets the percentage you are willing to slip below the above shown buy/sell price. Lower slippage decreases potential losses, but increases chances of transaction failure. ",
+    "slippage-from-settings": "Use slippage from settings",
+    "slippage-from-strategy": "Use slippage from strategy"
   },
   "vault-actions": {
     "deposit": "Deposita",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -537,7 +537,10 @@
     "third-party-fees": "3rd party protocol fees",
     "oasis-fee": "Oasis fee",
     "ltv": "LTV",
-    "outstanding-debt": "Outstanding debt"
+    "outstanding-debt": "Outstanding debt",
+    "slippage-info": "Slippage Limit sets the percentage you are willing to slip below the above shown buy/sell price. Lower slippage decreases potential losses, but increases chances of transaction failure. ",
+    "slippage-from-settings": "Use slippage from settings",
+    "slippage-from-strategy": "Use slippage from strategy"
   },
   "vault-changed": "Cofre alterado!",
   "vault-history": "Histório do Cofre",


### PR DESCRIPTION
# Changes
- Introduce a default slippage for the strategy.
- Default slippage for Earn `wstETH/ETH` -> 0.1%.
- All transaction for `wsETH/ETH` has the default slippage set.
- User can change it to theirs (get from user settings).
- New tooltip for Order Information. The tooltip can have action and doesn't disappear after moving the mouse. 
