### PR TITLE
🧿 Separate borrow related stuff into its own context

### DIFF
--- a/actions/ajna/oasisActionsLibWrapper.ts
+++ b/actions/ajna/oasisActionsLibWrapper.ts
@@ -15,7 +15,7 @@ interface AjnaTxHandlerInput {
   collateralToken: string
   quoteToken: string
   context: Context
-  currentPosition: AjnaPosition
+  position: AjnaPosition
 }
 
 export async function getAjnaParameters({
@@ -24,7 +24,7 @@ export async function getAjnaParameters({
   collateralToken,
   quoteToken,
   context,
-  currentPosition,
+  position,
 }: AjnaTxHandlerInput & {
   rpcProvider: ethers.providers.Provider
 }): Promise<AjnaActionData> {
@@ -79,7 +79,7 @@ export async function getAjnaParameters({
           quoteAmount: generateAmount || zero,
           collateralAmount: depositAmount,
           price,
-          position: currentPosition,
+          position,
         },
         dependencies,
       )
@@ -93,7 +93,7 @@ export async function getAjnaParameters({
           ...commonPayload,
           quoteAmount: paybackAmount || zero,
           collateralAmount: withdrawAmount,
-          position: currentPosition,
+          position,
         },
         dependencies,
       )
@@ -108,7 +108,7 @@ export async function getAjnaParameters({
           quoteAmount: generateAmount,
           collateralAmount: depositAmount || zero,
           price,
-          position: currentPosition,
+          position,
         },
         dependencies,
       )
@@ -122,7 +122,7 @@ export async function getAjnaParameters({
           ...commonPayload,
           quoteAmount: paybackAmount,
           collateralAmount: withdrawAmount || zero,
-          position: currentPosition,
+          position,
         },
         dependencies,
       )

--- a/features/ajna/borrow/contexts/AjnaBorrowContext.tsx
+++ b/features/ajna/borrow/contexts/AjnaBorrowContext.tsx
@@ -1,0 +1,174 @@
+import { AjnaSimulationData } from 'actions/ajna'
+import { useAppContext } from 'components/AppContextProvider'
+import { useGasEstimationContext } from 'components/GasEstimationContextProvider'
+import { ValidationMessagesInput } from 'components/ValidationMessages'
+import { isBorrowFormValid } from 'features/ajna/borrow/contexts/isBorrowFormValid'
+import { useAjnaBorrowFormReducto } from 'features/ajna/borrow/state/ajnaBorrowFormReducto'
+import {
+  defaultErrors,
+  defaultWarnings,
+  getAjnaBorrowValidations,
+} from 'features/ajna/borrow/validations'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useObservable } from 'helpers/observableHook'
+import React, {
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+import { AjnaPosition } from '@oasisdex/oasis-actions/lib/packages/oasis-actions/src/helpers/ajna'
+
+interface AjnaBorrowContextProviderProps {
+  position: AjnaPosition
+}
+
+type AjnaBorrowPositionSet = {
+  position: AjnaPosition
+  simulation?: AjnaPosition
+}
+
+export interface AjnaBorrowPosition {
+  cachedPosition?: AjnaBorrowPositionSet
+  currentPosition: AjnaBorrowPositionSet
+  isSimulationLoading?: boolean
+  resolvedId?: string
+  setCachedPosition: Dispatch<SetStateAction<AjnaBorrowPositionSet | undefined>>
+  setIsLoadingSimulation: Dispatch<SetStateAction<boolean>>
+  setSimulation: Dispatch<SetStateAction<AjnaSimulationData | undefined>>
+}
+
+interface AjnaBorrowContext {
+  form: ReturnType<typeof useAjnaBorrowFormReducto>
+  position: AjnaBorrowPosition
+  validation: {
+    errors: ValidationMessagesInput
+    isFormValid: boolean
+    warnings: ValidationMessagesInput
+  }
+}
+
+const ajnaBorrowContext = React.createContext<AjnaBorrowContext | undefined>(undefined)
+
+export function useAjnaBorrowContext(): AjnaBorrowContext {
+  const ac = useContext(ajnaBorrowContext)
+
+  if (!ac) {
+    throw new Error(
+      "AjnaBorrowContext not available! useAjnaBorrowContext can't be used serverside",
+    )
+  }
+  return ac
+}
+
+export function AjnaBorrowContextProvider({
+  children,
+  position,
+}: PropsWithChildren<AjnaBorrowContextProviderProps>) {
+  const gasEstimation = useGasEstimationContext()
+  const {
+    environment: { collateralBalance, collateralToken, ethBalance, ethPrice, flow, quoteBalance },
+    steps: { currentStep },
+    tx: { txDetails },
+  } = useAjnaProductContext()
+
+  const form = useAjnaBorrowFormReducto({
+    action: flow === 'open' ? 'open' : 'deposit',
+  })
+  const { positionIdFromDpmProxy$ } = useAppContext()
+  const [positionIdFromDpmProxyData] = useObservable(
+    useMemo(() => positionIdFromDpmProxy$(form.state.dpmAddress), [form.state.dpmAddress]),
+  )
+
+  const [simulation, setSimulation] = useState<AjnaSimulationData>()
+  const [isSimulationLoading, setIsLoadingSimulation] = useState(false)
+  const [cachedPosition, setCachedPosition] = useState<AjnaBorrowPositionSet>()
+
+  const { errors, warnings } = useMemo(
+    () =>
+      getAjnaBorrowValidations({
+        collateralBalance,
+        collateralToken,
+        depositAmount: form.state.depositAmount,
+        ethBalance,
+        ethPrice,
+        gasEstimationUsd: gasEstimation?.usdValue,
+        paybackAmount: form.state.paybackAmount,
+        quoteBalance,
+        simulationErrors: simulation?.errors,
+        simulationWarnings: simulation?.errors,
+        txError: txDetails?.txError,
+      }),
+    [
+      collateralBalance.toString(),
+      collateralToken,
+      ethBalance.toString(),
+      ethPrice.toString(),
+      form.state.depositAmount?.toString(),
+      form.state.paybackAmount?.toString(),
+      gasEstimation?.usdValue.toString(),
+      quoteBalance.toString(),
+      simulation?.errors,
+      txDetails?.txError,
+    ],
+  )
+
+  const [context, setContext] = useState<AjnaBorrowContext>({
+    form,
+    position: {
+      cachedPosition,
+      currentPosition: { position },
+      isSimulationLoading,
+      resolvedId: positionIdFromDpmProxyData,
+      setCachedPosition,
+      setIsLoadingSimulation,
+      setSimulation,
+    },
+    validation: {
+      errors: defaultErrors,
+      isFormValid: isBorrowFormValid({ currentStep, formState: form.state, errors }),
+      warnings: defaultWarnings,
+    },
+  })
+
+  useEffect(() => {
+    setContext((prev) => ({
+      ...prev,
+      position: {
+        ...prev.position,
+        cachedPosition,
+        currentPosition: {
+          position,
+          simulation: simulation?.position,
+        },
+        isSimulationLoading,
+        resolvedId: positionIdFromDpmProxyData,
+      },
+      form: { ...prev.form, state: form.state },
+      validation: {
+        errors,
+        isFormValid: isBorrowFormValid({ currentStep, formState: form.state, errors }),
+        warnings,
+      },
+    }))
+  }, [
+    cachedPosition,
+    collateralBalance,
+    currentStep,
+    errors,
+    form.state,
+    isSimulationLoading,
+    position,
+    positionIdFromDpmProxyData,
+    quoteBalance,
+    simulation,
+    txDetails,
+    warnings,
+  ])
+
+  return <ajnaBorrowContext.Provider value={context}>{children}</ajnaBorrowContext.Provider>
+}

--- a/features/ajna/borrow/contexts/AjnaBorrowContext.tsx
+++ b/features/ajna/borrow/contexts/AjnaBorrowContext.tsx
@@ -11,6 +11,7 @@ import {
 } from 'features/ajna/borrow/validations'
 import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useObservable } from 'helpers/observableHook'
+import { useAccount } from 'helpers/useAccount'
 import React, {
   Dispatch,
   PropsWithChildren,
@@ -69,6 +70,7 @@ export function AjnaBorrowContextProvider({
   children,
   position,
 }: PropsWithChildren<AjnaBorrowContextProviderProps>) {
+  const { walletAddress } = useAccount()
   const gasEstimation = useGasEstimationContext()
   const {
     environment: { collateralBalance, collateralToken, ethBalance, ethPrice, flow, quoteBalance },
@@ -168,6 +170,7 @@ export function AjnaBorrowContextProvider({
     simulation,
     txDetails,
     warnings,
+    walletAddress,
   ])
 
   return <ajnaBorrowContext.Provider value={context}>{children}</ajnaBorrowContext.Provider>

--- a/features/ajna/borrow/contexts/isBorrowFormValid.ts
+++ b/features/ajna/borrow/contexts/isBorrowFormValid.ts
@@ -2,31 +2,31 @@ import { ValidationMessagesInput } from 'components/ValidationMessages'
 import { AjnaBorrowFormState } from 'features/ajna/borrow/state/ajnaBorrowFormReducto'
 import { GeneralStepManager } from 'features/ajna/contexts/ajnaStepManager'
 
-interface StepManagerWithBorrowForm extends GeneralStepManager {
+interface IsBorrowFormValidParams extends GeneralStepManager {
   formState: AjnaBorrowFormState
   errors?: ValidationMessagesInput
 }
 
-export function isBorrowStepValid({ currentStep, formState, errors }: StepManagerWithBorrowForm) {
-  const isError = !!errors?.messages.length
-
-  if (isError) {
-    return false
-  }
+export function isBorrowFormValid({
+  currentStep,
+  formState: { action, generateAmount, depositAmount, paybackAmount, withdrawAmount },
+  errors,
+}: IsBorrowFormValidParams) {
+  if (errors && errors.messages.length > 0) return false
 
   switch (currentStep) {
     case 'setup':
     case 'manage':
-      switch (formState.action) {
+      switch (action) {
         case 'open':
         case 'deposit':
-          return !!formState.depositAmount?.gt(0)
+          return !!depositAmount?.gt(0)
         case 'withdraw':
-          return !!formState.withdrawAmount?.gt(0)
+          return !!withdrawAmount?.gt(0)
         case 'generate':
-          return !!formState.generateAmount?.gt(0)
+          return !!generateAmount?.gt(0)
         case 'payback':
-          return !!formState.paybackAmount?.gt(0)
+          return !!paybackAmount?.gt(0)
         default:
           return false
       }

--- a/features/ajna/borrow/helpers.tsx
+++ b/features/ajna/borrow/helpers.tsx
@@ -32,9 +32,9 @@ export function getAjnaSidebarButtonsStatus({
   currentStep,
   editingStep,
   isAllowanceLoading,
+  isFormValid,
   isOwner,
   isSimulationLoading,
-  isStepValid,
   isTxError,
   isTxInProgress,
   isTxStarted,
@@ -44,9 +44,9 @@ export function getAjnaSidebarButtonsStatus({
   currentStep: AjnaStatusStep
   editingStep: AjnaEditingStep
   isAllowanceLoading: boolean
+  isFormValid: boolean
   isOwner: boolean
   isSimulationLoading?: boolean
-  isStepValid: boolean
   isTxError: boolean
   isTxInProgress: boolean
   isTxStarted: boolean
@@ -55,7 +55,7 @@ export function getAjnaSidebarButtonsStatus({
 }) {
   const isPrimaryButtonDisabled =
     !!walletAddress &&
-    (!isStepValid ||
+    (!isFormValid ||
       isAllowanceLoading ||
       isSimulationLoading ||
       isTxInProgress ||
@@ -81,7 +81,7 @@ export function getAjnaSidebarPrimaryButtonActions({
   defaultAction,
   editingStep,
   flow,
-  id,
+  resolvedId,
   isTxSuccess,
   walletAddress,
 }: {
@@ -89,7 +89,7 @@ export function getAjnaSidebarPrimaryButtonActions({
   defaultAction: () => void
   editingStep: string
   flow: AjnaFlow
-  id?: string
+  resolvedId?: string
   isTxSuccess: boolean
   walletAddress?: string
 }) {
@@ -97,7 +97,7 @@ export function getAjnaSidebarPrimaryButtonActions({
     case !walletAddress && currentStep === editingStep:
       return { url: '/connect' }
     case isTxSuccess && flow === 'open':
-      return { url: `/ajna/position/${id}` }
+      return { url: `/ajna/position/${resolvedId}` }
     default:
       return { action: defaultAction }
   }

--- a/features/ajna/borrow/overview/AjnaBorrowOverviewWrapper.tsx
+++ b/features/ajna/borrow/overview/AjnaBorrowOverviewWrapper.tsx
@@ -1,12 +1,13 @@
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
 import { ContentCardCollateralLocked } from 'features/ajna/borrow/overview/ContentCardCollateralLocked'
 import { ContentCardLiquidationPrice } from 'features/ajna/borrow/overview/ContentCardLiquidationPrice'
 import { ContentCardLoanToValue } from 'features/ajna/borrow/overview/ContentCardLoanToValue'
 import { ContentCardPositionDebt } from 'features/ajna/borrow/overview/ContentCardPositionDebt'
 import { ContentFooterItemsBorrow } from 'features/ajna/borrow/overview/ContentFooterItemsBorrow'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { AjnaTokensBanner } from 'features/ajna/controls/AjnaTokensBanner'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -16,7 +17,11 @@ export function AjnaBorrowOverviewWrapper() {
   const { t } = useTranslation()
   const {
     environment: { collateralPrice, collateralToken, quotePrice, quoteToken },
-    position: { currentPosition, simulation },
+  } = useAjnaProductContext()
+  const {
+    position: {
+      currentPosition: { position, simulation },
+    },
   } = useAjnaBorrowContext()
 
   return (
@@ -28,27 +33,27 @@ export function AjnaBorrowOverviewWrapper() {
             <ContentCardLiquidationPrice
               collateralToken={collateralToken}
               quoteToken={quoteToken}
-              liquidationPrice={currentPosition.liquidationPrice}
-              afterLiquidationPrice={simulation?.position.liquidationPrice}
+              liquidationPrice={position.liquidationPrice}
+              afterLiquidationPrice={simulation?.liquidationPrice}
               belowCurrentPrice={collateralPrice
-                .minus(currentPosition.liquidationPrice)
+                .minus(position.liquidationPrice)
                 .dividedBy(collateralPrice)}
             />
             <ContentCardLoanToValue
-              loanToValue={currentPosition.riskRatio.loanToValue}
-              afterLoanToValue={simulation?.position.riskRatio.loanToValue}
+              loanToValue={position.riskRatio.loanToValue}
+              afterLoanToValue={simulation?.riskRatio.loanToValue}
             />
             <ContentCardCollateralLocked
               collateralToken={collateralToken}
-              collateralLocked={currentPosition.collateralAmount}
-              collateralLockedUSD={currentPosition.collateralAmount.times(collateralPrice)}
-              afterCollateralLocked={simulation?.position.collateralAmount}
+              collateralLocked={position.collateralAmount}
+              collateralLockedUSD={position.collateralAmount.times(collateralPrice)}
+              afterCollateralLocked={simulation?.collateralAmount}
             />
             <ContentCardPositionDebt
               quoteToken={quoteToken}
-              positionDebt={currentPosition.debtAmount}
-              positionDebtUSD={currentPosition.debtAmount.times(quotePrice)}
-              afterPositionDebt={simulation?.position.debtAmount}
+              positionDebt={position.debtAmount}
+              positionDebtUSD={position.debtAmount.times(quotePrice)}
+              afterPositionDebt={simulation?.debtAmount}
             />
           </DetailsSectionContentCardWrapper>
         }
@@ -57,11 +62,11 @@ export function AjnaBorrowOverviewWrapper() {
             <ContentFooterItemsBorrow
               collateralToken={collateralToken}
               quoteToken={quoteToken}
-              cost={currentPosition.pool.rate}
-              availableToBorrow={currentPosition.debtAvailable}
-              afterAvailableToBorrow={simulation?.position.debtAvailable}
-              availableToWithdraw={currentPosition.collateralAvailable}
-              afterAvailableToWithdraw={simulation?.position.collateralAvailable}
+              cost={position.pool.rate}
+              availableToBorrow={position.debtAvailable}
+              afterAvailableToBorrow={simulation?.debtAvailable}
+              availableToWithdraw={position.collateralAvailable}
+              afterAvailableToWithdraw={simulation?.collateralAvailable}
             />
           </DetailsSectionFooterItemWrapper>
         }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContent.tsx
@@ -1,5 +1,6 @@
 import { getToken } from 'blockchain/tokensMetadata'
 import { SidebarSection, SidebarSectionProps } from 'components/sidebar/SidebarSection'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
 import {
   getAjnaSidebarButtonsStatus,
   getAjnaSidebarPrimaryButtonActions,
@@ -9,7 +10,7 @@ import { AjnaBorrowFormContentManage } from 'features/ajna/borrow/sidebars/AjnaB
 import { AjnaBorrowFormContentRisk } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentRisk'
 import { AjnaBorrowFormContentTransaction } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentTransaction'
 import { getPrimaryButtonLabelKey } from 'features/ajna/common/helpers'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useAccount } from 'helpers/useAccount'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -28,12 +29,7 @@ export function AjnaBorrowFormContent({
   const { walletAddress } = useAccount()
   const {
     environment: { collateralToken, flow, product, quoteToken, isOwner },
-    form: {
-      dispatch,
-      state: { dpmAddress, uiDropdown },
-      updateState,
-    },
-    steps: { currentStep, editingStep, setNextStep, setStep, isStepWithTransaction, isStepValid },
+    steps: { currentStep, editingStep, setNextStep, setStep, isStepWithTransaction },
     tx: {
       isTxError,
       isTxSuccess,
@@ -42,7 +38,15 @@ export function AjnaBorrowFormContent({
       isTxInProgress,
       setTxDetails,
     },
-    position: { id, isSimulationLoading },
+  } = useAjnaProductContext()
+  const {
+    form: {
+      dispatch,
+      state: { dpmAddress, uiDropdown },
+      updateState,
+    },
+    position: { isSimulationLoading, resolvedId },
+    validation: { isFormValid },
   } = useAjnaBorrowContext()
 
   const {
@@ -54,9 +58,9 @@ export function AjnaBorrowFormContent({
     currentStep,
     editingStep,
     isAllowanceLoading,
+    isFormValid,
     isOwner,
     isSimulationLoading,
-    isStepValid,
     isTxError,
     isTxInProgress,
     isTxStarted,
@@ -84,7 +88,7 @@ export function AjnaBorrowFormContent({
     currentStep,
     editingStep,
     flow,
-    id,
+    resolvedId,
     isTxSuccess,
     walletAddress,
   })

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentDeposit.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentDeposit.tsx
@@ -1,34 +1,23 @@
-import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { AjnaBorrowFormContentSummary } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentSummary'
 import {
   AjnaBorrowFormFieldDeposit,
   AjnaBorrowFormFieldGenerate,
 } from 'features/ajna/borrow/sidebars/AjnaBorrowFormFields'
-import { AjnaBorrowFormOrder } from 'features/ajna/borrow/sidebars/AjnaBorrowFormOrder'
-import { AjnaValidationMessages } from 'features/ajna/components/AjnaValidationMessages'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import React from 'react'
 
 export function AjnaBorrowFormContentDeposit() {
   const {
     form: {
-      dispatch,
       state: { depositAmount },
     },
-    validation: { errors, warnings },
   } = useAjnaBorrowContext()
 
   return (
     <>
       <AjnaBorrowFormFieldDeposit resetOnClear />
       <AjnaBorrowFormFieldGenerate isDisabled={!depositAmount || depositAmount?.lte(0)} />
-      {depositAmount && (
-        <>
-          <SidebarResetButton clear={() => dispatch({ type: 'reset' })} />
-          <AjnaValidationMessages {...errors} />
-          <AjnaValidationMessages {...warnings} />
-          <AjnaBorrowFormOrder />
-        </>
-      )}
+      {depositAmount && <AjnaBorrowFormContentSummary />}
     </>
   )
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentGenerate.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentGenerate.tsx
@@ -1,34 +1,23 @@
-import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { AjnaBorrowFormContentSummary } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentSummary'
 import {
   AjnaBorrowFormFieldDeposit,
   AjnaBorrowFormFieldGenerate,
 } from 'features/ajna/borrow/sidebars/AjnaBorrowFormFields'
-import { AjnaBorrowFormOrder } from 'features/ajna/borrow/sidebars/AjnaBorrowFormOrder'
-import { AjnaValidationMessages } from 'features/ajna/components/AjnaValidationMessages'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import React from 'react'
 
 export function AjnaBorrowFormContentGenerate() {
   const {
     form: {
-      dispatch,
       state: { generateAmount },
     },
-    validation: { errors, warnings },
   } = useAjnaBorrowContext()
 
   return (
     <>
       <AjnaBorrowFormFieldGenerate resetOnClear />
       <AjnaBorrowFormFieldDeposit isDisabled={!generateAmount || generateAmount?.lte(0)} />
-      {generateAmount && (
-        <>
-          <SidebarResetButton clear={() => dispatch({ type: 'reset' })} />
-          <AjnaValidationMessages {...errors} />
-          <AjnaValidationMessages {...warnings} />
-          <AjnaBorrowFormOrder />
-        </>
-      )}
+      {generateAmount && <AjnaBorrowFormContentSummary />}
     </>
   )
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentManage.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentManage.tsx
@@ -1,9 +1,9 @@
 import { ActionPills } from 'components/ActionPills'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
 import { AjnaBorrowFormContentDeposit } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentDeposit'
 import { AjnaBorrowFormContentGenerate } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentGenerate'
 import { AjnaBorrowFormContentPayback } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentPayback'
 import { AjnaBorrowFormContentWithdraw } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentWithdraw'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
@@ -1,34 +1,23 @@
-import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { AjnaBorrowFormContentSummary } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentSummary'
 import {
   AjnaBorrowFormFieldPayback,
   AjnaBorrowFormFieldWithdraw,
 } from 'features/ajna/borrow/sidebars/AjnaBorrowFormFields'
-import { AjnaBorrowFormOrder } from 'features/ajna/borrow/sidebars/AjnaBorrowFormOrder'
-import { AjnaValidationMessages } from 'features/ajna/components/AjnaValidationMessages'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import React from 'react'
 
 export function AjnaBorrowFormContentPayback() {
   const {
     form: {
-      dispatch,
       state: { paybackAmount },
     },
-    validation: { errors, warnings },
   } = useAjnaBorrowContext()
 
   return (
     <>
       <AjnaBorrowFormFieldPayback resetOnClear />
       <AjnaBorrowFormFieldWithdraw isDisabled={!paybackAmount || paybackAmount?.lte(0)} />
-      {paybackAmount && (
-        <>
-          <SidebarResetButton clear={() => dispatch({ type: 'reset' })} />
-          <AjnaValidationMessages {...errors} />
-          <AjnaValidationMessages {...warnings} />
-          <AjnaBorrowFormOrder />
-        </>
-      )}
+      {paybackAmount && <AjnaBorrowFormContentSummary />}
     </>
   )
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentSummary.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentSummary.tsx
@@ -1,0 +1,21 @@
+import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { AjnaBorrowFormOrder } from 'features/ajna/borrow/sidebars/AjnaBorrowFormOrder'
+import { AjnaValidationMessages } from 'features/ajna/components/AjnaValidationMessages'
+import React from 'react'
+
+export function AjnaBorrowFormContentSummary() {
+  const {
+    form: { dispatch },
+    validation: { errors, warnings },
+  } = useAjnaBorrowContext()
+
+  return (
+    <>
+      <SidebarResetButton clear={() => dispatch({ type: 'reset' })} />
+      <AjnaValidationMessages {...errors} />
+      <AjnaValidationMessages {...warnings} />
+      <AjnaBorrowFormOrder />
+    </>
+  )
+}

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentTransaction.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentTransaction.tsx
@@ -1,6 +1,6 @@
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { AjnaBorrowFormOrder } from 'features/ajna/borrow/sidebars/AjnaBorrowFormOrder'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Text } from 'theme-ui'
@@ -11,7 +11,7 @@ export function AjnaBorrowFormContentTransaction() {
   const {
     environment: { collateralToken, quoteToken },
     tx: { isTxStarted, isTxError, isTxWaitingForApproval, isTxInProgress, isTxSuccess },
-  } = useAjnaBorrowContext()
+  } = useAjnaProductContext()
 
   return (
     <>

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
@@ -1,34 +1,23 @@
-import { SidebarResetButton } from 'components/vault/sidebar/SidebarResetButton'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { AjnaBorrowFormContentSummary } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContentSummary'
 import {
   AjnaBorrowFormFieldPayback,
   AjnaBorrowFormFieldWithdraw,
 } from 'features/ajna/borrow/sidebars/AjnaBorrowFormFields'
-import { AjnaBorrowFormOrder } from 'features/ajna/borrow/sidebars/AjnaBorrowFormOrder'
-import { AjnaValidationMessages } from 'features/ajna/components/AjnaValidationMessages'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
 import React from 'react'
 
 export function AjnaBorrowFormContentWithdraw() {
   const {
     form: {
-      dispatch,
       state: { withdrawAmount },
     },
-    validation: { errors, warnings },
   } = useAjnaBorrowContext()
 
   return (
     <>
       <AjnaBorrowFormFieldWithdraw resetOnClear />
       <AjnaBorrowFormFieldPayback isDisabled={!withdrawAmount || withdrawAmount?.lte(0)} />
-      {withdrawAmount && (
-        <>
-          <SidebarResetButton clear={() => dispatch({ type: 'reset' })} />
-          <AjnaValidationMessages {...errors} />
-          <AjnaValidationMessages {...warnings} />
-          <AjnaBorrowFormOrder />
-        </>
-      )}
+      {withdrawAmount && <AjnaBorrowFormContentSummary />}
     </>
   )
 }

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormFields.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormFields.tsx
@@ -1,5 +1,6 @@
 import { VaultActionInput } from 'components/vault/VaultActionInput'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { handleNumericInput } from 'helpers/input'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -12,11 +13,13 @@ interface AjnaBorrowFormField {
 export function AjnaBorrowFormFieldDeposit({ isDisabled, resetOnClear }: AjnaBorrowFormField) {
   const { t } = useTranslation()
   const {
+    environment: { collateralBalance, collateralPrice, collateralToken },
+  } = useAjnaProductContext()
+  const {
     form: {
       dispatch,
       state: { depositAmount, depositAmountUSD },
     },
-    environment: { collateralBalance, collateralPrice, collateralToken },
   } = useAjnaBorrowContext()
 
   return (
@@ -62,11 +65,13 @@ export function AjnaBorrowFormFieldDeposit({ isDisabled, resetOnClear }: AjnaBor
 
 export function AjnaBorrowFormFieldWithdraw({ isDisabled, resetOnClear }: AjnaBorrowFormField) {
   const {
+    environment: { collateralPrice, collateralToken },
+  } = useAjnaProductContext()
+  const {
     form: {
       dispatch,
       state: { withdrawAmount, withdrawAmountUSD },
     },
-    environment: { collateralPrice, collateralToken },
   } = useAjnaBorrowContext()
 
   return (
@@ -101,11 +106,13 @@ export function AjnaBorrowFormFieldWithdraw({ isDisabled, resetOnClear }: AjnaBo
 
 export function AjnaBorrowFormFieldGenerate({ isDisabled, resetOnClear }: AjnaBorrowFormField) {
   const {
+    environment: { quotePrice, quoteToken },
+  } = useAjnaProductContext()
+  const {
     form: {
       dispatch,
       state: { generateAmount, generateAmountUSD },
     },
-    environment: { quotePrice, quoteToken },
   } = useAjnaBorrowContext()
 
   return (
@@ -141,11 +148,13 @@ export function AjnaBorrowFormFieldGenerate({ isDisabled, resetOnClear }: AjnaBo
 export function AjnaBorrowFormFieldPayback({ isDisabled, resetOnClear }: AjnaBorrowFormField) {
   const { t } = useTranslation()
   const {
+    environment: { quoteBalance, quotePrice, quoteToken },
+  } = useAjnaProductContext()
+  const {
     form: {
       dispatch,
       state: { paybackAmount, paybackAmountUSD },
     },
-    environment: { quoteBalance, quotePrice, quoteToken },
   } = useAjnaBorrowContext()
 
   return (

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -1,6 +1,7 @@
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import {
   formatAmount,
   formatCryptoBalance,
@@ -14,13 +15,15 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
 
   const {
     environment: { collateralToken, quoteToken },
-    position: { currentPosition, simulation, cachedPosition },
+  } = useAjnaProductContext()
+  const {
+    position: { cachedPosition, currentPosition },
   } = useAjnaBorrowContext()
 
-  const positionData = cached && cachedPosition ? cachedPosition.currentPosition : currentPosition
-  const simulationData = cached && cachedPosition ? cachedPosition.simulation : simulation?.position
+  const positionData = cached && cachedPosition ? cachedPosition.position : currentPosition.position
+  const simulationData = cached && cachedPosition ? cachedPosition.simulation : currentPosition.simulation
 
-  const isLoading = !cached && simulation === undefined
+  const isLoading = !cached && currentPosition.simulation === undefined
   const formatted = {
     collateralLocked: formatCryptoBalance(positionData.collateralAmount),
     debt: formatCryptoBalance(positionData.debtAmount),

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -21,7 +21,8 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
   } = useAjnaBorrowContext()
 
   const positionData = cached && cachedPosition ? cachedPosition.position : currentPosition.position
-  const simulationData = cached && cachedPosition ? cachedPosition.simulation : currentPosition.simulation
+  const simulationData =
+    cached && cachedPosition ? cachedPosition.simulation : currentPosition.simulation
 
   const isLoading = !cached && currentPosition.simulation === undefined
   const formatted = {

--- a/features/ajna/borrow/sidebars/AjnaBorrowFormWrapper.tsx
+++ b/features/ajna/borrow/sidebars/AjnaBorrowFormWrapper.tsx
@@ -1,8 +1,9 @@
 import { FlowSidebar } from 'components/FlowSidebar'
 import { ethers } from 'ethers'
+import { useAjnaBorrowContext } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
 import { AjnaBorrowFormContent } from 'features/ajna/borrow/sidebars/AjnaBorrowFormContent'
 import { useAjnaTxHandler } from 'features/ajna/borrow/useAjnaTxHandler'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { useAccount } from 'helpers/useAccount'
 import { useFlowState } from 'helpers/useFlowState'
 import { zero } from 'helpers/zero'
@@ -12,12 +13,15 @@ export function AjnaBorrowFormWrapper() {
   const { walletAddress } = useAccount()
   const {
     environment: { dpmProxy, collateralToken, quoteToken },
+    steps: { currentStep, editingStep, isExternalStep, setNextStep, setStep, steps },
+  } = useAjnaProductContext()
+  const {
     form: {
       state: { action, depositAmount, paybackAmount },
       updateState,
     },
-    steps: { currentStep, editingStep, isExternalStep, setNextStep, setStep, steps },
   } = useAjnaBorrowContext()
+
   const txHandler = useAjnaTxHandler()
 
   const flowState = useFlowState({

--- a/features/ajna/borrow/views/AjnaBorrowView.tsx
+++ b/features/ajna/borrow/views/AjnaBorrowView.tsx
@@ -16,7 +16,16 @@ export function AjnaBorrowView() {
   const { t } = useTranslation()
   const { contextIsLoaded, walletAddress } = useAccount()
   const {
-    environment: { collateralPrice, collateralToken, flow, id, owner, product, quotePrice, quoteToken },
+    environment: {
+      collateralPrice,
+      collateralToken,
+      flow,
+      id,
+      owner,
+      product,
+      quotePrice,
+      quoteToken,
+    },
   } = useAjnaProductContext()
 
   return (

--- a/features/ajna/borrow/views/AjnaBorrowView.tsx
+++ b/features/ajna/borrow/views/AjnaBorrowView.tsx
@@ -3,7 +3,7 @@ import { VaultHeadline } from 'components/vault/VaultHeadline'
 import { getAjnaBorrowHeadlineProps } from 'features/ajna/borrow/helpers'
 import { AjnaBorrowOverviewWrapper } from 'features/ajna/borrow/overview/AjnaBorrowOverviewWrapper'
 import { AjnaBorrowFormWrapper } from 'features/ajna/borrow/sidebars/AjnaBorrowFormWrapper'
-import { useAjnaBorrowContext } from 'features/ajna/contexts/AjnaProductContext'
+import { useAjnaProductContext } from 'features/ajna/contexts/AjnaProductContext'
 import { VaultOwnershipBanner } from 'features/notices/VaultsNoticesView'
 import { formatCryptoBalance } from 'helpers/formatters/format'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
@@ -16,9 +16,8 @@ export function AjnaBorrowView() {
   const { t } = useTranslation()
   const { contextIsLoaded, walletAddress } = useAccount()
   const {
-    environment: { collateralPrice, collateralToken, flow, owner, product, quotePrice, quoteToken },
-    position: { id },
-  } = useAjnaBorrowContext()
+    environment: { collateralPrice, collateralToken, flow, id, owner, product, quotePrice, quoteToken },
+  } = useAjnaProductContext()
 
   return (
     <Container variant="vaultPageContainerStatic">

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -135,7 +135,7 @@ export function AjnaProductContextProvider({
       steps: setupStepManager(),
       tx: setupTxManager(),
     }))
-  }, [collateralBalance, currentStep, quoteBalance, txDetails])
+  }, [collateralBalance, currentStep, quoteBalance, txDetails, walletAddress])
 
   return <ajnaProductContext.Provider value={context}>{children}</ajnaProductContext.Provider>
 }

--- a/features/ajna/contexts/AjnaProductContext.tsx
+++ b/features/ajna/contexts/AjnaProductContext.tsx
@@ -1,25 +1,10 @@
 import { TxStatus } from '@oasisdex/transactions'
-import { AjnaSimulationData } from 'actions/ajna'
 import BigNumber from 'bignumber.js'
-import { isAppContextAvailable, useAppContext } from 'components/AppContextProvider'
-import { useGasEstimationContext } from 'components/GasEstimationContextProvider'
-import { ValidationMessagesInput } from 'components/ValidationMessages'
-import { isBorrowStepValid } from 'features/ajna/borrow/contexts/ajnaBorrowStepManager'
-import { useAjnaBorrowFormReducto } from 'features/ajna/borrow/state/ajnaBorrowFormReducto'
-import {
-  defaultErrors,
-  defaultWarnings,
-  getAjnaBorrowValidations,
-} from 'features/ajna/borrow/validations'
+import { isAppContextAvailable } from 'components/AppContextProvider'
 import { AjnaEditingStep, AjnaFlow, AjnaProduct, AjnaStatusStep } from 'features/ajna/common/types'
-import {
-  isExternalStep,
-  isNextStep,
-  isStepWithTransaction,
-} from 'features/ajna/contexts/ajnaStepManager'
+import { isExternalStep, isStepWithTransaction } from 'features/ajna/contexts/ajnaStepManager'
 import { getTxStatuses } from 'features/ajna/contexts/ajnaTxManager'
 import { TxDetails } from 'helpers/handleTransaction'
-import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
 import React, {
   Dispatch,
@@ -27,52 +12,32 @@ import React, {
   SetStateAction,
   useContext,
   useEffect,
-  useMemo,
   useState,
 } from 'react'
 
-import { AjnaPosition } from '@oasisdex/oasis-actions/lib/packages/oasis-actions/src/helpers/ajna'
-
-interface AjnaBorrowContextProviderProps {
+interface AjnaProductContextProviderProps {
   collateralBalance: BigNumber
-  ethBalance: BigNumber
   collateralPrice: BigNumber
   collateralToken: string
   dpmProxy?: string
+  ethBalance: BigNumber
   ethPrice: BigNumber
   flow: AjnaFlow
+  id?: string
+  owner: string
   product: AjnaProduct
   quoteBalance: BigNumber
   quotePrice: BigNumber
   quoteToken: string
-  owner: string
-  currentPosition: AjnaPosition
-  id?: string
   steps: AjnaStatusStep[]
 }
 
-type AjnaBorrowEnvironment = Omit<AjnaBorrowContextProviderProps, 'currentPosition' | 'steps'>
-type AjnaCachedPosition = {
-  currentPosition: AjnaPosition
-  simulation?: AjnaPosition
-}
+type AjnaProductEnvironment = Omit<AjnaProductContextProviderProps, 'steps'>
 
-export interface AjnaBorrowPosition {
-  cachedPosition?: AjnaCachedPosition
-  currentPosition: AjnaPosition
-  id?: string
-  isSimulationLoading?: boolean
-  setCachedPosition: Dispatch<SetStateAction<AjnaCachedPosition | undefined>>
-  setIsLoadingSimulation: Dispatch<SetStateAction<boolean>>
-  setSimulation: Dispatch<SetStateAction<AjnaSimulationData | undefined>>
-  simulation?: AjnaSimulationData
-}
-
-interface AjnaBorrowSteps {
+interface AjnaProductFlowSteps {
   currentStep: AjnaStatusStep
   editingStep: AjnaEditingStep
   isExternalStep: boolean
-  isStepValid: boolean
   isStepWithTransaction: boolean
   steps: AjnaStatusStep[]
   txStatus?: TxStatus
@@ -81,118 +46,49 @@ interface AjnaBorrowSteps {
   setPrevStep: () => void
 }
 
-interface AjnaBorrowTx {
+interface AjnaProductTx {
   isTxError: boolean
   isTxInProgress: boolean
   isTxStarted: boolean
   isTxSuccess: boolean
   isTxWaitingForApproval: boolean
-  txDetails?: TxDetails
   setTxDetails: Dispatch<SetStateAction<TxDetails | undefined>>
+  txDetails?: TxDetails
 }
 
-interface AjnaBorrowContext {
-  environment: AjnaBorrowEnvironment & {
+interface AjnaProductContext {
+  environment: AjnaProductEnvironment & {
     isOwner: boolean
   }
-  form: ReturnType<typeof useAjnaBorrowFormReducto>
-  position: AjnaBorrowPosition
-  steps: AjnaBorrowSteps
-  tx: AjnaBorrowTx
-  validation: {
-    errors: ValidationMessagesInput
-    warnings: ValidationMessagesInput
-  }
+  steps: AjnaProductFlowSteps
+  tx: AjnaProductTx
 }
 
-const ajnaBorrowContext = React.createContext<AjnaBorrowContext | undefined>(undefined)
+const ajnaProductContext = React.createContext<AjnaProductContext | undefined>(undefined)
 
-export function useAjnaBorrowContext(): AjnaBorrowContext {
-  const ac = useContext(ajnaBorrowContext)
+export function useAjnaProductContext(): AjnaProductContext {
+  const ac = useContext(ajnaProductContext)
 
   if (!ac) {
     throw new Error(
-      "AjnaBorrowContext not available! useAjnaBorrowContext can't be used serverside",
+      "AjnaProductContext not available! useAjnaProductContext can't be used serverside",
     )
   }
   return ac
 }
 
-export function AjnaBorrowContextProvider({
+export function AjnaProductContextProvider({
   children,
-  currentPosition,
-  id,
   steps,
   ...props
-}: PropsWithChildren<AjnaBorrowContextProviderProps>) {
+}: PropsWithChildren<AjnaProductContextProviderProps>) {
   if (!isAppContextAvailable()) return null
 
-  const {
-    flow,
-    collateralToken,
-    collateralBalance,
-    quoteBalance,
-    ethBalance,
-    ethPrice,
-    owner,
-  } = props
-
-  const form = useAjnaBorrowFormReducto({
-    action: flow === 'open' ? 'open' : 'deposit',
-  })
-  const { positionIdFromDpmProxy$ } = useAppContext()
-  const gasEstimation = useGasEstimationContext()
-
-  const _positionIdFromDpmProxy$ = useMemo(() => positionIdFromDpmProxy$(form.state.dpmAddress), [
-    form.state.dpmAddress,
-  ])
-  const [positionIdFromDpmProxy] = useObservable(_positionIdFromDpmProxy$)
-
-  const resolvedId = id && id !== '0' ? id : positionIdFromDpmProxy
+  const { flow, collateralBalance, quoteBalance, owner } = props
   const { walletAddress } = useAccount()
   const [currentStep, setCurrentStep] = useState<AjnaStatusStep>(steps[0])
   const [txDetails, setTxDetails] = useState<TxDetails>()
-  const [simulation, setSimulation] = useState<AjnaSimulationData>()
-  const [isSimulationLoading, setIsLoadingSimulation] = useState(false)
-  const [cachedPosition, setCachedPosition] = useState<AjnaCachedPosition>()
 
-  const { errors, warnings } = useMemo(
-    () =>
-      getAjnaBorrowValidations({
-        ethPrice: ethPrice,
-        ethBalance: ethBalance,
-        gasEstimationUsd: gasEstimation?.usdValue,
-        depositAmount: form.state.depositAmount,
-        paybackAmount: form.state.paybackAmount,
-        collateralBalance: collateralBalance,
-        quoteBalance: quoteBalance,
-        simulationErrors: simulation?.errors,
-        simulationWarnings: simulation?.errors,
-        txError: txDetails?.txError,
-        collateralToken: collateralToken,
-      }),
-    [
-      ethPrice.toString(),
-      ethBalance.toString(),
-      gasEstimation?.usdValue.toString(),
-      form.state.depositAmount?.toString(),
-      form.state.paybackAmount?.toString(),
-      collateralBalance.toString(),
-      quoteBalance.toString(),
-      simulation?.errors,
-      txDetails?.txError,
-      collateralToken,
-    ],
-  )
-
-  const setStep = (step: AjnaStatusStep) => {
-    if (
-      !isNextStep({ currentStep, step, steps }) ||
-      isBorrowStepValid({ currentStep, formState: form.state, errors })
-    )
-      setCurrentStep(step)
-    else throw new Error(`A state of current step in not valid.`)
-  }
   const shiftStep = (direction: 'next' | 'prev') => {
     const i = steps.indexOf(currentStep) + (direction === 'next' ? 1 : -1)
 
@@ -200,44 +96,31 @@ export function AjnaBorrowContextProvider({
     else throw new Error(`A step with index ${i} does not exist in form flow.`)
   }
 
-  const setupStepManager = (): AjnaBorrowSteps => {
+  const setupStepManager = (): AjnaProductFlowSteps => {
     return {
       currentStep,
       steps,
       editingStep: flow === 'open' ? 'setup' : 'manage',
       isExternalStep: isExternalStep({ currentStep }),
       isStepWithTransaction: isStepWithTransaction({ currentStep }),
-      isStepValid: isBorrowStepValid({ currentStep, formState: form.state, errors }),
-      setStep,
+      setStep: (step) => setCurrentStep(step),
       setNextStep: () => shiftStep('next'),
       setPrevStep: () => shiftStep('prev'),
     }
   }
 
-  const setupTxManager = (): AjnaBorrowTx => {
+  const setupTxManager = (): AjnaProductTx => {
     return {
-      txDetails,
-      setTxDetails,
       ...getTxStatuses(txDetails?.txStatus),
+      setTxDetails,
+      txDetails,
     }
   }
 
-  const [context, setContext] = useState<AjnaBorrowContext>({
+  const [context, setContext] = useState<AjnaProductContext>({
     environment: { ...props, isOwner: owner === walletAddress || flow === 'open' },
-    form,
-    position: {
-      id,
-      currentPosition,
-      setIsLoadingSimulation,
-      setSimulation,
-      setCachedPosition,
-    },
     steps: setupStepManager(),
     tx: setupTxManager(),
-    validation: {
-      errors: defaultErrors,
-      warnings: defaultWarnings,
-    },
   })
 
   useEffect(() => {
@@ -249,36 +132,10 @@ export function AjnaBorrowContextProvider({
         collateralBalance,
         quoteBalance,
       },
-      position: {
-        ...prev.position,
-        id: resolvedId,
-        cachedPosition,
-        currentPosition,
-        simulation,
-        isSimulationLoading,
-      },
-      form: { ...prev.form, state: form.state },
       steps: setupStepManager(),
       tx: setupTxManager(),
-      validation: {
-        errors,
-        warnings,
-      },
     }))
-  }, [
-    collateralBalance,
-    quoteBalance,
-    resolvedId,
-    cachedPosition,
-    currentPosition,
-    simulation,
-    isSimulationLoading,
-    form.state,
-    currentStep,
-    txDetails,
-    errors,
-    warnings,
-  ])
+  }, [collateralBalance, currentStep, quoteBalance, txDetails])
 
-  return <ajnaBorrowContext.Provider value={context}>{children}</ajnaBorrowContext.Provider>
+  return <ajnaProductContext.Provider value={context}>{children}</ajnaProductContext.Provider>
 }

--- a/features/ajna/controls/AjnaProductController.tsx
+++ b/features/ajna/controls/AjnaProductController.tsx
@@ -1,12 +1,13 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { WithConnection } from 'components/connectWallet/ConnectWallet'
 import { PositionLoadingState } from 'components/vault/PositionLoadingState'
+import { AjnaBorrowContextProvider } from 'features/ajna/borrow/contexts/AjnaBorrowContext'
 import { getAjnaBorrowHeadlineProps } from 'features/ajna/borrow/helpers'
 import { AjnaBorrowView } from 'features/ajna/borrow/views/AjnaBorrowView'
 import { steps } from 'features/ajna/common/consts'
 import { AjnaWrapper } from 'features/ajna/common/layout'
 import { AjnaFlow, AjnaProduct } from 'features/ajna/common/types'
-import { AjnaBorrowContextProvider } from 'features/ajna/contexts/AjnaProductContext'
+import { AjnaProductContextProvider } from 'features/ajna/contexts/AjnaProductContext'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { WithWalletAssociatedRisk } from 'features/walletAssociatedRisk/WalletAssociatedRisk'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
@@ -118,27 +119,30 @@ export function AjnaProductController({
               >
                 {([ajnaPosition, [collateralBalance, quoteBalance, ethBalance], tokenPriceUSD]) =>
                   ajnaPosition ? (
-                    <AjnaBorrowContextProvider
+                    <AjnaProductContextProvider
                       collateralBalance={collateralBalance}
-                      ethBalance={ethBalance}
-                      collateralToken={ajnaPosition.meta.collateralToken}
                       collateralPrice={tokenPriceUSD[ajnaPosition.meta.collateralToken]}
+                      collateralToken={ajnaPosition.meta.collateralToken}
+                      {...(flow === 'manage' && { dpmProxy: ajnaPosition.meta.proxy })}
+                      ethBalance={ethBalance}
+                      ethPrice={tokenPriceUSD.ETH}
                       flow={flow}
-                      currentPosition={ajnaPosition.position}
                       id={id}
+                      owner={ajnaPosition.meta.user}
                       product={ajnaPosition.meta.product}
                       quoteBalance={quoteBalance}
-                      quoteToken={ajnaPosition.meta.quoteToken}
                       quotePrice={tokenPriceUSD[ajnaPosition.meta.quoteToken]}
-                      ethPrice={tokenPriceUSD.ETH}
+                      quoteToken={ajnaPosition.meta.quoteToken}
                       steps={steps[ajnaPosition.meta.product][flow]}
-                      owner={ajnaPosition.meta.user}
-                      {...(flow === 'manage' && { dpmProxy: ajnaPosition.meta.proxy })}
                     >
-                      {ajnaPosition.meta.product === 'borrow' && <AjnaBorrowView />}
-                    </AjnaBorrowContextProvider>
+                      {ajnaPosition.meta.product === 'borrow' && (
+                        <AjnaBorrowContextProvider position={ajnaPosition.position}>
+                          <AjnaBorrowView />
+                        </AjnaBorrowContextProvider>
+                      )}
+                    </AjnaProductContextProvider>
                   ) : (
-                    <></>
+                    <>Earn UI placeholder</>
                   )
                 }
               </WithLoadingIndicator>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2378,7 +2378,7 @@
           "intro": "Select the crypto asset you want to earn for lending your {{token}}"
         },
         "headline": {
-          "header": "Lend {{quoteToken}} against {{collateralToken}}"
+          "header": "Lend {{collateralToken}} against {{quoteToken}}"
         },
         "form": {
           "confirm": "Please review the details of the {{collateralToken}}/{{quoteToken}} Earn Position you are opening."


### PR DESCRIPTION
# [🧿 Separate borrow related stuff into its own context](https://app.shortcut.com/oazo-apps/story/8091/earn-context-incorporated-in-borrow-context)

Dedicated proxy for Ajna Borrow. Does not change anything in Borrow reducto or transactions.
  
## Changes 👷‍♀️

- Split existing context into `AjnaBorrowContext` and `AjnaProductContext`,
- adjusted existing files to accommodate this change.
  
## How to test 🧪

See if open and manage flow are still working.
