### PR TITLE
position overview net value fix

### DIFF
--- a/features/earn/aave/components/PositionInfoComponent.tsx
+++ b/features/earn/aave/components/PositionInfoComponent.tsx
@@ -61,6 +61,7 @@ export const PositionInfoComponent = ({
 }: PositionInfoComponentProps) => {
   const { t } = useTranslation()
 
+  // Todo: move to lib
   const netValueInDebtToken = position.collateral.normalisedAmount
     .times(position.oraclePriceForCollateralDebtExchangeRate)
     .minus(position.debt.normalisedAmount)

--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -208,6 +208,7 @@ function buildAaveViewModel(
               .times(100)
           : zero
 
+        // Todo: move to lib
         const netValueInDebtToken = amountFromPrecision(
           position.collateral.normalisedAmount
             .times(position.oraclePriceForCollateralDebtExchangeRate)


### PR DESCRIPTION
https://app.shortcut.com/oazo-apps/story/8108/bug-net-value-in-usd-isn-t-showing-correct-compared-to-actual-net-value-of-eth-aave-v3-steth
  
## Changes 👷‍♀️
- read net value from library
  
## How to test 🧪

1. create earn v3 + v2 position
2. create aave multiply positions
3. ensure the net value matches the net value on the position page, accounting for ticker price
