### PR TITLE
update lib version to consume new low fee tier for aave v3 wsteth/eth

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oasisdex/automation": "1.3.1-alpha.0",
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
-    "@oasisdex/oasis-actions": "0.2.4",
+    "@oasisdex/oasis-actions": "0.2.5",
     "@oasisdex/transactions": "^0.1.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@
     "@types/mocha" "^9.0.0"
     bignumber.js "^9.0.1"
 
-"@oasisdex/oasis-actions@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.2.4.tgz#fbbc8c8e548395377d778ca638ea7918059d8083"
-  integrity sha512-2irtrYne4OLCmSzqTwQvMvOZL/YPBLqu0m0pUokFmYPcSJAzQADqYrqM5xd6UzY5srVWFNquZh9JVcCyfJIMfA==
+"@oasisdex/oasis-actions@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@oasisdex/oasis-actions/-/oasis-actions-0.2.5.tgz#2932bee9abf3b67d14603561de16fb0e2ba0b571"
+  integrity sha512-Jmx7odH7DKAv/btl1rVp/PgwWVnEcNxFWJNeTRtPNZviTlac1A2/fz4tjD1itCLsv87AQfJlw8IhAZQ2m1PkXA==
   dependencies:
     bignumber.js "^9.0.1"
     ethers "^5.6.2"


### PR DESCRIPTION
https://app.shortcut.com/oazo-apps/story/8104/add-new-fee-tier-use-it-for-wsteth-eth
  
## Changes 👷‍♀️

- lib update
  
## How to test 🧪

- open/mutate/close aave v3 position
- ensure low fee tier used from library