### PR TITLE
Set node version to 16 in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Cache YARN dependencies
         uses: actions/cache@v1
         with:

--- a/components/sidebar/SidebarSection.tsx
+++ b/components/sidebar/SidebarSection.tsx
@@ -12,6 +12,8 @@ export interface SidebarSectionProps
     Omit<SidebarSectionContentProps, 'activePanel'>,
     SidebarSectionFooterProps {}
 
+// here is a comment to make a new PR
+
 export function SidebarSection({
   title,
   dropdown,


### PR DESCRIPTION
Set node to 16 for oasis-borrow https://github.com/actions/runner-images/issues/7002