### PR TITLE
disable button when in loading state

### DIFF
--- a/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -194,7 +194,7 @@ function OpenAaveReviewingStateView({ state, send, isLoading }: OpenAaveStatePro
     : {
         steps: [state.context.currentStep, state.context.totalSteps] as [number, number],
         isLoading: isLoading(),
-        disabled: !state.can('NEXT_STEP'),
+        disabled: isLoading() || !state.can('NEXT_STEP'),
         label: t('open-earn.aave.vault-form.confirm-btn'),
         action: () => send('NEXT_STEP'),
       }
@@ -298,7 +298,7 @@ function EditingStateViewSidebarPrimaryButton({
 
   return {
     isLoading: isLoading(),
-    disabled: !state.can('NEXT_STEP') || (!hasProxy && isProxyCreationDisabled),
+    disabled: isLoading() || !state.can('NEXT_STEP') || (!hasProxy && isProxyCreationDisabled),
     label,
     action: () => send('NEXT_STEP'),
   }
@@ -397,7 +397,7 @@ export function AaveOpenPositionStopLoss({ state, send, isLoading }: OpenAaveSta
     primaryButton: {
       steps: [state.context.currentStep, state.context.totalSteps],
       isLoading: isLoading(),
-      disabled: !state.can('NEXT_STEP'),
+      disabled: isLoading() || !state.can('NEXT_STEP'),
       label: t('open-earn.aave.vault-form.confirm-btn'),
       action: () => send('NEXT_STEP'),
     },

--- a/features/stateMachines/allowance/AllowanceView.tsx
+++ b/features/stateMachines/allowance/AllowanceView.tsx
@@ -122,7 +122,7 @@ function AllowanceInfoStateView({
     primaryButton: {
       steps: steps,
       isLoading,
-      disabled: !state.can('NEXT_STEP'),
+      disabled: isLoading || !state.can('NEXT_STEP'),
       label: t('approve-allowance'),
       action: () => send('NEXT_STEP'),
     },


### PR DESCRIPTION
## Changes 👷‍♀️

- disables main sidebar button when it is in loading state in open aave sidebar
  
## How to test 🧪

Ensure button is disabled when in loading state (spinner) across:

- creating DPM
- loading DPM
- setting allowance
- adjusting risk (calling lib)
- confirming in metamask
