### PR TITLE
don't show nan when there is no collateral in a vault

### DIFF
--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -167,9 +167,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
             if (isLoading()) {
               return '...'
             } else {
-              return onChainPosition
-                ? viewConfig.liquidationPriceFormatter(value)
-                : hasUserInteracted(state)
+              return (onChainPosition || hasUserInteracted(state)) && !value.isNaN()
                 ? viewConfig.liquidationPriceFormatter(value)
                 : '-'
             }


### PR DESCRIPTION
## Changes 👷‍♀️

- show `-` instead of `NaN` for liquidation price when showing a position with zero collateral
  
## How to test 🧪

- test that aave position with zero collateral shows `-` instead of `$NaN`
- ensure `hasUserInteracted` displays liquidation price correctly
