### PR TITLE
🧿 Ajna manage form notifications

### DIFF
--- a/components/DetailsSectionNotification.tsx
+++ b/components/DetailsSectionNotification.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { AppLink } from 'components/Links'
 import { kebabCase } from 'lodash'
+import { useTranslation } from 'next-i18next'
 import React, { Fragment, useEffect, useState } from 'react'
 import { Box, Button, Flex, Text } from 'theme-ui'
 
@@ -19,10 +20,16 @@ export interface DetailsSectionNotificationItem {
   closable?: boolean
   icon?: string
   link?: (DetailsSectionNotificationWithAction | DetailsSectionNotificationWithUrl) & {
-    label: string
+    translationKey: string
   }
-  message?: string | null
-  title: string
+  message?: {
+    translationKey: string
+    params?: { [key: string]: string }
+  }
+  title: {
+    translationKey: string
+    params?: { [key: string]: string }
+  }
   type?: DetailsSectionNotificationType
 }
 
@@ -46,10 +53,10 @@ export function DetailsSectionNotification({
   notifications,
 }: DetailsSectionNotificationProps) {
   const [closedNotifications, setClosedNotifications] = useState<number[]>([])
-
+  const { t } = useTranslation()
   notifications.forEach(({ title }, i) => {
     if (
-      sessionStorage.getItem(getSessionStorageKey(title)) === 'true' &&
+      sessionStorage.getItem(getSessionStorageKey(title.translationKey)) === 'true' &&
       !closedNotifications.includes(i)
     )
       setClosedNotifications((prev) => [...prev, i])
@@ -71,7 +78,7 @@ export function DetailsSectionNotification({
       }}
     >
       {notifications.map(({ closable, icon, link, message, title, type = 'notice' }, i) => (
-        <Fragment key={getSessionStorageKey(title)}>
+        <Fragment key={getSessionStorageKey(title.translationKey)}>
           {!closedNotifications.includes(i) && (
             <Flex
               as="li"
@@ -100,11 +107,11 @@ export function DetailsSectionNotification({
               )}
               <Box>
                 <Text as="p" variant="boldParagraph2" sx={{ color: 'neutral10' }}>
-                  {title}
+                  {t(title.translationKey, title.params || {})}
                 </Text>
                 {message && (
                   <Text as="p" variant="paragraph3" sx={{ color: 'neutral10' }}>
-                    {message}
+                    {t(message.translationKey, message.params || {})}
                   </Text>
                 )}
               </Box>
@@ -122,7 +129,7 @@ export function DetailsSectionNotification({
                     <>
                       {link.url && (
                         <AppLink href={link.url} sx={{ color: 'neutral10' }}>
-                          {link.label}
+                          {link.translationKey}
                         </AppLink>
                       )}
                       {link.action && (
@@ -131,7 +138,7 @@ export function DetailsSectionNotification({
                           sx={{ p: 0, color: 'neutral10' }}
                           onClick={link.action}
                         >
-                          {link.label}
+                          {t(link.translationKey)}
                         </Button>
                       )}
                     </>
@@ -141,7 +148,7 @@ export function DetailsSectionNotification({
                       variant="unStyled"
                       sx={{ mr: 2, p: 0, lineHeight: 0 }}
                       onClick={() => {
-                        sessionStorage.setItem(getSessionStorageKey(title), 'true')
+                        sessionStorage.setItem(getSessionStorageKey(title.translationKey), 'true')
                         setClosedNotifications((prev) => [...prev, i])
                       }}
                     >

--- a/components/DetailsSectionNotification.tsx
+++ b/components/DetailsSectionNotification.tsx
@@ -21,7 +21,7 @@ export interface DetailsSectionNotificationItem {
   link?: (DetailsSectionNotificationWithAction | DetailsSectionNotificationWithUrl) & {
     label: string
   }
-  message?: string
+  message?: string | null
   title: string
   type?: DetailsSectionNotificationType
 }
@@ -102,9 +102,11 @@ export function DetailsSectionNotification({
                 <Text as="p" variant="boldParagraph2" sx={{ color: 'neutral10' }}>
                   {title}
                 </Text>
-                <Text as="p" variant="paragraph3" sx={{ color: 'neutral10' }}>
-                  {message}
-                </Text>
+                {message && (
+                  <Text as="p" variant="paragraph3" sx={{ color: 'neutral10' }}>
+                    {message}
+                  </Text>
+                )}
               </Box>
               {(link || closable) && (
                 <Flex

--- a/features/ajna/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/common/contexts/AjnaProductContext.tsx
@@ -18,7 +18,6 @@ import {
 } from 'features/ajna/earn/state/ajnaEarnFormReducto'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
-import { useTranslation } from 'next-i18next'
 import React, {
   Dispatch,
   PropsWithChildren,
@@ -122,7 +121,6 @@ export function AjnaProductContextProvider({
   const { walletAddress } = useAccount()
   const gasEstimation = useGasEstimationContext()
   const { positionIdFromDpmProxy$ } = useAppContext()
-  const { t } = useTranslation()
 
   const {
     environment: {
@@ -198,7 +196,6 @@ export function AjnaProductContextProvider({
         product,
         quoteToken,
         collateralToken,
-        t,
         dispatch: form.dispatch,
         updateState: form.updateState,
       }),

--- a/features/ajna/common/notifications.ts
+++ b/features/ajna/common/notifications.ts
@@ -3,7 +3,6 @@ import { DetailsSectionNotificationItem } from 'components/DetailsSectionNotific
 import { AjnaBorrowFormAction } from 'features/ajna/borrow/state/ajnaBorrowFormReducto'
 import { AjnaBorrowUpdateState, AjnaEarnUpdateState, AjnaProduct } from 'features/ajna/common/types'
 import { AjnaEarnFormAction } from 'features/ajna/earn/state/ajnaEarnFormReducto'
-import { TFunction } from 'next-i18next'
 import { Dispatch } from 'react'
 
 type DepositIsNotWithdrawableParams = {
@@ -16,7 +15,6 @@ type EarningNoApyParams = {
 }
 
 type NotificationCallbackWithParams<P> = (
-  t: TFunction,
   params: P,
   action?: () => void,
 ) => DetailsSectionNotificationItem
@@ -25,25 +23,34 @@ const ajnaNotifications: {
   depositIsNotWithdrawable: NotificationCallbackWithParams<DepositIsNotWithdrawableParams>
   earningNoApy: NotificationCallbackWithParams<EarningNoApyParams>
 } = {
-  depositIsNotWithdrawable: (t, { message, action }) => ({
-    title: t('ajna.earn.manage.notifications.deposit-is-not-withdrawable.title'),
-    message: t('ajna.earn.manage.notifications.deposit-is-not-withdrawable.message', message),
+  depositIsNotWithdrawable: ({ action, message }) => ({
+    title: {
+      translationKey: 'ajna.earn.manage.notifications.deposit-is-not-withdrawable.title',
+    },
+    message: {
+      translationKey: 'ajna.earn.manage.notifications.deposit-is-not-withdrawable.message',
+      params: message,
+    },
     icon: 'coins_cross',
     type: 'error',
     closable: true,
     link: {
-      label: t('ajna.earn.manage.notifications.deposit-is-not-withdrawable.label'),
+      translationKey: 'ajna.earn.manage.notifications.deposit-is-not-withdrawable.label',
       action,
     },
   }),
-  earningNoApy: (t, { action }) => ({
-    title: t('ajna.earn.manage.notifications.earning-no-apy.title'),
-    message: t('ajna.earn.manage.notifications.earning-no-apy.message'),
+  earningNoApy: ({ action }) => ({
+    title: {
+      translationKey: 'ajna.earn.manage.notifications.earning-no-apy.title',
+    },
+    message: {
+      translationKey: 'ajna.earn.manage.notifications.earning-no-apy.message',
+    },
     icon: 'coins_cross',
     type: 'warning',
     closable: true,
     link: {
-      label: t('ajna.earn.manage.notifications.earning-no-apy.label'),
+      translationKey: 'ajna.earn.manage.notifications.earning-no-apy.label',
       action,
     },
   }),
@@ -71,7 +78,6 @@ export function getAjnaNotifications({
   dispatch,
   updateState,
   product,
-  t,
 }: {
   params: NotificationParams
   collateralToken: string
@@ -79,7 +85,6 @@ export function getAjnaNotifications({
   dispatch: Dispatch<AjnaBorrowFormAction> | Dispatch<AjnaEarnFormAction>
   updateState: AjnaBorrowUpdateState | AjnaEarnUpdateState
   product: AjnaProduct
-  t: TFunction
 }) {
   const notifications: DetailsSectionNotificationItem[] = []
 
@@ -100,14 +105,14 @@ export function getAjnaNotifications({
 
       if (depositIsNotWithdrawable) {
         notifications.push(
-          ajnaNotifications.depositIsNotWithdrawable(t, {
+          ajnaNotifications.depositIsNotWithdrawable({
             message: { collateralToken, quoteToken },
             action: moveToAdjust,
           }),
         )
       }
       if (earningNoApy) {
-        notifications.push(ajnaNotifications.earningNoApy(t, { action: moveToAdjust }))
+        notifications.push(ajnaNotifications.earningNoApy({ action: moveToAdjust }))
       }
 
       break

--- a/features/ajna/common/notifications.ts
+++ b/features/ajna/common/notifications.ts
@@ -1,0 +1,120 @@
+import BigNumber from 'bignumber.js'
+import { DetailsSectionNotificationItem } from 'components/DetailsSectionNotification'
+import { AjnaBorrowFormAction } from 'features/ajna/borrow/state/ajnaBorrowFormReducto'
+import { AjnaBorrowUpdateState, AjnaEarnUpdateState, AjnaProduct } from 'features/ajna/common/types'
+import { AjnaEarnFormAction } from 'features/ajna/earn/state/ajnaEarnFormReducto'
+import { TFunction } from 'next-i18next'
+import { Dispatch } from 'react'
+
+type DepositIsNotWithdrawableParams = {
+  message: { collateralToken: string; quoteToken: string }
+  action: () => void
+}
+
+type EarningNoApyParams = {
+  action: () => void
+}
+
+type NotificationCallbackWithParams<P> = (
+  t: TFunction,
+  params: P,
+  action?: () => void,
+) => DetailsSectionNotificationItem
+
+const ajnaNotifications: {
+  depositIsNotWithdrawable: NotificationCallbackWithParams<DepositIsNotWithdrawableParams>
+  earningNoApy: NotificationCallbackWithParams<EarningNoApyParams>
+} = {
+  depositIsNotWithdrawable: (t, { message, action }) => ({
+    title: t('ajna.earn.manage.notifications.deposit-is-not-withdrawable.title'),
+    message: t('ajna.earn.manage.notifications.deposit-is-not-withdrawable.message', message),
+    icon: 'coins_cross',
+    type: 'error',
+    closable: true,
+    link: {
+      label: t('ajna.earn.manage.notifications.deposit-is-not-withdrawable.label'),
+      action,
+    },
+  }),
+  earningNoApy: (t, { action }) => ({
+    title: t('ajna.earn.manage.notifications.earning-no-apy.title'),
+    message: t('ajna.earn.manage.notifications.earning-no-apy.message'),
+    icon: 'coins_cross',
+    type: 'warning',
+    closable: true,
+    link: {
+      label: t('ajna.earn.manage.notifications.earning-no-apy.label'),
+      action,
+    },
+  }),
+}
+
+type NotificationEarnParams = {
+  price: BigNumber
+  htp: BigNumber
+  momp: BigNumber
+}
+
+// TODO added for now just to test typescript
+type NotificationBorrowParams = {
+  param1: BigNumber
+  param2: BigNumber
+  param3: BigNumber
+}
+
+type NotificationParams = NotificationBorrowParams | NotificationEarnParams
+
+export function getAjnaNotifications({
+  params,
+  collateralToken,
+  quoteToken,
+  dispatch,
+  updateState,
+  product,
+  t,
+}: {
+  params: NotificationParams
+  collateralToken: string
+  quoteToken: string
+  dispatch: Dispatch<AjnaBorrowFormAction> | Dispatch<AjnaEarnFormAction>
+  updateState: AjnaBorrowUpdateState | AjnaEarnUpdateState
+  product: AjnaProduct
+  t: TFunction
+}) {
+  const notifications: DetailsSectionNotificationItem[] = []
+
+  switch (product) {
+    case 'multiply':
+    case 'borrow':
+      break
+    case 'earn': {
+      const { price, htp, momp } = params as NotificationEarnParams
+      const earningNoApy = price.lt(htp)
+      const depositIsNotWithdrawable = price.gt(momp)
+
+      const moveToAdjust = () => {
+        dispatch({ type: 'reset' })
+        updateState('uiDropdown', 'adjust')
+        updateState('uiPill', 'deposit-earn')
+      }
+
+      if (depositIsNotWithdrawable) {
+        notifications.push(
+          ajnaNotifications.depositIsNotWithdrawable(t, {
+            message: { collateralToken, quoteToken },
+            action: moveToAdjust,
+          }),
+        )
+      }
+      if (earningNoApy) {
+        notifications.push(ajnaNotifications.earningNoApy(t, { action: moveToAdjust }))
+      }
+
+      break
+    }
+    default:
+      break
+  }
+
+  return notifications
+}

--- a/features/ajna/common/types.ts
+++ b/features/ajna/common/types.ts
@@ -1,10 +1,7 @@
-import { AjnaSimulationData } from 'actions/ajna'
 import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
-import { ValidationMessagesInput } from 'components/ValidationMessages'
 import { AjnaBorrowFormState } from 'features/ajna/borrow/state/ajnaBorrowFormReducto'
 import { AjnaEarnFormState } from 'features/ajna/earn/state/ajnaEarnFormReducto'
-import { Dispatch, SetStateAction } from 'react'
 
 export type AjnaProduct = 'borrow' | 'earn' | 'multiply'
 export type AjnaFlow = 'open' | 'manage'
@@ -40,25 +37,12 @@ export type AjnaPoolData = {
   }
 }
 
-export interface AjnaPositionSet<P> {
-  position: P
-  simulation?: P
-}
+export type AjnaBorrowUpdateState = (
+  key: keyof AjnaBorrowFormState,
+  value: AjnaBorrowFormState[keyof AjnaBorrowFormState],
+) => void
 
-export interface AjnaProductPosition<P> {
-  cachedPosition?: AjnaPositionSet<P>
-  currentPosition: AjnaPositionSet<P>
-  isSimulationLoading?: boolean
-  resolvedId?: string
-  setCachedPosition: Dispatch<SetStateAction<AjnaPositionSet<P> | undefined>>
-  setIsLoadingSimulation: Dispatch<SetStateAction<boolean>>
-  setSimulation: Dispatch<SetStateAction<AjnaSimulationData<P> | undefined>>
-}
-
-export interface AjnaProductValidation {
-  validation: {
-    errors: ValidationMessagesInput
-    isFormValid: boolean
-    warnings: ValidationMessagesInput
-  }
-}
+export type AjnaEarnUpdateState = (
+  key: keyof AjnaEarnFormState,
+  value: AjnaEarnFormState[keyof AjnaEarnFormState],
+) => void

--- a/features/ajna/earn/overview/AjnaEarnOverviewManage.tsx
+++ b/features/ajna/earn/overview/AjnaEarnOverviewManage.tsx
@@ -19,10 +19,12 @@ export function AjnaEarnOverviewManage() {
   } = useAjnaGeneralContext()
   const {
     position: { isSimulationLoading },
+    notifications,
   } = useAjnaProductContext('earn')
 
   return (
     <DetailsSection
+      notifications={notifications}
       title={t('system.overview')}
       content={
         <DetailsSectionContentCardWrapper>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2487,6 +2487,18 @@
         },
         "form": {
           "adjust-lending-price-bucket": "Adjust lending price bucket"
+        },
+        "notifications": {
+          "deposit-is-not-withdrawable": {
+            "title": "Warning your selected price is too close to market price",
+            "message": "In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}",
+            "label": "Adjust lending price"
+          },
+          "earning-no-apy": {
+            "title": "Warning your position is not earning any yield",
+            "message": "Your lending position is below the minimum yield bearing price",
+            "label": "Adjust lending price"
+          }
         }
       }
     },
@@ -2495,7 +2507,9 @@
       "payback-amount-exceeds-debt-token-balance": "You cannot payback more than the amount of debt token in your wallet",
       "has-insufficient-eth-funds-for-tx": "Your ETH balance is too low to pay for transaction",
       "has-potential-insufficient-eth-funds-for-tx": "Your ETH balance is too low to pay for transaction",
-      "undercollateralized": "You are trying to generate too much debt in relation to the collateral being deposited."
+      "undercollateralized": "You are trying to generate too much debt in relation to the collateral being deposited.",
+      "earning-no-apy": "You will be lending without earning any yield",
+      "deposit-is-not-withdrawable": "You cannot set price bucket above MOMP TBD"
     },
     "rewards": {
       "page-title": "Your Ajna token rewards",


### PR DESCRIPTION
# 🧿[Overview Validation - Earning no APY](https://app.shortcut.com/oazo-apps/story/7858/overview-validation-earning-no-apy)

# 🧿[Overview Validation - Deposit is not Withdrawable](https://app.shortcut.com/oazo-apps/story/8134/overview-validation-deposit-is-not-withdrawable)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added handling for notifications within context
- prepared 2x notifications for earn overview
- types clean up
  
## How to test 🧪
  <Please explain how to test your changes>

- manage earn view is not accessible now, if you want to test these notification add `borrow` case next to `earn` case in `features/ajna/common/notifications.ts` and visit borrow position
