### PR TITLE
🧿 Ajna content pages improvements

### DIFF
--- a/components/AnimatedWrapper.tsx
+++ b/components/AnimatedWrapper.tsx
@@ -1,0 +1,17 @@
+import React, { PropsWithChildren } from 'react'
+import { Box } from 'theme-ui'
+import { slideInAnimation } from 'theme/animations'
+
+export function AnimatedWrapper({ children }: PropsWithChildren<{}>) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        ...slideInAnimation,
+        position: 'relative',
+      }}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/components/navigation/NavigationMenuPanel.tsx
+++ b/components/navigation/NavigationMenuPanel.tsx
@@ -1,3 +1,4 @@
+import { AppLink } from 'components/Links'
 import React, { ReactNode } from 'react'
 import { Box, Text } from 'theme-ui'
 
@@ -18,6 +19,7 @@ export interface NavigationMenuPanelType {
     label: string
     link: string
   }
+  link?: string
   links: NavigationMenuPanelLink[]
   otherAssets?: NavigationMenuPanelAsset[]
 }
@@ -30,6 +32,7 @@ type NavigationMenuPanelProps = NavigationMenuPanelType & {
 export function NavigationMenuPanel({
   currentPanel,
   label,
+  link,
   isPanelOpen,
   onMouseEnter,
 }: NavigationMenuPanelProps) {
@@ -39,6 +42,7 @@ export function NavigationMenuPanel({
       sx={{
         p: 1,
         flexShrink: 0,
+        cursor: 'default',
       }}
       onMouseEnter={(e) => {
         const target = e.target as HTMLDivElement
@@ -46,19 +50,43 @@ export function NavigationMenuPanel({
         onMouseEnter(target.offsetLeft + target.offsetWidth / 2)
       }}
     >
-      <Text
-        as="span"
-        sx={{
-          fontSize: 2,
-          fontWeight: 'semiBold',
-          color: isPanelOpen && currentPanel === label ? 'primary100' : 'neutral80',
-          whiteSpace: 'nowrap',
-          cursor: 'default',
-          transition: 'color 200ms',
-        }}
-      >
-        {label}
-      </Text>
+      {link ? (
+        <AppLink href={link}>
+          <NavigationMenuPanelLabel
+            currentPanel={currentPanel}
+            label={label}
+            isPanelOpen={isPanelOpen}
+          />
+        </AppLink>
+      ) : (
+        <NavigationMenuPanelLabel
+          currentPanel={currentPanel}
+          label={label}
+          isPanelOpen={isPanelOpen}
+        />
+      )}
     </Box>
+  )
+}
+
+export function NavigationMenuPanelLabel({
+  currentPanel,
+  label,
+  isPanelOpen,
+}: Pick<NavigationMenuPanelProps, 'currentPanel' | 'label' | 'isPanelOpen'>) {
+  return (
+    <Text
+      as="span"
+      sx={{
+        fontSize: 2,
+        fontWeight: 'semiBold',
+        color: isPanelOpen && currentPanel === label ? 'primary100' : 'neutral80',
+        whiteSpace: 'nowrap',
+        cursor: 'inherit',
+        transition: 'color 200ms',
+      }}
+    >
+      {label}
+    </Text>
   )
 }

--- a/components/navigation/NavigationMenuPanel.tsx
+++ b/components/navigation/NavigationMenuPanel.tsx
@@ -29,6 +29,28 @@ type NavigationMenuPanelProps = NavigationMenuPanelType & {
   onMouseEnter(center: number): void
 }
 
+function NavigationMenuPanelLabel({
+  currentPanel,
+  label,
+  isPanelOpen,
+}: Pick<NavigationMenuPanelProps, 'currentPanel' | 'label' | 'isPanelOpen'>) {
+  return (
+    <Text
+      as="span"
+      sx={{
+        fontSize: 2,
+        fontWeight: 'semiBold',
+        color: isPanelOpen && currentPanel === label ? 'primary100' : 'neutral80',
+        whiteSpace: 'nowrap',
+        cursor: 'inherit',
+        transition: 'color 200ms',
+      }}
+    >
+      {label}
+    </Text>
+  )
+}
+
 export function NavigationMenuPanel({
   currentPanel,
   label,
@@ -66,27 +88,5 @@ export function NavigationMenuPanel({
         />
       )}
     </Box>
-  )
-}
-
-export function NavigationMenuPanelLabel({
-  currentPanel,
-  label,
-  isPanelOpen,
-}: Pick<NavigationMenuPanelProps, 'currentPanel' | 'label' | 'isPanelOpen'>) {
-  return (
-    <Text
-      as="span"
-      sx={{
-        fontSize: 2,
-        fontWeight: 'semiBold',
-        color: isPanelOpen && currentPanel === label ? 'primary100' : 'neutral80',
-        whiteSpace: 'nowrap',
-        cursor: 'inherit',
-        transition: 'color 200ms',
-      }}
-    >
-      {label}
-    </Text>
   )
 }

--- a/components/productCards/ProductCardsWrapper.tsx
+++ b/components/productCards/ProductCardsWrapper.tsx
@@ -1,35 +1,35 @@
 import { AppSpinner } from 'helpers/AppSpinner'
 import React, { ReactNode } from 'react'
+import { theme } from 'theme'
 import { Box, Flex, Grid, SxStyleProp } from 'theme-ui'
 import { fadeInAnimationDelay, slideInAnimation } from 'theme/animations'
-import { useTheme } from 'theme/useThemeUI'
 
 interface ProductCardWrapperProps {
   children: Array<ReactNode>
   desktopWidthOfCard?: number
+  gap?: number
   sx?: SxStyleProp
 }
 
 export function ProductCardsWrapper({
   children,
-  sx,
   desktopWidthOfCard = 378,
+  gap = theme.space[4],
+  sx,
 }: ProductCardWrapperProps) {
-  const { theme } = useTheme()
   const childrenLength = children.flat().filter(Boolean).length
-  const gapSpace = theme.space[4]
-  const desktopWidthOfGrid = (childrenLength - 1) * gapSpace + childrenLength * desktopWidthOfCard
+  const desktopWidthOfGrid = (childrenLength - 1) * gap + childrenLength * desktopWidthOfCard
 
   return (
     <Grid
       columns={childrenLength > 2 ? [1, 2, 3] : [1, childrenLength, childrenLength]}
       sx={{
-        justifyItems: 'center',
-        ...slideInAnimation,
         position: 'relative',
+        justifyItems: 'center',
+        gap: `${gap}px`,
         width: ['100%', childrenLength <= 2 ? `${desktopWidthOfGrid}px` : '100%'],
-        gap: `${gapSpace}px`,
         margin: '0 auto',
+        ...slideInAnimation,
         animationDelay: '0s',
         ...sx,
       }}

--- a/features/ajna/components/AjnaHeader.tsx
+++ b/features/ajna/components/AjnaHeader.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from 'react'
+import { Box, Text } from 'theme-ui'
+
+interface AjnaHeaderProps {
+  intro?: ReactNode
+  title: ReactNode
+}
+
+export function AjnaHeader({ intro, title }: AjnaHeaderProps) {
+  return (
+    <Box
+      sx={{
+        my: [3, null, '48px'],
+        textAlign: 'center',
+      }}
+    >
+      <Text as="h1" variant="header2">
+        {title}
+      </Text>
+      {intro && (
+        <Text
+          as="p"
+          variant="paragraph2"
+          sx={{
+            maxWidth: '740px',
+            mx: 'auto',
+            mt: 3,
+            color: 'neutral80',
+          }}
+        >
+          {intro}
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/features/ajna/components/AjnaHeader.tsx
+++ b/features/ajna/components/AjnaHeader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react'
-import { Box, Text } from 'theme-ui'
+import { Box, Heading, Text } from 'theme-ui'
 
 interface AjnaHeaderProps {
   intro?: ReactNode
@@ -14,9 +14,9 @@ export function AjnaHeader({ intro, title }: AjnaHeaderProps) {
         textAlign: 'center',
       }}
     >
-      <Text as="h1" variant="header2">
+      <Heading as="h1" variant="header2">
         {title}
-      </Text>
+      </Heading>
       {intro && (
         <Text
           as="p"

--- a/features/ajna/components/AjnaRewardCard.tsx
+++ b/features/ajna/components/AjnaRewardCard.tsx
@@ -1,5 +1,6 @@
 import { AppLink } from 'components/Links'
 import { WithArrow } from 'components/WithArrow'
+import { getAjnaWithArrowColorScheme } from 'features/ajna/common/helpers/getAjnaWithArrowColorScheme'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -31,7 +32,7 @@ export function AjnaRewardCard({
   const { t } = useTranslation()
 
   return (
-    <Card p={4} sx={{ height: '100%' }}>
+    <Card p={4} sx={{ height: '100%', borderRadius: 'large' }}>
       <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
         <Flex
           sx={{
@@ -39,17 +40,17 @@ export function AjnaRewardCard({
             height: '100px',
             justifyContent: 'center',
             alignItems: 'center',
-            borderRadius: '50%',
+            mb: [3, '24px'],
+            borderRadius: 'ellipse',
             background: gradient,
-            mb: [3, '21px'],
           }}
         >
           <Image src={staticFilesRuntimeUrl(image)} />
         </Flex>
         <Heading
           sx={{
-            fontSize: [3, 5],
             mb: 3,
+            fontSize: [3, 5],
             fontWeight: ['regular', 'semiBold'],
             color: ['neutral80', 'primary100'],
           }}
@@ -59,17 +60,19 @@ export function AjnaRewardCard({
         <Box
           as="ul"
           sx={{
+            display: ['none', 'flex'],
             flexDirection: 'column',
+            rowGap: 1,
             p: 0,
             mb: 3,
             listStylePosition: 'inside',
-            display: ['none', 'flex'],
           }}
         >
           {list.map((item) => (
-            <Box
-              as="li"
+            <Text
               key={item}
+              as="li"
+              variant="paragraph3"
               sx={{
                 alignItems: 'flex-start',
                 display: 'list-item',
@@ -77,39 +80,41 @@ export function AjnaRewardCard({
                 wordWrap: 'break-word',
               }}
             >
-              <Text as="span" variant="paragraph3" color="inherit">
-                {t(item)}
-              </Text>
-            </Box>
+              {t(item)}
+            </Text>
           ))}
         </Box>
         <AppLink href={link.href} sx={{ display: ['none', 'block'] }}>
-          <WithArrow gap={1} sx={{ color: 'inherit' }}>
+          <WithArrow gap={1} sx={{ ...getAjnaWithArrowColorScheme() }}>
             {t(link.title)}
           </WithArrow>
         </AppLink>
         <Card
           sx={{
-            background: ['unset', gradient],
+            width: '100%',
+            mt: [0, '24px'],
             p: 4,
-            pb: [4, banner.footer ? '22px' : 4],
-            mt: [0, '22px'],
+            pb: [4, banner.footer ? '24px' : 4],
             pt: [0, 4],
             border: 'none',
-            width: '100%',
+            borderRadius: 'large',
+            background: ['none', gradient],
           }}
         >
           <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
-            <Heading sx={{ fontSize: 2, mb: 2, display: ['none', 'block'] }}>
+            <Heading variant="boldParagraph3" sx={{ display: ['none', 'block'] }}>
               {t(banner.title)}
             </Heading>
-            <Text as="p" sx={{ fontSize: '28px', fontWeight: 'medium' }}>
-              {banner.value}
+            <Text as="p" sx={{ color: 'primary100', fontSize: '36px', fontWeight: 'semiBold' }}>
+              {banner.value}{' '}
+              <Text as="small" sx={{ fontSize: '28px' }}>
+                AJNA
+              </Text>
             </Text>
-            <Text as="p" variant="paragraph2" sx={{ color: 'neutral80', mb: [4, '21px'] }}>
+            <Text as="p" variant="paragraph2" sx={{ color: 'neutral80', mb: [4, '24px'] }}>
               {banner.subValue}
             </Text>
-            <Button sx={{ mb: [0, banner.footer ? '19px' : 0], fontSize: 1, p: 0 }}>
+            <Button sx={{ mb: [0, banner.footer ? 3 : 0], fontSize: 1, p: 0 }}>
               <WithArrow
                 gap={1}
                 sx={{ color: 'inherit', fontSize: 'inherit', p: 2, pl: '24px', pr: '36px' }}

--- a/features/ajna/controls/AjnaNavigationController.tsx
+++ b/features/ajna/controls/AjnaNavigationController.tsx
@@ -57,6 +57,7 @@ export function AjnaNavigationController() {
       panels={[
         {
           label: 'Borrow',
+          link: '/ajna/borrow',
           description: 'Borrow against your favorite crypto assets.',
           learn: {
             label: 'Learn more about Borrow',
@@ -100,6 +101,7 @@ export function AjnaNavigationController() {
         },
         {
           label: 'Multiply',
+          link: '/ajna/multiply',
           description: 'Multiply your exposure to your favorite crypto assets.',
           learn: {
             label: 'Learn more about Multiply',
@@ -126,6 +128,7 @@ export function AjnaNavigationController() {
         },
         {
           label: 'Earn',
+          link: '/ajna/earn',
           description: 'Put your crypto assets to work today.',
           learn: {
             label: 'Learn more about Earn',

--- a/features/ajna/controls/AjnaSelectorController.tsx
+++ b/features/ajna/controls/AjnaSelectorController.tsx
@@ -1,4 +1,5 @@
 import { getToken } from 'blockchain/tokensMetadata'
+import { AnimatedWrapper } from 'components/AnimatedWrapper'
 import { useAppContext } from 'components/AppContextProvider'
 import { WithConnection } from 'components/connectWallet/ConnectWallet'
 import { HeaderSelector, HeaderSelectorOption } from 'components/HeaderSelector'
@@ -8,6 +9,7 @@ import { ajnaPoolDummyData } from 'features/ajna/common/content'
 import { filterPoolData } from 'features/ajna/common/helpers/filterPoolData'
 import { AjnaWrapper } from 'features/ajna/common/layout'
 import { AjnaProduct } from 'features/ajna/common/types'
+import { AjnaHeader } from 'features/ajna/components/AjnaHeader'
 import { DiscoverResponsiveTable } from 'features/discover/common/DiscoverResponsiveTable'
 import { DiscoverTableContainer } from 'features/discover/common/DiscoverTableContainer'
 import {
@@ -22,7 +24,7 @@ import { useHash } from 'helpers/useHash'
 import { uniq } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Box, Button, Heading, Text } from 'theme-ui'
+import { Box, Button } from 'theme-ui'
 
 interface AjnaSelectorControllerProps {
   product: AjnaProduct
@@ -134,27 +136,27 @@ export function AjnaSelectorController({ product }: AjnaSelectorControllerProps)
     <WithConnection>
       <WithTermsOfService>
         <AjnaWrapper>
-          <Box sx={{ width: '100%' }}>
-            <Box sx={{ mb: 5, textAlign: 'center' }}>
-              <Heading ref={ref} variant="header2" sx={{ position: 'relative', mb: 3, zIndex: 2 }}>
-                {t(`ajna.${product}.open.select.heading.pre`)}
-                <HeaderSelector
-                  defaultOption={defaultOption}
-                  gradient={['#f154db', '#974eea']}
-                  options={options}
-                  parentRef={ref}
-                  onChange={setSelected}
-                />
-                {t(`ajna.${product}.open.select.heading.post`)}
-              </Heading>
-              <Text variant="paragraph2" sx={{ color: 'neutral80', maxWidth: 700, mx: 'auto' }}>
-                {t(`ajna.${product}.open.select.intro`, { token: selected.value })}
-              </Text>
-            </Box>
+          <AnimatedWrapper>
+            <AjnaHeader
+              title={
+                <Box ref={ref} sx={{ position: 'relative', mb: 3, zIndex: 2 }}>
+                  {t(`ajna.${product}.open.select.heading.pre`)}
+                  <HeaderSelector
+                    defaultOption={defaultOption}
+                    gradient={['#f154db', '#974eea']}
+                    options={options}
+                    parentRef={ref}
+                    onChange={setSelected}
+                  />
+                  {t(`ajna.${product}.open.select.heading.post`)}
+                </Box>
+              }
+              intro={t(`ajna.${product}.open.select.intro`, { token: selected.value })}
+            />
             <DiscoverTableContainer tableOnly>
               {rows.length > 0 && <DiscoverResponsiveTable rows={rows} skip={['icon']} />}
             </DiscoverTableContainer>
-          </Box>
+          </AnimatedWrapper>
         </AjnaWrapper>
       </WithTermsOfService>
     </WithConnection>

--- a/features/ajna/views/AjnaRewardsView.tsx
+++ b/features/ajna/views/AjnaRewardsView.tsx
@@ -1,10 +1,10 @@
+import { AnimatedWrapper } from 'components/AnimatedWrapper'
 import { ProductCardsWrapper } from 'components/productCards/ProductCardsWrapper'
 import { AjnaHaveSomeQuestions } from 'features/ajna/components/AjnaHaveSomeQuestions'
+import { AjnaHeader } from 'features/ajna/components/AjnaHeader'
 import { AjnaRewardCard } from 'features/ajna/components/AjnaRewardCard'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Box, Flex, Text } from 'theme-ui'
-import { slideInAnimation } from 'theme/animations'
 
 const rewardCards = [
   {
@@ -14,7 +14,7 @@ const rewardCards = [
     link: { title: 'ajna.rewards.cards.mining.link', href: '/' },
     banner: {
       title: 'ajna.rewards.cards.mining.banner.title',
-      value: '42.00 AJNA',
+      value: '42.00',
       subValue: '$80.20',
       button: {
         title: 'ajna.rewards.cards.button',
@@ -29,7 +29,7 @@ const rewardCards = [
     link: { title: 'ajna.rewards.cards.token.link', href: '/' },
     banner: {
       title: 'ajna.rewards.cards.token.banner.title',
-      value: '42.00 AJNA',
+      value: '42.00',
       subValue: '$80.20',
       button: {
         title: 'ajna.rewards.cards.button',
@@ -43,39 +43,14 @@ export function AjnaRewardsView() {
   const { t } = useTranslation()
 
   return (
-    <Box
-      sx={{
-        flex: 1,
-        ...slideInAnimation,
-        position: 'relative',
-        animationDuration: '0.4s',
-        animationTimingFunction: 'cubic-bezier(0.7, 0.01, 0.6, 1)',
-      }}
-    >
-      <Flex
-        sx={{
-          flexDirection: 'column',
-          alignItems: 'center',
-          mb: 3,
-        }}
-      >
-        <Text as="p" variant="header2" sx={{ mt: [3, 3, 5], mb: 3, textAlign: 'center' }}>
-          {t('ajna.rewards.page-title')}
-        </Text>
-        <Text
-          as="p"
-          variant="paragraph2"
-          sx={{ mb: [5, '48px'], color: 'neutral80', maxWidth: '740px', textAlign: 'center' }}
-        >
-          {t('ajna.rewards.page-description')}
-        </Text>
-      </Flex>
-      <ProductCardsWrapper desktopWidthOfCard={444}>
+    <AnimatedWrapper>
+      <AjnaHeader title={t('ajna.rewards.title')} intro={t('ajna.rewards.intro')} />
+      <ProductCardsWrapper gap={24} desktopWidthOfCard={448} sx={{ mt: 5 }}>
         {rewardCards.map((rewardCard, idx) => (
           <AjnaRewardCard key={idx} {...rewardCard} />
         ))}
       </ProductCardsWrapper>
       <AjnaHaveSomeQuestions />
-    </Box>
+    </AnimatedWrapper>
   )
 }

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { getToken } from 'blockchain/tokensMetadata'
+import { AnimatedWrapper } from 'components/AnimatedWrapper'
 import { useAppContext } from 'components/AppContextProvider'
 import { AssetPill } from 'components/AssetPill'
 import { BenefitCard, BenefitCardsWrapper } from 'components/BenefitCard'
@@ -17,7 +18,6 @@ import { useObservable } from 'helpers/observableHook'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Flex, Heading, Text } from 'theme-ui'
-import { slideInAnimation } from 'theme/animations'
 
 const benefitCardsAnja = [
   {
@@ -54,15 +54,7 @@ export function AjnaHomepageView() {
   const [context] = useObservable(context$)
 
   return (
-    <Box
-      sx={{
-        flex: 1,
-        ...slideInAnimation,
-        position: 'relative',
-        animationDuration: '0.4s',
-        animationTimingFunction: 'cubic-bezier(0.7, 0.01, 0.6, 1)',
-      }}
-    >
+    <AnimatedWrapper>
       <Hero
         isConnected={context?.status === 'connected'}
         sx={{
@@ -277,6 +269,6 @@ export function AjnaHomepageView() {
         }
       />
       <AjnaHaveSomeQuestions />
-    </Box>
+    </AnimatedWrapper>
   )
 }

--- a/pages/ajna/multiply.tsx
+++ b/pages/ajna/multiply.tsx
@@ -1,0 +1,32 @@
+import { PageSEOTags } from 'components/HeadTags'
+import { ajnaProducts } from 'features/ajna/common/consts'
+import { AjnaProductController } from 'features/ajna/common/controls/AjnaProductController'
+import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
+import { AjnaProduct } from 'features/ajna/common/types'
+import { GetServerSidePropsContext, GetStaticProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import React from 'react'
+
+function AjnaMultiplySelectorPage() {
+  return <>Multiply</>
+}
+
+AjnaMultiplySelectorPage.layout = AjnaLayout
+AjnaMultiplySelectorPage.seoTags = (
+  <PageSEOTags
+    title="seo.ajnaProductPage.title"
+    titleParams={{ product: 'Multiply' }}
+    description="seo.ajna.description"
+    url={'/ajna/multiply'}
+  />
+)
+
+export default AjnaMultiplySelectorPage
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale || 'en', ['common'])),
+    },
+  }
+}

--- a/pages/ajna/multiply.tsx
+++ b/pages/ajna/multiply.tsx
@@ -1,14 +1,28 @@
+import { AnimatedWrapper } from 'components/AnimatedWrapper'
+import { WithConnection } from 'components/connectWallet/ConnectWallet'
 import { PageSEOTags } from 'components/HeadTags'
-import { ajnaProducts } from 'features/ajna/common/consts'
-import { AjnaProductController } from 'features/ajna/common/controls/AjnaProductController'
-import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
-import { AjnaProduct } from 'features/ajna/common/types'
-import { GetServerSidePropsContext, GetStaticProps } from 'next'
+import { AjnaLayout, AjnaWrapper } from 'features/ajna/common/layout'
+import { AjnaHeader } from 'features/ajna/components/AjnaHeader'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 function AjnaMultiplySelectorPage() {
-  return <>Multiply</>
+  const { t } = useTranslation()
+
+  return (
+    <WithConnection>
+      <AjnaWrapper>
+        <AnimatedWrapper>
+          <AjnaHeader
+            title={t('ajna.multiply.coming-soon.title')}
+            intro={t('ajna.multiply.coming-soon.intro')}
+          />
+        </AnimatedWrapper>
+      </AjnaWrapper>
+    </WithConnection>
+  )
 }
 
 AjnaMultiplySelectorPage.layout = AjnaLayout

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2503,8 +2503,8 @@
       "undercollateralized": "You are trying to generate too much debt in relation to the collateral being deposited."
     },
     "rewards": {
-      "page-title": "Your Ajna token rewards",
-      "page-description": "When using the Ajna protocol you are entitled to earn $AJNA tokens in 2 different ways. Read below to find out more",
+      "title": "Your Ajna token rewards",
+      "intro": "When using the Ajna protocol you are entitled to earn $AJNA tokens in 2 different ways. Read below to find out more",
       "cards": {
         "mining": {
           "title": "$AJNA Liquidity Mining Rewards",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2489,6 +2489,12 @@
         }
       }
     },
+    "multiply": {
+      "coming-soon": {
+        "title": "Ajna Multiply coming soon",
+        "intro": "We’re busy building Multiply for Ajna and will be releasing it shortly. For now you can Borrow and Earn on Ajna."
+      }
+    },
     "validations": {
       "deposit-amount-exceeds-collateral-balance": "You cannot deposit more collateral than the amount in your wallet",
       "payback-amount-exceeds-debt-token-balance": "You cannot payback more than the amount of debt token in your wallet",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2504,7 +2504,7 @@
     },
     "rewards": {
       "title": "Your Ajna token rewards",
-      "intro": "When using the Ajna protocol you are entitled to earn $AJNA tokens in 2 different ways. Read below to find out more",
+      "intro": "When using the Ajna protocol you are entitled to earn $AJNA tokens in 2 different ways. Read below to find out more.",
       "cards": {
         "mining": {
           "title": "$AJNA Liquidity Mining Rewards",


### PR DESCRIPTION
# 🧿 Ajna content pages improvements

Couple QOL minor improvements to static pages for Ajna.
  
## Changes 👷‍♀️

- Extracted `AnimatedWrapper` component to be used along all Ajna pages (and also outside of Ajna context, but this PR does not do that),
- extracted `AjnaHeaderProps` component to be used at top of all Ajna pages except HP (or maybe HP includes if it's tweak enough?),
- added support for navigation components so an item in menu can both have it's own dropdown panel and be a link at the same time - also added links for Borrow, Earn and Multiply pages in Ajna navigation,
- fixed couple small inconsistencies with design on rewards page and simplified styles a little bit,
- created empty Ajna Multiply page - this one does not contain product cards as in the light of Oasis create I'm not sure if they are in they final version.
  
## How to test 🧪

No special instructions.
