### PR TITLE
🧿 Ajna Earn manage overview changes

### DIFF
--- a/components/DetailsSectionFooterItem.tsx
+++ b/components/DetailsSectionFooterItem.tsx
@@ -18,10 +18,10 @@ export function DetailsSectionFooterItemWrapper({ children }: { children: ReactN
     <Flex
       as="ul"
       sx={{
+        gap: 3,
         mt: [0, null, null, -3],
         mb: [0, null, null, -3],
-        px: '12px',
-        py: 0,
+        p: 0,
         flexWrap: 'wrap',
       }}
     >
@@ -43,9 +43,9 @@ export function DetailsSectionFooterItem({
         alignItems: 'flex-start',
         flexDirection: 'column',
         flexBasis: ['100%', null, null, '25%'],
-        p: 3,
-        pl: 0,
-        pr: 4,
+        py: 3,
+        pl: '12px',
+        pr: '28px',
         '&:nth-child(-n+3)': {
           flexGrow: 1,
         },

--- a/features/ajna/borrow/controls/AjnaBorrowPositionController.tsx
+++ b/features/ajna/borrow/controls/AjnaBorrowPositionController.tsx
@@ -4,29 +4,13 @@ import {
   AjnaPositionViewHistoryPlaceholder,
   AjnaPositionViewInfoPlaceholder,
 } from 'features/ajna/common/components/AjnaPositionViewPlaceholders'
-import { useAjnaGeneralContext } from 'features/ajna/common/contexts/AjnaGeneralContext'
 import { AjnaPositionView } from 'features/ajna/common/views/AjnaPositionView'
-import { formatCryptoBalance } from 'helpers/formatters/format'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 import { Grid } from 'theme-ui'
 
 export function AjnaBorrowPositionController() {
-  const { t } = useTranslation()
-  const {
-    environment: { collateralPrice, collateralToken, quotePrice, quoteToken },
-  } = useAjnaGeneralContext()
-
   return (
     <AjnaPositionView
-      headlineDetails={[
-        {
-          label: t('ajna.borrow.common.headline.current-market-price', { collateralToken }),
-          value: `${formatCryptoBalance(
-            collateralPrice.dividedBy(quotePrice),
-          )} ${collateralToken}/${quoteToken}`,
-        },
-      ]}
       tabs={{
         position: (
           <Grid variant="vaultContainer">

--- a/features/ajna/common/observables/getAjnaPosition.ts
+++ b/features/ajna/common/observables/getAjnaPosition.ts
@@ -76,7 +76,7 @@ export function getAjnaPosition$(
         ),
         meta: {
           ...meta,
-          product: (meta.product as string).toLowerCase() as AjnaProduct,
+          product: '(meta.product as string).toLowerCase() as AjnaProduct',
         },
       }
     }),

--- a/features/ajna/common/observables/getAjnaPosition.ts
+++ b/features/ajna/common/observables/getAjnaPosition.ts
@@ -76,7 +76,7 @@ export function getAjnaPosition$(
         ),
         meta: {
           ...meta,
-          product: '(meta.product as string).toLowerCase() as AjnaProduct',
+          product: (meta.product as string).toLowerCase() as AjnaProduct,
         },
       }
     }),

--- a/features/ajna/common/views/AjnaPositionView.tsx
+++ b/features/ajna/common/views/AjnaPositionView.tsx
@@ -4,6 +4,7 @@ import { HeadlineDetailsProp } from 'components/vault/VaultHeadlineDetails'
 import { useAjnaGeneralContext } from 'features/ajna/common/contexts/AjnaGeneralContext'
 import { getAjnaHeadlineProps } from 'features/ajna/common/helpers/getAjnaHeadlineProps'
 import { VaultOwnershipBanner } from 'features/notices/VaultsNoticesView'
+import { formatCryptoBalance } from 'helpers/formatters/format'
 import { useAccount } from 'helpers/useAccount'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
@@ -25,7 +26,16 @@ export function AjnaPositionView({
   const { t } = useTranslation()
   const { contextIsLoaded, walletAddress } = useAccount()
   const {
-    environment: { collateralToken, flow, id, owner, product, quoteToken },
+    environment: {
+      collateralPrice,
+      collateralToken,
+      flow,
+      id,
+      owner,
+      product,
+      quotePrice,
+      quoteToken,
+    },
   } = useAjnaGeneralContext()
 
   return (
@@ -39,7 +49,15 @@ export function AjnaPositionView({
         header=""
         {...getAjnaHeadlineProps({ collateralToken, flow, id, product, quoteToken })}
         {...(flow === 'manage' && { shareButton: true })}
-        details={headlineDetails || []}
+        details={[
+          ...(headlineDetails || []),
+          {
+            label: t('ajna.borrow.common.headline.current-market-price', { collateralToken }),
+            value: `${formatCryptoBalance(
+              collateralPrice.dividedBy(quotePrice),
+            )} ${collateralToken}/${quoteToken}`,
+          },
+        ]}
       />
       <TabBar
         variant="underline"

--- a/features/ajna/earn/controls/AjnaEarnPositionController.tsx
+++ b/features/ajna/earn/controls/AjnaEarnPositionController.tsx
@@ -6,7 +6,6 @@ import { useAjnaGeneralContext } from 'features/ajna/common/contexts/AjnaGeneral
 import { AjnaPositionView } from 'features/ajna/common/views/AjnaPositionView'
 import { AjnaEarnFormController } from 'features/ajna/earn/controls/AjnaEarnFormController'
 import { AjnaEarnOverviewController } from 'features/ajna/earn/controls/AjnaEarnOverviewController'
-import { formatCryptoBalance } from 'helpers/formatters/format'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Grid } from 'theme-ui'
@@ -14,7 +13,7 @@ import { Grid } from 'theme-ui'
 export function AjnaEarnPositionController() {
   const { t } = useTranslation()
   const {
-    environment: { collateralPrice, collateralToken, quotePrice, quoteToken },
+    environment: { collateralToken },
   } = useAjnaGeneralContext()
 
   return (
@@ -28,12 +27,6 @@ export function AjnaEarnPositionController() {
         {
           label: t('ajna.earn.common.headline.90-day-avg', { collateralToken }),
           value: '8.92',
-        },
-        {
-          label: t('ajna.borrow.common.headline.current-market-price', { collateralToken }),
-          value: `${formatCryptoBalance(
-            quotePrice.dividedBy(collateralPrice),
-          )} ${quoteToken}/${collateralToken}`,
         },
       ]}
       tabs={{

--- a/features/ajna/earn/overview/AjnaEarnOverviewManage.tsx
+++ b/features/ajna/earn/overview/AjnaEarnOverviewManage.tsx
@@ -46,7 +46,7 @@ export function AjnaEarnOverviewManage() {
             isLoading={isSimulationLoading}
             collateralToken={collateralToken}
             quoteToken={quoteToken}
-            positionLendingPrice={new BigNumber(23506.30)}
+            positionLendingPrice={new BigNumber(23506.3)}
             relationToMarketPrice={new BigNumber(-10)}
           />
         </DetailsSectionContentCardWrapper>

--- a/features/ajna/earn/overview/AjnaEarnOverviewManage.tsx
+++ b/features/ajna/earn/overview/AjnaEarnOverviewManage.tsx
@@ -29,26 +29,24 @@ export function AjnaEarnOverviewManage() {
           <ContentCardCurrentEarnings
             isLoading={isSimulationLoading}
             quoteToken={quoteToken}
-            currentEarnings={new BigNumber(0.56)}
+            currentEarnings={new BigNumber(190)}
             netPnL={new BigNumber(12.35)}
           />
           <ContentCardTokensDeposited
             isLoading={isSimulationLoading}
             quoteToken={quoteToken}
-            tokensDeposited={new BigNumber(25)}
-            tokensDepositedUSD={new BigNumber(25).times(quotePrice)}
+            tokensDeposited={new BigNumber(5250)}
+            tokensDepositedUSD={new BigNumber(5250).times(quotePrice)}
           />
           <ContentCardMaxLendingLTV
             isLoading={isSimulationLoading}
-            quoteToken={quoteToken}
             maxLendingPercentage={new BigNumber(65)}
-            maxLendingQuote={new BigNumber(120000000)}
           />
           <ContentPositionLendingPrice
             isLoading={isSimulationLoading}
             collateralToken={collateralToken}
             quoteToken={quoteToken}
-            positionLendingPrice={new BigNumber(0.332)}
+            positionLendingPrice={new BigNumber(23506.30)}
             relationToMarketPrice={new BigNumber(-10)}
           />
         </DetailsSectionContentCardWrapper>
@@ -57,7 +55,7 @@ export function AjnaEarnOverviewManage() {
         <DetailsSectionFooterItemWrapper>
           <ContentFooterItemsEarnManage
             quoteToken={quoteToken}
-            availableToWithdraw={new BigNumber(4.5)}
+            availableToWithdraw={new BigNumber(2750)}
             earlyWithdrawalPenalty={new BigNumber(2)}
             earlyWithdrawalPeriod={new Date(new Date().getTime() + 10000000)}
           />

--- a/features/ajna/earn/overview/ContentCardMaxLendingLTV.tsx
+++ b/features/ajna/earn/overview/ContentCardMaxLendingLTV.tsx
@@ -4,25 +4,21 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
-import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 interface ContentCardMaxLendingLTVProps {
   isLoading?: boolean
-  quoteToken: string
   maxLendingPercentage: BigNumber
   afterMaxLendingPercentage?: BigNumber
-  maxLendingQuote: BigNumber
   changeVariant?: ChangeVariantType
 }
 
 export function ContentCardMaxLendingLTV({
   isLoading,
-  quoteToken,
   maxLendingPercentage,
   afterMaxLendingPercentage,
-  maxLendingQuote,
   changeVariant = 'positive',
 }: ContentCardMaxLendingLTVProps) {
   const { t } = useTranslation()
@@ -31,7 +27,6 @@ export function ContentCardMaxLendingLTV({
     maxLendingPercentage: formatPercent(maxLendingPercentage, { precision: 2 }),
     afterMaxLendingPercentage:
       afterMaxLendingPercentage && formatPercent(afterMaxLendingPercentage, { precision: 2 }),
-    maxLendingQuote: `$${formatAmount(maxLendingQuote, quoteToken)} ${quoteToken}`,
   }
 
   const contentCardSettings: ContentCardProps = {
@@ -44,10 +39,6 @@ export function ContentCardMaxLendingLTV({
         `${formatted.afterMaxLendingPercentage} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     },
-  }
-
-  if (!maxLendingQuote.isZero()) {
-    contentCardSettings.footnote = formatted.maxLendingQuote
   }
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/features/ajna/earn/overview/ContentFooterItemsEarnManage.tsx
+++ b/features/ajna/earn/overview/ContentFooterItemsEarnManage.tsx
@@ -21,6 +21,7 @@ export function ContentFooterItemsEarnManage({
   earlyWithdrawalPenalty,
 }: ContentFooterItemsEarnOpenProps) {
   const { t } = useTranslation()
+  const now = new Date()
 
   const formatted = {
     availableToWithdraw: `${formatAmount(availableToWithdraw, quoteToken)} ${quoteToken}`,
@@ -37,14 +38,20 @@ export function ContentFooterItemsEarnManage({
         title={t('system.available-to-withdraw')}
         value={formatted.availableToWithdraw}
       />
-      <DetailsSectionFooterItem
-        title={t('ajna.earn.manage.overview.early-withdrawal-period')}
-        value={formatted.earlyWithdrawalPeriod}
-      />
-      <DetailsSectionFooterItem
-        title={t('ajna.earn.manage.overview.early-withdrawal-penalty')}
-        value={formatted.earlyWithdrawalPenalty}
-      />
+      {now > earlyWithdrawalPeriod ? (
+        <DetailsSectionFooterItem
+          title={t('ajna.earn.manage.overview.early-withdrawal-period')}
+          value={t('ajna.earn.manage.overview.early-withdrawal-ended', { earlyWithdrawalPeriod: formatted.earlyWithdrawalPeriod })}
+        />
+      ) : (
+        <DetailsSectionFooterItem
+          title={t('ajna.earn.manage.overview.early-withdrawal-penalty')}
+          value={t('ajna.earn.manage.overview.early-withdrawal-ends-in', {
+            earlyWithdrawalPenalty: formatted.earlyWithdrawalPenalty,
+            earlyWithdrawalPeriod: formatted.earlyWithdrawalPeriod,
+          })}
+        />
+      )}
     </>
   )
 }

--- a/features/ajna/earn/overview/ContentFooterItemsEarnManage.tsx
+++ b/features/ajna/earn/overview/ContentFooterItemsEarnManage.tsx
@@ -41,7 +41,9 @@ export function ContentFooterItemsEarnManage({
       {now > earlyWithdrawalPeriod ? (
         <DetailsSectionFooterItem
           title={t('ajna.earn.manage.overview.early-withdrawal-period')}
-          value={t('ajna.earn.manage.overview.early-withdrawal-ended', { earlyWithdrawalPeriod: formatted.earlyWithdrawalPeriod })}
+          value={t('ajna.earn.manage.overview.early-withdrawal-ended', {
+            earlyWithdrawalPeriod: formatted.earlyWithdrawalPeriod,
+          })}
         />
       ) : (
         <DetailsSectionFooterItem

--- a/features/ajna/earn/overview/ContentPositionLendingPrice.tsx
+++ b/features/ajna/earn/overview/ContentPositionLendingPrice.tsx
@@ -45,7 +45,7 @@ export function ContentPositionLendingPrice({
   const contentCardSettings: ContentCardProps = {
     title: t('ajna.earn.manage.overview.position-lending-price'),
     value: formatted.positionLendingPrice,
-    unit: `${quoteToken}/${collateralToken}`,
+    unit: `${collateralToken}/${quoteToken}`,
     change: {
       isLoading,
       value:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2479,6 +2479,8 @@
           "below-market-price": "{{amount}}% below market price",
           "current-earnings": "Current earnings",
           "early-withdrawal-penalty": "Early withdrawal penalty",
+          "early-withdrawal-ended": "Ended {{earlyWithdrawalPeriod}}",
+          "early-withdrawal-ends-in": "{{earlyWithdrawalPenalty}} (ends {{earlyWithdrawalPeriod}})",
           "early-withdrawal-period": "Early withdrawal period",
           "max-lending-ltv": "Max lending LTV ",
           "net-pnl": "Net PnL: {{netPnL}}",


### PR DESCRIPTION
# 🧿 Ajna Earn manage overview changes

Final (?) version of UI for content cards and overview section for Earn manage page.
![image](https://user-images.githubusercontent.com/16230404/221944397-af287388-11d5-49ae-9da9-0fd5286128de.png)
  
## Changes 👷‍♀️

- Adjusted details section component so it can display properly footer with just two items,
- brought back old price format to Earn, now it's back the same as on Borrow,
- updated collateral/quote token order on Earn content cards and details section footer.
  
## How to test 🧪

As Earn positions are not yet available anywhere, to test it you have to overwrite position's product in main product controller from "borrow" to "earn". Then open existing Borrow position, that should display Earn UI.
