### PR TITLE
Move to goerli button

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,9 +3,11 @@ import { LanguageSelect } from 'components/LanguageSelect'
 import { AppLink } from 'components/Links'
 import { NewsletterSection } from 'features/newsletter/NewsletterView'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import moment from 'moment'
 import { useTranslation } from 'next-i18next'
 import getConfig from 'next/config'
+import { default as NextLink } from 'next/link'
 import React from 'react'
 import { Box, Card, Container, Flex, Grid, Image, Link, Text } from 'theme-ui'
 import { FooterBackground } from 'theme/FooterBackground'
@@ -168,6 +170,7 @@ function SocialWithLogo() {
 
 export function Footer() {
   const { t } = useTranslation()
+  const goerliButton = useFeatureToggle('GoerliButton')
 
   return (
     <Box as="footer" sx={{ position: 'relative' }}>
@@ -200,6 +203,11 @@ export function Footer() {
           <Box sx={{ display: ['none', 'none', 'flex'], width: '100%' }}>
             <NewsletterSection small />
           </Box>
+          {goerliButton && (
+            <NextLink href="?network=goerli" target="_self">
+              Move to goerli
+            </NextLink>
+          )}
         </Grid>
         <Flex sx={{ display: ['flex', 'flex', 'none'], mt: 5 }}>
           <NewsletterSection small />

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -28,6 +28,7 @@ export type Feature =
   | 'Ajna'
   | 'DaiSavingsRate'
   | 'FollowAAVEVaults'
+  | 'GoerliButton'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -54,6 +55,8 @@ const configuredFeatures: Record<Feature, boolean> = {
   Ajna: false,
   DaiSavingsRate: true,
   FollowAAVEVaults: false,
+  // Added for gnosis safe testing
+  GoerliButton: false,
 }
 
 export function configureLocalStorageForTests(data: { [feature in Feature]?: boolean }) {


### PR DESCRIPTION
# Move to goerli button

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added button with link to goerli network hidden behind feature toggle
- button has been added to change network when using gnosis safe app

## How to test 🧪
  <Please explain how to test your changes>

- enable `GoerliButton` feature toggle, button should be visible in footer on homepage
