### PR TITLE
Remove share button from my positions

### DIFF
--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -15,7 +15,6 @@ import {
 } from 'features/follow/common/ShareButton'
 import { FollowButtonControl } from 'features/follow/controllers/FollowButtonControl'
 import { formatCryptoBalance, formatFiatBalance, formatPercent } from 'helpers/formatters/format'
-import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import getConfig from 'next/config'
 import React, { PropsWithChildren } from 'react'
@@ -34,7 +33,6 @@ export function DiscoverTableDataCellContent({
   row: DiscoverTableRowData
   onPositionClick?: (cdpId: string) => void
 }) {
-  const followVaultsEnabled = useFeatureToggle('FollowVaults')
   const { i18n, t } = useTranslation()
   const primitives = Object.keys(row)
     .filter((item) => typeof row[item] === 'string' || typeof row[item] === 'number')
@@ -90,7 +88,7 @@ export function DiscoverTableDataCellContent({
               {t('view')}
             </Button>
           </AppLink>
-          {followVaultsEnabled && (
+          {!row.skipShareButton && (
             <AppLink
               href={getTwitterShareUrl({
                 text: twitterSharePositionText,

--- a/features/vaultsOverview/containers/FollowedTable.tsx
+++ b/features/vaultsOverview/containers/FollowedTable.tsx
@@ -38,9 +38,9 @@ export function FollowedTable({ address }: { address: string }) {
         customLoader={<PositionTableLoadingState />}
       >
         {([context, followedMakerPositions]) => {
-          const borrowPositions = getMakerBorrowPositions(followedMakerPositions)
-          const multiplyPositions = getMakerMultiplyPositions(followedMakerPositions)
-          const earnPositions = getMakerEarnPositions(followedMakerPositions)
+          const borrowPositions = getMakerBorrowPositions({ positions: followedMakerPositions })
+          const multiplyPositions = getMakerMultiplyPositions({ positions: followedMakerPositions })
+          const earnPositions = getMakerEarnPositions({ positions: followedMakerPositions })
 
           return followedMakerPositions.length ? (
             <DiscoverTableContainer

--- a/features/vaultsOverview/containers/PositionsTable.tsx
+++ b/features/vaultsOverview/containers/PositionsTable.tsx
@@ -42,22 +42,41 @@ export function PositionsTable({ address }: { address: string }) {
         customLoader={<PositionTableLoadingState />}
       >
         {([ownersPositionsList]) => {
-          const dsrPosition = getDsrPosition({ dsr: ownersPositionsList.dsrPosition, address })
+          const dsrPosition = getDsrPosition({
+            dsr: ownersPositionsList.dsrPosition,
+            address,
+            skipShareButton: true,
+          })
           const combinedPositionsData = [
             ...ownersPositionsList.makerPositions,
             ...ownersPositionsList.aavePositions,
             ...dsrPosition,
           ]
-          const borrowPositions = getMakerBorrowPositions(ownersPositionsList.makerPositions)
-          const makerPositions = useMemo(() => {
+          const borrowPositions = getMakerBorrowPositions({
+            positions: ownersPositionsList.makerPositions,
+            skipShareButton: true,
+          })
+          const multiplyPositions = useMemo(() => {
             return [
-              ...getMakerMultiplyPositions(ownersPositionsList.makerPositions),
-              ...getAaveMultiplyPositions(ownersPositionsList.aavePositions),
+              ...getMakerMultiplyPositions({
+                positions: ownersPositionsList.makerPositions,
+                skipShareButton: true,
+              }),
+              ...getAaveMultiplyPositions({
+                positions: ownersPositionsList.aavePositions,
+                skipShareButton: true,
+              }),
             ]
           }, [ownersPositionsList])
           const earnPositions = [
-            ...getMakerEarnPositions(ownersPositionsList.makerPositions),
-            ...getAaveEarnPositions(ownersPositionsList.aavePositions),
+            ...getMakerEarnPositions({
+              positions: ownersPositionsList.makerPositions,
+              skipShareButton: true,
+            }),
+            ...getAaveEarnPositions({
+              positions: ownersPositionsList.aavePositions,
+              skipShareButton: true,
+            }),
             ...dsrPosition,
           ]
 
@@ -79,13 +98,13 @@ export function PositionsTable({ address }: { address: string }) {
                   />
                 </>
               )}
-              {makerPositions.length > 0 && (
+              {multiplyPositions.length > 0 && (
                 <>
                   <DiscoverTableHeading>
-                    Oasis {t('nav.multiply')} ({makerPositions.length})
+                    Oasis {t('nav.multiply')} ({multiplyPositions.length})
                   </DiscoverTableHeading>
                   <DiscoverResponsiveTable
-                    rows={makerPositions}
+                    rows={multiplyPositions}
                     skip={positionsTableSkippedHeaders}
                     tooltips={positionsTableTooltips}
                   />

--- a/features/vaultsOverview/helpers.ts
+++ b/features/vaultsOverview/helpers.ts
@@ -23,8 +23,28 @@ export const positionsTableTooltips = [
   'variable',
   'vaultDebt',
 ]
-export const positionsTableSkippedHeaders = ['icon', 'ilk', 'liquidityToken', 'url']
+export const positionsTableSkippedHeaders = [
+  'icon',
+  'ilk',
+  'liquidityToken',
+  'skipShareButton',
+  'url',
+]
 export const followTableSkippedHeaders = ['icon', 'ilk', 'protection', 'liquidityToken', 'url']
+
+interface GetMakerPositionParams {
+  positions: MakerPositionDetails[]
+  skipShareButton?: boolean
+}
+interface GetAavePositionParams {
+  positions: AavePosition[]
+  skipShareButton?: boolean
+}
+interface GetDsrPositionParams {
+  address: string
+  dsr?: Dsr
+  skipShareButton?: boolean
+}
 
 function getFundingCost({
   debt,
@@ -86,7 +106,10 @@ function getAavePositionOfType(position: AavePosition[]) {
   )
 }
 
-export function getMakerBorrowPositions(positions: MakerPositionDetails[]): DiscoverTableRowData[] {
+export function getMakerBorrowPositions({
+  positions,
+  skipShareButton,
+}: GetMakerPositionParams): DiscoverTableRowData[] {
   return getMakerPositionOfType(positions).borrow.map(
     ({
       atRiskLevelDanger,
@@ -114,13 +137,15 @@ export function getMakerBorrowPositions(positions: MakerPositionDetails[]): Disc
       variable: stabilityFee.times(100).toNumber(),
       ...(isOwner && { protection: getProtection({ stopLossData, autoSellData }) }),
       cdpId: id.toNumber(),
+      ...(skipShareButton && { skipShareButton }),
     }),
   )
 }
 
-export function getMakerMultiplyPositions(
-  positions: MakerPositionDetails[],
-): DiscoverTableRowData[] {
+export function getMakerMultiplyPositions({
+  positions,
+  skipShareButton,
+}: GetMakerPositionParams): DiscoverTableRowData[] {
   return getMakerPositionOfType(positions).multiply.map(
     ({
       autoSellData,
@@ -143,11 +168,15 @@ export function getMakerMultiplyPositions(
       fundingCost: getFundingCost({ debt, stabilityFee, value }).toNumber(),
       ...(isOwner && { protection: getProtection({ stopLossData, autoSellData }) }),
       cdpId: id.toNumber(),
+      ...(skipShareButton && { skipShareButton }),
     }),
   )
 }
 
-export function getMakerEarnPositions(positions: MakerPositionDetails[]): DiscoverTableRowData[] {
+export function getMakerEarnPositions({
+  positions,
+  skipShareButton,
+}: GetMakerPositionParams): DiscoverTableRowData[] {
   return getMakerPositionOfType(positions).earn.map(
     ({ debt, history, id, ilk, ilkDebtAvailable, lockedCollateralUSD, token, value }) => {
       return {
@@ -158,12 +187,16 @@ export function getMakerEarnPositions(positions: MakerPositionDetails[]): Discov
         liquidity: ilkDebtAvailable.toNumber(),
         protection: -1,
         cdpId: id.toNumber(),
+        ...(skipShareButton && { skipShareButton }),
       }
     },
   )
 }
 
-export function getAaveMultiplyPositions(positions: AavePosition[]): DiscoverTableRowData[] {
+export function getAaveMultiplyPositions({
+  positions,
+  skipShareButton,
+}: GetAavePositionParams): DiscoverTableRowData[] {
   return getAavePositionOfType(positions).multiply.map(
     ({
       fundingCost,
@@ -187,12 +220,16 @@ export function getAaveMultiplyPositions(positions: AavePosition[]): DiscoverTab
         ...(isOwner && { protection: getProtection({ stopLossData: stopLossData! }) }),
         cdpId: id,
         url,
+        ...(skipShareButton && { skipShareButton }),
       }
     },
   )
 }
 
-export function getAaveEarnPositions(positions: AavePosition[]): DiscoverTableRowData[] {
+export function getAaveEarnPositions({
+  positions,
+  skipShareButton,
+}: GetAavePositionParams): DiscoverTableRowData[] {
   return getAavePositionOfType(positions).earn.map(
     ({ id, liquidity, netValue, title, token, url }) => {
       return {
@@ -205,6 +242,7 @@ export function getAaveEarnPositions(positions: AavePosition[]): DiscoverTableRo
         protection: -1,
         cdpId: id,
         url,
+        ...(skipShareButton && { skipShareButton }),
       }
     },
   )
@@ -213,10 +251,8 @@ export function getAaveEarnPositions(positions: AavePosition[]): DiscoverTableRo
 export function getDsrPosition({
   address,
   dsr,
-}: {
-  address: string
-  dsr?: Dsr
-}): DiscoverTableRowData[] {
+  skipShareButton,
+}: GetDsrPositionParams): DiscoverTableRowData[] {
   const netValue =
     dsr?.pots.dsr.value && 'dai' in dsr?.pots.dsr.value ? dsr.pots.dsr.value.dai : zero
 
@@ -229,6 +265,7 @@ export function getDsrPosition({
       liquidity: 'Unlimited',
       protection: -1,
       url: `/earn/dsr/${address}`,
+      ...(skipShareButton && { skipShareButton }),
     },
   ]
 


### PR DESCRIPTION
# [Remove share button from my positions](https://app.shortcut.com/oazo-apps/story/8196/remove-the-share-position-button-from-the-my-positions-table)
  
## Changes 👷‍♀️

- Removed share button from my positions table on owner's page.
  
## How to test 🧪

See if:
- Sharing button is removed from my positions table,
- sharing button is kept on followed positions table and in Discover.
