### PR TITLE
Track default mixpanel params on backend

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -197,7 +197,7 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
 
   const { name, mobile, os, versionNumber } = browserDetect()
   const initialReferrer = mixpanel.get_property('$initial_referrer')
-  const initialReferrerDomain = initialReferrer
+  const initialReferringDomain = initialReferrer
     ? initialReferrer === '$direct'
       ? '$direct'
       : new URL(initialReferrer).hostname
@@ -217,7 +217,7 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
       eventBody,
       eventName,
       initialReferrer,
-      initialReferrerDomain,
+      initialReferringDomain,
       mobile,
       os,
       screenHeight: win.innerHeight,

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -2,6 +2,7 @@ import { ConnectionKind } from '@oasisdex/web3-context'
 import { ProductType } from 'analytics/common'
 import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
+import browserDetect from 'browser-detect'
 import { getDiscoverMixpanelPage } from 'features/discover/helpers'
 import { DiscoverPages } from 'features/discover/types'
 import { CloseVaultTo } from 'features/multiply/manage/pipes/manageMultiplyVault'
@@ -178,16 +179,13 @@ export enum EventTypes {
 // https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
 export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string]: any }) {
   let win: Window
+
   if (typeof window === 'undefined') {
-    var loc = {
-      hostname: '',
-    }
+    var loc = { hostname: '' }
+
     win = {
       navigator: { userAgent: '' },
-      document: {
-        location: loc,
-        referrer: '',
-      },
+      document: { location: loc, referrer: '' },
       screen: { width: 0, height: 0 },
       location: loc,
     } as Window
@@ -197,30 +195,34 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
 
   logMixpanelEventInDevelopmentMode(eventName, eventBody)
 
-  const distinctId = mixpanel.get_distinct_id()
-  const currentUrl = win.location.href
+  const { name, mobile, os, versionNumber } = browserDetect()
   const initialReferrer = mixpanel.get_property('$initial_referrer')
-  const initialReferrerHost = initialReferrer
+  const initialReferrerDomain = initialReferrer
     ? initialReferrer === '$direct'
       ? '$direct'
       : new URL(initialReferrer).hostname
     : ''
-  const userId = mixpanel.get_property('$user_id')
-  // eslint-disable-next-line
-  fetch(`/api/t`, {
+
+  void fetch(`/api/t`, {
     method: 'POST',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      eventName,
+      browser: upperFirst(name),
+      browserVersion: versionNumber,
+      currentUrl: win.location.href,
+      distinctId: mixpanel.get_distinct_id(),
       eventBody,
-      distinctId,
-      currentUrl,
+      eventName,
       initialReferrer,
-      initialReferrerHost,
-      userId,
+      initialReferrerDomain,
+      mobile,
+      os,
+      screenHeight: win.innerHeight,
+      screenWidth: win.innerWidth,
+      userId: mixpanel.get_property('$user_id'),
     }),
   })
 }

--- a/pages/api/t.tsx
+++ b/pages/api/t.tsx
@@ -11,12 +11,13 @@ let mixpanel: MixpanelType = Mixpanel.init(config.mixpanel.token, config.mixpane
 mixpanel = enableMixpanelDevelopmentMode(mixpanel)
 
 const handler = async function (
-  { body: { eventBody, eventName, ...rest } }: NextApiRequest,
+  { body: { distinctId, eventBody, eventName, ...rest } }: NextApiRequest,
   res: NextApiResponse<{ status: number }>,
 ) {
   try {
     !rest.currentUrl.endsWith('vault-info') && // disables tracking for this particular tab
       mixpanel.track(`${eventName}`, {
+        distinct_id: distinctId,
         ...eventBody,
         ...Object.keys(rest).reduce((a, v) => ({ ...a, [`$${snakeCase(v)}`]: rest[v] }), {}),
       })


### PR DESCRIPTION
# [Track default mixpanel params on backend](https://app.shortcut.com/oazo-apps/story/8270/mixpanel-default-properties)
 
## Changes 👷‍♀️

- Added set of parameters that are passed to mixpanel endpoint: browser, browser version, if device is mobile, device os, screen width and height.
  
## How to test 🧪

Trigger any mixpanel event and see if additional data was passed correctly.
