### PR TITLE
Common subgraph loader

### DIFF
--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -20,4 +20,5 @@ export const subgraphMethodsRecord: { [key in keyof Subgraphs['Ajna' & 'Temp']]:
       }
     }
   `,
+  tempMethod: '',
 }

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -1,0 +1,23 @@
+import { Subgraphs, SubgraphsRecord } from 'features/subgraphLoader/types'
+import { gql } from 'graphql-request'
+
+export const subgraphsRecord: SubgraphsRecord = {
+  Ajna: 'https://api.thegraph.com/subgraphs/name/halaprix/gajna',
+  TempGraph: '',
+}
+
+export const subgraphMethodsRecord: { [key in keyof Subgraphs['Ajna' & 'Temp']]: string } = {
+  getEarnData: gql`
+    query getAccount($dpmProxyAddress: ID!) {
+      account(id: $dpmProxyAddress) {
+        earnPositions {
+          lps
+          index
+          nft {
+            id
+          }
+        }
+      }
+    }
+  `,
+}

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -1,0 +1,11 @@
+export type Subgraphs = {
+  Ajna: {
+    getEarnData: { dpmProxyAddress: string }
+  }
+  TempGraph: {
+    tempMethod: undefined
+  }
+}
+
+export type SubgraphsRecord = { [key in keyof Subgraphs]: string }
+export type SubgraphMethodsRecord = { [key in keyof Subgraphs['Ajna' & 'Temp']]: string }

--- a/features/subgraphLoader/useSubgraphLoader.ts
+++ b/features/subgraphLoader/useSubgraphLoader.ts
@@ -1,0 +1,65 @@
+import { subgraphMethodsRecord, subgraphsRecord } from 'features/subgraphLoader/consts'
+import { Subgraphs } from 'features/subgraphLoader/types'
+import request from 'graphql-request'
+import { useEffect, useState } from 'react'
+
+interface UseSubgraphLoader {
+  isError: boolean
+  isLoading: boolean
+  response: Object | undefined
+}
+
+export async function loadSubgraph<
+  S extends keyof Subgraphs,
+  M extends keyof Subgraphs[S],
+  P extends Subgraphs[S][M]
+>(subgraph: S, method: M, params: P) {
+  return await request(subgraphsRecord[subgraph], subgraphMethodsRecord[method], params)
+}
+
+export function useSubgraphLoader<
+  S extends keyof Subgraphs,
+  M extends keyof Subgraphs[S],
+  P extends Subgraphs[S][M]
+>(subgraph: S, method: M, params: P) {
+  const stringifiedParams = JSON.stringify(params)
+  const [state, setState] = useState<UseSubgraphLoader>({
+    isError: false,
+    isLoading: false,
+    response: undefined,
+  })
+
+  useEffect(() => {
+    setState((prev) => ({
+      ...prev,
+      isLoading: true,
+    }))
+
+    loadSubgraph(subgraph, method, params)
+      .then((response) => {
+        setState((prev) => ({
+          ...prev,
+          isError: false,
+          response,
+        }))
+      })
+      .catch((error) => {
+        console.error(error)
+
+        setState((prev) => ({
+          ...prev,
+          isError: true,
+          response: undefined,
+        }))
+      })
+      .finally(() => {
+        // console.log('finally')
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+        }))
+      })
+  }, [subgraph, method, stringifiedParams])
+
+  return state
+}


### PR DESCRIPTION
# Common subgraph loader

Subgraph loader available as both hook and method.
Note: `TempGraph` and `tempMethod` are left intentionally as a hint how this method has to be extended in case someone wants to add support for more types of graphs or their methods.
  
## Changes 👷‍♀️

- Created `useSubgraphLoader` hook,
- created `loadSubgraph` method.
  
## How to test 🧪

As it is just a set of methods, not it's usage, you have to use one of the following:
```typescript
const { isError, isLoading, response } = useSubgraphLoader('Ajna', 'getEarnData', {
  dpmProxyAddress: '0x2e86fc1cca2c22a381b3dbdcf679a23cc63ed3a2',
})
```
or
```typescript
const response = await loadSubgraph('Ajna', 'getEarnData', {
  dpmProxyAddress: '0x2e86fc1cca2c22a381b3dbdcf679a23cc63ed3a2',
})
```
