### PR TITLE
FEAT - Add tracking for users on landing page that have not accepted cookies

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -255,11 +255,13 @@ export function getMixpanelUserContext(language: string, context?: Context): Mix
 }
 
 export const trackingEvents = {
-  landingPageView: (utmSource: string | null) => {
+  landingPageView: (utm: { [key: string]: string | string[] | undefined }) => {
     const eventBody = {
       product: ProductType.BORROW,
       page: Pages.LandingPage,
-      utm_source: utmSource,
+      utm_source: utm.utmSource ? utm.utmSource : 'direct',
+      utm_medium: utm.utmMedium ? utm.utmMedium : 'none',
+      utm_campaign: utm.utmCampaign ? utm.utmCampaign : 'none',
     }
 
     mixpanelInternalAPI(EventTypes.Pageview, eventBody)

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -233,12 +233,9 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        currentUrl: win.location.href,
         distinctId: 'not_tracked',
         eventBody,
         eventName,
-        initialReferrer,
-        initialReferringDomain,
       }),
     })
   }

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -211,23 +211,19 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
     body: JSON.stringify({
       eventBody,
       eventName,
-      ...(mixpanel.has_opted_out_tracking()
-        ? {
-            distinctId: 'not_tracked',
-          }
-        : {
-            browser: upperFirst(name),
-            browserVersion: versionNumber,
-            currentUrl: win.location.href,
-            distinctId: mixpanel.get_distinct_id(),
-            initialReferrer,
-            initialReferringDomain,
-            mobile,
-            os,
-            screenHeight: win.innerHeight,
-            screenWidth: win.innerWidth,
-            userId: mixpanel.get_property('$user_id'),
-          }),
+      distinctId: mixpanel.get_distinct_id(),
+      ...(!mixpanel.has_opted_out_tracking() && {
+        browser: upperFirst(name),
+        browserVersion: versionNumber,
+        currentUrl: win.location.href,
+        initialReferrer,
+        initialReferringDomain,
+        mobile,
+        os,
+        screenHeight: win.innerHeight,
+        screenWidth: win.innerWidth,
+        userId: mixpanel.get_property('$user_id'),
+      }),
     }),
   })
 }

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -241,6 +241,16 @@ export function getMixpanelUserContext(language: string, context?: Context): Mix
 }
 
 export const trackingEvents = {
+  landingPageView: (utmSource: string | null) => {
+    const eventBody = {
+      product: ProductType.BORROW,
+      page: Pages.LandingPage,
+      utm_source: utmSource,
+    }
+
+    mixpanelInternalAPI(EventTypes.Pageview, eventBody)
+  },
+
   pageView: (location: string) => {
     const eventBody = {
       product: ProductType.BORROW,

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -202,29 +202,46 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
       ? '$direct'
       : new URL(initialReferrer).hostname
     : ''
-
-  void fetch(`/api/t`, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      browser: upperFirst(name),
-      browserVersion: versionNumber,
-      currentUrl: win.location.href,
-      distinctId: mixpanel.get_distinct_id(),
-      eventBody,
-      eventName,
-      initialReferrer,
-      initialReferringDomain,
-      mobile,
-      os,
-      screenHeight: win.innerHeight,
-      screenWidth: win.innerWidth,
-      userId: mixpanel.get_property('$user_id'),
-    }),
-  })
+  if (!mixpanel.has_opted_out_tracking()) {
+    void fetch(`/api/t`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        browser: upperFirst(name),
+        browserVersion: versionNumber,
+        currentUrl: win.location.href,
+        distinctId: mixpanel.get_distinct_id(),
+        eventBody,
+        eventName,
+        initialReferrer,
+        initialReferringDomain,
+        mobile,
+        os,
+        screenHeight: win.innerHeight,
+        screenWidth: win.innerWidth,
+        userId: mixpanel.get_property('$user_id'),
+      }),
+    })
+  } else {
+    void fetch(`/api/t`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        currentUrl: win.location.href,
+        distinctId: 'not_tracked',
+        eventBody,
+        eventName,
+        initialReferrer,
+        initialReferringDomain,
+      }),
+    })
+  }
 }
 
 export interface MixpanelUserContext {

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -202,43 +202,34 @@ export function mixpanelInternalAPI(eventName: string, eventBody: { [key: string
       ? '$direct'
       : new URL(initialReferrer).hostname
     : ''
-  if (!mixpanel.has_opted_out_tracking()) {
-    void fetch(`/api/t`, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        browser: upperFirst(name),
-        browserVersion: versionNumber,
-        currentUrl: win.location.href,
-        distinctId: mixpanel.get_distinct_id(),
-        eventBody,
-        eventName,
-        initialReferrer,
-        initialReferringDomain,
-        mobile,
-        os,
-        screenHeight: win.innerHeight,
-        screenWidth: win.innerWidth,
-        userId: mixpanel.get_property('$user_id'),
-      }),
-    })
-  } else {
-    void fetch(`/api/t`, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        distinctId: 'not_tracked',
-        eventBody,
-        eventName,
-      }),
-    })
-  }
+  void fetch(`/api/t`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      eventBody,
+      eventName,
+      ...(mixpanel.has_opted_out_tracking()
+        ? {
+            distinctId: 'not_tracked',
+          }
+        : {
+            browser: upperFirst(name),
+            browserVersion: versionNumber,
+            currentUrl: win.location.href,
+            distinctId: mixpanel.get_distinct_id(),
+            initialReferrer,
+            initialReferringDomain,
+            mobile,
+            os,
+            screenHeight: win.innerHeight,
+            screenWidth: win.innerWidth,
+            userId: mixpanel.get_property('$user_id'),
+          }),
+    }),
+  })
 }
 
 export interface MixpanelUserContext {

--- a/analytics/mixpanel.ts
+++ b/analytics/mixpanel.ts
@@ -36,7 +36,6 @@ export function mixpanelInit() {
     console.debug(`[Mixpanel] Tracking initialized for ${env} env using ${config.mixpanel.token}`)
   }
   mixpanel.init(config.mixpanel.token, config.mixpanel.config)
-  mixpanelInternalAPI('Pageview', { product: 'borrow' })
 }
 
 export function mixpanelIdentify(id: string, props: any) {

--- a/analytics/mixpanel.ts
+++ b/analytics/mixpanel.ts
@@ -6,8 +6,6 @@ import * as mixpanel from 'mixpanel-browser'
 import { Config, Mixpanel } from 'mixpanel-browser'
 import getConfig from 'next/config'
 
-import { mixpanelInternalAPI } from './analytics'
-
 const env =
   getConfig()?.publicRuntimeConfig.mixpanelEnv === 'production' ||
   process.env.MIXPANEL_ENV === 'production'

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -127,7 +127,7 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
     // track the first page load
     if (router.pathname === '/') {
       const utmSource = router.query.utm_source
-      if (typeof utmSource === 'string') {
+      if (typeof utmSource === 'string' || !utmSource) {
         trackingEvents.landingPageView(utmSource || null)
       }
     } else {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -124,6 +124,14 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
 
   useEffect(() => {
     mixpanelInit()
+    // track the first page load
+    if (router.pathname === '/') {
+      const utmSource = router.query.utm_source as string
+      trackingEvents.landingPageView(utmSource.length > 0 ? utmSource : null)
+    } else {
+      trackingEvents.pageView(router.pathname)
+    }
+
     const handleRouteChange = (url: string) => {
       // track events when not in development
       if (process.env.NODE_ENV !== 'development') {
@@ -132,6 +140,7 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
     }
 
     router.events.on('routeChangeComplete', handleRouteChange)
+
     loadFeatureToggles()
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -126,8 +126,10 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
     mixpanelInit()
     // track the first page load
     if (router.pathname === '/') {
-      const utmSource = router.query.utm_source as string
-      trackingEvents.landingPageView(utmSource.length > 0 ? utmSource : null)
+      const utmSource = router.query.utm_source
+      if (typeof utmSource === 'string') {
+        trackingEvents.landingPageView(utmSource || null)
+      }
     } else {
       trackingEvents.pageView(router.pathname)
     }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -126,10 +126,13 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
     mixpanelInit()
     // track the first page load
     if (router.pathname === '/') {
-      const utmSource = router.query.utm_source
-      if (typeof utmSource === 'string' || !utmSource) {
-        trackingEvents.landingPageView(utmSource || null)
+      const utm: { [key: string]: string | string[] | undefined } = {
+        utmSource: router.query.utm_source,
+        utmMedium: router.query.utm_medium,
+        utmCampaign: router.query.utm_campaign,
       }
+
+      trackingEvents.landingPageView(utm)
     } else {
       trackingEvents.pageView(router.pathname)
     }


### PR DESCRIPTION
# [Add tracking for users on landing page that have not accepted cookies](https://app.shortcut.com/oazo-apps/story/8193/add-tracking-for-users-on-landing-page-that-have-not-accepted-cookies-do-not-store-any-metadata)


  
## Changes 👷‍♀️
- Added tracking fo rthe first load of Oasis.app on `/` home apge - track `utm_source`
- change api call based on user settings
  
## How to test 🧪
add `?utm_source=xxxx` to url and check mixpanel tracking events
