### PR TITLE
Change current behavior of gas estimation in FE app

### DIFF
--- a/blockchain/calls/callsHelpers.ts
+++ b/blockchain/calls/callsHelpers.ts
@@ -8,11 +8,10 @@ import {
   SendTransactionFunction as SendTransactionFunctionAbstractContext,
   TransactionDef as TransactionDefAbstractContext,
 } from '@oasisdex/transactions'
+import { Context, ContextConnected } from 'blockchain/network'
+import { GasPrice$ } from 'blockchain/prices'
 import { from, Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
-
-import { Context, ContextConnected } from '../network'
-import { GasPrice$ } from '../prices'
 
 export type CallDef<A, R> = CallDefAbstractContext<A, R, Context>
 
@@ -52,8 +51,9 @@ export function estimateGas<A extends TxMeta>(
   context: ContextConnected,
   txDef: TransactionDef<A>,
   args: A,
+  gasMultiplier?: number,
 ) {
-  return estimateGasAbstractContext<A, ContextConnected>(context, txDef, args)
+  return estimateGasAbstractContext<A, ContextConnected>(context, txDef, args, gasMultiplier)
 }
 
 export function createSendTransaction<A extends TxMeta>(

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -297,6 +297,7 @@ import {
   TxPayloadChange,
   TxPayloadChangeAction,
 } from 'helpers/gasEstimate'
+import { getGasMultiplier } from 'helpers/getGasMultiplier'
 import {
   createProductCardsData$,
   createProductCardsWithBalance$,
@@ -385,7 +386,7 @@ function createTxHelpers$(
       send: createSendTransaction(send, context),
       sendWithGasEstimation: createSendWithGasConstraints(send, context, gasPrice$),
       estimateGas: <B extends TxData>(def: TransactionDef<B>, args: B): Observable<number> => {
-        return estimateGas(context, def, args)
+        return estimateGas(context, def, args, getGasMultiplier(context))
       },
     })),
   )

--- a/helpers/getGasMultiplier.ts
+++ b/helpers/getGasMultiplier.ts
@@ -6,6 +6,8 @@ export function getGasMultiplier(context: ContextConnected) {
     case 'trezor':
       return 1.5
     default:
-      return 1
+      // boost it slightly for others in case there’s
+      // a deviation between the estimate and the actual gas used
+      return 1.1
   }
 }

--- a/helpers/getGasMultiplier.ts
+++ b/helpers/getGasMultiplier.ts
@@ -1,0 +1,11 @@
+import { ContextConnected } from 'blockchain/network'
+
+export function getGasMultiplier(context: ContextConnected) {
+  switch (context.connectionKind) {
+    case 'ledger':
+    case 'trezor':
+      return 1.5
+    default:
+      return 1
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@oasisdex/connectors": "^0.1.0",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/oasis-actions": "0.2.15",
-    "@oasisdex/transactions": "^0.1.0",
+    "@oasisdex/transactions": "0.1.1",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",
     "@prisma/client": "^3.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,10 +3049,10 @@
     ramda "^0.28.0"
     utility-types "^3.10.0"
 
-"@oasisdex/transactions@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@oasisdex/transactions/-/transactions-0.1.0.tgz#c8aebfe79ecc260d939c1091622ea55349621532"
-  integrity sha512-nRxtfDSs4nhzPrt+Zs0Y4w4h7DQk3+DjINU3qQrgvcUV0/MrUW8U0HBPw+guQ259mq/eYsQ6spqtpoAyHaDfnQ==
+"@oasisdex/transactions@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@oasisdex/transactions/-/transactions-0.1.1.tgz#47ef765f5c9b520ec1b9b2cdea49bf0456be9b1d"
+  integrity sha512-BkoKJ/gGyXE/HE32bcAczr6LKl9CqJzdqzDY1OlKFC7U47aV0FGMuLeFROjSECj1E/JoM9GQcChicsqeY1y3Cw==
   dependencies:
     "@types/ramda" "^0.25.38"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
# [Change current behavior of gas estimation in FE app](https://app.shortcut.com/oazo-apps/story/7570/change-current-behavior-of-gas-estimation-in-fe-app)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- removed the og multiplier from the transactions package: https://github.com/OasisDEX/common/pull/88
- added it to the frontend with the distinction: 1.5 multiplier for the HW wallets and 1 (meaning none) multiplier for the others
  
## How to test 🧪
- connect using metamask
- simulate a transaction
- disconnect, connect using hw wallet (ledger, trezor)
- simulate a transaction
- gas estimate should be higher on the second one
