### PR TITLE
Common subgraph loader API

### DIFF
--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -6,7 +6,7 @@ export const subgraphsRecord: SubgraphsRecord = {
   TempGraph: '',
 }
 
-export const subgraphMethodsRecord: { [key in keyof Subgraphs['Ajna' & 'Temp']]: string } = {
+export const subgraphMethodsRecord: { [key in keyof (Subgraphs['Ajna'] & Subgraphs['TempGraph'])]: string } = {
   getEarnData: gql`
     query getAccount($dpmProxyAddress: ID!) {
       account(id: $dpmProxyAddress) {

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -6,7 +6,9 @@ export const subgraphsRecord: SubgraphsRecord = {
   TempGraph: '',
 }
 
-export const subgraphMethodsRecord: { [key in keyof (Subgraphs['Ajna'] & Subgraphs['TempGraph'])]: string } = {
+export const subgraphMethodsRecord: {
+  [key in keyof (Subgraphs['Ajna'] & Subgraphs['TempGraph'])]: string
+} = {
   getEarnData: gql`
     query getAccount($dpmProxyAddress: ID!) {
       account(id: $dpmProxyAddress) {

--- a/features/subgraphLoader/useSubgraphLoader.ts
+++ b/features/subgraphLoader/useSubgraphLoader.ts
@@ -1,6 +1,4 @@
-import { subgraphMethodsRecord, subgraphsRecord } from 'features/subgraphLoader/consts'
 import { Subgraphs } from 'features/subgraphLoader/types'
-import request from 'graphql-request'
 import { useEffect, useState } from 'react'
 
 interface UseSubgraphLoader {
@@ -14,7 +12,16 @@ export async function loadSubgraph<
   M extends keyof Subgraphs[S],
   P extends Subgraphs[S][M]
 >(subgraph: S, method: M, params: P) {
-  return await request(subgraphsRecord[subgraph], subgraphMethodsRecord[method], params)
+  const response = await fetch(`/api/subgraph`, {
+    method: 'POST',
+    body: JSON.stringify({
+      subgraph,
+      method,
+      params,
+    }),
+  })
+
+  return await response.json()
 }
 
 export function useSubgraphLoader<
@@ -36,16 +43,14 @@ export function useSubgraphLoader<
     }))
 
     loadSubgraph(subgraph, method, params)
-      .then((response) => {
+      .then(({ success, response }) => {
         setState((prev) => ({
           ...prev,
-          isError: false,
+          isError: !success,
           response,
         }))
       })
-      .catch((error) => {
-        console.error(error)
-
+      .catch(() => {
         setState((prev) => ({
           ...prev,
           isError: true,

--- a/pages/api/subgraph.tsx
+++ b/pages/api/subgraph.tsx
@@ -1,0 +1,34 @@
+import { subgraphMethodsRecord, subgraphsRecord } from 'features/subgraphLoader/consts'
+import request from 'graphql-request'
+import { NextApiHandler, NextApiRequest } from 'next'
+
+async function get({ req: { body } }: { req: NextApiRequest }) {
+  try {
+    const { subgraph, method, params } = JSON.parse(body)
+    const response = await request(
+      subgraphsRecord[subgraph as keyof typeof subgraphsRecord],
+      subgraphMethodsRecord[method as keyof typeof subgraphMethodsRecord],
+      params,
+    )
+
+    return {
+      success: true,
+      response,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error,
+    }
+  }
+}
+
+const handler: NextApiHandler = async (req, res) => {
+  if (req.method === 'POST') {
+    const response = await get({ req })
+
+    return res.status(response.success ? 200 : 500).json(response)
+  } else return res.status(405).end()
+}
+
+export default handler


### PR DESCRIPTION
# Common subgraph loader API

Subgraph loader moved to the backend.
  
## Changes 👷‍♀️

- created `/api/subgraph` endpoint utilized by previously created `useSubgraphLoader` hook and `loadSubgraph` method,
- fixed some errors with types,
  
## How to test 🧪

As it is just a set of methods, not it's usage, you have to use one of the following:
```typescript
const { isError, isLoading, response } = useSubgraphLoader('Ajna', 'getEarnData', {
  dpmProxyAddress: '0x2e86fc1cca2c22a381b3dbdcf679a23cc63ed3a2',
})
```
or
```typescript
const response = await loadSubgraph('Ajna', 'getEarnData', {
  dpmProxyAddress: '0x2e86fc1cca2c22a381b3dbdcf679a23cc63ed3a2',
})
```

## TODO 📝

- Get subgraphs urls from env when https://github.com/OasisDEX/oasis-borrow/pull/2128 is merged and config is available.
