### PR TITLE
FIX - fix first render query

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,7 +29,7 @@ import nextI18NextConfig from 'next-i18next.config.js'
 import { AppProps } from 'next/app'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { theme } from 'theme'
 // @ts-ignore
 import { components, ThemeProvider } from 'theme-ui'
@@ -108,7 +108,7 @@ const noOverlayWorkaroundScript = `
 
 function App({ Component, pageProps }: AppProps & CustomAppProps) {
   const [value, setValue] = useLocalStorage(LOCALSTORAGE_KEY, '')
-
+  const mount = useRef(false)
   const Layout = Component.layout || AppLayout
 
   const layoutProps = Component.layoutProps
@@ -123,7 +123,7 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
   )
 
   useEffect(() => {
-    if (router.isReady) {
+    if (router.isReady && !mount.current) {
       mixpanelInit()
 
       if (router.pathname === '/') {
@@ -137,6 +137,7 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
       } else {
         trackingEvents.pageView(router.pathname)
       }
+      mount.current = true
     }
   }, [router.isReady])
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -123,20 +123,24 @@ function App({ Component, pageProps }: AppProps & CustomAppProps) {
   )
 
   useEffect(() => {
-    mixpanelInit()
-    // track the first page load
-    if (router.pathname === '/') {
-      const utm: { [key: string]: string | string[] | undefined } = {
-        utmSource: router.query.utm_source,
-        utmMedium: router.query.utm_medium,
-        utmCampaign: router.query.utm_campaign,
+    if (router.isReady) {
+      mixpanelInit()
+
+      if (router.pathname === '/') {
+        const utm: { [key: string]: string | string[] | undefined } = {
+          utmSource: router.query.utm_source,
+          utmMedium: router.query.utm_medium,
+          utmCampaign: router.query.utm_campaign,
+        }
+
+        trackingEvents.landingPageView(utm)
+      } else {
+        trackingEvents.pageView(router.pathname)
       }
-
-      trackingEvents.landingPageView(utm)
-    } else {
-      trackingEvents.pageView(router.pathname)
     }
+  }, [router.isReady])
 
+  useEffect(() => {
     const handleRouteChange = (url: string) => {
       // track events when not in development
       if (process.env.NODE_ENV !== 'development') {


### PR DESCRIPTION
# [Title](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
page view is now tracked when `router.isReady` is `true` since the query parameters were undefined on first render.

```ts
  useEffect(() => {
    if (router.isReady) {
      mixpanelInit()

      if (router.pathname === '/') {
        const utm: { [key: string]: string | string[] | undefined } = {
          utmSource: router.query.utm_source,
          utmMedium: router.query.utm_medium,
          utmCampaign: router.query.utm_campaign,
        }

        trackingEvents.landingPageView(utm)
      } else {
        trackingEvents.pageView(router.pathname)
      }
    }
  }, [router.isReady])
```

## How to test 🧪
go to `http://localhost:3000/?utm_source=zzzzz&utm_medium=xxxx&utm_campaign=yyyy#multiply` and check the console logs on first laod
