### PR TITLE
🧿 Split get Ajna position observable

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -135,6 +135,7 @@ import {
 import { PositionId } from 'features/aave/types'
 import { createAccountData } from 'features/account/AccountData'
 import { createTransactionManager } from 'features/account/transactionManager'
+import { AjnaProduct } from 'features/ajna/common/types'
 import { getAjnaPosition$ } from 'features/ajna/positions/common/observables/getAjnaPosition'
 import {
   DpmPositionData,
@@ -1400,14 +1401,14 @@ export function setupAppContext() {
     (token, spender) => `${token}-${spender}`,
   )
 
-  const dpmPositionData$ = memoize(
-    curry(getDpmPositionData$)(proxiesRelatedWithPosition$, lastCreatedPositionForProxy$),
+  const ajnaDpmPositionData$ = memoize(
+    curry(getDpmPositionData$<AjnaProduct>)(proxiesRelatedWithPosition$, lastCreatedPositionForProxy$),
     (positionId: PositionId) => `${positionId.walletAddress}-${positionId.vaultId}`,
   )
 
   const ajnaPosition$ = memoize(
     curry(getAjnaPosition$)(context$, onEveryBlock$),
-    (dpmPositionData: DpmPositionData) => dpmPositionData,
+    (dpmPositionData: DpmPositionData<AjnaProduct>) => dpmPositionData,
   )
 
   return {
@@ -1492,7 +1493,7 @@ export function setupAppContext() {
     allowanceStateMachine,
     allowanceForAccount$,
     contextForAddress$,
-    dpmPositionData$,
+    ajnaDpmPositionData$,
     ajnaPosition$,
     chainContext$,
     positionIdFromDpmProxy$,

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -135,11 +135,11 @@ import {
 import { PositionId } from 'features/aave/types'
 import { createAccountData } from 'features/account/AccountData'
 import { createTransactionManager } from 'features/account/transactionManager'
+import { getAjnaPosition$ } from 'features/ajna/positions/common/observables/getAjnaPosition'
 import {
-  getAjnaPosition$,
-  GetAjnaPositionIdentification,
-} from 'features/ajna/positions/common/observables/getAjnaPosition'
-import { getDpmPositionData$ } from 'features/ajna/positions/common/observables/getDpmPositionData'
+  DpmPositionData,
+  getDpmPositionData$,
+} from 'features/ajna/positions/common/observables/getDpmPositionData'
 import { createAutomationTriggersData } from 'features/automation/api/automationTriggersData'
 import {
   AUTO_BUY_FORM_CHANGE,
@@ -1406,8 +1406,8 @@ export function setupAppContext() {
   )
 
   const ajnaPosition$ = memoize(
-    curry(getAjnaPosition$)(context$, dpmPositionData$, onEveryBlock$),
-    (ajnaPositionIdentification: GetAjnaPositionIdentification) => ajnaPositionIdentification,
+    curry(getAjnaPosition$)(context$, onEveryBlock$),
+    (dpmPositionData: DpmPositionData) => dpmPositionData,
   )
 
   return {

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -135,7 +135,6 @@ import {
 import { PositionId } from 'features/aave/types'
 import { createAccountData } from 'features/account/AccountData'
 import { createTransactionManager } from 'features/account/transactionManager'
-import { AjnaProduct } from 'features/ajna/common/types'
 import { getAjnaPosition$ } from 'features/ajna/positions/common/observables/getAjnaPosition'
 import {
   DpmPositionData,
@@ -1401,14 +1400,14 @@ export function setupAppContext() {
     (token, spender) => `${token}-${spender}`,
   )
 
-  const ajnaDpmPositionData$ = memoize(
-    curry(getDpmPositionData$<AjnaProduct>)(proxiesRelatedWithPosition$, lastCreatedPositionForProxy$),
+  const dpmPositionData$ = memoize(
+    curry(getDpmPositionData$)(proxiesRelatedWithPosition$, lastCreatedPositionForProxy$),
     (positionId: PositionId) => `${positionId.walletAddress}-${positionId.vaultId}`,
   )
 
   const ajnaPosition$ = memoize(
     curry(getAjnaPosition$)(context$, onEveryBlock$),
-    (dpmPositionData: DpmPositionData<AjnaProduct>) => dpmPositionData,
+    (dpmPositionData: DpmPositionData) => dpmPositionData,
   )
 
   return {
@@ -1493,7 +1492,7 @@ export function setupAppContext() {
     allowanceStateMachine,
     allowanceForAccount$,
     contextForAddress$,
-    ajnaDpmPositionData$,
+    dpmPositionData$,
     ajnaPosition$,
     chainContext$,
     positionIdFromDpmProxy$,

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -58,49 +58,57 @@ export function AjnaProductController({
 }: AjnaProductControllerProps) {
   const { t } = useTranslation()
   const { push } = useRouter()
-  const { ajnaPosition$, dpmPositionData$, balancesInfoArray$, tokenPriceUSD$ } = useAppContext()
+  const {
+    ajnaPosition$,
+    ajnaDpmPositionData$,
+    balancesInfoArray$,
+    tokenPriceUSD$,
+  } = useAppContext()
   const { walletAddress } = useAccount()
 
-  const [dpmPositionData, dpmPositionError] = useObservable(
+  const [ajnaDpmPositionData, ajnaDpmPositionError] = useObservable(
     useMemo(
       () =>
         id
-          ? dpmPositionData$(getPositionIdentity(id))
+          ? ajnaDpmPositionData$(getPositionIdentity(id))
           : collateralToken && product && quoteToken
-          ? getStaticDpmPositionData$({ collateralToken, product, quoteToken })
+          ? getStaticDpmPositionData$({ collateralToken, product, protocol: 'Ajna', quoteToken })
           : EMPTY,
-      [collateralToken, dpmPositionData$, id, product, quoteToken],
+      [collateralToken, id, product, quoteToken],
     ),
   )
   const [balancesInfoArrayData, balancesInfoArrayError] = useObservable(
     useMemo(
       () =>
-        dpmPositionData && walletAddress
+        ajnaDpmPositionData && walletAddress
           ? balancesInfoArray$(
-              [dpmPositionData.collateralToken, dpmPositionData.quoteToken, 'ETH'],
+              [ajnaDpmPositionData.collateralToken, ajnaDpmPositionData.quoteToken, 'ETH'],
               walletAddress,
             )
           : EMPTY,
-      [balancesInfoArray$, dpmPositionData, walletAddress],
+      [ajnaDpmPositionData, walletAddress],
     ),
   )
   const [tokenPriceUSDData, tokenPriceUSDError] = useObservable(
     useMemo(
       () =>
-        dpmPositionData
-          ? tokenPriceUSD$([dpmPositionData.collateralToken, dpmPositionData.quoteToken, 'ETH'])
+        ajnaDpmPositionData
+          ? tokenPriceUSD$([
+              ajnaDpmPositionData.collateralToken,
+              ajnaDpmPositionData.quoteToken,
+              'ETH',
+            ])
           : EMPTY,
-      [dpmPositionData, tokenPriceUSD$],
+      [ajnaDpmPositionData],
     ),
   )
   const [ajnaPositionData, ajnaPositionError] = useObservable(
-    useMemo(() => (dpmPositionData ? ajnaPosition$(dpmPositionData) : EMPTY), [
-      ajnaPosition$,
-      dpmPositionData,
+    useMemo(() => (ajnaDpmPositionData ? ajnaPosition$(ajnaDpmPositionData) : EMPTY), [
+      ajnaDpmPositionData,
     ]),
   )
 
-  if ((dpmPositionData || ajnaPositionData) === null) void push('/not-found')
+  if ((ajnaDpmPositionData || ajnaPositionData) === null) void push('/not-found')
 
   return (
     <WithConnection>
@@ -109,35 +117,35 @@ export function AjnaProductController({
           <AjnaWrapper>
             <WithErrorHandler
               error={[
+                ajnaDpmPositionError,
                 ajnaPositionError,
                 balancesInfoArrayError,
-                dpmPositionError,
                 tokenPriceUSDError,
               ]}
             >
               <WithLoadingIndicator
                 value={[
+                  ajnaDpmPositionData,
                   ajnaPositionData,
                   balancesInfoArrayData,
-                  dpmPositionData,
                   tokenPriceUSDData,
                 ]}
                 customLoader={
                   <PositionLoadingState
                     {...getAjnaHeadlineProps({
-                      collateralToken: dpmPositionData?.collateralToken,
+                      collateralToken: ajnaDpmPositionData?.collateralToken,
                       flow,
-                      product: dpmPositionData?.product,
-                      quoteToken: dpmPositionData?.quoteToken,
+                      product: ajnaDpmPositionData?.product,
+                      quoteToken: ajnaDpmPositionData?.quoteToken,
                       id,
                     })}
                   />
                 }
               >
                 {([
+                  ajnaDpmPosition,
                   ajnaPosition,
                   [collateralBalance, quoteBalance, ethBalance],
-                  dpmPosition,
                   tokenPriceUSD,
                 ]) =>
                   ajnaPosition ? (
@@ -146,44 +154,44 @@ export function AjnaProductController({
                         title="seo.title-product-w-tokens"
                         titleParams={{
                           product: t(`seo.ajnaProductPage.title`, {
-                            product: startCase(dpmPosition.product),
+                            product: startCase(ajnaDpmPosition.product),
                           }),
                           protocol: 'Ajna',
-                          token1: dpmPosition.collateralToken,
-                          token2: dpmPosition.quoteToken,
+                          token1: ajnaDpmPosition.collateralToken,
+                          token2: ajnaDpmPosition.quoteToken,
                         }}
                         description="seo.ajna.description"
                         url={document.location.pathname}
                       />
                       <AjnaGeneralContextProvider
                         collateralBalance={collateralBalance}
-                        collateralPrice={tokenPriceUSD[dpmPosition.collateralToken]}
-                        collateralToken={dpmPosition.collateralToken}
-                        {...(flow === 'manage' && { dpmProxy: dpmPosition.proxy })}
+                        collateralPrice={tokenPriceUSD[ajnaDpmPosition.collateralToken]}
+                        collateralToken={ajnaDpmPosition.collateralToken}
+                        {...(flow === 'manage' && { dpmProxy: ajnaDpmPosition.proxy })}
                         ethBalance={ethBalance}
                         ethPrice={tokenPriceUSD.ETH}
                         flow={flow}
                         id={id}
-                        owner={dpmPosition.user}
-                        product={dpmPosition.product}
+                        owner={ajnaDpmPosition.user}
+                        product={ajnaDpmPosition.product}
                         quoteBalance={quoteBalance}
-                        quotePrice={tokenPriceUSD[dpmPosition.quoteToken]}
-                        quoteToken={dpmPosition.quoteToken}
-                        steps={steps[dpmPosition.product][flow]}
+                        quotePrice={tokenPriceUSD[ajnaDpmPosition.quoteToken]}
+                        quoteToken={ajnaDpmPosition.quoteToken}
+                        steps={steps[ajnaDpmPosition.product][flow]}
                       >
-                        {dpmPosition.product === 'borrow' && (
+                        {ajnaDpmPosition.product === 'borrow' && (
                           <AjnaProductContextProvider
                             formDefaults={{
                               action: flow === 'open' ? 'open-borrow' : 'deposit-borrow',
                             }}
                             formReducto={useAjnaBorrowFormReducto}
                             position={ajnaPosition as AjnaPosition}
-                            product={dpmPosition.product}
+                            product={ajnaDpmPosition.product}
                           >
                             <AjnaBorrowPositionController />
                           </AjnaProductContextProvider>
                         )}
-                        {dpmPosition.product === 'earn' && (
+                        {ajnaDpmPosition.product === 'earn' && (
                           <AjnaProductContextProvider
                             formDefaults={{
                               action: flow === 'open' ? 'open-earn' : 'deposit-earn',
@@ -191,7 +199,7 @@ export function AjnaProductController({
                             }}
                             formReducto={useAjnaEarnFormReducto}
                             position={ajnaPosition as AjnaEarnPosition}
-                            product={dpmPosition.product}
+                            product={ajnaDpmPosition.product}
                           >
                             <AjnaEarnPositionController />
                           </AjnaProductContextProvider>

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -11,6 +11,7 @@ import { useAjnaBorrowFormReducto } from 'features/ajna/positions/borrow/state/a
 import { AjnaGeneralContextProvider } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { AjnaProductContextProvider } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { getAjnaHeadlineProps } from 'features/ajna/positions/common/helpers/getAjnaHeadlineProps'
+import { getStaticDpmPositionData$ } from 'features/ajna/positions/common/observables/getDpmPositionData'
 import { AjnaEarnPositionController } from 'features/ajna/positions/earn/controls/AjnaEarnPositionController'
 import { useAjnaEarnFormReducto } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
@@ -57,51 +58,49 @@ export function AjnaProductController({
 }: AjnaProductControllerProps) {
   const { t } = useTranslation()
   const { push } = useRouter()
-  const { ajnaPosition$, balancesInfoArray$, tokenPriceUSD$ } = useAppContext()
+  const { ajnaPosition$, dpmPositionData$, balancesInfoArray$, tokenPriceUSD$ } = useAppContext()
   const { walletAddress } = useAccount()
 
-  const [ajnaPositionData, ajnaPositionError] = useObservable(
+  const [dpmPositionData, dpmPositionError] = useObservable(
     useMemo(
       () =>
-        ajnaPosition$(
-          id
-            ? { positionId: getPositionIdentity(id) }
-            : {
-                collateralToken: collateralToken as string,
-                product: product as string,
-                quoteToken: quoteToken as string,
-              },
-        ),
-      [id, collateralToken, product, quoteToken],
+        id
+          ? dpmPositionData$(getPositionIdentity(id))
+          : collateralToken && product && quoteToken
+          ? getStaticDpmPositionData$({ collateralToken, product, quoteToken })
+          : EMPTY,
+      [collateralToken, dpmPositionData$, id, product, quoteToken],
     ),
   )
   const [balancesInfoArrayData, balancesInfoArrayError] = useObservable(
     useMemo(
       () =>
-        ajnaPositionData?.meta.collateralToken && ajnaPositionData?.meta.quoteToken
+        dpmPositionData && walletAddress
           ? balancesInfoArray$(
-              [ajnaPositionData.meta.collateralToken, ajnaPositionData.meta.quoteToken, 'ETH'],
-              walletAddress || '',
+              [dpmPositionData.collateralToken, dpmPositionData.quoteToken, 'ETH'],
+              walletAddress,
             )
           : EMPTY,
-      [ajnaPositionData],
+      [balancesInfoArray$, dpmPositionData, walletAddress],
     ),
   )
   const [tokenPriceUSDData, tokenPriceUSDError] = useObservable(
     useMemo(
       () =>
-        ajnaPositionData?.meta.collateralToken && ajnaPositionData?.meta.quoteToken
-          ? tokenPriceUSD$([
-              ajnaPositionData.meta.collateralToken,
-              ajnaPositionData.meta.quoteToken,
-              'ETH',
-            ])
+        dpmPositionData
+          ? tokenPriceUSD$([dpmPositionData.collateralToken, dpmPositionData.quoteToken, 'ETH'])
           : EMPTY,
-      [ajnaPositionData],
+      [dpmPositionData, tokenPriceUSD$],
     ),
   )
+  const [ajnaPositionData, ajnaPositionError] = useObservable(
+    useMemo(() => (dpmPositionData ? ajnaPosition$(dpmPositionData) : EMPTY), [
+      ajnaPosition$,
+      dpmPositionData,
+    ]),
+  )
 
-  if (ajnaPositionData === null) void push('/not-found')
+  if ((dpmPositionData || ajnaPositionData) === null) void push('/not-found')
 
   return (
     <WithConnection>
@@ -109,77 +108,90 @@ export function AjnaProductController({
         <WithWalletAssociatedRisk>
           <AjnaWrapper>
             <WithErrorHandler
-              error={[ajnaPositionError, balancesInfoArrayError, tokenPriceUSDError]}
+              error={[
+                ajnaPositionError,
+                balancesInfoArrayError,
+                dpmPositionError,
+                tokenPriceUSDError,
+              ]}
             >
               <WithLoadingIndicator
-                value={[ajnaPositionData, balancesInfoArrayData, tokenPriceUSDData]}
+                value={[
+                  ajnaPositionData,
+                  balancesInfoArrayData,
+                  dpmPositionData,
+                  tokenPriceUSDData,
+                ]}
                 customLoader={
                   <PositionLoadingState
                     {...getAjnaHeadlineProps({
-                      collateralToken: ajnaPositionData?.meta.collateralToken,
+                      collateralToken: dpmPositionData?.collateralToken,
                       flow,
-                      product: ajnaPositionData?.meta.product,
-                      quoteToken: ajnaPositionData?.meta.quoteToken,
+                      product: dpmPositionData?.product,
+                      quoteToken: dpmPositionData?.quoteToken,
                       id,
                     })}
                   />
                 }
               >
-                {([ajnaPosition, [collateralBalance, quoteBalance, ethBalance], tokenPriceUSD]) =>
+                {([
+                  ajnaPosition,
+                  [collateralBalance, quoteBalance, ethBalance],
+                  dpmPosition,
+                  tokenPriceUSD,
+                ]) =>
                   ajnaPosition ? (
                     <>
                       <PageSEOTags
                         title="seo.title-product-w-tokens"
                         titleParams={{
                           product: t(`seo.ajnaProductPage.title`, {
-                            product: startCase(ajnaPosition.meta.product),
+                            product: startCase(dpmPosition.product),
                           }),
                           protocol: 'Ajna',
-                          token1: ajnaPosition.meta.collateralToken,
-                          token2: ajnaPosition.meta.quoteToken,
+                          token1: dpmPosition.collateralToken,
+                          token2: dpmPosition.quoteToken,
                         }}
                         description="seo.ajna.description"
                         url={document.location.pathname}
                       />
                       <AjnaGeneralContextProvider
                         collateralBalance={collateralBalance}
-                        collateralPrice={tokenPriceUSD[ajnaPosition.meta.collateralToken]}
-                        collateralToken={ajnaPosition.meta.collateralToken}
-                        {...(flow === 'manage' && { dpmProxy: ajnaPosition.meta.proxy })}
+                        collateralPrice={tokenPriceUSD[dpmPosition.collateralToken]}
+                        collateralToken={dpmPosition.collateralToken}
+                        {...(flow === 'manage' && { dpmProxy: dpmPosition.proxy })}
                         ethBalance={ethBalance}
                         ethPrice={tokenPriceUSD.ETH}
                         flow={flow}
                         id={id}
-                        owner={ajnaPosition.meta.user}
-                        product={ajnaPosition.meta.product}
+                        owner={dpmPosition.user}
+                        product={dpmPosition.product}
                         quoteBalance={quoteBalance}
-                        quotePrice={tokenPriceUSD[ajnaPosition.meta.quoteToken]}
-                        quoteToken={ajnaPosition.meta.quoteToken}
-                        steps={steps[ajnaPosition.meta.product][flow]}
+                        quotePrice={tokenPriceUSD[dpmPosition.quoteToken]}
+                        quoteToken={dpmPosition.quoteToken}
+                        steps={steps[dpmPosition.product][flow]}
                       >
-                        {ajnaPosition.meta.product === 'borrow' && (
+                        {dpmPosition.product === 'borrow' && (
                           <AjnaProductContextProvider
                             formDefaults={{
                               action: flow === 'open' ? 'open-borrow' : 'deposit-borrow',
                             }}
                             formReducto={useAjnaBorrowFormReducto}
-                            position={ajnaPosition.position as AjnaPosition}
-                            product={ajnaPosition.meta.product}
+                            position={ajnaPosition as AjnaPosition}
+                            product={dpmPosition.product}
                           >
                             <AjnaBorrowPositionController />
                           </AjnaProductContextProvider>
                         )}
-                        {ajnaPosition.meta.product === 'earn' && (
+                        {dpmPosition.product === 'earn' && (
                           <AjnaProductContextProvider
                             formDefaults={{
                               action: flow === 'open' ? 'open-earn' : 'deposit-earn',
-                              price: (ajnaPosition.position as AjnaEarnPosition).pool.highestThresholdPrice.decimalPlaces(
-                                2,
-                              ),
+                              price: ajnaPosition.pool.highestThresholdPrice.decimalPlaces(2),
                             }}
                             formReducto={useAjnaEarnFormReducto}
-                            position={ajnaPosition.position as AjnaEarnPosition}
-                            product={ajnaPosition.meta.product}
+                            position={ajnaPosition as AjnaEarnPosition}
+                            product={dpmPosition.product}
                           >
                             <AjnaEarnPositionController />
                           </AjnaProductContextProvider>

--- a/features/ajna/positions/common/observables/getAjnaPosition.ts
+++ b/features/ajna/positions/common/observables/getAjnaPosition.ts
@@ -1,71 +1,25 @@
 import { AjnaEarnPosition, AjnaPosition, views } from '@oasisdex/oasis-actions-poc'
 import { Context } from 'blockchain/network'
-import { ethers } from 'ethers'
-import { PositionId } from 'features/aave/types'
-import { AjnaProduct } from 'features/ajna/common/types'
 import { DpmPositionData } from 'features/ajna/positions/common/observables/getDpmPositionData'
 import { getAjnaEarnData } from 'features/ajna/positions/earn/helpers/getAjnaEarnData'
 import { isEqual } from 'lodash'
-import { combineLatest, Observable, of } from 'rxjs'
+import { combineLatest, Observable } from 'rxjs'
 import { distinctUntilChanged, shareReplay, switchMap } from 'rxjs/operators'
-
-interface AjnaMeta extends Omit<DpmPositionData, 'product'> {
-  product: AjnaProduct
-}
-interface GetAjnaPositionIdentificationWithPosition {
-  positionId: PositionId
-  collateralToken?: never
-  product?: never
-  quoteToken?: never
-}
-interface GetAjnaPositionIdentificationWithoutPosition {
-  collateralToken: string
-  product: string
-  quoteToken: string
-  positionId?: never
-}
-export type GetAjnaPositionIdentification =
-  | GetAjnaPositionIdentificationWithPosition
-  | GetAjnaPositionIdentificationWithoutPosition
-
-interface AjnaPositionWithMeta {
-  position: AjnaPosition | AjnaEarnPosition
-  meta: AjnaMeta
-}
 
 export function getAjnaPosition$(
   context$: Observable<Context>,
-  dpmPositionData$: (positionId: PositionId) => Observable<DpmPositionData | null>,
   onEveryBlock$: Observable<number>,
-  { collateralToken, positionId, product, quoteToken }: GetAjnaPositionIdentification,
-): Observable<AjnaPositionWithMeta | null> {
-  return combineLatest(
-    context$,
-    positionId ? dpmPositionData$(positionId) : of(undefined),
-    onEveryBlock$,
-  ).pipe(
-    switchMap(async ([context, dpmPositionData]) => {
-      if (dpmPositionData && dpmPositionData.protocol !== 'Ajna') return null
-
-      const meta = positionId
-        ? (dpmPositionData as DpmPositionData)
-        : {
-            collateralToken,
-            product: product as AjnaProduct,
-            protocol: 'Ajna',
-            proxy: ethers.constants.AddressZero,
-            quoteToken,
-            user: ethers.constants.AddressZero,
-            vaultId: '0',
-          }
-
-      const resolvedProduct = (meta.product as string).toLowerCase() as AjnaProduct
+  { collateralToken, product, protocol, proxy, quoteToken }: DpmPositionData,
+): Observable<AjnaPosition | AjnaEarnPosition> {
+  return combineLatest(context$, onEveryBlock$).pipe(
+    switchMap(async ([context]) => {
+      if (protocol !== 'Ajna') return null
 
       const commonPayload = {
-        proxyAddress: meta.proxy,
+        proxyAddress: proxy,
         poolAddress:
           context.ajnaPoolPairs[
-            `${meta.collateralToken}-${meta.quoteToken}` as keyof typeof context.ajnaPoolPairs
+            `${collateralToken}-${quoteToken}` as keyof typeof context.ajnaPoolPairs
           ].address,
       }
 
@@ -74,23 +28,12 @@ export function getAjnaPosition$(
         provider: context.rpcProvider,
       }
 
-      const positionPerProduct = {
-        borrow: async () => views.ajna.getPosition(commonPayload, commonDependency),
-        earn: async () =>
-          views.ajna.getEarnPosition(commonPayload, {
+      return product === 'earn'
+        ? await views.ajna.getEarnPosition(commonPayload, {
             ...commonDependency,
             getEarnData: getAjnaEarnData,
-          }),
-        multiply: async () => views.ajna.getPosition(commonPayload, commonDependency),
-      }
-
-      return {
-        position: await positionPerProduct[resolvedProduct](),
-        meta: {
-          ...meta,
-          product: resolvedProduct,
-        },
-      }
+          })
+        : await views.ajna.getPosition(commonPayload, commonDependency)
     }),
     distinctUntilChanged(isEqual),
     shareReplay(1),

--- a/features/ajna/positions/common/observables/getDpmPositionData.ts
+++ b/features/ajna/positions/common/observables/getDpmPositionData.ts
@@ -1,14 +1,16 @@
 import { UserDpmAccount } from 'blockchain/userDpmProxies'
+import { ethers } from 'ethers'
 import { ProxiesRelatedWithPosition } from 'features/aave/helpers/getProxiesRelatedWithPosition'
 import { PositionCreated } from 'features/aave/services/readPositionCreatedEvents'
 import { PositionId } from 'features/aave/types'
+import { AjnaProduct } from 'features/ajna/common/types'
 import { isEqual } from 'lodash'
-import { combineLatest, Observable, of } from 'rxjs'
-import { distinctUntilChanged, map, shareReplay, switchMap } from 'rxjs/operators'
+import { combineLatest, EMPTY, Observable, of } from 'rxjs'
+import { distinctUntilChanged, map, shareReplay, startWith, switchMap } from 'rxjs/operators'
 
 export interface DpmPositionData extends UserDpmAccount {
   collateralToken: string
-  product: string
+  product: AjnaProduct
   protocol: string
   quoteToken: string
 }
@@ -17,7 +19,7 @@ export function getDpmPositionData$(
   proxiesForPosition$: (positionId: PositionId) => Observable<ProxiesRelatedWithPosition>,
   lastCreatedPositionForProxy$: (proxyAddress: string) => Observable<PositionCreated>,
   positionId: PositionId,
-): Observable<DpmPositionData | null> {
+): Observable<DpmPositionData> {
   return proxiesForPosition$(positionId).pipe(
     switchMap(({ dpmProxy }) => {
       return combineLatest(
@@ -30,7 +32,7 @@ export function getDpmPositionData$(
         ? {
             ...dpmProxy,
             collateralToken: lastCreatedPosition.collateralTokenSymbol,
-            product: lastCreatedPosition.positionType,
+            product: lastCreatedPosition.positionType.toLowerCase() as AjnaProduct,
             protocol: lastCreatedPosition.protocol,
             quoteToken: lastCreatedPosition.debtTokenSymbol,
           }
@@ -38,5 +40,27 @@ export function getDpmPositionData$(
     }),
     distinctUntilChanged(isEqual),
     shareReplay(1),
+  )
+}
+
+export function getStaticDpmPositionData$({
+  collateralToken,
+  product,
+  quoteToken,
+}: {
+  collateralToken: string
+  product: AjnaProduct
+  quoteToken: string
+}): Observable<DpmPositionData> {
+  return EMPTY.pipe(
+    startWith({
+      collateralToken,
+      product,
+      protocol: 'Ajna',
+      proxy: ethers.constants.AddressZero,
+      quoteToken,
+      user: ethers.constants.AddressZero,
+      vaultId: '0',
+    }),
   )
 }

--- a/features/ajna/positions/common/observables/getDpmPositionData.ts
+++ b/features/ajna/positions/common/observables/getDpmPositionData.ts
@@ -7,18 +7,18 @@ import { isEqual } from 'lodash'
 import { combineLatest, EMPTY, Observable, of } from 'rxjs'
 import { distinctUntilChanged, map, shareReplay, startWith, switchMap } from 'rxjs/operators'
 
-export interface DpmPositionData<P> extends UserDpmAccount {
+export interface DpmPositionData extends UserDpmAccount {
   collateralToken: string
-  product: P
+  product: string
   protocol: string
   quoteToken: string
 }
 
-export function getDpmPositionData$<P>(
+export function getDpmPositionData$(
   proxiesForPosition$: (positionId: PositionId) => Observable<ProxiesRelatedWithPosition>,
   lastCreatedPositionForProxy$: (proxyAddress: string) => Observable<PositionCreated>,
   positionId: PositionId,
-): Observable<DpmPositionData<P>> {
+): Observable<DpmPositionData> {
   return proxiesForPosition$(positionId).pipe(
     switchMap(({ dpmProxy }) => {
       return combineLatest(
@@ -31,7 +31,7 @@ export function getDpmPositionData$<P>(
         ? {
             ...dpmProxy,
             collateralToken: lastCreatedPosition.collateralTokenSymbol,
-            product: lastCreatedPosition.positionType.toLowerCase() as P,
+            product: lastCreatedPosition.positionType.toLowerCase(),
             protocol: lastCreatedPosition.protocol,
             quoteToken: lastCreatedPosition.debtTokenSymbol,
           }
@@ -42,17 +42,17 @@ export function getDpmPositionData$<P>(
   )
 }
 
-export function getStaticDpmPositionData$<P extends string>({
+export function getStaticDpmPositionData$({
   collateralToken,
   product,
   protocol,
   quoteToken,
 }: {
   collateralToken: string
-  product: P
+  product: string
   protocol: string
   quoteToken: string
-}): Observable<DpmPositionData<P>> {
+}): Observable<DpmPositionData> {
   return EMPTY.pipe(
     startWith({
       collateralToken,


### PR DESCRIPTION
# 🧿 Split get Ajna position observable

Since library requires quote price, token prices has to loaded first before position is loaded, main observable had to be split into two separated ones. This PR does not pass quote price to library (library is not updated so it doesn't require it) but allows to do it in easy way.
  
## Changes 👷‍♀️

- Remove `dpmPositionData$` observable dependency from `ajnaPosition$` and replaced it with `dpmPositionData` interface,
- created `getStaticDpmPositionData$` fakeish observable,
- updated `AjnaProductController` observable order and dependencies.
  
## How to test 🧪

Try both open and manage flow and see if empty position and existing positions are loading correctly.
