### PR TITLE
Fix - Put default gas multiplier back to 1.5 until we can revisit

### DIFF
--- a/helpers/getGasMultiplier.ts
+++ b/helpers/getGasMultiplier.ts
@@ -8,6 +8,6 @@ export function getGasMultiplier(context: ContextConnected) {
     default:
       // boost it slightly for others in case there’s
       // a deviation between the estimate and the actual gas used
-      return 1.1
+      return 1.5
   }
 }


### PR DESCRIPTION
Hotfix to revert gas estimate multiplier back to 1.5 given failing T/x for users.