### PR TITLE
Hotfix 2 | add gasMultiplier to sendTx function calls

### DIFF
--- a/blockchain/calls/callsHelpers.ts
+++ b/blockchain/calls/callsHelpers.ts
@@ -67,6 +67,12 @@ export function createSendWithGasConstraints<A extends TxMeta>(
   send: SendFunction<A>,
   context: ContextConnected,
   gasPrice$: GasPrice$,
+  gasMultiplier?: number,
 ) {
-  return createSendWithGasConstraintsAbstractContext<A, ContextConnected>(send, context, gasPrice$)
+  return createSendWithGasConstraintsAbstractContext<A, ContextConnected>(
+    send,
+    context,
+    gasPrice$,
+    gasMultiplier,
+  )
 }

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -324,6 +324,7 @@ import {
 } from 'rxjs/operators'
 
 import curry from 'ramda/src/curry'
+
 export type TxData =
   | OpenData
   | DepositAndGenerateData
@@ -384,7 +385,12 @@ function createTxHelpers$(
     filter(({ status }) => status === 'connected'),
     map((context) => ({
       send: createSendTransaction(send, context),
-      sendWithGasEstimation: createSendWithGasConstraints(send, context, gasPrice$),
+      sendWithGasEstimation: createSendWithGasConstraints(
+        send,
+        context,
+        gasPrice$,
+        getGasMultiplier(context),
+      ),
       estimateGas: <B extends TxData>(def: TransactionDef<B>, args: B): Observable<number> => {
         return estimateGas(context, def, args, getGasMultiplier(context))
       },

--- a/helpers/getGasMultiplier.ts
+++ b/helpers/getGasMultiplier.ts
@@ -8,6 +8,7 @@ export function getGasMultiplier(context: ContextConnected) {
     default:
       // boost it slightly for others in case there’s
       // a deviation between the estimate and the actual gas used
-      return 1.5
+      // TODO: have these be configurable without a code change
+      return 1.25
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/oasis-actions": "0.2.15",
     "@oasisdex/oasis-actions-poc": "npm:@oasisdex/oasis-actions@0.2.15-ajna-earn-11",
-    "@oasisdex/transactions": "0.1.1",
+    "@oasisdex/transactions": "0.1.3-alpha.0",
     "@oasisdex/utils": "^0.0.8",
     "@oasisdex/web3-context": "^0.1.0",
     "@prisma/client": "^3.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,10 +3049,10 @@
     ramda "^0.28.0"
     utility-types "^3.10.0"
 
-"@oasisdex/transactions@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@oasisdex/transactions/-/transactions-0.1.1.tgz#47ef765f5c9b520ec1b9b2cdea49bf0456be9b1d"
-  integrity sha512-BkoKJ/gGyXE/HE32bcAczr6LKl9CqJzdqzDY1OlKFC7U47aV0FGMuLeFROjSECj1E/JoM9GQcChicsqeY1y3Cw==
+"@oasisdex/transactions@0.1.3-alpha.0":
+  version "0.1.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@oasisdex/transactions/-/transactions-0.1.3-alpha.0.tgz#80bdc20e292832b5b1b703ed3498925fd88094f6"
+  integrity sha512-61mxKFGxCeGLgsvnaXdcxolTFAUc/Zkw7PaF93kpAptBImI7GUhuzCi9NXG94GmJGHZZZ3a9d3QiV9Iv6GRwBQ==
   dependencies:
     "@types/ramda" "^0.25.38"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
Ensure the gasEstimate multiplier is being passed to the sendWithGasEstimates function not just estimateGas function