### PR TITLE
Get rid of title errors

### DIFF
--- a/components/HeadTags.tsx
+++ b/components/HeadTags.tsx
@@ -66,13 +66,13 @@ export function PageSEOTags({
   }
 
   const networkParameter = query.network as string
+  const tabTitle = `${networkParameter ? { hardhat: '👷 ', goerli: '🌲 ' }[networkParameter] : ''}${
+    titleParams ? t(title, titleParams) : t(title)
+  }`
 
   return (
     <Head>
-      <title>
-        {networkParameter ? { hardhat: '👷 ', goerli: '🌲 ' }[networkParameter] : ''}
-        {titleParams ? t(title, titleParams) : t(title)}
-      </title>
+      <title>{tabTitle}</title>
       <meta property="og:title" content={t(title)!} />
       <meta property="twitter:title" content={t(title)!} />
 


### PR DESCRIPTION
Little fix for this:
```
Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering
    at title
    at head
    at Head (webpack-internal:///./node_modules/next/dist/pages/_document.js:279:1)
    at html
    at Html (webpack-internal:///./node_modules/next/dist/pages/_document.js:678:104)
    at MyDocument (webpack-internal:///./pages/_document.tsx:23:1)
```