### PR TITLE
[SC-8434] Retry on Getting Parameters on AAVE. Default Page - Earn

### DIFF
--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -290,7 +290,7 @@ export function HomepageView() {
         <TabBar
           variant="large"
           useDropdownOnMobile
-          defaultTab="multiply"
+          defaultTab="earn"
           sections={[
             {
               label: t('landing.tabs.maker.multiply.tabLabel'),


### PR DESCRIPTION
# Changes
- Retry getting parameters when gas estimation fails. Mostly we want to ask 1inch about the best route again. 
- Default tab on mainpage: Earn. 