### PR TITLE
:bug: Web3-OnBoard Brave connection, new properties in change-address event

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -263,13 +263,21 @@ export const trackingEvents = {
     !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(EventTypes.Pageview, eventBody)
   },
 
-  accountChange: (account: string, network: string, walletType: string) => {
+  accountChange: (
+    account: string,
+    network: string,
+    walletType: string,
+    connectionMethod: string,
+    walletLabel: string | undefined,
+  ) => {
     const eventBody = {
       id: 'AccountChange',
       account,
       network,
       product: ProductType.BORROW,
       walletType,
+      connectionMethod,
+      walletLabel,
     }
 
     mixpanelInternalAPI(EventTypes.AccountChange, eventBody)

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -567,14 +567,16 @@ export function setupAppContext() {
           networkName: network.name,
           connectionKind: network.connectionKind,
           account: account?.toLowerCase(),
+          method: network.connectionMethod,
+          walletLabel: network.walletLabel,
         })
       }),
       distinctUntilChanged(isEqual),
     )
-    .subscribe(({ account, networkName, connectionKind }) => {
+    .subscribe(({ account, networkName, connectionKind, method, walletLabel }) => {
       if (account) {
-        mixpanelIdentify(account, { walletType: connectionKind })
-        trackingEvents.accountChange(account, networkName, connectionKind)
+        mixpanelIdentify(account, { walletType: connectionKind, walletLabel: walletLabel })
+        trackingEvents.accountChange(account, networkName, connectionKind, method, walletLabel)
       }
     })
 

--- a/components/connectWallet/ConnectWallet.tsx
+++ b/components/connectWallet/ConnectWallet.tsx
@@ -679,7 +679,7 @@ export function WithConnection({ children }: WithChildren) {
 
   useEffect(() => {
     if (useBlockNativeOnBoard) {
-      if (!connected && !connecting) executeConnection()
+      if (!connected && !connecting) void executeConnection()
       return
     }
     if (web3Context?.status === 'error' && web3Context.error instanceof UnsupportedChainIdError) {
@@ -713,7 +713,7 @@ export function WithWalletConnection({ children }: WithChildren) {
 
   useEffect(() => {
     if (useBlockNativeOnBoard) {
-      if (!connected && !connecting) executeConnection()
+      if (!connected && !connecting) void executeConnection()
       return
     }
     if (web3Context?.status === 'error' && web3Context.error instanceof UnsupportedChainIdError) {

--- a/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
+++ b/features/aave/open/sidebars/SidebarOpenAaveVault.tsx
@@ -189,7 +189,7 @@ function useConnectWalletPrimaryButton(): SidebarSectionFooterButtonSettings {
       action: () => {
         if (useBlockNativeOnBoard) {
           if (!connected && !connecting) {
-            executeConnection()
+            void executeConnection()
           }
         } else {
           push(INTERNAL_LINKS.connect, getCustomNetworkParameter())

--- a/features/termsOfService/termsAcceptance.test.ts
+++ b/features/termsOfService/termsAcceptance.test.ts
@@ -24,6 +24,8 @@ const defaultParams: PipelineInput = {
     connectionKind: 'injected',
     chainId: 42,
     deactivate: () => null,
+    walletLabel: 'MetaMask',
+    connectionMethod: 'web3-onboard',
   }),
   version: 'v1',
   jwtAuthSetupToken$: () => NEVER,

--- a/features/web3Context/types.ts
+++ b/features/web3Context/types.ts
@@ -58,6 +58,8 @@ export interface Web3ContextConnected {
   deactivate: () => void
   account: string
   magicLinkEmail?: string
+  connectionMethod: 'legacy' | 'web3-onboard'
+  walletLabel?: string
 }
 
 export interface Web3ContextError extends Connectable {

--- a/features/web3Context/web3_context.ts
+++ b/features/web3Context/web3_context.ts
@@ -5,6 +5,7 @@ import { useWeb3React } from '@web3-react/core'
 import { NetworkConnector } from '@web3-react/network-connector'
 import BigNumber from 'bignumber.js'
 import { Provider as Web3Provider } from 'ethereum-types'
+import { BridgeConnector } from 'features/web3OnBoard'
 import { isEqual } from 'lodash'
 import { useCallback, useEffect, useState } from 'react'
 import { Observable, ReplaySubject } from 'rxjs'
@@ -198,6 +199,8 @@ export function createWeb3Context$(
           account: ['ledger', 'trezor'].indexOf(connectionKind) >= 0 ? hwAccount! : account,
           deactivate,
           magicLinkEmail: undefined,
+          connectionMethod: connector instanceof BridgeConnector ? 'web3-onboard' : 'legacy',
+          walletLabel: connector instanceof BridgeConnector ? connector.wallet.label : undefined,
           // REFACTOR!
           // connectionKind === 'magicLink'
           //   ? (connector as MagicLinkConnector).getEmail()

--- a/features/web3OnBoard/BridgeConnector.ts
+++ b/features/web3OnBoard/BridgeConnector.ts
@@ -10,18 +10,16 @@ interface ConnectorUpdate {
 }
 
 export class BridgeConnector extends AbstractConnector {
-  private basicInfo: { chainId: number; provider: EIP1193Provider; account: string | undefined }
+  public readonly basicInfo: {
+    chainId: number
+    provider: EIP1193Provider
+    account: string | undefined
+  }
 
-  constructor(private wallet: WalletState, private chains: Chain[]) {
+  constructor(public readonly wallet: WalletState, private chains: Chain[]) {
     const chainsIds = chains.map((chain) => parseInt(chain.id, 16))
     super({ supportedChainIds: chainsIds })
     this.basicInfo = this.getBasicInfoFromWallet()
-  }
-
-  async changeWallet(wallet: WalletState): Promise<void> {
-    this.wallet = wallet
-    this.basicInfo = this.getBasicInfoFromWallet()
-    await this.activate()
   }
 
   get connectionKind(): ConnectionKind {

--- a/features/web3OnBoard/useBridgeConnection.tsx
+++ b/features/web3OnBoard/useBridgeConnection.tsx
@@ -1,41 +1,29 @@
 import { useAppContext } from 'components/AppContextProvider'
-import { useAsyncEffect } from 'helpers/hooks/useAsyncEffect'
 import { useObservable } from 'helpers/observableHook'
-import { useEffect } from 'react'
+import { useCallback } from 'react'
 
-import { BridgeConnector } from './BridgeConnector'
 import { useBridgeConnector } from './useBridgeConnector'
 
 export function useBridgeConnection() {
-  const bridgeConnector: BridgeConnector | undefined = useBridgeConnector()
+  const createBridgeConnector = useBridgeConnector()
   const { web3Context$ } = useAppContext()
-  const [web3Context, web3Error] = useObservable(web3Context$)
+  const [web3Context] = useObservable(web3Context$)
 
-  const { error } = useAsyncEffect(
-    async () => {
-      if (
-        bridgeConnector &&
-        (web3Context?.status === 'error' ||
-          web3Context?.status === 'notConnected' ||
-          web3Context?.status === 'connectedReadonly')
-      ) {
-        try {
-          await web3Context.connect(bridgeConnector, bridgeConnector.connectionKind)
-        } catch (error) {
-          console.error(error)
-        }
+  const connect = useCallback(async () => {
+    const bridgeConnector = await createBridgeConnector()
+    if (
+      bridgeConnector &&
+      (web3Context?.status === 'error' ||
+        web3Context?.status === 'notConnected' ||
+        web3Context?.status === 'connectedReadonly')
+    ) {
+      try {
+        await web3Context.connect(bridgeConnector, bridgeConnector.connectionKind)
+      } catch (error) {
+        console.error(error)
       }
-    },
-    () => Promise.resolve(),
-    [bridgeConnector, web3Context],
-  )
+    }
+  }, [createBridgeConnector, web3Context])
 
-  useEffect(() => {
-    if (error) {
-      console.error(error)
-    }
-    if (web3Error) {
-      console.error(web3Error)
-    }
-  }, [error, web3Error])
+  return { connect }
 }

--- a/features/web3OnBoard/useBridgeConnector.tsx
+++ b/features/web3OnBoard/useBridgeConnector.tsx
@@ -7,7 +7,7 @@ import { BridgeConnector } from './BridgeConnector'
 
 export function useBridgeConnector(): () => Promise<BridgeConnector | undefined> {
   const [, connect, disconnect] = useConnectWallet()
-  const [{ chains, connectedChain }, setChain] = useSetChain()
+  const [{ chains }, setChain] = useSetChain()
   const networkFromUrl = useCustomNetworkParameter()
 
   const reconnect = useCallback(
@@ -21,14 +21,14 @@ export function useBridgeConnector(): () => Promise<BridgeConnector | undefined>
   const changeNetwork = useCallback(
     async (wallet: WalletState) => {
       const forcedChain = chains.find((chain) => chain.id === networkFromUrl.hexId)
-      if (forcedChain && connectedChain?.id !== forcedChain.id) {
+      if (forcedChain && wallet.chains[0].id !== forcedChain.id) {
         await setChain({ chainId: forcedChain.id })
         const result = await reconnect(wallet)
         return result[0]
       }
       return wallet
     },
-    [networkFromUrl, chains, connectedChain, setChain, reconnect],
+    [networkFromUrl, chains, setChain, reconnect],
   )
 
   const bridgeConnector = useCallback(

--- a/features/web3OnBoard/useBridgeConnector.tsx
+++ b/features/web3OnBoard/useBridgeConnector.tsx
@@ -1,32 +1,46 @@
+import { WalletState } from '@web3-onboard/core'
 import { useConnectWallet, useSetChain } from '@web3-onboard/react'
 import { useCustomNetworkParameter } from 'helpers/getCustomNetworkParameter'
-import { useAsyncEffect } from 'helpers/hooks/useAsyncEffect'
-import { useMemo } from 'react'
+import { useCallback } from 'react'
 
 import { BridgeConnector } from './BridgeConnector'
 
-export function useBridgeConnector() {
-  const [{ wallet, connecting }] = useConnectWallet()
+export function useBridgeConnector(): () => Promise<BridgeConnector | undefined> {
+  const [, connect, disconnect] = useConnectWallet()
   const [{ chains, connectedChain }, setChain] = useSetChain()
   const networkFromUrl = useCustomNetworkParameter()
 
-  useAsyncEffect(
-    async () => {
-      if (!networkFromUrl) return
-      if (!wallet) return
+  const reconnect = useCallback(
+    async (wallet: WalletState) => {
+      await disconnect(wallet)
+      return await connect({ autoSelect: { label: wallet.label, disableModals: true } })
+    },
+    [disconnect, connect],
+  )
+
+  const changeNetwork = useCallback(
+    async (wallet: WalletState) => {
       const forcedChain = chains.find((chain) => chain.id === networkFromUrl.hexId)
       if (forcedChain && connectedChain?.id !== forcedChain.id) {
         await setChain({ chainId: forcedChain.id })
+        const result = await reconnect(wallet)
+        return result[0]
       }
+      return wallet
     },
-    () => Promise.resolve(),
-    [wallet, chains, connectedChain, networkFromUrl, setChain],
+    [networkFromUrl, chains, connectedChain, setChain, reconnect],
   )
 
-  const bridgeConnector: BridgeConnector | undefined = useMemo(() => {
-    if (!wallet || connecting) return undefined
-    return new BridgeConnector(wallet, chains)
-  }, [chains, wallet, connecting])
+  const bridgeConnector = useCallback(
+    (wallet: WalletState) => {
+      return new BridgeConnector(wallet, chains)
+    },
+    [chains],
+  )
 
-  return bridgeConnector
+  return useCallback(async () => {
+    const wallet = await connect()
+    const walletWithCorrectNetwork = await changeNetwork(wallet[0])
+    return bridgeConnector(walletWithCorrectNetwork)
+  }, [connect, changeNetwork, bridgeConnector])
 }

--- a/features/web3OnBoard/useNetworkConnector.tsx
+++ b/features/web3OnBoard/useNetworkConnector.tsx
@@ -1,14 +1,14 @@
 import { NetworkConnector } from '@web3-react/network-connector'
 import { networksById } from 'blockchain/config'
-import { getNetworkId } from 'features/web3Context'
+import { useCustomNetworkParameter } from 'helpers/getCustomNetworkParameter'
 import { useMemo } from 'react'
 
-export function useNetworkConnector() {
-  const networkId = getNetworkId()
+export function useNetworkConnector(): NetworkConnector {
+  const network = useCustomNetworkParameter()
   return useMemo(() => {
     return new NetworkConnector({
-      urls: { [networkId]: networksById[networkId].infuraUrl },
-      defaultChainId: networkId,
+      urls: { [network?.id]: networksById[network?.id].infuraUrl },
+      defaultChainId: parseInt(network?.id),
     })
-  }, [networkId])
+  }, [network])
 }

--- a/features/web3OnBoard/useWeb3OnBoardConnection.tsx
+++ b/features/web3OnBoard/useWeb3OnBoardConnection.tsx
@@ -1,4 +1,3 @@
-import { useConnectWallet } from '@web3-onboard/react'
 import { useAppContext } from 'components/AppContextProvider'
 import { useObservable } from 'helpers/observableHook'
 import { useCallback, useMemo } from 'react'
@@ -7,34 +6,29 @@ import { useBridgeConnection } from './useBridgeConnection'
 import { useNetworkConnection } from './useNetworkConnection'
 
 export function useWeb3OnBoardConnection({ walletConnect }: { walletConnect: boolean }) {
-  const [{ wallet, connecting }, connect] = useConnectWallet()
   const { web3Context$ } = useAppContext()
   const [web3Context] = useObservable(web3Context$)
-  useBridgeConnection()
+  const { connect } = useBridgeConnection()
   const { networkConnect } = useNetworkConnection()
 
   const connected = useMemo(() => {
     if (!walletConnect) {
-      return (
-        (web3Context?.status === 'connectedReadonly' || web3Context?.status === 'connected') &&
-        web3Context.connectionKind === 'network'
-      )
+      return web3Context?.status === 'connectedReadonly' || web3Context?.status === 'connected'
     }
-    return web3Context?.status === 'connected' && wallet !== undefined
-  }, [wallet, web3Context, walletConnect])
+    return web3Context?.status === 'connected'
+  }, [web3Context, walletConnect])
 
   const connectingMemo = useMemo(() => {
-    return web3Context === undefined || web3Context.status === 'connecting' || connecting
-  }, [web3Context, connecting])
+    return web3Context === undefined || web3Context.status === 'connecting'
+  }, [web3Context])
 
-  const executeConnection = useCallback(() => {
-    if (connecting || connected) return
+  const executeConnection = useCallback(async () => {
     if (walletConnect) {
-      void connect()
+      await connect()
     } else {
-      void networkConnect()
+      await networkConnect()
     }
-  }, [networkConnect, connect, connected, connecting, walletConnect])
+  }, [networkConnect, connect, walletConnect])
 
   return { executeConnection, connected, connecting: connectingMemo }
 }

--- a/helpers/getCustomNetworkParameter.ts
+++ b/helpers/getCustomNetworkParameter.ts
@@ -12,8 +12,12 @@ type CustomNetwork = {
   hexId: string
 }
 
-export function useCustomNetworkParameter(): CustomNetwork | undefined {
-  const [customNetworkName, setCustomNetworkName] = useState<CustomNetwork | undefined>(undefined)
+export function useCustomNetworkParameter(): CustomNetwork {
+  const [customNetworkName, setCustomNetworkName] = useState<CustomNetwork>({
+    network: 'mainnet',
+    id: '1',
+    hexId: '0x1',
+  })
 
   const networkChanged = useCallback(() => {
     const customNetworkName = new URLSearchParams(window.location.search).get('network')
@@ -27,11 +31,6 @@ export function useCustomNetworkParameter(): CustomNetwork | undefined {
         })
       }
     }
-    return setCustomNetworkName({
-      network: 'mainnet',
-      id: '1',
-      hexId: '0x1',
-    })
   }, [])
 
   useEffect(() => {

--- a/helpers/mocks/web3Context.mock.ts
+++ b/helpers/mocks/web3Context.mock.ts
@@ -29,6 +29,8 @@ export const mockWeb3ContextConnected: Web3ContextConnected = {
   chainId: 1,
   deactivate: () => null,
   account: '0xUserAddress',
+  walletLabel: 'MetaMask',
+  connectionMethod: 'web3-onboard',
 }
 
 export interface MockWeb3ContextProps {


### PR DESCRIPTION
# Changes
- Refactor connecting against web3-OnBoard. 
- When switching the network on connect, we reconnect the user. 
- Connecting use only `useCallback`
- Mixpanel event contains a `walletLabel` and method. 