### PR TITLE
Fix missing token metadata

### DIFF
--- a/features/discover/common/DiscoverTableDataCellContent.tsx
+++ b/features/discover/common/DiscoverTableDataCellContent.tsx
@@ -53,7 +53,7 @@ export function DiscoverTableDataCellContent({
           }
           id={primitives.cdpId as string}
           follow={follow}
-          icons={[(primitives?.icon || asset?.label || primitives?.asset) as string]}
+          icons={[(primitives?.icon || asset?.value || primitives?.asset) as string]}
         />
       )
     case 'status':


### PR DESCRIPTION
# Fix missing token metadata

![image](https://user-images.githubusercontent.com/16230404/227210827-7bf61c53-89fc-4226-82cf-d9b53ae024e5.png)
  
## Changes 👷‍♀️

- Token metadata is loaded from `value` field, not `label`.
  
## How to test 🧪

Test on `0x468d1ef7a1204d592537dab35794aac640c97505` wallet as it has closed Curve LP vault and probably would be good idea to see couple more random wallets just to be sure.