### PR TITLE
Ajna UI decimals

### DIFF
--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -342,7 +342,7 @@ export const tokens: TokenConfig[] = [
   {
     symbol: 'USDC',
     precision: 6,
-    digits: 6,
+    digits: 2,
     digitsInstant: 2,
     maxSell: '1000000000000000',
     name: 'USD Coin',

--- a/features/ajna/positions/borrow/overview/ContentCardCollateralLocked.tsx
+++ b/features/ajna/positions/borrow/overview/ContentCardCollateralLocked.tsx
@@ -4,7 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -28,10 +28,10 @@ export function ContentCardCollateralLocked({
   const { t } = useTranslation()
 
   const formatted = {
-    collateralLocked: formatAmount(collateralLocked, collateralToken),
+    collateralLocked: formatCryptoBalance(collateralLocked),
     afterCollateralLocked:
       afterCollateralLocked &&
-      `${formatAmount(afterCollateralLocked, collateralToken)} ${collateralToken}`,
+      `${formatCryptoBalance(afterCollateralLocked)} ${collateralToken}`,
     collateralLockedUSD: `$${formatAmount(collateralLockedUSD, 'USD')}`,
   }
 

--- a/features/ajna/positions/borrow/overview/ContentCardCollateralLocked.tsx
+++ b/features/ajna/positions/borrow/overview/ContentCardCollateralLocked.tsx
@@ -30,8 +30,7 @@ export function ContentCardCollateralLocked({
   const formatted = {
     collateralLocked: formatCryptoBalance(collateralLocked),
     afterCollateralLocked:
-      afterCollateralLocked &&
-      `${formatCryptoBalance(afterCollateralLocked)} ${collateralToken}`,
+      afterCollateralLocked && `${formatCryptoBalance(afterCollateralLocked)} ${collateralToken}`,
     collateralLockedUSD: `$${formatAmount(collateralLockedUSD, 'USD')}`,
   }
 

--- a/features/ajna/positions/borrow/overview/ContentCardPositionDebt.tsx
+++ b/features/ajna/positions/borrow/overview/ContentCardPositionDebt.tsx
@@ -4,7 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -28,9 +28,9 @@ export function ContentCardPositionDebt({
   const { t } = useTranslation()
 
   const formatted = {
-    positionDebt: formatAmount(positionDebt, quoteToken),
+    positionDebt: formatCryptoBalance(positionDebt),
     afterPositionDebt:
-      afterPositionDebt && `${formatAmount(afterPositionDebt, quoteToken)} ${quoteToken}`,
+      afterPositionDebt && `${formatCryptoBalance(afterPositionDebt)} ${quoteToken}`,
     positionDebtUSD: `$${formatAmount(positionDebtUSD, 'USD')}`,
   }
 

--- a/features/ajna/positions/borrow/overview/ContentFooterItemsBorrow.tsx
+++ b/features/ajna/positions/borrow/overview/ContentFooterItemsBorrow.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { ChangeVariantType } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItem } from 'components/DetailsSectionFooterItem'
-import { formatAmount, formatDecimalAsPercent } from 'helpers/formatters/format'
+import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -32,12 +32,12 @@ export function ContentFooterItemsBorrow({
 
   const formatted = {
     cost: formatDecimalAsPercent(cost),
-    availableToBorrow: `${formatAmount(availableToBorrow, quoteToken)}`,
+    availableToBorrow: `${formatCryptoBalance(availableToBorrow)}`,
     afterAvailableToBorrow:
-      afterAvailableToBorrow && `${formatAmount(afterAvailableToBorrow, quoteToken)}`,
-    availableToWithdraw: `${formatAmount(availableToWithdraw, collateralToken)}`,
+      afterAvailableToBorrow && `${formatCryptoBalance(afterAvailableToBorrow)}`,
+    availableToWithdraw: `${formatCryptoBalance(availableToWithdraw)}`,
     afterAvailableToWithdraw:
-      afterAvailableToWithdraw && `${formatAmount(afterAvailableToWithdraw, collateralToken)}`,
+      afterAvailableToWithdraw && `${formatCryptoBalance(afterAvailableToWithdraw)}`,
   }
 
   return (

--- a/features/ajna/positions/borrow/overview/ContentFooterItemsBorrow.tsx
+++ b/features/ajna/positions/borrow/overview/ContentFooterItemsBorrow.tsx
@@ -32,12 +32,12 @@ export function ContentFooterItemsBorrow({
 
   const formatted = {
     cost: formatDecimalAsPercent(cost),
-    availableToBorrow: `${formatAmount(availableToBorrow, collateralToken)}`,
+    availableToBorrow: `${formatAmount(availableToBorrow, quoteToken)}`,
     afterAvailableToBorrow:
-      afterAvailableToBorrow && `${formatAmount(afterAvailableToBorrow, collateralToken)}`,
-    availableToWithdraw: `${formatAmount(availableToWithdraw, quoteToken)}`,
+      afterAvailableToBorrow && `${formatAmount(afterAvailableToBorrow, quoteToken)}`,
+    availableToWithdraw: `${formatAmount(availableToWithdraw, collateralToken)}`,
     afterAvailableToWithdraw:
-      afterAvailableToWithdraw && `${formatAmount(afterAvailableToWithdraw, quoteToken)}`,
+      afterAvailableToWithdraw && `${formatAmount(afterAvailableToWithdraw, collateralToken)}`,
   }
 
   return (

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -33,8 +33,8 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
     debt: formatCryptoBalance(positionData.debtAmount),
     ltv: formatDecimalAsPercent(positionData.riskRatio.loanToValue),
     liquidationPrice: formatCryptoBalance(positionData.liquidationPrice),
-    availableToBorrow: formatAmount(positionData.debtAvailable, quoteToken),
-    availableToWithdraw: formatAmount(positionData.collateralAvailable, collateralToken),
+    availableToBorrow: formatCryptoBalance(positionData.debtAvailable),
+    availableToWithdraw: formatCryptoBalance(positionData.collateralAvailable),
     afterLiquidationPrice:
       simulationData?.liquidationPrice && formatCryptoBalance(simulationData.liquidationPrice),
     afterLtv:
@@ -43,10 +43,10 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
     afterCollateralLocked:
       simulationData?.collateralAmount && formatCryptoBalance(simulationData.collateralAmount),
     afterAvailableToBorrow:
-      simulationData?.debtAvailable && formatAmount(simulationData.debtAvailable, quoteToken),
+      simulationData?.debtAvailable && formatCryptoBalance(simulationData.debtAvailable),
     afterAvailableToWithdraw:
       simulationData?.collateralAvailable &&
-      formatAmount(simulationData.collateralAvailable, collateralToken),
+      formatCryptoBalance(simulationData.collateralAvailable),
     totalCost: txDetails?.txCost ? `$${formatAmount(txDetails.txCost, 'USD')}` : '-',
   }
 

--- a/features/ajna/positions/earn/helpers/getAjnaSimulationRows.ts
+++ b/features/ajna/positions/earn/helpers/getAjnaSimulationRows.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatCryptoBalance } from 'helpers/formatters/format'
 
 const getAjnaSimulationData = ({
   depositAmount,
@@ -26,8 +26,8 @@ export const getAjnaSimulationRows = ({
 
     return [
       row.translation,
-      earnings ? `${formatAmount(earnings, quoteToken)} ${quoteToken}` : '-',
-      netValue ? `${formatAmount(netValue, quoteToken)} ${quoteToken}` : '-',
+      earnings ? `${formatCryptoBalance(earnings)} ${quoteToken}` : '-',
+      netValue ? `${formatCryptoBalance(netValue)} ${quoteToken}` : '-',
     ]
   })
 }

--- a/features/ajna/positions/earn/helpers/getAjnaSimulationRows.ts
+++ b/features/ajna/positions/earn/helpers/getAjnaSimulationRows.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { formatCryptoBalance } from 'helpers/formatters/format'
+import { formatAmount } from 'helpers/formatters/format'
 
 const getAjnaSimulationData = ({
   depositAmount,
@@ -26,8 +26,8 @@ export const getAjnaSimulationRows = ({
 
     return [
       row.translation,
-      earnings ? `${formatCryptoBalance(earnings)} ${quoteToken}` : '-',
-      netValue ? `${formatCryptoBalance(netValue)} ${quoteToken}` : '-',
+      earnings ? `${formatAmount(earnings, quoteToken)} ${quoteToken}` : '-',
+      netValue ? `${formatAmount(netValue, quoteToken)} ${quoteToken}` : '-',
     ]
   })
 }

--- a/features/ajna/positions/earn/overview/ContentCardCurrentEarnings.tsx
+++ b/features/ajna/positions/earn/overview/ContentCardCurrentEarnings.tsx
@@ -4,7 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
-import { formatAmount, formatPercent } from 'helpers/formatters/format'
+import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Card, Grid, Heading, Text } from 'theme-ui'
@@ -55,9 +55,9 @@ export function ContentCardCurrentEarnings({
   const { t } = useTranslation()
 
   const formatted = {
-    currentEarnings: formatAmount(currentEarnings, quoteToken),
+    currentEarnings: formatCryptoBalance(currentEarnings),
     afterCurrentEarnings:
-      afterCurrentEarnings && `${formatAmount(afterCurrentEarnings, quoteToken)} ${quoteToken}`,
+      afterCurrentEarnings && `${formatCryptoBalance(afterCurrentEarnings)} ${quoteToken}`,
     netPnL: formatPercent(netPnL, { precision: 2 }),
   }
 

--- a/features/ajna/positions/earn/overview/ContentCardTokensDeposited.tsx
+++ b/features/ajna/positions/earn/overview/ContentCardTokensDeposited.tsx
@@ -4,7 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
-import { formatAmount } from 'helpers/formatters/format'
+import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Card, Grid, Heading, Text } from 'theme-ui'
@@ -56,9 +56,9 @@ export function ContentCardTokensDeposited({
   const { t } = useTranslation()
 
   const formatted = {
-    tokensDeposited: formatAmount(tokensDeposited, quoteToken),
+    tokensDeposited: formatCryptoBalance(tokensDeposited),
     afterTokensDeposited:
-      afterTokensDeposited && `${formatAmount(afterTokensDeposited, quoteToken)} ${quoteToken}`,
+      afterTokensDeposited && `${formatCryptoBalance(afterTokensDeposited)} ${quoteToken}`,
     tokensDepositedUSD: `$${formatAmount(tokensDepositedUSD, 'USD')}`,
   }
 

--- a/features/ajna/positions/earn/overview/ContentFooterItemsEarnManage.tsx
+++ b/features/ajna/positions/earn/overview/ContentFooterItemsEarnManage.tsx
@@ -1,10 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { DetailsSectionFooterItem } from 'components/DetailsSectionFooterItem'
-import {
-  formatAmount,
-  formatCryptoBalance,
-  formatDecimalAsPercent,
-} from 'helpers/formatters/format'
+import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -26,10 +22,9 @@ export function ContentFooterItemsEarnManage({
   const { t } = useTranslation()
 
   const formatted = {
-    availableToWithdraw: `${formatAmount(availableToWithdraw, quoteToken)} ${quoteToken}`,
+    availableToWithdraw: `${formatCryptoBalance(availableToWithdraw)} ${quoteToken}`,
     afterAvailableToWithdraw:
-      afterAvailableToWithdraw &&
-      `${formatAmount(afterAvailableToWithdraw, quoteToken)} ${quoteToken}`,
+      afterAvailableToWithdraw && `${formatCryptoBalance(afterAvailableToWithdraw)} ${quoteToken}`,
     projectedAnnualReward: `${formatDecimalAsPercent(projectedAnnualReward)}`,
     totalAjnaRewards: `${formatCryptoBalance(totalAjnaRewards)} AJNA`,
   }


### PR DESCRIPTION
# [Ajna UI decimals](https://app.shortcut.com/oazo-apps/story/8540/fix-usdc-decimal-places-on-overview-screen)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted USDC digits from 6 to 2
- fixed all places in Ajna UI where quote token or collateral token wasn't displayed properly
  
## How to test 🧪
  <Please explain how to test your changes>

- check ajna open & manage earn / borrow flow to see whether quote token and collateral token have correct number of decimals
