### PR TITLE
bump up the version of usehooks + bump minor node version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2
+FROM node:16.15.0
 
 EXPOSE 3000
 

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ts-essentials": "^7.0.1",
     "ts-node": "^7.0.1",
     "url-loader": "^4.1.0",
-    "usehooks-ts": "2.7.0",
+    "usehooks-ts": "^2.9.1",
     "uuid": "^8.3.0",
     "web3": "1.5.3",
     "web3-eth-abi": "1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17981,10 +17981,10 @@ use-sync-external-store@1.2.0, use-sync-external-store@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
-usehooks-ts@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-2.7.0.tgz#11ca19368be621ec610d99deb224c23c006ce72b"
-  integrity sha512-HNNBgWBrLqnEkZQmdbxuMF4bdiqPw4iwh/RalCglhJJsPFZd4cgMbIBsB1SeavOAFkIJ5G8BheJYaEtKt9A8IA==
+usehooks-ts@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-2.9.1.tgz#953d3284851ffd097432379e271ce046a8180b37"
+  integrity sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==
 
 utf-8-validate@^5.0.2:
   version "5.0.3"


### PR DESCRIPTION
Fix for broken build since https://github.com/OasisDEX/oasis-borrow/pull/2179 was merged.