### PR TITLE
🧿 Liquidation threshold in Ajna Borrow 

### DIFF
--- a/components/vault/VaultActionInput.tsx
+++ b/components/vault/VaultActionInput.tsx
@@ -11,13 +11,14 @@ import { createNumberMask } from 'text-mask-addons'
 import { Box, Grid, Text } from 'theme-ui'
 
 export type VaultAction =
+  | 'Borrow'
+  | 'Buy'
   | 'Deposit'
-  | 'Withdraw'
+  | 'Enter'
   | 'Generate'
   | 'Payback'
   | 'Sell'
-  | 'Buy'
-  | 'Enter'
+  | 'Withdraw'
   | TranslateStringType
 const FIAT_PRECISION = 2
 

--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { AjnaFlow, AjnaProduct, AjnaSidebarStep } from 'features/ajna/common/types'
 
 // TODO: add 'earn' and 'multiply' in distant future
@@ -46,3 +47,5 @@ export const steps: {
 
 export const ajnaFormExternalSteps: AjnaSidebarStep[] = ['dpm']
 export const ajnaFormStepsWithTransaction: AjnaSidebarStep[] = ['transaction']
+
+export const LTVWarningThreshold = new BigNumber(0.05)

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -54,7 +54,7 @@ export function AjnaBorrowOverviewController() {
               isLoading={isSimulationLoading}
               loanToValue={position.riskRatio.loanToValue}
               afterLoanToValue={simulation?.riskRatio.loanToValue}
-              liquidationTreshold={position.maxRiskRatio.loanToValue}
+              liquidationThreshold={position.maxRiskRatio.loanToValue}
               changeVariant={changeVariant}
             />
             <ContentCardCollateralLocked

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -1,6 +1,7 @@
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
+import { LTVWarningThreshold } from 'features/ajna/common/consts'
 import { ContentCardCollateralLocked } from 'features/ajna/positions/borrow/overview/ContentCardCollateralLocked'
 import { ContentCardLiquidationPrice } from 'features/ajna/positions/borrow/overview/ContentCardLiquidationPrice'
 import { ContentCardLoanToValue } from 'features/ajna/positions/borrow/overview/ContentCardLoanToValue'
@@ -26,6 +27,14 @@ export function AjnaBorrowOverviewController() {
     },
   } = useAjnaProductContext('borrow')
 
+  const changeVariant = simulation
+    ? simulation.maxRiskRatio.loanToValue
+        .minus(simulation.riskRatio.loanToValue)
+        .gt(LTVWarningThreshold)
+      ? 'positive'
+      : 'negative'
+    : 'positive'
+
   return (
     <Grid gap={2}>
       <DetailsSection
@@ -39,12 +48,14 @@ export function AjnaBorrowOverviewController() {
               liquidationPrice={position.liquidationPrice}
               afterLiquidationPrice={simulation?.liquidationPrice}
               belowCurrentPrice={one.minus(position.liquidationToMarketPrice)}
+              changeVariant={changeVariant}
             />
             <ContentCardLoanToValue
               isLoading={isSimulationLoading}
               loanToValue={position.riskRatio.loanToValue}
               afterLoanToValue={simulation?.riskRatio.loanToValue}
               liquidationTreshold={position.maxRiskRatio.loanToValue}
+              changeVariant={changeVariant}
             />
             <ContentCardCollateralLocked
               isLoading={isSimulationLoading}
@@ -52,6 +63,7 @@ export function AjnaBorrowOverviewController() {
               collateralLocked={position.collateralAmount}
               collateralLockedUSD={position.collateralAmount.times(collateralPrice)}
               afterCollateralLocked={simulation?.collateralAmount}
+              changeVariant={changeVariant}
             />
             <ContentCardPositionDebt
               isLoading={isSimulationLoading}
@@ -59,6 +71,7 @@ export function AjnaBorrowOverviewController() {
               positionDebt={position.debtAmount}
               positionDebtUSD={position.debtAmount.times(quotePrice)}
               afterPositionDebt={simulation?.debtAmount}
+              changeVariant={changeVariant}
             />
           </DetailsSectionContentCardWrapper>
         }
@@ -73,6 +86,7 @@ export function AjnaBorrowOverviewController() {
               afterAvailableToBorrow={simulation?.debtAvailable}
               availableToWithdraw={position.collateralAvailable}
               afterAvailableToWithdraw={simulation?.collateralAvailable}
+              changeVariant={changeVariant}
             />
           </DetailsSectionFooterItemWrapper>
         }

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -44,6 +44,7 @@ export function AjnaBorrowOverviewController() {
               isLoading={isSimulationLoading}
               loanToValue={position.riskRatio.loanToValue}
               afterLoanToValue={simulation?.riskRatio.loanToValue}
+              liquidationTreshold={position.maxRiskRatio.loanToValue}
             />
             <ContentCardCollateralLocked
               isLoading={isSimulationLoading}

--- a/features/ajna/positions/borrow/overview/ContentCardLoanToValue.tsx
+++ b/features/ajna/positions/borrow/overview/ContentCardLoanToValue.tsx
@@ -12,7 +12,7 @@ interface ContentCardLoanToValueProps {
   isLoading?: boolean
   loanToValue: BigNumber
   afterLoanToValue?: BigNumber
-  liquidationTreshold: BigNumber
+  liquidationThreshold: BigNumber
   changeVariant?: ChangeVariantType
 }
 
@@ -20,7 +20,7 @@ export function ContentCardLoanToValue({
   isLoading,
   loanToValue,
   afterLoanToValue,
-  liquidationTreshold,
+  liquidationThreshold,
   changeVariant = 'positive',
 }: ContentCardLoanToValueProps) {
   const { t } = useTranslation()
@@ -28,7 +28,7 @@ export function ContentCardLoanToValue({
   const formatted = {
     loanToValue: formatDecimalAsPercent(loanToValue),
     afterLoanToValue: afterLoanToValue && formatDecimalAsPercent(afterLoanToValue),
-    liquidationTreshold: liquidationTreshold && formatDecimalAsPercent(liquidationTreshold),
+    liquidationThreshold: liquidationThreshold && formatDecimalAsPercent(liquidationThreshold),
   }
 
   const contentCardSettings: ContentCardProps = {
@@ -40,7 +40,7 @@ export function ContentCardLoanToValue({
       variant: changeVariant,
     },
     footnote: t('ajna.position-page.borrow.common.overview.liquidation-threshold', {
-      liquidationTreshold: formatted.liquidationTreshold,
+      liquidationThreshold: formatted.liquidationThreshold,
     }),
   }
 

--- a/features/ajna/positions/borrow/overview/ContentCardLoanToValue.tsx
+++ b/features/ajna/positions/borrow/overview/ContentCardLoanToValue.tsx
@@ -12,6 +12,7 @@ interface ContentCardLoanToValueProps {
   isLoading?: boolean
   loanToValue: BigNumber
   afterLoanToValue?: BigNumber
+  liquidationTreshold: BigNumber
   changeVariant?: ChangeVariantType
 }
 
@@ -19,6 +20,7 @@ export function ContentCardLoanToValue({
   isLoading,
   loanToValue,
   afterLoanToValue,
+  liquidationTreshold,
   changeVariant = 'positive',
 }: ContentCardLoanToValueProps) {
   const { t } = useTranslation()
@@ -26,6 +28,7 @@ export function ContentCardLoanToValue({
   const formatted = {
     loanToValue: formatDecimalAsPercent(loanToValue),
     afterLoanToValue: afterLoanToValue && formatDecimalAsPercent(afterLoanToValue),
+    liquidationTreshold: liquidationTreshold && formatDecimalAsPercent(liquidationTreshold),
   }
 
   const contentCardSettings: ContentCardProps = {
@@ -36,6 +39,9 @@ export function ContentCardLoanToValue({
       value: afterLoanToValue && `${formatted.afterLoanToValue} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     },
+    footnote: t('ajna.position-page.borrow.common.overview.liquidation-threshold', {
+      liquidationTreshold: formatted.liquidationTreshold,
+    }),
   }
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentManage.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentManage.tsx
@@ -48,7 +48,7 @@ export function AjnaBorrowFormContentManage() {
               items: [
                 {
                   id: 'generate-borrow',
-                  label: t('vault-actions.generate'),
+                  label: t('vault-actions.borrow'),
                   action: () => {
                     dispatch({ type: 'reset' })
                     updateState('uiPill', 'generate-borrow')

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -85,7 +85,7 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
           isLoading,
         },
         {
-          label: t('system.available-to-generate'),
+          label: t('system.available-to-borrow'),
           value: `${formatted.availableToBorrow} ${quoteToken}`,
           secondaryValue: `${formatted.afterAvailableToBorrow} ${quoteToken}`,
           isLoading,

--- a/features/ajna/positions/common/sidebars/AjnaFormFields.tsx
+++ b/features/ajna/positions/common/sidebars/AjnaFormFields.tsx
@@ -95,7 +95,7 @@ export function AjnaFormFieldGenerate({
 
   return 'generateAmount' in state && 'generateAmountUSD' in state ? (
     <VaultActionInput
-      action="Generate"
+      action="Borrow"
       currencyCode={quoteToken}
       tokenUsdPrice={quotePrice}
       amount={state.generateAmount}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2481,6 +2481,7 @@
             "liquidation-price": "Liquidation Price",
             "below-current-price": "{{belowCurrentPrice}} below current price",
             "loan-to-value": "Loan to value",
+            "liquidation-threshold": "Liquidation Threshold: {{liquidationTreshold}}",
             "collateral-locked": "Collateral locked",
             "position-debt": "Position debt"
           },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1041,6 +1041,7 @@
     "est-break-even-value": "{{days}} days",
     "est-entry-fees": "Est. entry fees",
     "apy": "APY",
+    "available-to-borrow": "Available to Borrow",
     "available-to-generate": "Available to Generate",
     "coll-locked": "Coll. Locked",
     "coll-ratio": "Coll. Ratio",
@@ -1303,6 +1304,7 @@
     "slippage-from-strategy": "Use slippage from strategy"
   },
   "vault-actions": {
+    "borrow": "Borrow",
     "deposit": "Deposit",
     "generate": "Generate",
     "payback": "Payback",


### PR DESCRIPTION
# 🧿 Liquidation threshold in Ajna Borrow 

Some smaller updated according to latest changes in figma.

![image](https://user-images.githubusercontent.com/16230404/230377248-956eeec3-16b7-4cd5-b3eb-d184dd65de96.png)
![image](https://user-images.githubusercontent.com/16230404/230377861-85c66bd2-8e4d-4970-a5a8-7bcdeee45049.png)
  
## Changes 👷‍♀️

- Changed "generate" to "borrow" across Borrow UI,
- added "Liquidation Threshold" to LTV card,
- set all afterpills to warning color if user is within 5% to Max LTV (similar to Maker).
  
## How to test 🧪

Self explanatory.
