### PR TITLE
🧿 Extend Ajna Context for Multiply Product

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -1,8 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { AjnaFlow, AjnaProduct, AjnaSidebarStep } from 'features/ajna/common/types'
 
-// TODO: add 'earn' and 'multiply' in distant future
-export const ajnaProducts: AjnaProduct[] = ['borrow', 'earn']
+export const ajnaProducts: AjnaProduct[] = ['borrow', 'earn', 'multiply']
 
 export const DEFAULT_SELECTED_TOKEN = 'ETH'
 
@@ -40,8 +39,8 @@ export const steps: {
     manage: ['manage', 'dpm', 'transaction'],
   },
   multiply: {
-    open: [],
-    manage: [],
+    open: ['risk', 'setup', 'dpm', 'transaction'],
+    manage: ['manage', 'dpm', 'transaction'],
   },
 }
 

--- a/features/ajna/common/types.ts
+++ b/features/ajna/common/types.ts
@@ -3,11 +3,13 @@ import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
 import { AjnaBorrowFormState } from 'features/ajna/positions/borrow/state/ajnaBorrowFormReducto'
 import { AjnaEarnFormState } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
+import { AjnaMultiplyFormState } from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
+import { AjnaMultiplyPosition } from 'features/ajna/positions/multiply/temp'
 
-export type AjnaGenericPosition = AjnaPosition | AjnaEarnPosition
+export type AjnaGenericPosition = AjnaPosition | AjnaEarnPosition | AjnaMultiplyPosition
 export type AjnaProduct = 'borrow' | 'earn' | 'multiply'
 export type AjnaFlow = 'open' | 'manage'
-export type AjnaFormState = AjnaBorrowFormState | AjnaEarnFormState
+export type AjnaFormState = AjnaBorrowFormState | AjnaEarnFormState | AjnaMultiplyFormState
 
 export type AjnaBorrowAction =
   | 'open-borrow'
@@ -19,6 +21,17 @@ export type AjnaBorrowPanel = 'collateral' | 'quote'
 
 export type AjnaEarnAction = 'open-earn' | 'deposit-earn' | 'withdraw-earn'
 export type AjnaEarnPanel = 'adjust' | 'liquidity'
+
+export type AjnaMultiplyAction =
+  | 'open-multiply'
+  | 'deposit-multiply'
+  | 'withdraw-multiply'
+  | 'payback-multiply'
+  | 'deposit-quote-multiply'
+  | 'withdraw-quote-multiply'
+  | 'switch-multiply'
+  | 'close-multiply'
+export type AjnaMultiplyPanel = 'collateral' | 'quote' | 'switch' | 'close'
 
 export type AjnaSidebarStep = 'risk' | 'setup' | 'manage' | 'dpm' | 'transaction'
 export type AjnaSidebarEditingStep = Extract<AjnaSidebarStep, 'setup' | 'manage'>
@@ -39,15 +52,7 @@ export type AjnaPoolData = {
   }
 }
 
-export type AjnaBorrowUpdateState = (
-  key: keyof AjnaBorrowFormState,
-  value: AjnaBorrowFormState[keyof AjnaBorrowFormState],
-) => void
-
-export type AjnaEarnUpdateState = (
-  key: keyof AjnaEarnFormState,
-  value: AjnaEarnFormState[keyof AjnaEarnFormState],
-) => void
+export type AjnaUpdateState<T> = (key: keyof T, value: T[keyof T]) => void
 
 export type AlternateProductCardBase = {
   token: string

--- a/features/ajna/positions/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaProductContext.tsx
@@ -16,6 +16,11 @@ import {
   AjnaEarnFormState,
   useAjnaEarnFormReducto,
 } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
+import {
+  AjnaMultiplyFormState,
+  useAjnaMultiplyFormReducto,
+} from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
+import { AjnaMultiplyPosition } from 'features/ajna/positions/multiply/temp'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
 import React, {
@@ -41,10 +46,9 @@ interface AjnaProductContextProviderPropsWithEarn {
   product: 'earn'
 }
 interface AjnaProductContextProviderPropsWithMultiply {
-  // TODO: to be replaced with useAjnaMultiplyFormReducto when availavble
-  formReducto: typeof useAjnaBorrowFormReducto
-  formDefaults: Partial<AjnaBorrowFormState>
-  position: AjnaPosition
+  formReducto: typeof useAjnaMultiplyFormReducto
+  formDefaults: Partial<AjnaMultiplyFormState>
+  position: AjnaMultiplyPosition
   product: 'multiply'
 }
 type AjnaProductDetailsContextProviderProps =
@@ -87,19 +91,33 @@ type AjnaProductContextWithEarn = AjnaProductContext<
   AjnaEarnPosition,
   ReturnType<typeof useAjnaEarnFormReducto>
 >
+type AjnaProductContextWithMultiply = AjnaProductContext<
+  AjnaMultiplyPosition,
+  ReturnType<typeof useAjnaMultiplyFormReducto>
+>
 
 const ajnaBorrowContext = React.createContext<AjnaProductContextWithBorrow | undefined>(undefined)
 const ajnaEarnContext = React.createContext<AjnaProductContextWithEarn | undefined>(undefined)
+const ajnaMultiplyContext = React.createContext<AjnaProductContextWithMultiply | undefined>(
+  undefined,
+)
 
 type PickProductType<T extends AjnaProduct> = T extends 'borrow'
   ? AjnaProductContextWithBorrow
   : T extends 'earn'
-  ? AjnaProductContextWithEarn // TODO: Add AjnaProductContextWithMultiply
+  ? AjnaProductContextWithEarn
+  : T extends 'multiply'
+  ? AjnaProductContextWithMultiply
   : never
 
 export function useAjnaProductContext<T extends AjnaProduct>(product: T): PickProductType<T> {
   const { environment } = useAjnaGeneralContext()
-  const context = product === 'borrow' ? useContext(ajnaBorrowContext) : useContext(ajnaEarnContext)
+  const context =
+    product === 'borrow'
+      ? useContext(ajnaBorrowContext)
+      : product === 'earn'
+      ? useContext(ajnaEarnContext)
+      : useContext(ajnaMultiplyContext)
 
   if (product !== environment.product)
     throw new Error(
@@ -255,6 +273,10 @@ export function AjnaProductContextProvider({
         </ajnaEarnContext.Provider>
       )
     case 'multiply':
-      return <></>
+      return (
+        <ajnaMultiplyContext.Provider value={context as AjnaProductContextWithMultiply}>
+          {children}
+        </ajnaMultiplyContext.Provider>
+      )
   }
 }

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -15,6 +15,8 @@ import { getStaticDpmPositionData$ } from 'features/ajna/positions/common/observ
 import { AjnaEarnPositionController } from 'features/ajna/positions/earn/controls/AjnaEarnPositionController'
 import { getEarnDefaultPrice } from 'features/ajna/positions/earn/helpers/getEarnDefaultPrice'
 import { useAjnaEarnFormReducto } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
+import { useAjnaMultiplyFormReducto } from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
+import { AjnaMultiplyPosition } from 'features/ajna/positions/multiply/temp'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { WithWalletAssociatedRisk } from 'features/walletAssociatedRisk/WalletAssociatedRisk'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
@@ -213,6 +215,18 @@ export function AjnaProductController({
                             product={dpmPosition.product}
                           >
                             <AjnaEarnPositionController />
+                          </AjnaProductContextProvider>
+                        )}
+                        {dpmPosition.product === 'multiply' && (
+                          <AjnaProductContextProvider
+                            formDefaults={{
+                              action: flow === 'open' ? 'open-multiply' : 'deposit-multiply',
+                            }}
+                            formReducto={useAjnaMultiplyFormReducto}
+                            position={ajnaPosition as AjnaMultiplyPosition}
+                            product={dpmPosition.product}
+                          >
+                            Ajna Multiply UI
                           </AjnaProductContextProvider>
                         )}
                       </AjnaGeneralContextProvider>

--- a/features/ajna/positions/common/notifications.ts
+++ b/features/ajna/positions/common/notifications.ts
@@ -1,13 +1,18 @@
 import { AjnaEarnPosition } from '@oasisdex/oasis-actions-poc'
 import { DetailsSectionNotificationItem } from 'components/DetailsSectionNotification'
+import { AjnaGenericPosition, AjnaProduct, AjnaUpdateState } from 'features/ajna/common/types'
 import {
-  AjnaBorrowUpdateState,
-  AjnaEarnUpdateState,
-  AjnaGenericPosition,
-  AjnaProduct,
-} from 'features/ajna/common/types'
-import { AjnaBorrowFormAction } from 'features/ajna/positions/borrow/state/ajnaBorrowFormReducto'
-import { AjnaEarnFormAction } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
+  AjnaBorrowFormAction,
+  AjnaBorrowFormState,
+} from 'features/ajna/positions/borrow/state/ajnaBorrowFormReducto'
+import {
+  AjnaEarnFormAction,
+  AjnaEarnFormState,
+} from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
+import {
+  AjnaMultiplyFormAction,
+  AjnaMultiplyFormState,
+} from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
 import { Dispatch } from 'react'
 
 type DepositIsNotWithdrawableParams = {
@@ -75,8 +80,14 @@ export function getAjnaNotifications({
   position: AjnaGenericPosition
   collateralToken: string
   quoteToken: string
-  dispatch: Dispatch<AjnaBorrowFormAction> | Dispatch<AjnaEarnFormAction>
-  updateState: AjnaBorrowUpdateState | AjnaEarnUpdateState
+  dispatch:
+    | Dispatch<AjnaBorrowFormAction>
+    | Dispatch<AjnaEarnFormAction>
+    | Dispatch<AjnaMultiplyFormAction>
+  updateState:
+    | AjnaUpdateState<AjnaBorrowFormState>
+    | AjnaUpdateState<AjnaEarnFormState>
+    | AjnaUpdateState<AjnaMultiplyFormState>
   product: AjnaProduct
 }) {
   const notifications: DetailsSectionNotificationItem[] = []

--- a/features/ajna/positions/common/observables/getAjnaPosition.ts
+++ b/features/ajna/positions/common/observables/getAjnaPosition.ts
@@ -3,8 +3,9 @@ import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
 import { Tickers } from 'blockchain/prices'
 import { UserDpmAccount } from 'blockchain/userDpmProxies'
+import { ethers } from 'ethers'
 import { PositionCreated } from 'features/aave/services/readPositionCreatedEvents'
-import { AjnaGenericPosition } from 'features/ajna/common/types'
+import { AjnaGenericPosition, AjnaProduct } from 'features/ajna/common/types'
 import { getAjnaPoolData } from 'features/ajna/positions/common/helpers/getAjnaPoolData'
 import { DpmPositionData } from 'features/ajna/positions/common/observables/getDpmPositionData'
 import { getAjnaEarnData } from 'features/ajna/positions/earn/helpers/getAjnaEarnData'
@@ -48,12 +49,26 @@ export function getAjnaPosition$(
         getPoolData: getAjnaPoolData,
       }
 
-      return product === 'earn'
-        ? await views.ajna.getEarnPosition(commonPayload, {
+      switch (product as AjnaProduct) {
+        case 'borrow':
+          return await views.ajna.getPosition(commonPayload, commonDependency)
+        case 'earn':
+          return await views.ajna.getEarnPosition(commonPayload, {
             ...commonDependency,
             getEarnData: getAjnaEarnData,
           })
-        : await views.ajna.getPosition(commonPayload, commonDependency)
+        case 'multiply':
+          // TODO: replace with getting multiply position from lib
+          const fakeMultiplyPosition = await views.ajna.getPosition(
+            { ...commonPayload, proxyAddress: ethers.constants.AddressZero },
+            commonDependency,
+          )
+
+          return {
+            ...fakeMultiplyPosition,
+            multiply: new BigNumber(1.5),
+          }
+      }
     }),
     distinctUntilChanged(isEqual),
     shareReplay(1),

--- a/features/ajna/positions/common/state/ajnaFormReductoActions.ts
+++ b/features/ajna/positions/common/state/ajnaFormReductoActions.ts
@@ -20,6 +20,10 @@ export interface AjnaFormActionsUpdateWithdraw {
   withdrawAmount?: BigNumber
   withdrawAmountUSD?: BigNumber
 }
+export interface AjnaFormActionsUpdateTargetLiquidationPrice {
+  type: 'update-target-liquidation-price'
+  targetLiquidationPrice?: BigNumber
+}
 export interface AjnaFormActionsUpdateDpm {
   type: 'update-dpm'
   dpmAddress: string

--- a/features/ajna/positions/multiply/state/ajnaMultiplyFormReducto.ts
+++ b/features/ajna/positions/multiply/state/ajnaMultiplyFormReducto.ts
@@ -1,0 +1,83 @@
+import BigNumber from 'bignumber.js'
+import { ethers } from 'ethers'
+import { AjnaMultiplyAction, AjnaMultiplyPanel } from 'features/ajna/common/types'
+import {
+  AjnaFormActionsReset,
+  AjnaFormActionsUpdateDeposit,
+  AjnaFormActionsUpdateDpm,
+  AjnaFormActionsUpdateTargetLiquidationPrice,
+} from 'features/ajna/positions/common/state/ajnaFormReductoActions'
+import { ReductoActions, useReducto } from 'helpers/useReducto'
+
+export interface AjnaMultiplyFormState {
+  action?: AjnaMultiplyAction
+  dpmAddress: string
+  depositAmount?: BigNumber
+  depositAmountUSD?: BigNumber
+  targetLiquidationPrice?: BigNumber
+  uiDropdown: AjnaMultiplyPanel
+  uiPill: Exclude<AjnaMultiplyAction, 'open-multiply' | 'switch-multiply' | 'close-multiply'>
+}
+
+export type AjnaMultiplyFormAction = ReductoActions<
+  AjnaMultiplyFormState,
+  | AjnaFormActionsUpdateDeposit
+  | AjnaFormActionsUpdateTargetLiquidationPrice
+  | AjnaFormActionsUpdateDpm
+  | AjnaFormActionsReset
+>
+
+export const ajnaMultiplyReset = {
+  depositAmount: undefined,
+  depositAmountUSD: undefined,
+}
+
+export const ajnaMultiplyDefault: AjnaMultiplyFormState = {
+  ...ajnaMultiplyReset,
+  dpmAddress: ethers.constants.AddressZero,
+  uiDropdown: 'collateral',
+  uiPill: 'deposit-multiply',
+}
+
+export function useAjnaMultiplyFormReducto({ ...rest }: Partial<AjnaMultiplyFormState>) {
+  const { dispatch, state, updateState } = useReducto<AjnaMultiplyFormState, AjnaMultiplyFormAction>({
+    defaults: {
+      ...ajnaMultiplyDefault,
+      ...rest,
+    },
+    reducer: (state: AjnaMultiplyFormState, action: AjnaMultiplyFormAction) => {
+      switch (action.type) {
+        case 'update-deposit':
+          return {
+            ...state,
+            depositAmount: action.depositAmount,
+            depositAmountUSD: action.depositAmountUSD,
+          }
+        case 'update-target-liquidation-price':
+          return {
+            ...state,
+            targetLiquidationPrice: action.targetLiquidationPrice,
+          }
+        case 'update-dpm':
+          return {
+            ...state,
+            dpmAddress: action.dpmAddress,
+          }
+        case 'reset':
+          return {
+            ...state,
+            ...ajnaMultiplyReset,
+            targetLiquidationPrice: rest.targetLiquidationPrice,
+          }
+        default:
+          return state
+      }
+    },
+  })
+
+  return {
+    dispatch,
+    state,
+    updateState,
+  }
+}

--- a/features/ajna/positions/multiply/state/ajnaMultiplyFormReducto.ts
+++ b/features/ajna/positions/multiply/state/ajnaMultiplyFormReducto.ts
@@ -40,7 +40,10 @@ export const ajnaMultiplyDefault: AjnaMultiplyFormState = {
 }
 
 export function useAjnaMultiplyFormReducto({ ...rest }: Partial<AjnaMultiplyFormState>) {
-  const { dispatch, state, updateState } = useReducto<AjnaMultiplyFormState, AjnaMultiplyFormAction>({
+  const { dispatch, state, updateState } = useReducto<
+    AjnaMultiplyFormState,
+    AjnaMultiplyFormAction
+  >({
     defaults: {
       ...ajnaMultiplyDefault,
       ...rest,

--- a/features/ajna/positions/multiply/temp.ts
+++ b/features/ajna/positions/multiply/temp.ts
@@ -1,0 +1,7 @@
+import { AjnaPosition } from '@oasisdex/oasis-actions-poc'
+import BigNumber from 'bignumber.js'
+
+// TODO: temporary interface, replace with one imported from lib
+export interface AjnaMultiplyPosition extends AjnaPosition {
+  multiply: BigNumber
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2483,7 +2483,7 @@
             "liquidation-price": "Liquidation Price",
             "below-current-price": "{{belowCurrentPrice}} below current price",
             "loan-to-value": "Loan to value",
-            "liquidation-threshold": "Liquidation Threshold: {{liquidationTreshold}}",
+            "liquidation-threshold": "Liquidation Threshold: {{liquidationThreshold}}",
             "collateral-locked": "Collateral locked",
             "position-debt": "Position debt"
           },


### PR DESCRIPTION
# [Extend Ajna Context for Multiply Product](https://app.shortcut.com/oazo-apps/story/8660/extend-ajna-context-for-multiply-product)

Extended `AjnaProductContext` and `AjnaProductController` to fit Multiply product. So far this is just the context, no UI changes were made.
  
## Changes 👷‍♀️

- Created fake `AjnaMuliplyPosition` interface to be replaced in the future with one from library,
- added support for Multiply product in Ajna context,
- created `AjnaMultiplyFormReducto` for opening part of the flow.
  
## How to test 🧪

- See if `/ajna/multiply/WBTC-USDC` doesn't break the application,
- see if Borrow/Earn flows are still working.
