### PR TITLE
[L2] Add "Network" row to the product card

### DIFF
--- a/blockchain/calls/chainlink/chainlinkPriceOracle.ts
+++ b/blockchain/calls/chainlink/chainlinkPriceOracle.ts
@@ -2,6 +2,7 @@ import { amountFromWei } from '@oasisdex/utils'
 import BigNumber from 'bignumber.js'
 import { CallDef } from 'blockchain/calls/callsHelpers'
 import { NetworkConfig, networksByName } from 'blockchain/config'
+import { NetworkNames } from 'helpers/networkNames'
 import { ChainlinkPriceOracle } from 'types/web3-v1-contracts'
 
 const USD_CHAINLINK_PRECISION = 8
@@ -9,7 +10,10 @@ const USD_CHAINLINK_PRECISION = 8
 export function getChainlinkOraclePrice(
   contractName: keyof NetworkConfig['chainlinkPriceOracle'],
 ): CallDef<void, BigNumber> {
-  if (!contractName || !networksByName['ethereumMainnet']['chainlinkPriceOracle'][contractName]) {
+  if (
+    !contractName ||
+    !networksByName[NetworkNames.ethereumMainnet]['chainlinkPriceOracle'][contractName]
+  ) {
     throw new Error(`ChainlinkPriceOracle ${contractName} not found`)
   }
   return {

--- a/blockchain/config.ts
+++ b/blockchain/config.ts
@@ -1,4 +1,5 @@
 import { ContractDesc } from 'features/web3Context'
+import { NetworkNames } from 'helpers/networkNames'
 import { Abi } from 'helpers/types'
 import { keyBy } from 'lodash'
 import getConfig from 'next/config'
@@ -187,7 +188,7 @@ const protoMain = {
   id: '1',
   hexId: '0x1',
   token: 'ETH',
-  name: 'ethereumMainnet',
+  name: NetworkNames.ethereumMainnet,
   label: 'Ethereum',
   color: '#728aee',
   icon: ethereumMainnetIcon as string,
@@ -329,7 +330,7 @@ const goerli: NetworkConfig = {
   id: '5',
   hexId: '0x5',
   token: 'GoerliETH',
-  name: 'ethereumGoerli',
+  name: NetworkNames.ethereumGoerli,
   label: 'Ethereum Goerli',
   color: '#728aee',
   icon: ethereumMainnetIcon as string,
@@ -468,7 +469,7 @@ const hardhat: NetworkConfig = {
   ...protoMain,
   id: '2137',
   hexId: '0x859',
-  name: 'ethereumHardhat',
+  name: NetworkNames.ethereumHardhat,
   label: 'Ethereum Hardhat',
   color: '#728aee',
   icon: ethereumMainnetIcon as string,
@@ -483,7 +484,7 @@ const arbitrum: NetworkConfig = {
   ...protoMain,
   id: '42161',
   hexId: '0xa4b1',
-  name: 'arbitrumMainnet',
+  name: NetworkNames.arbitrumMainnet,
   label: 'Arbitrum',
   color: '#28a0f0',
   icon: arbitrumMainnetIcon as string,
@@ -497,7 +498,7 @@ const avalanche: NetworkConfig = {
   ...protoMain,
   id: '43114',
   hexId: '0xa86a',
-  name: 'avalancheMainnet',
+  name: NetworkNames.avalancheMainnet,
   label: 'Avalanche',
   color: '#ed494a',
   icon: avalancheMainnetIcon as string,
@@ -511,7 +512,7 @@ const optimism: NetworkConfig = {
   ...protoMain,
   id: '10',
   hexId: '0xa',
-  name: 'optimismMainnet',
+  name: NetworkNames.optimismMainnet,
   label: 'Optimism',
   color: '#ff3f49',
   icon: optimismMainnetIcon as string,
@@ -525,7 +526,7 @@ const polygon: NetworkConfig = {
   ...protoMain,
   id: '137',
   hexId: '0x89',
-  name: 'polygonMainnet',
+  name: NetworkNames.polygonMainnet,
   label: 'Polygon',
   color: '#9866ed',
   icon: polygonMainnetIcon as string,

--- a/blockchain/tokensMetadata.test.ts
+++ b/blockchain/tokensMetadata.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
+import { MainNetworkNames } from 'helpers/networkNames'
 
-import { getToken, getTokens, tokens } from './tokensMetadata'
+import { getToken, getTokens, getTokensWithChain, tokens } from './tokensMetadata'
 
 const tokenKeys = [
   'symbol',
@@ -15,6 +16,7 @@ const tokenKeys = [
   'bannerIcon',
   'bannerGif',
   'tags',
+  'chain',
 ]
 
 describe('tokens metadata', () => {
@@ -29,6 +31,14 @@ describe('tokens metadata', () => {
   })
   it('should return metadata for multiple tokens', () => {
     getTokens(tokens.map((token) => token.symbol)).forEach((tokenData) => {
+      expect(tokenData).to.include.keys(tokenKeys)
+    })
+  })
+  it('should return metadata for multiple tokens, filtering the chain', () => {
+    getTokensWithChain(
+      tokens.map((token) => token.symbol),
+      MainNetworkNames.ethereumMainnet,
+    ).forEach((tokenData) => {
       expect(tokenData).to.include.keys(tokenKeys)
     })
   })

--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -1,4 +1,4 @@
-import { NetworkNames } from 'helpers/networkNames'
+import { MainNetworkNames } from 'helpers/networkNames'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { findKey, keyBy } from 'lodash'
 import type { ElementOf } from 'ts-essentials'
@@ -30,7 +30,7 @@ export interface TokenConfig {
   digitsInstant?: number
   safeCollRatio?: number
   protocol: 'maker' | 'aaveV2' | 'aaveV3'
-  chains: NetworkNames[]
+  chain: MainNetworkNames
 }
 
 export const COIN_TAGS = ['stablecoin', 'lp-token'] as const
@@ -58,11 +58,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'STETH',
@@ -79,11 +75,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_stETH.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'MKR',
@@ -101,11 +93,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'WETH',
@@ -123,11 +111,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'ETH',
@@ -147,11 +131,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'BAT',
@@ -167,11 +147,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'WBTC',
@@ -193,11 +169,7 @@ export const tokens: TokenConfig[] = [
     tags: [],
     rootToken: 'BTC',
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'RENBTC',
@@ -219,11 +191,7 @@ export const tokens: TokenConfig[] = [
     tags: [],
     rootToken: 'BTC',
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'TUSD',
@@ -239,11 +207,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'KNC',
@@ -259,11 +223,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'MANA',
@@ -281,11 +241,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_MANA.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'PAXUSD',
@@ -301,11 +257,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'USDT',
@@ -321,11 +273,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'COMP',
@@ -341,11 +289,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'LRC',
@@ -361,11 +305,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'LINK',
@@ -383,11 +323,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_LINK.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'GUSD',
@@ -405,11 +341,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_GUSD.gif'),
     tags: ['stablecoin'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'ZRX',
@@ -425,11 +357,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'USDC',
@@ -448,11 +376,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/usdc.gif'),
     tags: ['stablecoin'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'BAL',
@@ -469,11 +393,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'YFI',
@@ -492,11 +412,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_YFI.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNI',
@@ -514,11 +430,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'AAVE',
@@ -535,11 +447,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2USDCETH',
@@ -556,11 +464,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_usdc_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2DAIUSDC',
@@ -577,11 +481,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_dai_usdc.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2WBTCETH',
@@ -598,11 +498,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_wbtc_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2DAIETH',
@@ -619,11 +515,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_dai_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2ETHUSDT',
@@ -640,11 +532,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2UNIETH',
@@ -661,11 +549,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_uni_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2LINKETH',
@@ -682,11 +566,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2WBTCDAI',
@@ -703,11 +583,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_wbtc_dai.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2AAVEETH',
@@ -724,11 +600,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'UNIV2DAIUSDT',
@@ -745,11 +617,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'GUNIV3DAIUSDC1',
@@ -768,11 +636,7 @@ export const tokens: TokenConfig[] = [
     token0: 'DAI',
     token1: 'USDC',
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'GUNIV3DAIUSDC2',
@@ -791,11 +655,7 @@ export const tokens: TokenConfig[] = [
     token0: 'DAI',
     token1: 'USDC',
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'MATIC',
@@ -814,11 +674,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_MATIC.gif'),
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'WSTETH',
@@ -839,11 +695,7 @@ export const tokens: TokenConfig[] = [
     tags: [],
     rootToken: 'ETH',
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'DAI',
@@ -862,11 +714,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'CRVV1ETHSTETH',
@@ -883,11 +731,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/crv_steth_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'stETHeth',
@@ -904,11 +748,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'stETHusdc',
@@ -925,11 +765,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'ethusdc',
@@ -946,11 +782,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_ETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'wBTCusdc',
@@ -967,11 +799,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_WBTC_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'wstETHeth',
@@ -988,11 +816,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v3.gif'),
     tags: [],
     protocol: 'aaveV3',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'borrow-against-ETH',
@@ -1009,11 +833,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_ETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'RETH',
@@ -1032,11 +852,7 @@ export const tokens: TokenConfig[] = [
     rootToken: 'ETH',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'CBETH',
@@ -1058,11 +874,7 @@ export const tokens: TokenConfig[] = [
     rootToken: 'ETH',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
   {
     symbol: 'GNO',
@@ -1080,11 +892,7 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
-    chains: [
-      NetworkNames.ethereumMainnet,
-      NetworkNames.ethereumGoerli,
-      NetworkNames.ethereumHardhat,
-    ],
+    chain: MainNetworkNames.ethereumMainnet,
   },
 ]
 
@@ -1104,6 +912,18 @@ export function getToken(tokenSymbol: TokenSymbolType): TokenMetadataType {
 export function getTokens(tokenSymbol: TokenSymbolType[]): typeof tokens {
   if (tokenSymbol instanceof Array) {
     return tokenSymbol.map(getToken)
+  }
+  throw new Error(`tokenSymbol should be an array, got ${tokenSymbol}`)
+}
+
+export function getTokensWithChain(
+  tokenSymbol: TokenSymbolType[],
+  chain?: MainNetworkNames,
+): typeof tokens {
+  if (tokenSymbol instanceof Array) {
+    return tokenSymbol
+      .map(getToken)
+      .filter((token) => token.chain === chain || MainNetworkNames.ethereumGoerli)
   }
   throw new Error(`tokenSymbol should be an array, got ${tokenSymbol}`)
 }

--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -1,3 +1,4 @@
+import { NetworkNames } from 'helpers/networkNames'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { findKey, keyBy } from 'lodash'
 import type { ElementOf } from 'ts-essentials'
@@ -29,6 +30,7 @@ export interface TokenConfig {
   digitsInstant?: number
   safeCollRatio?: number
   protocol: 'maker' | 'aaveV2' | 'aaveV3'
+  chains: NetworkNames[]
 }
 
 export const COIN_TAGS = ['stablecoin', 'lp-token'] as const
@@ -56,6 +58,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'STETH',
@@ -72,6 +79,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_stETH.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'MKR',
@@ -89,6 +101,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'WETH',
@@ -106,6 +123,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'ETH',
@@ -125,6 +147,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/MAKER_ETH.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'BAT',
@@ -140,6 +167,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'WBTC',
@@ -161,6 +193,11 @@ export const tokens: TokenConfig[] = [
     tags: [],
     rootToken: 'BTC',
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'RENBTC',
@@ -182,6 +219,11 @@ export const tokens: TokenConfig[] = [
     tags: [],
     rootToken: 'BTC',
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'TUSD',
@@ -197,6 +239,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'KNC',
@@ -212,6 +259,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'MANA',
@@ -229,6 +281,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_MANA.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'PAXUSD',
@@ -244,6 +301,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'USDT',
@@ -259,6 +321,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'COMP',
@@ -274,6 +341,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'LRC',
@@ -289,6 +361,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'LINK',
@@ -306,6 +383,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_LINK.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'GUSD',
@@ -323,6 +405,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_GUSD.gif'),
     tags: ['stablecoin'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'ZRX',
@@ -338,6 +425,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'USDC',
@@ -356,6 +448,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/usdc.gif'),
     tags: ['stablecoin'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'BAL',
@@ -372,6 +469,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'YFI',
@@ -390,6 +492,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_YFI.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNI',
@@ -407,6 +514,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'AAVE',
@@ -423,6 +535,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2USDCETH',
@@ -439,6 +556,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_usdc_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2DAIUSDC',
@@ -455,6 +577,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_dai_usdc.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2WBTCETH',
@@ -471,6 +598,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_wbtc_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2DAIETH',
@@ -487,6 +619,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_dai_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2ETHUSDT',
@@ -503,6 +640,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2UNIETH',
@@ -519,6 +661,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_uni_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2LINKETH',
@@ -535,6 +682,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2WBTCDAI',
@@ -551,6 +703,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/uni_old_wbtc_dai.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2AAVEETH',
@@ -567,6 +724,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'UNIV2DAIUSDT',
@@ -583,6 +745,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'GUNIV3DAIUSDC1',
@@ -601,6 +768,11 @@ export const tokens: TokenConfig[] = [
     token0: 'DAI',
     token1: 'USDC',
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'GUNIV3DAIUSDC2',
@@ -619,6 +791,11 @@ export const tokens: TokenConfig[] = [
     token0: 'DAI',
     token1: 'USDC',
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'MATIC',
@@ -637,6 +814,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/Maker_MATIC.gif'),
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'WSTETH',
@@ -657,6 +839,11 @@ export const tokens: TokenConfig[] = [
     tags: [],
     rootToken: 'ETH',
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'DAI',
@@ -675,6 +862,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: ['stablecoin'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'CRVV1ETHSTETH',
@@ -691,6 +883,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/crv_steth_eth.gif'),
     tags: ['lp-token'],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'stETHeth',
@@ -707,6 +904,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'stETHusdc',
@@ -723,6 +925,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'ethusdc',
@@ -739,6 +946,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_ETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'wBTCusdc',
@@ -755,6 +967,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_WBTC_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'wstETHeth',
@@ -771,6 +988,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_stETH_v3.gif'),
     tags: [],
     protocol: 'aaveV3',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'borrow-against-ETH',
@@ -787,6 +1009,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: staticFilesRuntimeUrl('/static/img/tokens/AAVE_ETH_v2.gif'),
     tags: [],
     protocol: 'aaveV2',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'RETH',
@@ -805,6 +1032,11 @@ export const tokens: TokenConfig[] = [
     rootToken: 'ETH',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'CBETH',
@@ -826,6 +1058,11 @@ export const tokens: TokenConfig[] = [
     rootToken: 'ETH',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
   {
     symbol: 'GNO',
@@ -843,6 +1080,11 @@ export const tokens: TokenConfig[] = [
     bannerGif: '',
     tags: [],
     protocol: 'maker',
+    chains: [
+      NetworkNames.ethereumMainnet,
+      NetworkNames.ethereumGoerli,
+      NetworkNames.ethereumHardhat,
+    ],
   },
 ]
 

--- a/components/HeadTags.tsx
+++ b/components/HeadTags.tsx
@@ -1,6 +1,6 @@
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useCustomNetworkParameter } from 'helpers/getCustomNetworkParameter'
-import { networkIconMap } from 'helpers/networkIconMap'
+import { networkTabTitleIconMap } from 'helpers/networkIconMap'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
@@ -70,7 +70,7 @@ export function PageSEOTags({
     twitterImage,
   }
   const properNetworkIconMap = useNetworkSwitcher
-    ? networkIconMap
+    ? networkTabTitleIconMap
     : { hardhat: '👷 ', goerli: '🌲 ' }
   const networkParameter = useNetworkSwitcher
     ? web3OnboardNetworkParameter?.network

--- a/components/ProductCardLabels.tsx
+++ b/components/ProductCardLabels.tsx
@@ -1,37 +1,41 @@
 import React, { ReactNode } from 'react'
 import { Flex, SxStyleProp, Text } from 'theme-ui'
 
+export type ProductCardLabel = {
+  title: string
+  value: ReactNode
+  enabled?: boolean
+}
 interface ProductCardLabelsProps {
-  labels?: {
-    title: string
-    value: ReactNode
-  }[]
+  labels?: ProductCardLabel[]
   textSx?: SxStyleProp
 }
 
 export function ProductCardLabels({ labels, textSx = {} }: ProductCardLabelsProps) {
   return (
     <Flex sx={{ flexDirection: 'column', justifyContent: 'space-around' }}>
-      {labels?.map(({ title, value }, index) => {
+      {labels?.map(({ title, value, enabled = true }: ProductCardLabel, index) => {
         return (
-          <Flex
-            key={`${index}-${title}`}
-            sx={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              lineHeight: '22px',
-              pb: 2,
-              fontSize: '14px',
-              '&:last-child': {
-                pb: '0',
-              },
-            }}
-          >
-            <Text sx={{ color: 'neutral80', pb: 1, ...textSx }} variant="paragraph3">
-              {title}
-            </Text>
-            <Text variant="boldParagraph3">{value}</Text>
-          </Flex>
+          enabled && (
+            <Flex
+              key={`${index}-${title}`}
+              sx={{
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                lineHeight: '22px',
+                pb: 2,
+                fontSize: '14px',
+                '&:last-child': {
+                  pb: '0',
+                },
+              }}
+            >
+              <Text sx={{ color: 'neutral80', pb: 1, ...textSx }} variant="paragraph3">
+                {title}
+              </Text>
+              <Text variant="boldParagraph3">{value}</Text>
+            </Flex>
+          )
         )
       })}
     </Flex>

--- a/components/productCards/ProductCard.tsx
+++ b/components/productCards/ProductCard.tsx
@@ -1,9 +1,10 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import BigNumber from 'bignumber.js'
+import { networksByName } from 'blockchain/config'
 import { ProtocolLongNames, TokenMetadataType } from 'blockchain/tokensMetadata'
 import { FloatingLabel } from 'components/FloatingLabel'
 import { AppLink } from 'components/Links'
-import { ProductCardLabels } from 'components/ProductCardLabels'
+import { ProductCardLabel, ProductCardLabels } from 'components/ProductCardLabels'
 import { WithArrow } from 'components/WithArrow'
 import { AppSpinner } from 'helpers/AppSpinner'
 import { formatCryptoBalance } from 'helpers/formatters/format'
@@ -11,7 +12,7 @@ import { ProductCardData, productCardsConfig } from 'helpers/productCards'
 import { TranslateStringType } from 'helpers/translateStringType'
 import { useWindowSize } from 'helpers/useWindowSize'
 import { useTranslation } from 'next-i18next'
-import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Box, Button, Card, Flex, Heading, Image, Spinner, Text } from 'theme-ui'
 import { fadeInAnimation } from 'theme/animations'
 
@@ -79,6 +80,21 @@ interface ProductCardBannerProps {
   title: string
   description: string
   isLoading?: boolean
+}
+
+export function ProductCardNetworkRow({ chain }: Pick<ProductCardData, 'chain'>) {
+  const network = networksByName[chain]
+  console.log('network', network)
+  if (!network) {
+    console.error('Network not found', chain)
+    return null
+  }
+  return (
+    <Flex sx={{ alignItems: 'center' }}>
+      <Image src={network.icon} sx={{ height: 3, mr: 2 }} />
+      {network.label || '-'}
+    </Flex>
+  )
 }
 
 // changed "ilk" to "strategyName" cause not everything is an ilk
@@ -216,7 +232,7 @@ export interface ProductCardProps {
   isFull: boolean
   floatingLabelText?: TranslateStringType
   inactive?: boolean
-  labels?: { title: string; value: ReactNode }[]
+  labels?: ProductCardLabel[]
   protocol?: TokenMetadataType['protocol']
 }
 

--- a/components/productCards/ProductCardBorrow.tsx
+++ b/components/productCards/ProductCardBorrow.tsx
@@ -2,11 +2,17 @@ import { BigNumber } from 'bignumber.js'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { ProductCardData, productCardsConfig } from 'helpers/productCards'
 import { roundToThousand } from 'helpers/roundToThousand'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { calculateTokenAmount, ProductCard, ProductCardProtocolLink } from './ProductCard'
+import {
+  calculateTokenAmount,
+  ProductCard,
+  ProductCardNetworkRow,
+  ProductCardProtocolLink,
+} from './ProductCard'
 
 function personaliseCardData({
   productCardData,
@@ -80,6 +86,7 @@ export function ProductCardBorrow(props: { cardData: ProductCardData }) {
   const { cardData } = props
 
   const { maxBorrow, tokenAmount } = bannerValues(cardData)
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
 
   const tagKey = productCardsConfig.borrow.tags[cardData.ilk]
 
@@ -121,6 +128,11 @@ export function ProductCardBorrow(props: { cardData: ProductCardData }) {
         {
           title: t('system.protocol'),
           value: <ProductCardProtocolLink {...cardData}></ProductCardProtocolLink>,
+        },
+        {
+          title: t('system.network'),
+          value: <ProductCardNetworkRow chain={cardData.chain} />,
+          enabled: displayNetwork,
         },
       ]}
       button={{ link: `/vaults/open/${cardData.ilk}`, text: t('nav.borrow') }}

--- a/components/productCards/ProductCardBorrowAave.tsx
+++ b/components/productCards/ProductCardBorrowAave.tsx
@@ -8,10 +8,11 @@ import { WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { ProductCard, ProductCardProtocolLink } from './ProductCard'
+import { ProductCard, ProductCardNetworkRow, ProductCardProtocolLink } from './ProductCard'
 import { ProductCardsLoader } from './ProductCardsWrapper'
 
 type ProductCardBorrowAaveProps = {
@@ -31,7 +32,7 @@ export function ProductCardBorrowAave({ cardData }: ProductCardBorrowAaveProps) 
     getAaveAssetsPrices$,
   } = useAaveContext()
   const [strategy] = getAaveStrategy(cardData.symbol)
-
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
   const [aaveReserveState, aaveReserveStateError] = useObservable(
     aaveReserveConfigurationData$({ token: strategy.tokens.collateral }),
   )
@@ -82,6 +83,11 @@ export function ProductCardBorrowAave({ cardData }: ProductCardBorrowAaveProps) 
                 value: (
                   <ProductCardProtocolLink ilk={cardData.symbol} protocol={cardData.protocol} />
                 ),
+              },
+              {
+                title: t('system.network'),
+                value: <ProductCardNetworkRow chain={cardData.chain} />,
+                enabled: displayNetwork,
               },
             ]}
             button={{

--- a/components/productCards/ProductCardEarnAave.tsx
+++ b/components/productCards/ProductCardEarnAave.tsx
@@ -9,11 +9,12 @@ import { displayMultiple } from 'helpers/display-multiple'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { ProductCard, ProductCardProtocolLink } from './ProductCard'
+import { ProductCard, ProductCardNetworkRow, ProductCardProtocolLink } from './ProductCard'
 import { ProductCardsLoader } from './ProductCardsWrapper'
 
 type ProductCardEarnAaveProps = {
@@ -28,6 +29,7 @@ const aaveEarnCalcValueBasis = {
 
 export function ProductCardEarnAave({ cardData, strategy }: ProductCardEarnAaveProps) {
   const { t } = useTranslation()
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
 
   const { earnCollateralsReserveData, aaveAvailableLiquidityInUSDC$ } = useAaveContext(
     strategy.protocol,
@@ -110,6 +112,11 @@ export function ProductCardEarnAave({ cardData, strategy }: ProductCardEarnAaveP
                 value: (
                   <ProductCardProtocolLink ilk={cardData.symbol} protocol={cardData.protocol} />
                 ),
+              },
+              {
+                title: t('system.network'),
+                value: <ProductCardNetworkRow chain={cardData.chain} />,
+                enabled: displayNetwork,
               },
             ]}
             button={{

--- a/components/productCards/ProductCardEarnDsr.tsx
+++ b/components/productCards/ProductCardEarnDsr.tsx
@@ -4,16 +4,19 @@ import { getYearlyRate } from 'features/dsr/helpers/dsrPot'
 import { useWeb3OnBoardConnection } from 'features/web3OnBoard'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { formatAmount, formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
+import { MainNetworkNames } from 'helpers/networkNames'
 import { useObservable } from 'helpers/observableHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useRedirect } from 'helpers/useRedirect'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React, { useCallback, useMemo } from 'react'
 
-import { ProductCard, ProductCardProtocolLink } from './ProductCard'
+import { ProductCard, ProductCardNetworkRow, ProductCardProtocolLink } from './ProductCard'
 
 export function ProductCardEarnDsr() {
   const { t } = useTranslation()
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
   const { connectedContext$, potDsr$, potTotalValueLocked$ } = useAppContext()
   const [potDsr] = useObservable(potDsr$)
   const [potTotalValueLocked] = useObservable(potTotalValueLocked$)
@@ -62,6 +65,11 @@ export function ProductCardEarnDsr() {
         {
           title: t('system.protocol'),
           value: <ProductCardProtocolLink ilk={'DAI'} protocol="maker" />,
+        },
+        {
+          title: t('system.network'),
+          value: <ProductCardNetworkRow chain={MainNetworkNames.ethereumMainnet} />, // could be read from the context
+          enabled: displayNetwork,
         },
       ]}
       button={{

--- a/components/productCards/ProductCardEarnMaker.tsx
+++ b/components/productCards/ProductCardEarnMaker.tsx
@@ -9,12 +9,18 @@ import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
 import { ProductCardData, productCardsConfig } from 'helpers/productCards'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Flex, Text } from 'theme-ui'
 
-import { calculateTokenAmount, ProductCard, ProductCardProtocolLink } from './ProductCard'
+import {
+  calculateTokenAmount,
+  ProductCard,
+  ProductCardNetworkRow,
+  ProductCardProtocolLink,
+} from './ProductCard'
 
 interface UnprofitableTooltipProps {
   value: string
@@ -63,6 +69,7 @@ interface ProductCardEarnMakerProps {
 export function ProductCardEarnMaker({ cardData }: ProductCardEarnMakerProps) {
   const { t } = useTranslation()
   const defaultDaiValue = new BigNumber(100000)
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
   const { yields$ } = useAppContext()
 
   const [yields, yieldsError] = useObservable(yields$(cardData.ilk))
@@ -126,6 +133,11 @@ export function ProductCardEarnMaker({ cardData }: ProductCardEarnMakerProps) {
     {
       title: t('system.protocol'),
       value: <ProductCardProtocolLink {...cardData}></ProductCardProtocolLink>,
+    },
+    {
+      title: t('system.network'),
+      value: <ProductCardNetworkRow chain={cardData.chain} />,
+      enabled: displayNetwork,
     },
   ]
 

--- a/components/productCards/ProductCardMultiplyAave.tsx
+++ b/components/productCards/ProductCardMultiplyAave.tsx
@@ -7,11 +7,12 @@ import { AppSpinner } from 'helpers/AppSpinner'
 import { displayMultiple } from 'helpers/display-multiple'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { ProductCard, ProductCardProtocolLink } from './ProductCard'
+import { ProductCard, ProductCardNetworkRow, ProductCardProtocolLink } from './ProductCard'
 
 type ProductCardMultiplyAaveProps = {
   cardData: TokenMetadataType
@@ -23,6 +24,7 @@ const aaveMultiplyCalcValueBasis = {
 
 export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAaveProps) {
   const { t } = useTranslation()
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
   const { getAaveReserveData$, aaveReserveConfigurationData$ } = useAaveContext()
   const [strategy] = getAaveStrategy(cardData.symbol)
   const [debtReserveData] = useObservable(getAaveReserveData$({ token: strategy.tokens.debt }))
@@ -83,6 +85,11 @@ export function ProductCardMultiplyAave({ cardData }: ProductCardMultiplyAavePro
         {
           title: t('system.protocol'),
           value: <ProductCardProtocolLink ilk={cardData.symbol} protocol={cardData.protocol} />,
+        },
+        {
+          title: t('system.network'),
+          value: <ProductCardNetworkRow chain={cardData.chain} />,
+          enabled: displayNetwork,
         },
       ]}
       floatingLabelText={t('product-card.tags.new')}

--- a/components/productCards/ProductCardMultiplyMaker.tsx
+++ b/components/productCards/ProductCardMultiplyMaker.tsx
@@ -2,11 +2,17 @@ import { BigNumber } from 'bignumber.js'
 import { displayMultiple } from 'helpers/display-multiple'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { ProductCardData, productCardsConfig } from 'helpers/productCards'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import { calculateTokenAmount, ProductCard, ProductCardProtocolLink } from './ProductCard'
+import {
+  calculateTokenAmount,
+  ProductCard,
+  ProductCardNetworkRow,
+  ProductCardProtocolLink,
+} from './ProductCard'
 
 function personaliseCardData({
   productCardData,
@@ -44,6 +50,7 @@ function bannerValues(props: ProductCardData, maxMultiple: BigNumber) {
 export function ProductCardMultiplyMaker(props: { cardData: ProductCardData }) {
   const { t } = useTranslation()
   const { cardData } = props
+  const displayNetwork = useFeatureToggle('UseNetworkRowProductCard')
 
   const isGuniToken = cardData.token === 'GUNIV3DAIUSDC2' || cardData.token === 'GUNIV3DAIUSDC1'
   const maxMultiple = !isGuniToken
@@ -100,6 +107,11 @@ export function ProductCardMultiplyMaker(props: { cardData: ProductCardData }) {
         {
           title: t('system.protocol'),
           value: <ProductCardProtocolLink {...cardData}></ProductCardProtocolLink>,
+        },
+        {
+          title: t('system.network'),
+          value: <ProductCardNetworkRow chain={cardData.chain} />,
+          enabled: displayNetwork,
         },
       ]}
       button={{

--- a/helpers/getCustomNetworkParameter.ts
+++ b/helpers/getCustomNetworkParameter.ts
@@ -1,5 +1,6 @@
 import { networksByName } from 'blockchain/config'
 
+import { NetworkNames } from './networkNames'
 import { useLocalStorage } from './useLocalStorage'
 
 export function getCustomNetworkParameter() {
@@ -8,9 +9,9 @@ export function getCustomNetworkParameter() {
 }
 
 export const mainnetNetworkParameter = {
-  network: networksByName['ethereumMainnet'].name!,
-  id: networksByName['ethereumMainnet'].id!,
-  hexId: networksByName['ethereumMainnet'].hexId!,
+  network: networksByName[NetworkNames.ethereumMainnet].name!,
+  id: networksByName[NetworkNames.ethereumMainnet].id!,
+  hexId: networksByName[NetworkNames.ethereumMainnet].hexId!,
 }
 
 export const CustomNetworkStorageKey = 'CustomNetwork'

--- a/helpers/networkIconMap.ts
+++ b/helpers/networkIconMap.ts
@@ -1,11 +1,13 @@
+import { NetworkNames } from './networkNames'
+
 export const networkIconMap: Record<string, string> = {
-  ethereumMainnet: '',
-  ethereumHardhat: '👷 ',
-  ethereumGoerli: '🌲 ',
-  arbitrumMainnet: '',
-  arbitrumGoerli: '🌲 ',
-  avalancheMainnet: '',
-  optimismMainnet: '',
-  optimismGoerli: '🌲',
-  polygonMainnet: '',
+  [NetworkNames.ethereumMainnet]: '',
+  [NetworkNames.ethereumHardhat]: '👷 ',
+  [NetworkNames.ethereumGoerli]: '🌲 ',
+  [NetworkNames.arbitrumMainnet]: '',
+  [NetworkNames.arbitrumGoerli]: '🌲 ',
+  [NetworkNames.avalancheMainnet]: '',
+  [NetworkNames.optimismMainnet]: '',
+  [NetworkNames.optimismGoerli]: '🌲',
+  [NetworkNames.polygonMainnet]: '',
 }

--- a/helpers/networkIconMap.ts
+++ b/helpers/networkIconMap.ts
@@ -1,6 +1,7 @@
 import { NetworkNames } from './networkNames'
 
-export const networkIconMap: Record<string, string> = {
+// these are used for the tab title
+export const networkTabTitleIconMap: Record<NetworkNames, string> = {
   [NetworkNames.ethereumMainnet]: '',
   [NetworkNames.ethereumHardhat]: '👷 ',
   [NetworkNames.ethereumGoerli]: '🌲 ',

--- a/helpers/networkNames.ts
+++ b/helpers/networkNames.ts
@@ -1,0 +1,11 @@
+export enum NetworkNames {
+  ethereumMainnet = 'ethereumMainnet',
+  ethereumGoerli = 'ethereumGoerli',
+  ethereumHardhat = 'ethereumHardhat',
+  arbitrumMainnet = 'arbitrumMainnet',
+  arbitrumGoerli = 'arbitrumGoerli',
+  avalancheMainnet = 'avalancheMainnet',
+  optimismMainnet = 'optimismMainnet',
+  optimismGoerli = 'optimismGoerli',
+  polygonMainnet = 'polygonMainnet',
+}

--- a/helpers/networkNames.ts
+++ b/helpers/networkNames.ts
@@ -1,11 +1,32 @@
+// all the network names we use in the app
 export enum NetworkNames {
   ethereumMainnet = 'ethereumMainnet',
   ethereumGoerli = 'ethereumGoerli',
   ethereumHardhat = 'ethereumHardhat',
+
   arbitrumMainnet = 'arbitrumMainnet',
   arbitrumGoerli = 'arbitrumGoerli',
-  avalancheMainnet = 'avalancheMainnet',
+
   optimismMainnet = 'optimismMainnet',
   optimismGoerli = 'optimismGoerli',
+
+  avalancheMainnet = 'avalancheMainnet',
+  polygonMainnet = 'polygonMainnet',
+}
+
+// main network names skipping the testnets mapping
+export enum MainNetworkNames {
+  ethereumMainnet = 'ethereumMainnet',
+  ethereumGoerli = 'ethereumMainnet',
+  ethereumHardhat = 'ethereumMainnet',
+
+  arbitrumMainnet = 'arbitrumMainnet',
+  arbitrumGoerli = 'arbitrumMainnet',
+
+  optimismMainnet = 'optimismMainnet',
+  optimismGoerli = 'optimismMainnet',
+
+  avalancheMainnet = 'avalancheMainnet',
+
   polygonMainnet = 'polygonMainnet',
 }

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -35,6 +35,7 @@ export interface ProductCardData {
   name: string
   isFull: boolean
   protocol: TokenMetadataType['protocol']
+  chain: TokenMetadataType['chain']
 }
 
 export type ProductLandingPagesFiltersKeys =
@@ -656,6 +657,7 @@ export function createProductCardsData$(
           name: tokenMeta.name,
           isFull: ilkData.ilkDebtAvailable.lt(ilkData.debtFloor),
           protocol: tokenMeta.protocol,
+          chain: tokenMeta.chain,
         }
       })
     }),

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -30,6 +30,7 @@ export type Feature =
   | 'FollowAAVEVaults'
   | 'Sillyness'
   | 'UseNetworkSwitcher'
+  | 'UseNetworkRowProductCard'
   | '🌞'
 
 const configuredFeatures: Record<Feature, boolean> = {
@@ -59,6 +60,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   FollowAAVEVaults: false,
   Sillyness: false,
   UseNetworkSwitcher: false,
+  UseNetworkRowProductCard: false,
   '🌞': false, // or https://oasis.app/harheeharheeharhee to enable.  https://oasis.app/<any vault ID> to disable.
 }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1106,6 +1106,7 @@
     "manage-debt": "Manage debt",
     "manage-liquidity": "Manage liquidity ({{token}})",
     "close-position": "Close position",
+    "network": "Network",
     "actions": {
       "common": {
         "close-vault": "Close vault",


### PR DESCRIPTION
# [[L2] Add "Network" row to the product card](https://app.shortcut.com/oazo-apps/story/8731/l2-add-network-row-to-the-product-card)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- some minor fixes with the network names, so we wont use `networksByName['ethereumMainnet']` cause its ugly
- added network row to the product cards (feature togglified)
  
## How to test 🧪
- enable `UseNetworkRowProductCard`
- check out the product cards
