### PR TITLE
🧿 Open Multiply position form

### DIFF
--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -17,7 +17,10 @@ import { getEarnDefaultPrice } from 'features/ajna/positions/earn/helpers/getEar
 import { useAjnaEarnFormReducto } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
 import { AjnaMultiplyPositionController } from 'features/ajna/positions/multiply/controls/AjnaMultiplyPositionController'
 import { useAjnaMultiplyFormReducto } from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
-import { AjnaMultiplyPosition } from 'features/ajna/positions/multiply/temp'
+import {
+  AjnaMultiplyPosition,
+  ajnaMultiplySliderDefaults,
+} from 'features/ajna/positions/multiply/temp'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { WithWalletAssociatedRisk } from 'features/walletAssociatedRisk/WalletAssociatedRisk'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
@@ -222,6 +225,8 @@ export function AjnaProductController({
                           <AjnaProductContextProvider
                             formDefaults={{
                               action: flow === 'open' ? 'open-multiply' : 'deposit-multiply',
+                              // TODO: get default price from library?
+                              targetLiquidationPrice: ajnaMultiplySliderDefaults.initial,
                             }}
                             formReducto={useAjnaMultiplyFormReducto}
                             position={ajnaPosition as AjnaMultiplyPosition}

--- a/features/ajna/positions/common/helpers/getPrimaryButtonLabelKey.ts
+++ b/features/ajna/positions/common/helpers/getPrimaryButtonLabelKey.ts
@@ -2,8 +2,9 @@ import { AjnaFlow, AjnaProduct, AjnaSidebarStep } from 'features/ajna/common/typ
 
 interface GetPrimaryButtonLabelKeyParams {
   currentStep: AjnaSidebarStep
-  hasDpmAddress: boolean
   flow: AjnaFlow
+  hasAllowance: boolean
+  hasDpmAddress: boolean
   isTxError: boolean
   isTxSuccess: boolean
   product: AjnaProduct
@@ -12,8 +13,9 @@ interface GetPrimaryButtonLabelKeyParams {
 
 export function getPrimaryButtonLabelKey({
   currentStep,
-  hasDpmAddress,
   flow,
+  hasAllowance,
+  hasDpmAddress,
   isTxError,
   isTxSuccess,
   walletAddress,
@@ -26,7 +28,8 @@ export function getPrimaryButtonLabelKey({
       else if (isTxError) return 'retry'
       else return 'confirm'
     default:
-      if (walletAddress && hasDpmAddress) return 'confirm'
+      if (walletAddress && hasDpmAddress && hasAllowance) return 'confirm'
+      else if (walletAddress && hasDpmAddress) return 'set-token-allowance'
       else if (walletAddress) return 'dpm.create-flow.welcome-screen.create-button'
       else return 'connect-wallet-button'
   }

--- a/features/ajna/positions/common/validation.ts
+++ b/features/ajna/positions/common/validation.ts
@@ -11,6 +11,7 @@ import {
 import { AjnaBorrowFormState } from 'features/ajna/positions/borrow/state/ajnaBorrowFormReducto'
 import { areEarnPricesEqual } from 'features/ajna/positions/earn/helpers/areEarnPricesEqual'
 import { AjnaEarnFormState } from 'features/ajna/positions/earn/state/ajnaEarnFormReducto'
+import { AjnaMultiplyFormState } from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
 import { ethFundsForTxValidator, notEnoughETHtoPayForTx } from 'features/form/commonValidators'
 import { TxError } from 'helpers/types'
 import { zero } from 'helpers/zero'
@@ -133,7 +134,20 @@ function isFormValid({
       }
     }
     case 'multiply':
-      return false
+      const { action, depositAmount } = state as AjnaMultiplyFormState
+
+      switch (currentStep) {
+        case 'setup':
+        case 'manage':
+          switch (action) {
+            case 'open-multiply':
+              return !!depositAmount?.gt(0)
+            default:
+              return false
+          }
+        default:
+          return true
+      }
   }
 }
 

--- a/features/ajna/positions/common/views/AjnaFormView.tsx
+++ b/features/ajna/positions/common/views/AjnaFormView.tsx
@@ -84,13 +84,14 @@ export function AjnaFormView({ dropdown, children }: PropsWithChildren<AjnaFormV
     walletAddress,
   })
   const primaryButtonLabel = getPrimaryButtonLabelKey({
-    flow,
     currentStep,
-    product,
+    flow,
+    hasAllowance: flowState.isAllowanceReady,
     hasDpmAddress: flowState.isProxyReady,
-    walletAddress,
-    isTxSuccess,
     isTxError,
+    isTxSuccess,
+    product,
+    walletAddress,
   })
   const primaryButtonActions = getAjnaSidebarPrimaryButtonActions({
     defaultAction: async () => {
@@ -128,7 +129,7 @@ export function AjnaFormView({ dropdown, children }: PropsWithChildren<AjnaFormV
     dropdown,
     content: <Grid gap={3}>{children}</Grid>,
     primaryButton: {
-      label: t(primaryButtonLabel),
+      label: t(primaryButtonLabel, { token: flowState.token }),
       disabled: isPrimaryButtonDisabled,
       isLoading: isPrimaryButtonLoading,
       hidden: isPrimaryButtonHidden,

--- a/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
+++ b/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
@@ -9,7 +9,11 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Text } from 'theme-ui'
 
-export function AjnaMultiplySlider() {
+interface AjnaMultiplySliderProps {
+  disabled?: boolean
+}
+
+export function AjnaMultiplySlider({ disabled = false }: AjnaMultiplySliderProps) {
   const { t } = useTranslation()
   const {
     environment: { collateralToken, quoteToken },
@@ -54,7 +58,7 @@ export function AjnaMultiplySlider() {
       minBoundry={min}
       maxBoundry={max}
       lastValue={resolvedValue}
-      disabled={false}
+      disabled={disabled}
       step={1}
       leftBottomLabel={t('slider.adjust-multiply.left-footer')}
       leftLabel={t('slider.adjust-multiply.left-label')}

--- a/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
+++ b/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
@@ -1,0 +1,65 @@
+import { Icon } from '@makerdao/dai-ui-icons'
+import BigNumber from 'bignumber.js'
+import { SliderValuePicker } from 'components/dumb/SliderValuePicker'
+import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
+import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { ajnaMultiplySliderDefaults } from 'features/ajna/positions/multiply/temp'
+import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Text } from 'theme-ui'
+
+export function AjnaMultiplySlider() {
+  const { t } = useTranslation()
+  const {
+    environment: { collateralToken, quoteToken },
+  } = useAjnaGeneralContext()
+  const {
+    form: {
+      dispatch,
+      state: { targetLiquidationPrice },
+    },
+  } = useAjnaProductContext('multiply')
+
+  const resolvedValue = targetLiquidationPrice || ajnaMultiplySliderDefaults.initial
+  const min = ajnaMultiplySliderDefaults.min
+  const max = ajnaMultiplySliderDefaults.max
+  const percentage = resolvedValue.minus(min).div(max.minus(min)).times(100)
+  const ltv = new BigNumber(0.6265)
+  const afterLtv = new BigNumber(0.7141)
+  const variant = 'positive'
+
+  return (
+    <SliderValuePicker
+      sliderPercentageFill={percentage}
+      leftBoundry={resolvedValue}
+      leftBoundryFormatter={(val) => `${formatCryptoBalance(val)} ${collateralToken}/${quoteToken}`}
+      rightBoundry={afterLtv}
+      rightBoundryFormatter={(val) => (
+        <>
+          {formatDecimalAsPercent(ltv)}
+          {afterLtv && !ltv.eq(afterLtv) && (
+            <>
+              <Icon name="arrow_right" size={14} sx={{ mx: 2 }} />
+              <Text as="span" sx={{ color: variant === 'positive' ? 'success100' : 'critical100' }}>
+                {formatDecimalAsPercent(val)}
+              </Text>
+            </>
+          )}
+        </>
+      )}
+      onChange={(targetLiquidationPrice) => {
+        dispatch({ type: 'update-target-liquidation-price', targetLiquidationPrice })
+      }}
+      minBoundry={min}
+      maxBoundry={max}
+      lastValue={resolvedValue}
+      disabled={false}
+      step={1}
+      leftBottomLabel={t('slider.adjust-multiply.left-footer')}
+      leftLabel={t('slider.adjust-multiply.left-label')}
+      rightBottomLabel={t('slider.adjust-multiply.right-footer')}
+      rightLabel={t('system.loan-to-value')}
+    />
+  )
+}

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
@@ -1,7 +1,9 @@
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { AjnaFormContentRisk } from 'features/ajna/positions/common/sidebars/AjnaFormContentRisk'
+import { AjnaFormContentTransaction } from 'features/ajna/positions/common/sidebars/AjnaFormContentTransaction'
 import { AjnaFormView } from 'features/ajna/positions/common/views/AjnaFormView'
 import { AjnaMultiplyFormContentOpen } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentOpen'
+import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
 import React from 'react'
 
 export function AjnaMultiplyFormController() {
@@ -15,8 +17,7 @@ export function AjnaMultiplyFormController() {
       {currentStep === 'setup' && <AjnaMultiplyFormContentOpen />}
       {currentStep === 'manage' && <>Multiply Manage UI</>}
       {currentStep === 'transaction' && (
-        <>Transaction</>
-        // <AjnaFormContentTransaction orderInformation={AjnaBorrowFormOrder} />
+        <AjnaFormContentTransaction orderInformation={AjnaMultiplyFormOrder} />
       )}
     </AjnaFormView>
   )

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
@@ -1,0 +1,23 @@
+import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
+import { AjnaFormContentRisk } from 'features/ajna/positions/common/sidebars/AjnaFormContentRisk'
+import { AjnaFormView } from 'features/ajna/positions/common/views/AjnaFormView'
+import { AjnaMultiplyFormContentDeposit } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDeposit'
+import React from 'react'
+
+export function AjnaMultiplyFormController() {
+  const {
+    steps: { currentStep },
+  } = useAjnaGeneralContext()
+
+  return (
+    <AjnaFormView>
+      {currentStep === 'risk' && <AjnaFormContentRisk />}
+      {currentStep === 'setup' && <AjnaMultiplyFormContentDeposit />}
+      {currentStep === 'manage' && <>Multiply Manage UI</>}
+      {currentStep === 'transaction' && (
+        <>Transaction</>
+        // <AjnaFormContentTransaction orderInformation={AjnaBorrowFormOrder} />
+      )}
+    </AjnaFormView>
+  )
+}

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
@@ -1,7 +1,7 @@
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { AjnaFormContentRisk } from 'features/ajna/positions/common/sidebars/AjnaFormContentRisk'
 import { AjnaFormView } from 'features/ajna/positions/common/views/AjnaFormView'
-import { AjnaMultiplyFormContentDeposit } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDeposit'
+import { AjnaMultiplyFormContentOpen } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentOpen'
 import React from 'react'
 
 export function AjnaMultiplyFormController() {
@@ -12,7 +12,7 @@ export function AjnaMultiplyFormController() {
   return (
     <AjnaFormView>
       {currentStep === 'risk' && <AjnaFormContentRisk />}
-      {currentStep === 'setup' && <AjnaMultiplyFormContentDeposit />}
+      {currentStep === 'setup' && <AjnaMultiplyFormContentOpen />}
       {currentStep === 'manage' && <>Multiply Manage UI</>}
       {currentStep === 'transaction' && (
         <>Transaction</>

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
@@ -38,7 +38,7 @@ export function AjnaMultiplyOverviewController() {
   const totalExposure = new BigNumber(22461.32)
   const afterTotalExposure = new BigNumber(28436.37)
   const positionDebt = new BigNumber(5)
-  const afterPositionDebt = new BigNumber(6.13)
+  const afterPositionDebt = new BigNumber(124.13)
   const multiple = new BigNumber(1.5)
   const afterMultiple = new BigNumber(1.67)
   const buyingPower = new BigNumber(1255.12)

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyPositionController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyPositionController.tsx
@@ -3,6 +3,7 @@ import {
   AjnaPositionViewInfoPlaceholder,
 } from 'features/ajna/positions/common/components/AjnaPositionViewPlaceholders'
 import { AjnaPositionView } from 'features/ajna/positions/common/views/AjnaPositionView'
+import { AjnaMultiplyFormController } from 'features/ajna/positions/multiply/controls/AjnaMultiplyFormController'
 import { AjnaMultiplyOverviewController } from 'features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -14,6 +15,7 @@ export function AjnaMultiplyPositionController() {
         position: (
           <Grid variant="vaultContainer">
             <AjnaMultiplyOverviewController />
+            <AjnaMultiplyFormController />
           </Grid>
         ),
         info: <AjnaPositionViewInfoPlaceholder />,

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDeposit.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDeposit.tsx
@@ -1,0 +1,35 @@
+import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
+import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { AjnaFormContentSummary } from 'features/ajna/positions/common/sidebars/AjnaFormContentSummary'
+import { AjnaFormFieldDeposit } from 'features/ajna/positions/common/sidebars/AjnaFormFields'
+import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
+import React from 'react'
+
+export function AjnaMultiplyFormContentDeposit() {
+  const {
+    environment: { collateralBalance, collateralPrice, collateralToken },
+  } = useAjnaGeneralContext()
+  const {
+    form: {
+      dispatch,
+      state: { depositAmount },
+    },
+  } = useAjnaProductContext('multiply')
+
+  return (
+    <>
+      <AjnaFormFieldDeposit
+        dispatchAmount={dispatch}
+        maxAmount={collateralBalance}
+        resetOnClear
+        token={collateralToken}
+        tokenPrice={collateralPrice}
+      />
+      {depositAmount && (
+        <AjnaFormContentSummary>
+          <AjnaMultiplyFormOrder />
+        </AjnaFormContentSummary>
+      )}
+    </>
+  )
+}

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentOpen.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentOpen.tsx
@@ -2,10 +2,11 @@ import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/A
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaFormContentSummary } from 'features/ajna/positions/common/sidebars/AjnaFormContentSummary'
 import { AjnaFormFieldDeposit } from 'features/ajna/positions/common/sidebars/AjnaFormFields'
+import { AjnaMultiplySlider } from 'features/ajna/positions/multiply/components/AjnaMultiplySlider'
 import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
 import React from 'react'
 
-export function AjnaMultiplyFormContentDeposit() {
+export function AjnaMultiplyFormContentOpen() {
   const {
     environment: { collateralBalance, collateralPrice, collateralToken },
   } = useAjnaGeneralContext()
@@ -25,6 +26,7 @@ export function AjnaMultiplyFormContentDeposit() {
         token={collateralToken}
         tokenPrice={collateralPrice}
       />
+      <AjnaMultiplySlider />
       {depositAmount && (
         <AjnaFormContentSummary>
           <AjnaMultiplyFormOrder />

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentOpen.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentOpen.tsx
@@ -26,7 +26,7 @@ export function AjnaMultiplyFormContentOpen() {
         token={collateralToken}
         tokenPrice={collateralPrice}
       />
-      <AjnaMultiplySlider />
+      <AjnaMultiplySlider disabled={!depositAmount} />
       {depositAmount && (
         <AjnaFormContentSummary>
           <AjnaMultiplyFormOrder />

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -3,7 +3,11 @@ import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
-import { formatAmount, formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
+import {
+  formatAmount,
+  formatCryptoBalance,
+  formatDecimalAsPercent,
+} from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -1,23 +1,42 @@
 import BigNumber from 'bignumber.js'
+import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { formatAmount, formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken },
+    environment: { collateralToken, quoteToken },
+    tx: { isTxSuccess, txDetails },
   } = useAjnaGeneralContext()
   const {
     position: { isSimulationLoading },
   } = useAjnaProductContext('multiply')
 
+  const totalExposure = new BigNumber(22461.32)
+  const afterTotalExposure = new BigNumber(28436.37)
+  const multiple = new BigNumber(1.5)
+  const afterMultiple = new BigNumber(1.67)
+  const slippageLimit = new BigNumber(0.05)
+  const outstandingDebt = new BigNumber(124.13)
+  const loanToValue = new BigNumber(0.6265)
+  const afterLoanToValue = new BigNumber(0.7141)
+
   const isLoading = !cached && isSimulationLoading
   const formatted = {
-    totalExposure: `${new BigNumber(22461.32)} ${collateralToken}`,
-    afterTotalExposure: `${new BigNumber(28436.37)} ${collateralToken}`,
+    totalExposure: `${totalExposure} ${collateralToken}`,
+    afterTotalExposure: `${afterTotalExposure} ${collateralToken}`,
+    multiple: `${multiple.toFixed(2)}x`,
+    afterMultiple: afterMultiple && `${afterMultiple.toFixed(2)}x`,
+    slippageLimit: formatDecimalAsPercent(slippageLimit),
+    positionDebt: `${formatCryptoBalance(outstandingDebt)} ${quoteToken}`,
+    loanToValue: formatDecimalAsPercent(loanToValue),
+    afterLoanToValue: afterLoanToValue && formatDecimalAsPercent(afterLoanToValue),
+    totalCost: txDetails?.txCost ? `$${formatAmount(txDetails.txCost, 'USD')}` : '-',
   }
 
   return (
@@ -30,6 +49,39 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
           secondaryValue: formatted.afterTotalExposure,
           isLoading,
         },
+        {
+          label: t('system.multiple'),
+          value: formatted.multiple,
+          secondaryValue: formatted.afterMultiple,
+          isLoading,
+        },
+        {
+          label: t('vault-changes.slippage-limit'),
+          value: formatted.slippageLimit,
+          isLoading,
+        },
+        {
+          label: t('vault-changes.outstanding-debt'),
+          value: formatted.positionDebt,
+          isLoading,
+        },
+        {
+          label: t('vault-changes.ltv'),
+          value: formatted.loanToValue,
+          secondaryValue: formatted.afterLoanToValue,
+          isLoading,
+        },
+        isTxSuccess && cached
+          ? {
+              label: t('system.total-cost'),
+              value: formatted.totalCost,
+              isLoading,
+            }
+          : {
+              label: t('system.max-transaction-cost'),
+              value: <GasEstimation />,
+              isLoading,
+            },
       ]}
     />
   )

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -1,0 +1,36 @@
+import BigNumber from 'bignumber.js'
+import { InfoSection } from 'components/infoSection/InfoSection'
+import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
+import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) {
+  const { t } = useTranslation()
+  const {
+    environment: { collateralToken },
+  } = useAjnaGeneralContext()
+  const {
+    position: { isSimulationLoading },
+  } = useAjnaProductContext('multiply')
+
+  const isLoading = !cached && isSimulationLoading
+  const formatted = {
+    totalExposure: `${new BigNumber(22461.32)} ${collateralToken}`,
+    afterTotalExposure: `${new BigNumber(28436.37)} ${collateralToken}`,
+  }
+
+  return (
+    <InfoSection
+      title={t('vault-changes.order-information')}
+      items={[
+        {
+          label: t('system.total-exposure', { token: collateralToken }),
+          value: formatted.totalExposure,
+          secondaryValue: formatted.afterTotalExposure,
+          isLoading,
+        },
+      ]}
+    />
+  )
+}

--- a/features/ajna/positions/multiply/temp.ts
+++ b/features/ajna/positions/multiply/temp.ts
@@ -5,3 +5,9 @@ import BigNumber from 'bignumber.js'
 export interface AjnaMultiplyPosition extends AjnaPosition {
   multiply: BigNumber
 }
+
+export const ajnaMultiplySliderDefaults = {
+  initial: new BigNumber(1500),
+  min: new BigNumber(500),
+  max: new BigNumber(5000),
+}


### PR DESCRIPTION
# [Open Multiply position form](https://app.shortcut.com/oazo-apps/story/8661/open-multiply-position-form)

Opening part of Ajna Multiply form.

![image](https://user-images.githubusercontent.com/16230404/231797402-92735000-ecae-46f3-ac08-2f0ea4b35c40.png)
  
## Changes 👷‍♀️

- created opening form UI,
- created multiply slider,
- added additional state for primary button in form - "Set {{token}} allowance".
  
## How to test 🧪

Check form on `/ajna/multiply/WBTC-USDC`.

## TODO 📝

- All data is fake, just some random generated placeholders,
- "Total cost" in order information is intentionally inconsistent with designs. All three products has this designed in a different way - [after this PR is merged I will created separated one that standardize displaying cost across Borrow, Earn and Multiply](https://app.shortcut.com/oazo-apps/story/8742/standardize-displaying-transaction-cost-across-borrow-earn-and-multiply).