### PR TITLE
Flow Sidebar minor fix

### DIFF
--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -147,8 +147,8 @@ export function FlowSidebar({
           />
         )
       default:
-        return <>adsadsa</>
+        return <></>
     }
   }
-  return <>asdasdsaaaaaa</>
+  return <></>
 }

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -105,13 +105,13 @@ export function FlowSidebar({
 
   // wrapping up
   useEffect(() => {
-    if (isAllowanceReady && amount && token && availableProxies.length) {
+    if (isAllowanceReady && token && availableProxies.length) {
       callBackIfDefined<UseFlowStateCBType, UseFlowStateCBParamsType>(
         callbackParams,
         onEverythingReady,
       )
     }
-  }, [isAllowanceReady, availableProxies, amount?.toString()])
+  }, [isAllowanceReady, availableProxies])
 
   if (!isWalletConnected) {
     return <NoConnectionStateView noConnectionContent={noConnectionContent} />
@@ -147,8 +147,8 @@ export function FlowSidebar({
           />
         )
       default:
-        return <></>
+        return <>adsadsa</>
     }
   }
-  return <></>
+  return <>asdasdsaaaaaa</>
 }

--- a/components/FlowSidebar.tsx
+++ b/components/FlowSidebar.tsx
@@ -105,13 +105,13 @@ export function FlowSidebar({
 
   // wrapping up
   useEffect(() => {
-    if (isAllowanceReady && token && availableProxies.length) {
+    if (isAllowanceReady && amount && token && availableProxies.length) {
       callBackIfDefined<UseFlowStateCBType, UseFlowStateCBParamsType>(
         callbackParams,
         onEverythingReady,
       )
     }
-  }, [isAllowanceReady, availableProxies])
+  }, [isAllowanceReady, availableProxies, amount?.toString()])
 
   if (!isWalletConnected) {
     return <NoConnectionStateView noConnectionContent={noConnectionContent} />

--- a/features/ajna/positions/common/helpers/getFlowStateConfig.ts
+++ b/features/ajna/positions/common/helpers/getFlowStateConfig.ts
@@ -32,7 +32,7 @@ export function getFlowStateConfig({
         }
       }
       return {
-        amount: state.depositAmount,
+        amount: state.depositAmount || zero,
         token: quoteToken,
       }
     case 'withdraw-earn':


### PR DESCRIPTION
# Flows Sidebar minor fix

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue where user wasn't depositing / paybacking tokens but FlowSidebar was shown anyway with fallback return of `<></>`
  
## How to test 🧪
  <Please explain how to test your changes>

- on Ajna earn position go to `Manage Liquidity`, adjust lending price bucket without depositing anything and click confirm (order information should be shown instead of form disappearing)
