### PR TITLE
Update aws-staging.yaml

### DIFF
--- a/.github/workflows/aws-staging.yaml
+++ b/.github/workflows/aws-staging.yaml
@@ -67,7 +67,7 @@ jobs:
                      --build-arg MIXPANEL_KEY=${{ secrets.MIXPANEL_STAGING_KEY }} \
                      --build-arg ADROLL_ADV_ID=${{ secrets.ADROLL_ADV_ID_STAGING }} \
                      --build-arg ADROLL_PIX_ID=${{ secrets.ADROLL_PIX_ID_STAGING }} \
-                     --build-arg MAINNET_CACHE_URL=${{ secrets.MAINNET_CACHE_URL }} \
+                     --build-arg MAINNET_CACHE_URL=${{ secrets.MAINNET_CACHE_URL_STAGING }} \
                      --build-arg MAILCHIMP_ENDPOINT=${{ secrets.MAILCHIMP_ENDPOINT }} \
                      --build-arg MAILCHIMP_API_KEY=${{ secrets.MAILCHIMP_API_KEY }} \
                      --build-arg INFURA_PROJECT_ID=${{ secrets.INFURA_PROJECT_ID }} \


### PR DESCRIPTION
Revert changes in the cache endpoint. 
Mainnet cache on staging works fine, and we can use it.

