### PR TITLE
Liquidation overview notifications

### DIFF
--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -25,6 +25,7 @@ export function AjnaBorrowOverviewController() {
       isSimulationLoading,
       currentPosition: { position, simulation },
     },
+    notifications,
   } = useAjnaProductContext('borrow')
 
   const changeVariant = simulation
@@ -39,6 +40,7 @@ export function AjnaBorrowOverviewController() {
     <Grid gap={2}>
       <DetailsSection
         title={t('system.overview')}
+        notifications={notifications}
         content={
           <DetailsSectionContentCardWrapper>
             <ContentCardLiquidationPrice

--- a/features/ajna/positions/common/notifications.ts
+++ b/features/ajna/positions/common/notifications.ts
@@ -29,6 +29,10 @@ type EmptyPositionParams = {
   quoteToken: string
 }
 
+type TimeToLiquidationParams = {
+  time: string
+}
+
 type NotificationCallbackWithParams<P> = (
   params: P,
   action?: () => void,
@@ -38,6 +42,12 @@ const ajnaNotifications: {
   depositIsNotWithdrawable: NotificationCallbackWithParams<DepositIsNotWithdrawableParams>
   earningNoApy: NotificationCallbackWithParams<EarningNoApyParams>
   emptyPosition: NotificationCallbackWithParams<EmptyPositionParams>
+  timeToLiquidation: NotificationCallbackWithParams<TimeToLiquidationParams>
+  beingLiquidated: NotificationCallbackWithParams<null>
+  gotLiquidated: NotificationCallbackWithParams<null>
+  gotPartiallyLiquidated: NotificationCallbackWithParams<null>
+  lendingPriceFrozen: NotificationCallbackWithParams<null>
+  bucketLiquidated: NotificationCallbackWithParams<null>
 } = {
   depositIsNotWithdrawable: ({ action, message }) => ({
     title: {
@@ -85,6 +95,73 @@ const ajnaNotifications: {
     type: 'warning',
     closable: true,
   }),
+  timeToLiquidation: ({ time }) => ({
+    title: {
+      translationKey: 'ajna.position-page.common.notifications.time-to-liquidation.title',
+      params: { time },
+    },
+    message: {
+      translationKey: 'ajna.position-page.common.notifications.time-to-liquidation.message',
+    },
+    icon: 'coins_cross',
+    type: 'warning',
+    closable: true,
+  }),
+  beingLiquidated: () => ({
+    title: {
+      translationKey: 'ajna.position-page.common.notifications.being-liquidated.title',
+    },
+    message: {
+      translationKey: 'ajna.position-page.common.notifications.being-liquidated.message',
+    },
+    icon: 'coins_cross',
+    type: 'error',
+    closable: true,
+  }),
+  gotLiquidated: () => ({
+    title: {
+      translationKey: 'ajna.position-page.common.notifications.got-liquidated.title',
+    },
+    message: {
+      translationKey: 'ajna.position-page.common.notifications.got-liquidated.message',
+    },
+    icon: 'coins_cross',
+    type: 'error',
+    closable: true,
+  }),
+  gotPartiallyLiquidated: () => ({
+    title: {
+      translationKey: 'ajna.position-page.common.notifications.got-partially-liquidated.title',
+    },
+    message: {
+      translationKey: 'ajna.position-page.common.notifications.got-partially-liquidated.message',
+    },
+    icon: 'coins_cross',
+    type: 'error',
+    closable: true,
+  }),
+  lendingPriceFrozen: () => ({
+    title: {
+      translationKey: 'ajna.position-page.common.notifications.got-partially-liquidated.title',
+    },
+    message: {
+      translationKey: 'ajna.position-page.common.notifications.got-partially-liquidated.message',
+    },
+    icon: 'coins_cross',
+    type: 'error',
+    closable: true,
+  }),
+  bucketLiquidated: () => ({
+    title: {
+      translationKey: 'ajna.position-page.earn.manage.notifications.bucket-liquidated.title',
+    },
+    message: {
+      translationKey: 'ajna.position-page.earn.manage.notifications.bucket-liquidated.message',
+    },
+    icon: 'coins_cross',
+    type: 'error',
+    closable: true,
+  }),
 }
 
 export function getAjnaNotifications({
@@ -113,6 +190,11 @@ export function getAjnaNotifications({
   switch (product) {
     case 'multiply':
     case 'borrow':
+      // TODO adjust it when data source available
+      // notifications.push(ajnaNotifications.timeToLiquidation({ time: '4 days' }))
+      // notifications.push(ajnaNotifications.beingLiquidated(null))
+      // notifications.push(ajnaNotifications.gotLiquidated(null))
+      // notifications.push(ajnaNotifications.gotPartiallyLiquidated(null))
       break
     case 'earn': {
       const {
@@ -145,6 +227,10 @@ export function getAjnaNotifications({
       if (emptyPosition) {
         notifications.push(ajnaNotifications.emptyPosition({ quoteToken }))
       }
+
+      // TODO adjust it when data source available
+      // notifications.push(ajnaNotifications.lendingPriceFrozen(null))
+      // notifications.push(ajnaNotifications.bucketLiquidated(null))
 
       break
     }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2478,6 +2478,24 @@
             "success-open": "Your your {{collateralToken}}/{{quoteToken}} Ajna Position was created",
             "success-manage": "Your your {{collateralToken}}/{{quoteToken}} Ajna Position was updated"
           }
+        },
+        "notifications": {
+          "time-to-liquidation": {
+            "title": "{{time}} remaining to save position from liquidation",
+            "message": "Your position is at risk of liquidation, adjust it now to save it"
+          },
+          "being-liquidated": {
+            "title": "This position is currently being liquidated",
+            "message": "You can’t change your position right now, check back on your position later to see the status"
+          },
+          "got-liquidated": {
+            "title": "This position got liquidated. You have collateral to withdraw",
+            "message": "You have collateral you can withdraw"
+          },
+          "got-partially-liquidated": {
+            "title": "This position was partially liquidated. Some part of your collateral was sold to cover your debt",
+            "message": "Your debt was increased by 90 days before liquidation as a penalty. During the liquidation your position recollateralized and was removed from liquidation"
+          }
         }
       },
       "borrow": {
@@ -2556,6 +2574,14 @@
             "empty-position": {
               "title": "Your lending position is empty",
               "message": "To start earning you need to provide liquidity using your quote tokens"
+            },
+            "lending-price-frozen": {
+              "title": "This lending price is currently frozen and borrowers are being liquidated",
+              "message": "This process can take at least 6 hours. Check Position later for updates"
+            },
+            "bucket-liquidated": {
+              "title": "This bucket got liqudited. You have collateral to withdraw",
+              "message": "This process can take at least 6 hours. Check Position later for updates"
             }
           }
         }


### PR DESCRIPTION
# [Liquidation overview notifications](https://app.shortcut.com/oazo-apps/story/8797/ui-liquidation-notification-banners-borrow)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added handling for liquidation banners in scope of borrow and earn
  
## How to test 🧪
  <Please explain how to test your changes>

- it's just UI implementation, in order to show there in file `features/ajna/position/common/notification.ts` uncomment todos
