### PR TITLE
🧿 Standardize displaying transaction cost across Borrow, Earn and Multiply

### DIFF
--- a/components/GasEstimation.tsx
+++ b/components/GasEstimation.tsx
@@ -1,9 +1,14 @@
+import BigNumber from 'bignumber.js'
 import { useGasEstimationContext } from 'components/GasEstimationContextProvider'
 import { getEstimatedGasFeeText } from 'components/vault/VaultChangesInformation'
 import React from 'react'
 
-export function GasEstimation() {
+interface GasEstimationProps {
+  addition?: BigNumber
+}
+
+export function GasEstimation({ addition }: GasEstimationProps) {
   const gasEstimation = useGasEstimationContext()
 
-  return <>{getEstimatedGasFeeText(gasEstimation)}</>
+  return <>{getEstimatedGasFeeText(gasEstimation, addition)}</>
 }

--- a/components/vault/VaultChangesInformation.tsx
+++ b/components/vault/VaultChangesInformation.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Box, Flex, Text } from '@theme-ui/components'
+import BigNumber from 'bignumber.js'
 import { DimmedList } from 'components/DImmedList'
 import { GasEstimationContext } from 'components/GasEstimationContextProvider'
 import { InfoSectionLoadingState } from 'components/infoSection/Item'
@@ -8,6 +9,7 @@ import { GasEstimationStatus, HasGasEstimation } from 'helpers/form'
 import { formatAmount } from 'helpers/formatters/format'
 import { isTouchDevice } from 'helpers/isTouchDevice'
 import { WithChildren } from 'helpers/types'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode, useCallback, useMemo } from 'react'
 
@@ -145,7 +147,10 @@ export function getEstimatedGasFeeTextOld(
   }
 }
 
-export function getEstimatedGasFeeText(gasEstimation?: GasEstimationContext, withBrackets = false) {
+export function getEstimatedGasFeeText(
+  gasEstimation?: GasEstimationContext,
+  addition: BigNumber = zero,
+) {
   if (!gasEstimation) {
     return 'n/a'
   }
@@ -160,11 +165,9 @@ export function getEstimatedGasFeeText(gasEstimation?: GasEstimationContext, wit
       return <InfoSectionLoadingState />
     case GasEstimationStatus.error:
     case undefined:
-      return <EstimationError withBrackets={withBrackets} />
+      return <EstimationError withBrackets={false} />
     case GasEstimationStatus.calculated:
-      const textGas = `$${formatAmount(gasEstimation?.usdValue, 'USD')}`
-
-      return withBrackets ? `(${textGas})` : textGas
+      return `$${formatAmount(gasEstimation?.usdValue.plus(addition), 'USD')}`
   }
 }
 

--- a/features/ajna/positions/borrow/components/ContentFooterItemsBorrow.tsx
+++ b/features/ajna/positions/borrow/components/ContentFooterItemsBorrow.tsx
@@ -48,17 +48,6 @@ export function ContentFooterItemsBorrow({
         value={formatted.cost}
       />
       <DetailsSectionFooterItem
-        title={t('ajna.position-page.borrow.common.footer.available-to-borrow')}
-        value={formatted.availableToBorrow}
-        change={{
-          isLoading,
-          value:
-            afterAvailableToBorrow &&
-            `${formatted.afterAvailableToBorrow} ${t('system.cards.common.after')}`,
-          variant: changeVariant,
-        }}
-      />
-      <DetailsSectionFooterItem
         title={t('ajna.position-page.borrow.common.footer.available-to-withdraw')}
         value={formatted.availableToWithdraw}
         change={{
@@ -66,6 +55,17 @@ export function ContentFooterItemsBorrow({
           value:
             afterAvailableToWithdraw &&
             `${formatted.afterAvailableToWithdraw} ${t('system.cards.common.after')}`,
+          variant: changeVariant,
+        }}
+      />
+      <DetailsSectionFooterItem
+        title={t('ajna.position-page.borrow.common.footer.available-to-borrow')}
+        value={formatted.availableToBorrow}
+        change={{
+          isLoading,
+          value:
+            afterAvailableToBorrow &&
+            `${formatted.afterAvailableToBorrow} ${t('system.cards.common.after')}`,
           variant: changeVariant,
         }}
       />

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -47,13 +47,16 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
     afterDebt:
       simulationData?.debtAmount &&
       `${formatCryptoBalance(simulationData.debtAmount)} ${quoteToken}`,
-    availableToWithdraw: `${formatCryptoBalance(positionData.collateralAvailable)} ${collateralToken}`,
+    availableToWithdraw: `${formatCryptoBalance(
+      positionData.collateralAvailable,
+    )} ${collateralToken}`,
     afterAvailableToWithdraw:
       simulationData?.collateralAvailable &&
       `${formatCryptoBalance(simulationData.collateralAvailable)} ${collateralToken}`,
     availableToBorrow: `${formatCryptoBalance(positionData.debtAvailable)} ${quoteToken}`,
     afterAvailableToBorrow:
-      simulationData?.debtAvailable && `${formatCryptoBalance(simulationData.debtAvailable)} ${quoteToken}`,
+      simulationData?.debtAvailable &&
+      `${formatCryptoBalance(simulationData.debtAvailable)} ${quoteToken}`,
     totalCost: txDetails?.txCost ? `$${formatAmount(txDetails.txCost, 'USD')}` : '-',
   }
 

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -15,6 +15,7 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
   const { t } = useTranslation()
   const {
     environment: { collateralToken, quoteToken },
+    steps: { isFlowStateReady },
     tx: { isTxSuccess, txDetails },
   } = useAjnaGeneralContext()
   const {
@@ -90,17 +91,23 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
           change: `${formatted.afterAvailableToBorrow} ${quoteToken}`,
           isLoading,
         },
-        isTxSuccess && cached
-          ? {
-              label: t('system.total-cost'),
-              value: formatted.totalCost,
-              isLoading,
-            }
-          : {
-              label: t('system.max-transaction-cost'),
-              value: <GasEstimation />,
-              isLoading,
-            },
+        ...(isTxSuccess && cached
+          ? [
+              {
+                label: t('system.total-cost'),
+                value: formatted.totalCost,
+                isLoading,
+              },
+            ]
+          : isFlowStateReady
+          ? [
+              {
+                label: t('system.max-transaction-cost'),
+                value: <GasEstimation />,
+                isLoading,
+              },
+            ]
+          : []),
       ]}
     />
   )

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -30,24 +30,30 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
 
   const isLoading = !cached && isSimulationLoading
   const formatted = {
-    collateralLocked: formatCryptoBalance(positionData.collateralAmount),
-    debt: formatCryptoBalance(positionData.debtAmount),
+    collateralLocked: `${formatCryptoBalance(positionData.collateralAmount)} ${collateralToken}`,
+    afterCollateralLocked:
+      simulationData?.collateralAmount &&
+      `${formatCryptoBalance(simulationData.collateralAmount)} ${collateralToken}`,
     ltv: formatDecimalAsPercent(positionData.riskRatio.loanToValue),
-    liquidationPrice: formatCryptoBalance(positionData.liquidationPrice),
-    availableToBorrow: formatCryptoBalance(positionData.debtAvailable),
-    availableToWithdraw: formatCryptoBalance(positionData.collateralAvailable),
-    afterLiquidationPrice:
-      simulationData?.liquidationPrice && formatCryptoBalance(simulationData.liquidationPrice),
     afterLtv:
       simulationData?.riskRatio && formatDecimalAsPercent(simulationData.riskRatio.loanToValue),
-    afterDebt: simulationData?.debtAmount && formatCryptoBalance(simulationData.debtAmount),
-    afterCollateralLocked:
-      simulationData?.collateralAmount && formatCryptoBalance(simulationData.collateralAmount),
-    afterAvailableToBorrow:
-      simulationData?.debtAvailable && formatCryptoBalance(simulationData.debtAvailable),
+    liquidationPrice: `${formatCryptoBalance(
+      positionData.liquidationPrice,
+    )} ${quoteToken}/${collateralToken}`,
+    afterLiquidationPrice:
+      simulationData?.liquidationPrice &&
+      `${formatCryptoBalance(simulationData.liquidationPrice)} ${quoteToken}/${collateralToken}`,
+    debt: `${formatCryptoBalance(positionData.debtAmount)} ${quoteToken}`,
+    afterDebt:
+      simulationData?.debtAmount &&
+      `${formatCryptoBalance(simulationData.debtAmount)} ${quoteToken}`,
+    availableToWithdraw: `${formatCryptoBalance(positionData.collateralAvailable)} ${collateralToken}`,
     afterAvailableToWithdraw:
       simulationData?.collateralAvailable &&
-      formatCryptoBalance(simulationData.collateralAvailable),
+      `${formatCryptoBalance(simulationData.collateralAvailable)} ${collateralToken}`,
+    availableToBorrow: `${formatCryptoBalance(positionData.debtAvailable)} ${quoteToken}`,
+    afterAvailableToBorrow:
+      simulationData?.debtAvailable && `${formatCryptoBalance(simulationData.debtAvailable)} ${quoteToken}`,
     totalCost: txDetails?.txCost ? `$${formatAmount(txDetails.txCost, 'USD')}` : '-',
   }
 
@@ -57,8 +63,8 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
       items={[
         {
           label: t('system.collateral-locked'),
-          value: `${formatted.collateralLocked} ${collateralToken}`,
-          change: `${formatted.afterCollateralLocked} ${collateralToken}`,
+          value: formatted.collateralLocked,
+          change: formatted.afterCollateralLocked,
           isLoading,
         },
         {
@@ -69,26 +75,26 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
         },
         {
           label: t('system.liquidation-price'),
-          value: `${formatted.liquidationPrice} ${quoteToken}/${collateralToken}`,
-          change: `${formatted.afterLiquidationPrice} ${quoteToken}/${collateralToken}`,
+          value: formatted.liquidationPrice,
+          change: formatted.afterLiquidationPrice,
           isLoading,
         },
         {
           label: t('system.debt'),
-          value: `${formatted.debt} ${quoteToken}`,
-          change: `${formatted.afterDebt} ${quoteToken}`,
+          value: formatted.debt,
+          change: formatted.afterDebt,
           isLoading,
         },
         {
           label: t('system.available-to-withdraw'),
-          value: `${formatted.availableToWithdraw} ${collateralToken}`,
-          change: `${formatted.afterAvailableToWithdraw} ${collateralToken}`,
+          value: formatted.availableToWithdraw,
+          change: formatted.afterAvailableToWithdraw,
           isLoading,
         },
         {
           label: t('system.available-to-borrow'),
-          value: `${formatted.availableToBorrow} ${quoteToken}`,
-          change: `${formatted.afterAvailableToBorrow} ${quoteToken}`,
+          value: formatted.availableToBorrow,
+          change: formatted.afterAvailableToBorrow,
           isLoading,
         },
         ...(isTxSuccess && cached

--- a/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
@@ -42,15 +42,19 @@ interface AjnaGeneralContextProviderProps {
   gasPrice: GasPriceParams
 }
 
-type AjnaGeneralContextEnvironment = Omit<AjnaGeneralContextProviderProps, 'steps'>
+type AjnaGeneralContextEnvironment = Omit<AjnaGeneralContextProviderProps, 'steps'> & {
+  isOwner: boolean
+}
 
 interface AjnaGeneralContextSteps {
   currentStep: AjnaSidebarStep
   editingStep: AjnaSidebarEditingStep
   isExternalStep: boolean
+  isFlowStateReady: boolean
   isStepWithTransaction: boolean
   steps: AjnaSidebarStep[]
   txStatus?: TxStatus
+  setIsFlowStateReady: Dispatch<SetStateAction<boolean>>
   setStep: (step: AjnaSidebarStep) => void
   setNextStep: () => void
   setPrevStep: () => void
@@ -67,9 +71,7 @@ interface AjnaGeneralContextTx {
 }
 
 interface AjnaGeneralContext {
-  environment: AjnaGeneralContextEnvironment & {
-    isOwner: boolean
-  }
+  environment: AjnaGeneralContextEnvironment
   steps: AjnaGeneralContextSteps
   tx: AjnaGeneralContextTx
 }
@@ -93,6 +95,7 @@ export function AjnaGeneralContextProvider({
   const { flow, collateralBalance, quoteBalance, owner } = props
   const { walletAddress } = useAccount()
   const [currentStep, setCurrentStep] = useState<AjnaSidebarStep>(steps[0])
+  const [isFlowStateReady, setIsFlowStateReady] = useState<boolean>(false)
   const [txDetails, setTxDetails] = useState<TxDetails>()
 
   const shiftStep = (direction: 'next' | 'prev') => {
@@ -108,7 +111,9 @@ export function AjnaGeneralContextProvider({
       steps,
       editingStep: flow === 'open' ? 'setup' : 'manage',
       isExternalStep: isExternalStep({ currentStep }),
+      isFlowStateReady,
       isStepWithTransaction: isStepWithTransaction({ currentStep }),
+      setIsFlowStateReady,
       setStep: (step) => setCurrentStep(step),
       setNextStep: () => shiftStep('next'),
       setPrevStep: () => shiftStep('prev'),
@@ -141,7 +146,7 @@ export function AjnaGeneralContextProvider({
       steps: setupStepManager(),
       tx: setupTxManager(),
     }))
-  }, [collateralBalance, currentStep, quoteBalance, txDetails, walletAddress])
+  }, [collateralBalance, currentStep, isFlowStateReady, quoteBalance, txDetails, walletAddress])
 
   return <ajnaGeneralContext.Provider value={context}>{children}</ajnaGeneralContext.Provider>
 }

--- a/features/ajna/positions/common/views/AjnaFormView.tsx
+++ b/features/ajna/positions/common/views/AjnaFormView.tsx
@@ -40,6 +40,7 @@ export function AjnaFormView({
       editingStep,
       isExternalStep,
       isStepWithTransaction,
+      setIsFlowStateReady,
       setNextStep,
       setStep,
       steps,
@@ -157,6 +158,7 @@ export function AjnaFormView({
         : ethers.constants.AddressZero,
     })
   }, [flowState.availableProxies])
+  useEffect(() => setIsFlowStateReady(flowState.isEverythingReady), [flowState.isEverythingReady])
   useEffect(() => {
     if (!walletAddress && steps.indexOf(currentStep) > steps.indexOf(editingStep))
       setStep(editingStep)

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormOrder.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormOrder.tsx
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { useGasEstimationContext } from 'components/GasEstimationContextProvider'
 import { InfoSection } from 'components/infoSection/InfoSection'
@@ -41,19 +40,23 @@ export function AjnaEarnFormOrder({ cached = false }: { cached?: boolean }) {
 
   const isLoading = !cached && isSimulationLoading
   const formatted = {
-    amountToLend: formatCryptoBalance(positionData.quoteTokenAmount),
-    maxLtv: formatDecimalAsPercent(positionData.price.div(collateralPrice.div(quotePrice))),
+    amountToLend: `${formatCryptoBalance(positionData.quoteTokenAmount)} ${quoteToken}`,
+    afterAmountToLend:
+      simulationData?.quoteTokenAmount &&
+      `${formatCryptoBalance(simulationData.quoteTokenAmount)} ${quoteToken}`,
     netApy: apyCurrentPosition.per365d
       ? formatDecimalAsPercent(apyCurrentPosition.per365d)
       : formatDecimalAsPercent(zero),
-    lendingPrice: formatCryptoBalance(positionData.price),
-    afterAmountToLend:
-      simulationData?.quoteTokenAmount && formatCryptoBalance(simulationData.quoteTokenAmount),
     afterNetApy: apySimulation?.per365d && formatDecimalAsPercent(apySimulation.per365d),
+    lendingPrice: `${formatCryptoBalance(positionData.price)} ${collateralToken}/${quoteToken}`,
+    afterLendingPrice: `${
+      simulationData?.price && formatCryptoBalance(simulationData.price)
+    } ${collateralToken}/${quoteToken}`,
+    maxLtv: formatDecimalAsPercent(positionData.price.div(collateralPrice.div(quotePrice))),
     afterMaxLtv:
       simulationData?.price &&
       formatDecimalAsPercent(simulationData?.price.div(collateralPrice.div(quotePrice))),
-    afterLendingPrice: simulationData?.price && formatCryptoBalance(simulationData.price),
+    feeWhenActionBelowLup: `$${formatAmount(feeWhenActionBelowLup, 'USD')}`,
     totalCost: txDetails?.txCost
       ? `$${formatAmount(txDetails.txCost.plus(feeWhenActionBelowLup), 'USD')}`
       : '-',
@@ -68,8 +71,8 @@ export function AjnaEarnFormOrder({ cached = false }: { cached?: boolean }) {
       items={[
         {
           label: t('amount-to-lend'),
-          value: `${formatted.amountToLend} ${quoteToken}`,
-          change: `${formatted.afterAmountToLend} ${quoteToken}`,
+          value: formatted.amountToLend,
+          change: formatted.afterAmountToLend,
           isLoading,
         },
         {
@@ -80,8 +83,8 @@ export function AjnaEarnFormOrder({ cached = false }: { cached?: boolean }) {
         },
         {
           label: t('lending-price'),
-          value: `${formatted.lendingPrice} ${collateralToken}/${quoteToken}`,
-          change: `${formatted.afterLendingPrice} ${collateralToken}/${quoteToken}`,
+          value: formatted.lendingPrice,
+          change: formatted.afterLendingPrice,
           isLoading,
         },
         {
@@ -102,12 +105,12 @@ export function AjnaEarnFormOrder({ cached = false }: { cached?: boolean }) {
           ? [
               {
                 label: t('system.max-transaction-cost'),
-                value: <GasEstimation addition={new BigNumber(feeWhenActionBelowLup)} />,
+                value: <GasEstimation addition={feeWhenActionBelowLup} />,
                 dropdownValues: withAjnaFee
                   ? [
                       {
                         label: t('ajna.position-page.earn.common.form.ajna-fee'),
-                        value: `$${formatAmount(feeWhenActionBelowLup, 'USD')}`,
+                        value: formatted.feeWhenActionBelowLup,
                       },
                       {
                         label: t('max-gas-fee'),

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormOrder.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormOrder.tsx
@@ -1,5 +1,4 @@
 import { GasEstimation } from 'components/GasEstimation'
-import { useGasEstimationContext } from 'components/GasEstimationContextProvider'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
@@ -16,7 +15,6 @@ import React from 'react'
 export function AjnaEarnFormOrder({ cached = false }: { cached?: boolean }) {
   const { t } = useTranslation()
 
-  const gasEstimation = useGasEstimationContext()
   const {
     environment: { collateralToken, quoteToken, collateralPrice, quotePrice },
     steps: { isFlowStateReady },
@@ -61,9 +59,6 @@ export function AjnaEarnFormOrder({ cached = false }: { cached?: boolean }) {
       ? `$${formatAmount(txDetails.txCost.plus(feeWhenActionBelowLup), 'USD')}`
       : '-',
   }
-
-  console.log(`gasEstimation: ${gasEstimation?.usdValue}`)
-  console.log(gasEstimation)
 
   return (
     <InfoSection

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -163,7 +163,7 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
           ? [
               {
                 label: t('system.max-transaction-cost'),
-                value: <GasEstimation addition={new BigNumber(oasisFee)} />,
+                value: <GasEstimation addition={oasisFee} />,
                 dropdownValues: oasisFee
                   ? [
                       {


### PR DESCRIPTION
# [Standardize displaying transaction cost across Borrow, Earn and Multiply](https://app.shortcut.com/oazo-apps/story/8742/standardize-displaying-transaction-cost-across-borrow-earn-and-multiply)

All three products had total transaction cost designed in a different way, this PR standardizes this and some other minor things.
  
## Changes 👷‍♀️

- Standardized total cost in order information - according to newest design cost should be summed up, not displayed separately. It's already displayed separately in the dropdown.
- Added `addition` prop to gas estimation for that purpose and removed `withBrackets` as it's not used anywhere.
- Hid transaction cost until DPM and allowance flow is finished as it always fail anyway until it's that,
- Swapped available to borrow and withdraw in Borrow overview section per Luciano's request (https://www.figma.com/file/XAUn9bc0mlzIS63d9yDUUF/Ajna-x-Oasis?node-id=2071-89109&t=0VlSNEJrrx0SMmow-0#417223614).
- Fixed formatting in Borrow and Earn order information - units should be a part of `formatted` config.
  
## How to test 🧪

See order information of all three Ajna products.