### PR TITLE
update tooltip + remove guni from homepage

### DIFF
--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -285,7 +285,7 @@ export const productCardsConfig: {
       ],
       multiply: ['ETH-B', 'WBTC-B', 'WSTETH-A'],
       // TODO prepare proper handling for DSR
-      earn: ['DSR', 'GUNIV3DAIUSDC2-A'],
+      earn: ['DSR'],
     },
     featuredAaveCards: {
       borrow: getAaveEnabledStrategies([

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -763,7 +763,7 @@
     "liquidation-threshold": "Liq Threshold: {{percentage}}",
     "has-asset-already": "There is an active Aave position open in this address. Therefore, you cannot open a stETH earn position. Close your Aave position first to continue.",
     "net-value-modal": "Net Value",
-    "net-value-calculation": "The current net value is calculated based on the oracle price of {{oraclePrice}} {{collateralSymbol}}/{{debtSymbol}}.",
+    "net-value-calculation": "The current net value is calculated based on the oracle price of {{oraclePrice}} {{collateralSymbol}}/{{debtSymbol}}. This net value doesn't include the cost of the closing fee or the difference that might happen due to slippage or price changes once you close your position. Net value of position if closed will likely be lower.",
     "after-ltv-ratio-below-stop-loss-ltv": "You cannot make adjustments to your position which take it below your Stop-Loss Loan to Value"
   },
   "aave-position-modal": {


### PR DESCRIPTION
Based on small feature requests on discord
  
## Changes 👷‍♀️
- updated the net value tooltip for aave earn positions
- Removed guni from the landingpage
  
## How to test 🧪
- checkout the tooltip for aave v2/3 positions -> should be the new one
- Checkout the homepage -> should have guni removed.