### PR TITLE
Newsletter input max length

### DIFF
--- a/features/newsletter/NewsletterView.tsx
+++ b/features/newsletter/NewsletterView.tsx
@@ -130,6 +130,7 @@ function NewsletterForm({ small }: { small?: boolean }) {
             lineHeight: 1.2,
           }}
           value={email}
+          maxLength={320}
           onChange={(e) => {
             change({ kind: 'email', email: e.target.value })
           }}


### PR DESCRIPTION
# [Newsletter input max length](https://app.shortcut.com/oazo-apps/story/8412/add-checking-the-email-length-on-the-newsletter-endpoint)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- limit newsletter input length to 320 characters
  
## How to test 🧪
  <Please explain how to test your changes>

- try to input more to newsletter input field
