### PR TITLE
TECH-1524 - Upgrading Node.js 12 (End-of-Life) Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/aws-prod-rollback.yaml
+++ b/.github/workflows/aws-prod-rollback.yaml
@@ -33,7 +33,7 @@ jobs:
           VALID_HASH=$(env -i git log --max-count=10 --no-walk --tags --pretty='%h' --decorate=full | grep ${{ github.event.inputs.commit_hash }})
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.OAZO_PROD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.OAZO_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws-prod.yaml
+++ b/.github/workflows/aws-prod.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.OAZO_PROD_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.OAZO_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws-staging-rollback.yaml
+++ b/.github/workflows/aws-staging-rollback.yaml
@@ -33,7 +33,7 @@ jobs:
           VALID_HASH=$(env -i git log --max-count=10 --no-walk --tags --pretty='%h' --decorate=full | grep ${{ github.event.inputs.commit_hash }})
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws-staging.yaml
+++ b/.github/workflows/aws-staging.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -31,7 +31,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,5 @@ jobs:
         run: CI=true yarn test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
TECH-1524 - Node.js 12 Github Actions are deprecated as Node.js 12 reached End-of-Life on April 2022. This PR upgrades them to Node.js 16. This PR extends previous ticket - TECH-1124