### PR TITLE
Temporary disable codecov reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Test
         run: CI=true yarn test
+
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,3 @@ jobs:
 
       - name: Test
         run: CI=true yarn test
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-


### PR DESCRIPTION
# Temporary disable codecov reports

It's not useful until migration from Mocha to Jest is completed.
  
## Changes 👷‍♀️

- Commented out Codecov action.
  
## How to test 🧪

🤷‍♂️
