### PR TITLE
🧿 Ajna Borrow order information liq price tokens order

### DIFF
--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -39,10 +39,10 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
       simulationData?.riskRatio && formatDecimalAsPercent(simulationData.riskRatio.loanToValue),
     liquidationPrice: `${formatCryptoBalance(
       positionData.liquidationPrice,
-    )} ${quoteToken}/${collateralToken}`,
+    )} ${collateralToken}/${quoteToken}`,
     afterLiquidationPrice:
       simulationData?.liquidationPrice &&
-      `${formatCryptoBalance(simulationData.liquidationPrice)} ${quoteToken}/${collateralToken}`,
+      `${formatCryptoBalance(simulationData.liquidationPrice)} ${collateralToken}/${quoteToken}`,
     debt: `${formatCryptoBalance(positionData.debtAmount)} ${quoteToken}`,
     afterDebt:
       simulationData?.debtAmount &&


### PR DESCRIPTION
# [Ajna Borrow order information liq price tokens order](https://app.shortcut.com/oazo-apps/story/8956/borrow-order-summary-liq-price-change?ct_workflow=all&cf_workflow=500000053)

Bugfix.
  
## Changes 👷‍♀️

- Reversed collateral token and quote token in liquidation price value.
  
## How to test 🧪

Self explanatory.
