### PR TITLE
Fix RPC Provider for Ajna

### DIFF
--- a/features/ajna/positions/common/hooks/useAjnaTxHandler.ts
+++ b/features/ajna/positions/common/hooks/useAjnaTxHandler.ts
@@ -3,6 +3,7 @@ import { TxStatus } from '@oasisdex/transactions'
 import { AjnaTxData, getAjnaParameters } from 'actions/ajna'
 import { callOasisActionsWithDpmProxy } from 'blockchain/calls/oasisActions'
 import { TxMetaKind } from 'blockchain/calls/txMeta'
+import { networksById } from 'blockchain/networksConfig'
 import { cancelable, CancelablePromise } from 'cancelable-promise'
 import { useAppContext } from 'components/AppContextProvider'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
@@ -55,7 +56,7 @@ export function useAjnaTxHandler(): () => void {
     } else {
       setIsLoadingSimulation(true)
     }
-  }, [context?.rpcProvider, dpmAddress, state])
+  }, [context?.chainId, dpmAddress, state])
 
   useDebouncedEffect(
     () => {
@@ -68,7 +69,7 @@ export function useAjnaTxHandler(): () => void {
             position,
             quotePrice,
             quoteToken,
-            rpcProvider: context.rpcProvider,
+            rpcProvider: networksById[context.chainId].readProvider,
             state,
             isFormValid,
           }),
@@ -98,7 +99,7 @@ export function useAjnaTxHandler(): () => void {
           })
       }
     },
-    [context?.rpcProvider, dpmAddress, state, isExternalStep],
+    [context?.chainId, dpmAddress, state, isExternalStep],
     250,
   )
 

--- a/features/ajna/positions/common/observables/getAjnaPosition.ts
+++ b/features/ajna/positions/common/observables/getAjnaPosition.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { Context } from 'blockchain/network'
 import { NetworkIds } from 'blockchain/networkIds'
+import { networksById } from 'blockchain/networksConfig'
 import { Tickers } from 'blockchain/prices'
 import { UserDpmAccount } from 'blockchain/userDpmProxies'
 import { ethers } from 'ethers'
@@ -49,7 +50,7 @@ export function getAjnaPosition$(
       const commonDependency = {
         poolInfoAddress: ajnaPoolInfo.address,
         rewardsManagerAddress: ajnaRewardsManager.address,
-        provider: context.rpcProvider,
+        provider: networksById[context.chainId].readProvider,
         getPoolData: getAjnaPoolData,
       }
 


### PR DESCRIPTION
# Fix RPC Provider for Ajna

Bugfix.
  
## Changes 👷‍♀️

- Replaced `context.rpcProvider` with `networksById[context.chainId].readProvider`.
  
## How to test 🧪

See if Ajna positions are loading and simulations is working.