### PR TITLE
🧿 Allow to set price above MOMP in Ajna Earn position

### DIFF
--- a/components/dumb/SliderValuePicker.tsx
+++ b/components/dumb/SliderValuePicker.tsx
@@ -15,7 +15,6 @@ export interface SliderValuePickerProps {
   maxBoundry: BigNumber
   lastValue: BigNumber
   disabled: boolean
-  disabledVisually?: boolean
   leftBoundryStyling?: SxStyleProp
   rightBoundryStyling?: SxStyleProp
   step: number
@@ -44,7 +43,8 @@ export function SliderValuePicker(props: SliderValuePickerProps) {
     <Grid
       gap={2}
       sx={{
-        opacity: props.disabledVisually && props.disabled ? 0.6 : 1,
+        opacity: props.disabled ? 0.5 : 1,
+        transition: '200ms opacity',
       }}
     >
       <Flex
@@ -74,6 +74,9 @@ export function SliderValuePicker(props: SliderValuePickerProps) {
           sx={{
             background: props.colorfulRanges || background,
             direction: props.direction || 'ltr',
+            '&:disabled': {
+              opacity: 1,
+            },
           }}
           disabled={props.disabled}
           step={props.step}

--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -168,7 +168,6 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
           maxBoundry={maxRisk}
           lastValue={sliderValue || zero}
           disabled={viewLocked || !maxRisk}
-          disabledVisually={viewLocked || !maxRisk}
           step={0.001}
           sliderPercentageFill={
             maxRisk && sliderValue

--- a/features/ajna/positions/common/notifications.tsx
+++ b/features/ajna/positions/common/notifications.tsx
@@ -46,7 +46,7 @@ const AjnaLiquidationNotificationWithLink: FC<AjnaLiquidationNotificationWithLin
   />
 )
 
-type DepositIsNotWithdrawableParams = {
+type PriceAboveMompParams = {
   message: { collateralToken: string; quoteToken: string }
   action: () => void
 }
@@ -70,7 +70,7 @@ type LendingPriceFrozenParams = {
 type NotificationCallbackWithParams<P> = (params: P) => DetailsSectionNotificationItem
 
 const ajnaNotifications: {
-  depositIsNotWithdrawable: NotificationCallbackWithParams<DepositIsNotWithdrawableParams>
+  priceAboveMomp: NotificationCallbackWithParams<PriceAboveMompParams>
   earningNoApy: NotificationCallbackWithParams<EarningNoApyParams>
   emptyPosition: NotificationCallbackWithParams<EmptyPositionParams>
   timeToLiquidation: NotificationCallbackWithParams<TimeToLiquidationParams>
@@ -80,7 +80,7 @@ const ajnaNotifications: {
   lendingPriceFrozen: NotificationCallbackWithParams<LendingPriceFrozenParams>
   collateralToWithdraw: NotificationCallbackWithParams<null>
 } = {
-  depositIsNotWithdrawable: ({ action, message }) => ({
+  priceAboveMomp: ({ action, message }) => ({
     title: {
       translationKey:
         'ajna.position-page.earn.manage.notifications.deposit-is-not-withdrawable.title',
@@ -265,7 +265,7 @@ export function getAjnaNotifications({
         quoteTokenAmount,
       } = position as AjnaEarnPosition
       const earningNoApy = price.lt(highestThresholdPrice) && price.gt(zero)
-      const depositIsNotWithdrawable = price.gt(mostOptimisticMatchingPrice)
+      const priceAboveMomp = price.gt(mostOptimisticMatchingPrice)
       const emptyPosition = quoteTokenAmount.isZero()
       const earnPositionAuction = positionAuction as AjnaEarnPositionAuction
 
@@ -275,9 +275,9 @@ export function getAjnaNotifications({
         updateState('uiPill', 'deposit-earn')
       }
 
-      if (depositIsNotWithdrawable) {
+      if (priceAboveMomp) {
         notifications.push(
-          ajnaNotifications.depositIsNotWithdrawable({
+          ajnaNotifications.priceAboveMomp({
             message: { collateralToken, quoteToken },
             action: moveToAdjust,
           }),

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -92,7 +92,7 @@ function convertSliderThresholds({
   }
 }
 
-export function AjnaEarnSlider() {
+export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
   const { t } = useTranslation()
   const {
     environment: { collateralToken, quoteToken },
@@ -158,7 +158,7 @@ export function AjnaEarnSlider() {
       rightBoundryFormatter={(v) =>
         !v.isZero() ? `${t('max-ltv')} ${formatDecimalAsPercent(v)}` : '-'
       }
-      disabled={isFormFrozen}
+      disabled={isDisabled || isFormFrozen}
       onChange={handleChange}
       leftLabel={t('ajna.position-page.earn.common.form.max-lending-price', {
         quoteToken,

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormContentOpen.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormContentOpen.tsx
@@ -11,7 +11,10 @@ export function AjnaEarnFormContentOpen() {
     environment: { quotePrice, quoteToken },
   } = useAjnaGeneralContext()
   const {
-    form: { dispatch },
+    form: {
+      dispatch,
+      state: { depositAmount },
+    },
     validation: { isFormValid },
   } = useAjnaProductContext('earn')
 
@@ -23,7 +26,7 @@ export function AjnaEarnFormContentOpen() {
         tokenPrice={quotePrice}
         resetOnClear
       />
-      <AjnaEarnSlider />
+      <AjnaEarnSlider isDisabled={!depositAmount || depositAmount?.lte(0)} />
       {isFormValid && (
         <AjnaFormContentSummary>
           <AjnaEarnFormOrder />

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.8",
     "@oasisdex/automation": "1.4.0",
-    "@oasisdex/dma-library": "0.3.6",
+    "@oasisdex/dma-library": "0.3.9",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/oasis-actions": "0.2.16",
     "@oasisdex/transactions": "0.1.4-alpha.0",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2581,12 +2581,12 @@
           },
           "notifications": {
             "deposit-is-not-withdrawable": {
-              "title": "Warning your selected price is too close to market price",
+              "title": "Your selected price is too close to market price",
               "message": "In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}",
               "label": "Adjust lending price"
             },
             "earning-no-apy": {
-              "title": "Warning your position is not earning any yield",
+              "title": "Your position is not earning any yield",
               "message": "Your lending position is below the minimum yield bearing price",
               "label": "Adjust lending price"
             },
@@ -2630,7 +2630,7 @@
       "borrow-undercollateralized": "You cannot generate more than {{amount}} {{quoteToken}}, as this would take your position below the minimum LTV. Please enter a lower amount.",
       "earning-no-apy": "You will be lending without earning any yield.",
       "price-below-htp": "You will be lending without earning any yield.",
-      "price-above-momp": "Warning your selected price is too close to market price. In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}. You are selecting a riskier level for lending.",
+      "price-above-momp": "Your selected price is too close to market price. In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}. You are selecting a riskier level for lending.",
       "withdraw-more-than-available": "You cannot withdraw more than {{amount}} {{token}}, please select a lower amount.",
       "after-lup-index-bigger-than-htp-index": "You cannot withdraw this amount, please try to withdraw less.",
       "debt-less-then-dust-limit": "Minimum debt amount you can draw is {{minDebtAmount}}, as this is the dust limit of the pool. Please enter an amount at least equal to dust limit.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,10 +3820,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.6.tgz#868114f17035083e5628f80c279ca4a53eca7285"
-  integrity sha512-IUEdsyhKoedgvRwdH4/36qj1a9tO7HvF9SW2buqMSxXaBy4RUDTrebiEYuh8tnTvGN/cFyAbNbqNa5S24SsJcA==
+"@oasisdex/dma-library@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.9.tgz#25d787c65730b0f625f6ddab1293fc9e97f9d2aa"
+  integrity sha512-2SLrm6yHRf03Vl+GFMrCs++zHAibQO8G82uvv0PoHTYJcG+6qdpAjLJP69ZUe0Tqq4kTQeUkzUIu1umyM13lrA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Allow to set price above MOMP in Ajna Earn position](https://app.shortcut.com/oazo-apps/story/9141/earn-can-t-deposit-above-momp)

Bugfix.
  
## Changes 👷‍♀️

- Validation of price above MOMP is now warning, not error,
- fixed visually disabling slider component,
- bonus: slider is disabled until user input something in deposit field.
  
## How to test 🧪

Self explanatory.
