### PR TITLE
🧿 Ajna homepage typo

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -457,7 +457,7 @@
       },
       "ajna": {
         "headline": "Borrow and lend your crypto on Ajna",
-        "subheader": "Anja is a new money markets DeFi protocol. Benefiting from more comeptitive, market-driven parameters. <0>Learn more about Ajna on Oasis.app →</0>"
+        "subheader": "Anja is a new money markets DeFi protocol. Benefiting from more competitive, market-driven parameters. <0>Learn more about Ajna on Oasis.app →</0>"
       }
     },
     "stats": {
@@ -972,11 +972,11 @@
     },
     "ajna": {
       "title": "Oasis.app × Ajna",
-      "description": "Ajna is a new money markets DeFi protocol. Benefiting from more comeptitive, market-driven parameters."
+      "description": "Ajna is a new money markets DeFi protocol. Benefiting from more competitive, market-driven parameters."
     },
     "ajnaProductPage": {
       "title": "{{product}} - Oasis.app × Ajna",
-      "description": "Ajna is a new money markets DeFi protocol. Benefiting from more comeptitive, market-driven parameters."
+      "description": "Ajna is a new money markets DeFi protocol. Benefiting from more competitive, market-driven parameters."
     },
     "multiply": {
       "title": "Multiply - Oasis.app",


### PR DESCRIPTION
# [Ajna homepage typo](https://app.shortcut.com/oazo-apps/story/9086/on-the-ajna-homepage-there-is-a-typo-comeptitive-is-meant-to-be-spelled-competitive)

Bugfix.
  
## Changes 👷‍♀️

- Fixed typo "comeptitive" on homepage and seo tags.
  
## How to test 🧪

Selfexplanatory.
