### PR TITLE
Bump dma-library version 0.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.12",
     "@oasisdex/automation": "1.4.0",
-    "@oasisdex/dma-library": "0.3.9",
+    "@oasisdex/dma-library": "0.3.10",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/oasis-actions": "0.2.16",
     "@oasisdex/transactions": "0.1.4-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,10 +3820,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.9.tgz#25d787c65730b0f625f6ddab1293fc9e97f9d2aa"
-  integrity sha512-2SLrm6yHRf03Vl+GFMrCs++zHAibQO8G82uvv0PoHTYJcG+6qdpAjLJP69ZUe0Tqq4kTQeUkzUIu1umyM13lrA==
+"@oasisdex/dma-library@0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.10.tgz#de8d2e4a8d86ad3cce309c46bb6f5018de5cb4a7"
+  integrity sha512-XPjKKlGkoFD9kBI8M8DR/PtN2BJUyQ+4gxjjSF4k1+yIJGp9BMbsf0E8fK+rixzkAkGvHkD9p1c3JH/N8Ff/Dg==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Bump dma-library version 0.3.10](https://app.shortcut.com/oazo-apps/story/9144/earn-order-summary-net-apy-is-incorrect)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated dma-library version which contain fix for net apy calculations when user deposits below htp
  
## How to test 🧪
  <Please explain how to test your changes>

- when user tries to deposit quote tokens below htp, net apy should be 0
