### PR TITLE
🧿 Modals for Ajna Borrow

### DIFF
--- a/components/DetailsSectionContentSimpleModal.tsx
+++ b/components/DetailsSectionContentSimpleModal.tsx
@@ -1,0 +1,34 @@
+import React, { PropsWithChildren } from 'react'
+import { Card, Grid, Heading, Text } from 'theme-ui'
+
+export interface DetailsSectionContentSimpleModalProps {
+  description?: string
+  title: string
+  value?: string
+}
+
+export function DetailsSectionContentSimpleModal({
+  children,
+  description,
+  title,
+  value,
+}: PropsWithChildren<DetailsSectionContentSimpleModalProps>) {
+  return (
+    <Grid gap={2}>
+      <Heading variant="header5" sx={{ fontWeight: 'bold' }}>
+        {title}
+      </Heading>
+      {description && (
+        <Text variant="paragraph3" as="p" sx={{ color: 'neutral80' }}>
+          {description}
+        </Text>
+      )}
+      <>{children}</>
+      {value && (
+        <Card variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
+          {value}
+        </Card>
+      )}
+    </Grid>
+  )
+}

--- a/components/DetailsSectionContentSimpleModal.tsx
+++ b/components/DetailsSectionContentSimpleModal.tsx
@@ -1,34 +1,32 @@
-import React, { PropsWithChildren } from 'react'
+import React, { FC } from 'react'
 import { Card, Grid, Heading, Text } from 'theme-ui'
 
 export interface DetailsSectionContentSimpleModalProps {
-  description?: string
   title: string
+  description?: string
   value?: string
 }
 
-export function DetailsSectionContentSimpleModal({
+export const DetailsSectionContentSimpleModal: FC<DetailsSectionContentSimpleModalProps> = ({
+  title,
   children,
   description,
-  title,
   value,
-}: PropsWithChildren<DetailsSectionContentSimpleModalProps>) {
-  return (
-    <Grid gap={2}>
-      <Heading variant="header5" sx={{ fontWeight: 'bold' }}>
-        {title}
-      </Heading>
-      {description && (
-        <Text variant="paragraph3" as="p" sx={{ color: 'neutral80' }}>
-          {description}
-        </Text>
-      )}
-      <>{children}</>
-      {value && (
-        <Card variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
-          {value}
-        </Card>
-      )}
-    </Grid>
-  )
-}
+}) => (
+  <Grid gap={2}>
+    <Heading variant="header5" sx={{ fontWeight: 'bold' }}>
+      {title}
+    </Heading>
+    {description && (
+      <Text variant="paragraph3" as="p" sx={{ color: 'neutral80' }}>
+        {description}
+      </Text>
+    )}
+    <>{children}</>
+    {value && (
+      <Card variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
+        {value}
+      </Card>
+    )}
+  </Grid>
+)

--- a/features/ajna/common/components/AjnaDetailsSectionContentSimpleModal.tsx
+++ b/features/ajna/common/components/AjnaDetailsSectionContentSimpleModal.tsx
@@ -1,0 +1,15 @@
+import {
+  DetailsSectionContentSimpleModal,
+  DetailsSectionContentSimpleModalProps,
+} from 'components/DetailsSectionContentSimpleModal'
+import React, { PropsWithChildren } from 'react'
+import { ajnaExtensionTheme } from 'theme'
+import { ThemeProvider } from 'theme-ui'
+
+export const AjnaDetailsSectionContentSimpleModal = (
+  props: PropsWithChildren<DetailsSectionContentSimpleModalProps>,
+) => (
+  <ThemeProvider theme={ajnaExtensionTheme}>
+    <DetailsSectionContentSimpleModal {...props} />
+  </ThemeProvider>
+)

--- a/features/ajna/common/components/AjnaDetailsSectionContentSimpleModal.tsx
+++ b/features/ajna/common/components/AjnaDetailsSectionContentSimpleModal.tsx
@@ -2,12 +2,12 @@ import {
   DetailsSectionContentSimpleModal,
   DetailsSectionContentSimpleModalProps,
 } from 'components/DetailsSectionContentSimpleModal'
-import React, { PropsWithChildren } from 'react'
+import React, { FC } from 'react'
 import { ajnaExtensionTheme } from 'theme'
 import { ThemeProvider } from 'theme-ui'
 
-export const AjnaDetailsSectionContentSimpleModal = (
-  props: PropsWithChildren<DetailsSectionContentSimpleModalProps>,
+export const AjnaDetailsSectionContentSimpleModal: FC<DetailsSectionContentSimpleModalProps> = (
+  props,
 ) => (
   <ThemeProvider theme={ajnaExtensionTheme}>
     <DetailsSectionContentSimpleModal {...props} />

--- a/features/ajna/positions/common/components/contentCards/ContentCardCollateralLocked.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardCollateralLocked.tsx
@@ -4,6 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -45,6 +46,13 @@ export function ContentCardCollateralLocked({
         `${formatted.afterCollateralLocked} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     },
+    modal: (
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.borrow.common.overview.collateral-locked')}
+        description={t('ajna.position-page.borrow.common.overview.collateral-locked-modal-desc')}
+        value={`${formatted.collateralLocked} ${collateralToken}`}
+      />
+    ),
   }
 
   if (!collateralLocked.isZero()) {

--- a/features/ajna/positions/common/components/contentCards/ContentCardCurrentEarnings.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardCurrentEarnings.tsx
@@ -4,36 +4,10 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Card, Grid, Heading, Text } from 'theme-ui'
-
-interface ContentCardCurrentEarningsModalProps {
-  earnings: string
-  quoteToken: string
-}
-
-function ContentCardCurrentEarningsModal({
-  earnings,
-  quoteToken,
-}: ContentCardCurrentEarningsModalProps) {
-  const { t } = useTranslation()
-
-  return (
-    <Grid gap={2}>
-      <Heading variant="header3">
-        {t('ajna.position-page.earn.manage.overview.current-earnings')}
-      </Heading>
-      <Text variant="paragraph2" as="p" sx={{ pb: 2 }}>
-        {t('ajna.position-page.earn.manage.overview.current-earnings-modal-desc', { quoteToken })}
-      </Text>
-      <Card variant="vaultDetailsCardModal" sx={{ my: 2 }}>
-        {earnings} {quoteToken}
-      </Card>
-    </Grid>
-  )
-}
 
 interface ContentCardCurrentEarningsProps {
   isLoading?: boolean
@@ -73,9 +47,12 @@ export function ContentCardCurrentEarnings({
       variant: changeVariant,
     },
     modal: (
-      <ContentCardCurrentEarningsModal
-        earnings={formatted.currentEarnings}
-        quoteToken={quoteToken}
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.earn.manage.overview.current-earnings')}
+        description={t('ajna.position-page.earn.manage.overview.current-earnings-modal-desc', {
+          quoteToken,
+        })}
+        value={`${formatted.currentEarnings} ${quoteToken}`}
       />
     ),
   }

--- a/features/ajna/positions/common/components/contentCards/ContentCardLiquidationPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardLiquidationPrice.tsx
@@ -4,6 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -48,6 +49,13 @@ export function ContentCardLiquidationPrice({
         )}`,
       variant: changeVariant,
     },
+    modal: (
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.borrow.common.overview.liquidation-price')}
+        description={t('ajna.position-page.borrow.common.overview.liquidation-price-modal-desc')}
+        value={`${formatted.liquidationPrice} ${collateralToken}/${quoteToken}`}
+      />
+    ),
   }
 
   if (!liquidationPrice.isZero()) {

--- a/features/ajna/positions/common/components/contentCards/ContentCardLoanToValue.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardLoanToValue.tsx
@@ -4,6 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -42,6 +43,13 @@ export function ContentCardLoanToValue({
     footnote: t('ajna.position-page.borrow.common.overview.liquidation-threshold', {
       liquidationThreshold: formatted.liquidationThreshold,
     }),
+    modal: (
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.borrow.common.overview.loan-to-value')}
+        description={t('ajna.position-page.borrow.common.overview.loan-to-value-modal-desc')}
+        value={formatted.loanToValue}
+      />
+    ),
   }
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/features/ajna/positions/common/components/contentCards/ContentCardMaxLendingLTV.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardMaxLendingLTV.tsx
@@ -4,41 +4,10 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Card, Grid, Heading, Text } from 'theme-ui'
-
-interface ContentCardMaxLendingLTVModalProps {
-  maxLendingPercentage: string
-  quoteToken: string
-  collateralToken: string
-}
-
-function ContentCardMaxLendingLTVModal({
-  maxLendingPercentage,
-  quoteToken,
-  collateralToken,
-}: ContentCardMaxLendingLTVModalProps) {
-  const { t } = useTranslation()
-
-  return (
-    <Grid gap={2}>
-      <Heading variant="header3">
-        {t('ajna.position-page.earn.manage.overview.max-lending-ltv')}
-      </Heading>
-      <Text variant="paragraph2" as="p" sx={{ pb: 2 }}>
-        {t('ajna.position-page.earn.manage.overview.max-lending-ltv-modal-desc', {
-          quoteToken,
-          collateralToken,
-        })}
-      </Text>
-      <Card variant="vaultDetailsCardModal" sx={{ my: 2 }}>
-        {maxLendingPercentage}
-      </Card>
-    </Grid>
-  )
-}
 
 interface ContentCardMaxLendingLTVProps {
   maxLendingPercentage: BigNumber
@@ -79,10 +48,13 @@ export function ContentCardMaxLendingLTV({
     },
     footnote: `${formatCryptoBalance(price)} ${quoteToken}`,
     modal: (
-      <ContentCardMaxLendingLTVModal
-        collateralToken={collateralToken}
-        quoteToken={quoteToken}
-        maxLendingPercentage={formatted.maxLendingPercentage}
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.earn.manage.overview.max-lending-ltv')}
+        description={t('ajna.position-page.earn.manage.overview.max-lending-ltv-modal-desc', {
+          quoteToken,
+          collateralToken,
+        })}
+        value={formatted.maxLendingPercentage}
       />
     ),
   }

--- a/features/ajna/positions/common/components/contentCards/ContentCardPositionDebt.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardPositionDebt.tsx
@@ -4,6 +4,7 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -44,6 +45,13 @@ export function ContentCardPositionDebt({
         afterPositionDebt && `${formatted.afterPositionDebt} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     },
+    modal: (
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.borrow.common.overview.position-debt')}
+        description={t('ajna.position-page.borrow.common.overview.position-debt-modal-desc')}
+        value={`${formatted.positionDebt} ${quoteToken}`}
+      />
+    ),
   }
 
   if (!positionDebt.isZero()) {

--- a/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
@@ -9,7 +9,7 @@ import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import {  Card, Heading, Text } from 'theme-ui'
+import { Card, Heading, Text } from 'theme-ui'
 
 interface ContentCardPositionLendingPriceModalProps {
   positionLendingPrice: string

--- a/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
@@ -4,11 +4,12 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Card, Grid, Heading, Text } from 'theme-ui'
+import {  Card, Heading, Text } from 'theme-ui'
 
 interface ContentCardPositionLendingPriceModalProps {
   positionLendingPrice: string
@@ -26,11 +27,8 @@ function ContentCardPositionLendingPriceModal({
   const { t } = useTranslation()
 
   return (
-    <Grid gap={2}>
-      <Heading variant="header3">
-        {t('ajna.position-page.earn.manage.overview.position-lending-price')}
-      </Heading>
-      <Text variant="paragraph2" as="p" sx={{ pb: 2 }}>
+    <>
+      <Text variant="paragraph3" as="p" sx={{ color: 'neutral80' }}>
         {t('ajna.position-page.earn.manage.overview.position-lending-price-modal-desc', {
           quoteToken,
         })}
@@ -38,18 +36,18 @@ function ContentCardPositionLendingPriceModal({
       <Card variant="vaultDetailsCardModal" sx={{ my: 2 }}>
         {positionLendingPrice} {quoteToken}
       </Card>
-      <Heading variant="header3">
+      <Heading variant="header5" sx={{ fontWeight: 'bold' }}>
         {t('ajna.position-page.earn.manage.overview.minimum-yield-price-modal')}
       </Heading>
-      <Text variant="paragraph2" as="p" sx={{ pb: 2 }}>
+      <Text variant="paragraph3" as="p" sx={{ color: 'neutral80' }}>
         {t('ajna.position-page.earn.manage.overview.minimum-yield-price-modal-desc', {
           quoteToken,
         })}
       </Text>
-      <Card variant="vaultDetailsCardModal" sx={{ my: 2 }}>
+      <Card variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
         {highestThresholdPrice} {collateralToken}/{quoteToken}
       </Card>
-    </Grid>
+    </>
   )
 }
 
@@ -102,12 +100,16 @@ export function ContentCardPositionLendingPrice({
     },
     footnote: formatted.relationToMarketPrice,
     modal: (
-      <ContentCardPositionLendingPriceModal
-        collateralToken={collateralToken}
-        quoteToken={quoteToken}
-        positionLendingPrice={formatted.positionLendingPrice}
-        highestThresholdPrice={formatted.highestThresholdPrice}
-      />
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.earn.manage.overview.position-lending-price')}
+      >
+        <ContentCardPositionLendingPriceModal
+          positionLendingPrice={formatted.positionLendingPrice}
+          highestThresholdPrice={formatted.highestThresholdPrice}
+          collateralToken={collateralToken}
+          quoteToken={quoteToken}
+        />
+      </AjnaDetailsSectionContentSimpleModal>
     ),
   }
 

--- a/features/ajna/positions/common/components/contentCards/ContentCardTokensDeposited.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardTokensDeposited.tsx
@@ -4,36 +4,10 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Card, Grid, Heading, Text } from 'theme-ui'
-
-interface ContentCardTokensDepositedModalProps {
-  tokensDeposited: string
-  quoteToken: string
-}
-
-function ContentCardTokensDepositedModal({
-  tokensDeposited,
-  quoteToken,
-}: ContentCardTokensDepositedModalProps) {
-  const { t } = useTranslation()
-
-  return (
-    <Grid gap={2}>
-      <Heading variant="header3">
-        {t('ajna.position-page.earn.manage.overview.tokens-deposited')}
-      </Heading>
-      <Text variant="paragraph2" as="p" sx={{ pb: 2 }}>
-        {t('ajna.position-page.earn.manage.overview.tokens-deposited-modal-desc')}
-      </Text>
-      <Card variant="vaultDetailsCardModal" sx={{ my: 2 }}>
-        {tokensDeposited} {quoteToken}
-      </Card>
-    </Grid>
-  )
-}
 
 interface ContentCardCurrentEarningsProps {
   isLoading?: boolean
@@ -74,9 +48,10 @@ export function ContentCardTokensDeposited({
       variant: changeVariant,
     },
     modal: (
-      <ContentCardTokensDepositedModal
-        tokensDeposited={formatted.tokensDeposited}
-        quoteToken={quoteToken}
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.earn.manage.overview.tokens-deposited')}
+        description={t('ajna.position-page.earn.manage.overview.tokens-deposited-modal-desc')}
+        value={`${formatted.tokensDeposited} ${quoteToken}`}
       />
     ),
   }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2484,9 +2484,7 @@
                 "There is an origination fee when borrowing to avoid rapid changes in rates.",
                 "Ajna has no oracles and a unique liquidation mechanism. <3><4>Read more on how Ajna works</4></3>"
               ],
-              "multiply": [
-                "Lorem ipsum dolor sit amet"
-              ],
+              "multiply": ["Lorem ipsum dolor sit amet"],
               "earn": [
                 "Its a new DeFi protocol. <2><4>See Ajna Audits here</4></2>",
                 "Your position will lend only against one asset.",
@@ -2527,11 +2525,15 @@
         "common": {
           "overview": {
             "liquidation-price": "Liquidation Price",
+            "liquidation-price-modal-desc": "The liquidation prices represents the price at which it is expected that liquidatiors sucesfully action your collateral to repay your debt. Monitor this value compared to market price.",
             "below-current-price": "{{belowCurrentPrice}} below current price",
             "loan-to-value": "Loan to value",
+            "loan-to-value-modal-desc": "Your Loan to Value ratio represents how much you have borrowed based on your collateral supplied.",
             "liquidation-threshold": "Liquidation Threshold: {{liquidationThreshold}}",
             "collateral-locked": "Collateral locked",
-            "position-debt": "Position debt"
+            "collateral-locked-modal-desc": "This is the amount of tokens you have as collateral for your debt.",
+            "position-debt": "Position debt",
+            "position-debt-modal-desc": "This is the total number of tokens you have borrowed plus any accrued interests."
           },
           "form": {
             "origination-fee": "{{quoteToken}} Origination Fee"

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -376,6 +376,7 @@ export const oasisBaseTheme = {
       width: ['250px', '352px'],
     },
     vaultDetailsCardModal: {
+      variant: 'text.header5',
       p: 3,
       bg: 'neutral30',
       borderRadius: 'large',


### PR DESCRIPTION
# [Modals for Ajna Borrow](https://app.shortcut.com/oazo-apps/story/8965/borrow-add-modals)

Only modals, no tooltips as there must have been a misunderstanding with tooltips - their content and titles doesn't match what we currently have in footer so they are probably are supposed to be in some other place, than we anticipated while estimating the story.

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/792601ee-eee7-46b7-b60b-4e638dfce563)
  
## Changes 👷‍♀️

- Added modals to overview section cards for Ajna Borrow,
- created helper component `DetailsSectionContentSimpleModal` for all default looking modals* - that allowed to get rid of a lot of duplication previously needed to handle all modals,
- created Ajna specific helper `AjnaDetailsSectionContentSimpleModal` for `DetailsSectionContentSimpleModal` that wraps modals in Ajna theme and applies appropriate colors.

* `ContentCardPositionLendingPrice` is an example of card then modal is more complicated than default. In that case, separated component for modal content is still needed, and `DetailsSectionContentSimpleModal` serves just as a wrapper.
  
## How to test 🧪

- See modals on any Ajna Borrow position,
- see if preexisting modals on Ajna Earn positions didn't break.
