### PR TITLE
🧿 Remove est. break even

### DIFF
--- a/features/ajna/positions/earn/components/ContentFooterItemsEarnOpen.tsx
+++ b/features/ajna/positions/earn/components/ContentFooterItemsEarnOpen.tsx
@@ -3,17 +3,14 @@ import { DetailsSectionFooterItem } from 'components/DetailsSectionFooterItem'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { timeAgo } from 'utils'
 
 interface ContentFooterItemsEarnOpenProps {
-  estimatedBreakEven?: Date
   totalValueLocked?: BigNumber
   days: number
   apy?: BigNumber
 }
 
 export function ContentFooterItemsEarnOpen({
-  estimatedBreakEven,
   totalValueLocked,
   apy,
   days,
@@ -21,17 +18,12 @@ export function ContentFooterItemsEarnOpen({
   const { t } = useTranslation()
 
   const formatted = {
-    estimatedBreakEven: estimatedBreakEven ? timeAgo({ to: estimatedBreakEven }) : '-',
     totalValueLocked: totalValueLocked ? `$${formatCryptoBalance(totalValueLocked)}` : '-',
     apy: apy ? `${formatDecimalAsPercent(apy)}` : '-',
   }
 
   return (
     <>
-      <DetailsSectionFooterItem
-        title={t('system.est-break-even')}
-        value={formatted.estimatedBreakEven}
-      />
       <DetailsSectionFooterItem
         title={t('total-value-locked')}
         value={formatted.totalValueLocked}

--- a/features/ajna/positions/earn/consts.ts
+++ b/features/ajna/positions/earn/consts.ts
@@ -1,5 +1,1 @@
-import BigNumber from 'bignumber.js'
-
 export const AJNA_LUP_MOMP_OFFSET = 0.2 // 20%
-
-export const averageGasWhenOpeningAjnaEarnPosition = new BigNumber(1201887) // open with nft

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
@@ -5,7 +5,6 @@ import { SimulateTitle } from 'components/SimulateTitle'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { ContentFooterItemsEarnOpen } from 'features/ajna/positions/earn/components/ContentFooterItemsEarnOpen'
-import { averageGasWhenOpeningAjnaEarnPosition } from 'features/ajna/positions/earn/consts'
 import { getAjnaSimulationRows } from 'features/ajna/positions/earn/helpers/getAjnaSimulationRows'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -13,7 +12,7 @@ import React from 'react'
 export function AjnaEarnOverviewOpenController() {
   const { t } = useTranslation()
   const {
-    environment: { quoteToken, quotePrice, gasPrice, ethPrice },
+    environment: { quoteToken, quotePrice },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -23,13 +22,6 @@ export function AjnaEarnOverviewOpenController() {
       currentPosition: { simulation, position },
     },
   } = useAjnaProductContext('earn')
-
-  // TODO currently its based on open nft in future we may need
-  // different value when position is being opened without nft
-  const openPositionGasFee = averageGasWhenOpeningAjnaEarnPosition
-    .times(gasPrice.maxFeePerGas.plus(gasPrice.maxPriorityFeePerGas).shiftedBy(-9))
-    .times(ethPrice)
-    .shiftedBy(-9)
 
   const rowsInput = [
     {
@@ -45,8 +37,6 @@ export function AjnaEarnOverviewOpenController() {
       translation: t('ajna.position-page.earn.open.simulation.earnings-per-1y'),
     },
   ]
-
-  const breakEvenInDays = simulation?.getBreakEven(openPositionGasFee)
 
   return (
     <DetailsSection
@@ -67,11 +57,6 @@ export function AjnaEarnOverviewOpenController() {
       footer={
         <DetailsSectionFooterItemWrapper>
           <ContentFooterItemsEarnOpen
-            estimatedBreakEven={
-              breakEvenInDays
-                ? new Date(new Date().getTime() + breakEvenInDays * 24 * 60 * 60 * 1000)
-                : undefined
-            }
             totalValueLocked={position.pool.depositSize.times(quotePrice)}
             apy={simulation?.apy.per30d}
             days={30}


### PR DESCRIPTION
# [Remove est. break even](https://app.shortcut.com/oazo-apps/story/9038/earn-remove-estimated-break-even)

On the design, when there are two items in overview section footer, the items are starting to take a wider space, but this is inconsistent with previous designs that were applied to all the other places, so I did not change that. A single item is still taking the same amount of space, as it used to.
  
## Changes 👷‍♀️

- Removed "Estimated break even" from open Ajna Earn flow and all its dependencies that weren't used anywhere else.
  
## How to test 🧪

Self explanatory.