### PR TITLE
Added tracking swap widget events

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -1,3 +1,5 @@
+import type { Route } from '@lifi/sdk'
+import type { RouteExecutionUpdate } from '@lifi/widget'
 import { ProductType } from 'analytics/common'
 import BigNumber from 'bignumber.js'
 import { Context } from 'blockchain/network'
@@ -143,6 +145,13 @@ export interface AutomationEventsAdditionalParams {
   closeTo?: CloseVaultTo
 }
 
+export enum SwapWidgetEvents {
+  ExecutionStarted = 'SwapWidgetExecutionStarted',
+  ExecutionUpdated = 'SwapWidgetExecutionUpdated',
+  ExecutionCompleted = 'SwapWidgetExecutionCompleted',
+  ExecutionFailed = 'SwapWidgetExecutionFailed',
+}
+
 export enum NotificationsEventIds {
   OpenNotificationCenter = 'OpenNotificationCenter',
   ScrollNotificationCenter = 'ScrollNotificationCenter',
@@ -174,6 +183,7 @@ export enum EventTypes {
   InputChange = 'input-change',
   ButtonClick = 'btn-click',
   OnScroll = 'on-scroll',
+  SwapWidgetEvent = 'swap-widget-event',
 }
 
 // https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
@@ -1125,6 +1135,10 @@ export const trackingEvents = {
 
       !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(EventTypes.ButtonClick, eventBody)
     },
+  },
+  swapWidgetEvent: (id: SwapWidgetEvents, eventData: Route | RouteExecutionUpdate) => {
+    const eventBody = { id, section: 'SwapWidget', product: 'SwapWidget', eventData }
+    !mixpanel.has_opted_out_tracking() && mixpanelInternalAPI(EventTypes.SwapWidgetEvent, eventBody)
   },
 }
 

--- a/components/swapWidget/SwapWidget.tsx
+++ b/components/swapWidget/SwapWidget.tsx
@@ -2,6 +2,7 @@ import { LiFiWalletManagement, supportedWallets } from '@lifi/wallet-management'
 import { LiFiWidget } from '@lifi/widget'
 import { useWallets } from '@web3-onboard/react'
 import { useAppContext } from 'components/AppContextProvider'
+import { useTrackSwapWidgetEvents } from 'helpers/hooks/useTrackSwapWidgetEvents'
 import { useObservable } from 'helpers/observableHook'
 import { useOnboarding } from 'helpers/useOnboarding'
 import React, { useEffect, useMemo } from 'react'
@@ -17,6 +18,7 @@ export function SwapWidget() {
   const [isOnboarded] = useOnboarding('SwapWidget')
   const activeOnboardWallets = useWallets()
   const liFiWalletManagement = useMemo(() => new LiFiWalletManagement(), [])
+  useTrackSwapWidgetEvents()
 
   const web3Provider =
     web3Context?.status !== 'connectedReadonly' ? web3Context?.web3.currentProvider : null

--- a/helpers/hooks/useTrackSwapWidgetEvents.ts
+++ b/helpers/hooks/useTrackSwapWidgetEvents.ts
@@ -1,0 +1,36 @@
+import type { Route } from '@lifi/sdk'
+import type { RouteExecutionUpdate } from '@lifi/widget'
+import { useWidgetEvents, WidgetEvent } from '@lifi/widget'
+import { SwapWidgetEvents, trackingEvents } from 'analytics/analytics'
+import { useEffect } from 'react'
+
+export const useTrackSwapWidgetEvents = () => {
+  const widgetEvents = useWidgetEvents()
+
+  const swapWidgetEventHandler =
+    (event: SwapWidgetEvents) => (eventData: Route | RouteExecutionUpdate) => {
+      trackingEvents.swapWidgetEvent(event, eventData)
+    }
+
+  useEffect(() => {
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionStarted,
+      swapWidgetEventHandler(SwapWidgetEvents.ExecutionCompleted),
+    )
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionUpdated,
+      swapWidgetEventHandler(SwapWidgetEvents.ExecutionUpdated),
+    )
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionCompleted,
+      swapWidgetEventHandler(SwapWidgetEvents.ExecutionCompleted),
+    )
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionFailed,
+      swapWidgetEventHandler(SwapWidgetEvents.ExecutionFailed),
+    )
+    return () => widgetEvents.all.clear()
+  }, [widgetEvents])
+
+  return null
+}


### PR DESCRIPTION
# [LiFi mixpanel](https://app.shortcut.com/oazo-apps/story/9354/lifi-mixpanel)


## Changes 👷‍♀️
- added useTrackSwapWidgetEvents hook to track swap widget events

## How to test 🧪
- you dont need to make a swap to test this, you can just attempt and then reject
