### PR TITLE
🧬 Filtering promo cards on Oasis Create page

### DIFF
--- a/components/PromoCard.tsx
+++ b/components/PromoCard.tsx
@@ -5,9 +5,9 @@ import { WithArrow } from 'components/WithArrow'
 import React from 'react'
 import { Box, Flex, Heading, SxStyleProp, Text } from 'theme-ui'
 
-type PromoCardVariant = 'neutral' | 'positive' | 'negative'
+export type PromoCardVariant = 'neutral' | 'positive' | 'negative'
 
-interface PromoCardProps {
+export interface PromoCardProps {
   icon: string
   title: string
   protocol?: ProtocolLabelProps

--- a/features/oasisCreate/types.ts
+++ b/features/oasisCreate/types.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { PromoCardProps } from 'components/PromoCard'
 import { BaseNetworkNames } from 'helpers/networkNames'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -34,6 +35,20 @@ export interface OasisCreateItemDetails {
 }
 
 export type OasisCreateItem = OasisCreateItemBasics & OasisCreateItemDetails
+
+export type OasisCreatePromoCards = {
+  [key in ProductType]: {
+    default: PromoCardProps[]
+    tokens: {
+      [key: string]: PromoCardProps[]
+    }
+  }
+}
+
+export interface OasisCreateData {
+  promoCards: OasisCreatePromoCards
+  table: OasisCreateItem[]
+}
 
 export interface OasisCreateFiltersCriteria {
   network?: OasisCreateItem['network'][]

--- a/features/oasisCreate/views/OasisCreateView.tsx
+++ b/features/oasisCreate/views/OasisCreateView.tsx
@@ -27,7 +27,6 @@ import {
   OasisCreateProductStrategy,
   ProductType,
 } from 'features/oasisCreate/types'
-import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import { oasisCreateData } from 'helpers/mocks/oasisCreateData.mock'
 import { BaseNetworkNames } from 'helpers/networkNames'
 import { LendingProtocol } from 'lendingProtocols'
@@ -50,8 +49,15 @@ export function OasisCreateView({ product, token }: OasisCreateViewProps) {
   const [selectedToken, setSelectedToken] = useState<string>(token || ALL_ASSETS)
   const [selectedFilters, setSelectedFilters] = useState<OasisCreateFilters>(EMPTY_FILTERS)
 
+  const promoCards = useMemo(
+    () =>
+      Object.keys(oasisCreateData.promoCards[selectedProduct].tokens).includes(selectedToken)
+        ? oasisCreateData.promoCards[selectedProduct].tokens[selectedToken]
+        : oasisCreateData.promoCards[selectedProduct].default,
+    [selectedProduct, selectedToken],
+  )
   const rowsMatchedByNL = useMemo(
-    () => matchRowsByNL(oasisCreateData, selectedProduct, selectedToken),
+    () => matchRowsByNL(oasisCreateData.table, selectedProduct, selectedToken),
     [selectedProduct, selectedToken],
   )
   const rowsMatchedByFilters = useMemo(
@@ -94,8 +100,10 @@ export function OasisCreateView({ product, token }: OasisCreateViewProps) {
     <AnimatedWrapper sx={{ mb: 5 }}>
       <Box
         sx={{
+          position: 'relative',
           my: [3, null, '48px'],
           textAlign: 'center',
+          zIndex: 3,
         }}
       >
         <NaturalLanguageSelectorController
@@ -133,26 +141,9 @@ export function OasisCreateView({ product, token }: OasisCreateViewProps) {
         </Text>
       </Box>
       <Grid columns={[1, null, 2, 3]} gap={3} sx={{ mb: 4 }}>
-        <PromoCard
-          icon={getToken('ETH').iconCircle}
-          title="Borrow cheap USDC with ETH"
-          protocol={{ network: BaseNetworkNames.Ethereum, protocol: LendingProtocol.Maker }}
-          pills={[{ label: 'Constant Multiple' }, { label: 'Stop-Loss Enabled' }]}
-          data={[{ label: 'Net Annual Borrow Cost', value: '11.9%', variant: 'negative' }]}
-        />
-        <PromoCard
-          icon={getToken('USDC').iconCircle}
-          title="2.5x ETH/USDC Multiple"
-          protocol={{ network: BaseNetworkNames.Ethereum, protocol: LendingProtocol.Ajna }}
-          pills={[{ label: 'Up to 9.99x' }, { label: 'Liquidation risk', variant: 'negative' }]}
-          data={[{ label: '90 Day Net APY', value: '12.43%' }]}
-        />
-        <PromoCard
-          icon={getToken('USDC').iconCircle}
-          title="2.5x ETH/USDC Multiple"
-          description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vel neque quis nisl."
-          link={{ href: EXTERNAL_LINKS.KB.HELP, label: t('learn-more') }}
-        />
+        {promoCards.map((promoCard, i) => (
+          <PromoCard key={`${selectedProduct}-${i}`} {...promoCard} />
+        ))}
       </Grid>
       <AssetsTableContainer>
         <AssetsFiltersContainer

--- a/helpers/mocks/oasisCreateData.mock.ts
+++ b/helpers/mocks/oasisCreateData.mock.ts
@@ -1,11 +1,284 @@
 //TODO: to be replaced with data from API
 
 import BigNumber from 'bignumber.js'
-import { OasisCreateItem, ProductType } from 'features/oasisCreate/types'
+import { getToken } from 'blockchain/tokensMetadata'
+import { PromoCardProps, PromoCardVariant } from 'components/PromoCard'
+import {
+  OasisCreateData,
+  OasisCreateItem,
+  OasisCreatePromoCards,
+  ProductType,
+} from 'features/oasisCreate/types'
 import { BaseNetworkNames } from 'helpers/networkNames'
 import { LendingProtocol } from 'lendingProtocols'
 
-export const oasisCreateData: OasisCreateItem[] = [
+const protocol = {
+  aavev2: { network: BaseNetworkNames.Ethereum, protocol: LendingProtocol.AaveV2 },
+  aavev3: { network: BaseNetworkNames.Ethereum, protocol: LendingProtocol.AaveV3 },
+  aavev3Arbitrum: { network: BaseNetworkNames.Arbitrum, protocol: LendingProtocol.AaveV3 },
+  aavev3Optimism: { network: BaseNetworkNames.Optimism, protocol: LendingProtocol.AaveV3 },
+  ajna: { network: BaseNetworkNames.Ethereum, protocol: LendingProtocol.Ajna },
+  maker: { network: BaseNetworkNames.Ethereum, protocol: LendingProtocol.Maker },
+}
+const pill = {
+  negative: { label: 'Negative label', variant: 'negative' as PromoCardVariant },
+  neutral: { label: 'Neutral label' },
+  positive: { label: 'Positive label', variant: 'positive' as PromoCardVariant },
+}
+const data = {
+  negative: (v: string) => ({
+    label: 'Negative value',
+    value: v,
+    variant: 'negative' as PromoCardVariant,
+  }),
+  neutral: (v: string) => ({ label: 'Neutral value', value: v }),
+  positive: (v: string) => ({
+    label: 'Positive value',
+    value: v,
+    variant: 'positive' as PromoCardVariant,
+  }),
+}
+
+const oasisCreatePromoCardBorrowEth: PromoCardProps = {
+  icon: getToken('ETH').iconCircle,
+  title: 'Main borrow ETH promo card',
+  protocol: protocol.maker,
+  pills: [pill.neutral, pill.positive],
+  data: [data.positive('11.9%')],
+}
+const oasisCreatePromoCardBorrowWbtc: PromoCardProps = {
+  icon: getToken('WBTC').iconCircle,
+  title: 'Main borrow WBTC promo card',
+  protocol: protocol.maker,
+  pills: [pill.neutral, pill.negative],
+  data: [data.negative('-0.40%')],
+}
+const oasisCreatePromoCardBorrowUsdc: PromoCardProps = {
+  icon: getToken('USDC').iconCircle,
+  title: 'Main borrow USDC promo card',
+  protocol: protocol.ajna,
+  pills: [pill.neutral, pill.positive],
+  data: [data.positive('6.13%')],
+}
+const oasisCreatePromoCardMultiplyEth: PromoCardProps = {
+  icon: getToken('ETH').iconCircle,
+  title: 'Main multiply ETH promo card',
+  protocol: protocol.maker,
+  pills: [pill.neutral, pill.negative],
+  data: [data.negative('-2.71%')],
+}
+const oasisCreatePromoCardMultiplyWbtc: PromoCardProps = {
+  icon: getToken('WBTC').iconCircle,
+  title: 'Main multiply WBTC promo card',
+  protocol: protocol.aavev2,
+  pills: [pill.neutral, pill.positive],
+  data: [data.positive('1.46%')],
+}
+const oasisCreatePromoCardMultiplyUsdc: PromoCardProps = {
+  icon: getToken('USDC').iconCircle,
+  title: 'Main multiply USDC promo card',
+  protocol: protocol.aavev3Optimism,
+  pills: [pill.neutral, pill.positive],
+  data: [data.positive('48.62%')],
+}
+const oasisCreatePromoCardEarnDai: PromoCardProps = {
+  icon: getToken('DAI').iconCircle,
+  title: 'Earn DAI promo card',
+  protocol: protocol.maker,
+  pills: [pill.neutral, pill.positive],
+  description: 'Lorem ipsum dolor sit amet.',
+}
+const oasisCreatePromoCardEarnWsteth: PromoCardProps = {
+  icon: getToken('WSTETH').iconCircle,
+  title: 'Main earn wstETH promo card',
+  protocol: protocol.ajna,
+  pills: [pill.neutral, pill.positive],
+  data: [data.positive('$1,235.56')],
+}
+const oasisCreatePromoCardGeneric: PromoCardProps = {
+  icon: 'selectEarn',
+  title: 'Generic promo card',
+  description: 'Lorem ipsum dolor sit amet, consectetur.',
+  link: { href: '/', label: 'Learn more' },
+}
+
+const oasisCreatePromoCards: OasisCreatePromoCards = {
+  [ProductType.Borrow]: {
+    default: [
+      oasisCreatePromoCardBorrowEth,
+      oasisCreatePromoCardBorrowWbtc,
+      oasisCreatePromoCardBorrowUsdc,
+    ],
+    tokens: {
+      ETH: [
+        oasisCreatePromoCardBorrowEth,
+        {
+          icon: getToken('WSTETH').iconCircle,
+          title: 'Secondary borrow wstETH promo card',
+          protocol: protocol.maker,
+          pills: [pill.neutral, pill.neutral],
+          data: [data.neutral('10.03%')],
+        },
+        {
+          icon: getToken('RETH').iconCircle,
+          title: 'Secondary borrow rETH promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.positive],
+          data: [data.positive('$724.12')],
+        },
+      ],
+      WBTC: [
+        oasisCreatePromoCardBorrowWbtc,
+        {
+          icon: getToken('WBTC').iconCircle,
+          title: 'Secondary borrow WBTC promo card',
+          protocol: protocol.maker,
+          pills: [pill.neutral, pill.neutral],
+          data: [data.neutral('$2.55M')],
+        },
+        {
+          icon: getToken('WBTC').iconCircle,
+          title: 'Secondary borrow WBTC promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.positive],
+          data: [data.positive('13.52%')],
+        },
+      ],
+      USDC: [
+        oasisCreatePromoCardBorrowUsdc,
+        {
+          icon: getToken('USDC').iconCircle,
+          title: 'Secondary borrow USDC promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.negative],
+          data: [data.negative('-2.65%')],
+        },
+        oasisCreatePromoCardGeneric,
+      ],
+    },
+  },
+  [ProductType.Multiply]: {
+    default: [
+      oasisCreatePromoCardMultiplyEth,
+      oasisCreatePromoCardMultiplyWbtc,
+      oasisCreatePromoCardMultiplyUsdc,
+    ],
+    tokens: {
+      ETH: [
+        oasisCreatePromoCardMultiplyEth,
+        {
+          icon: getToken('RETH').iconCircle,
+          title: 'Secondary multiply rETH promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.neutral],
+          data: [data.neutral('2.27% - 8.81%')],
+        },
+        {
+          icon: getToken('CBETH').iconCircle,
+          title: 'Secondary multiply cbETH promo card',
+          protocol: protocol.aavev2,
+          pills: [pill.neutral, pill.negative],
+          data: [data.neutral('$3.01')],
+        },
+      ],
+      WBTC: [
+        oasisCreatePromoCardMultiplyWbtc,
+        {
+          icon: getToken('WBTC').iconCircle,
+          title: 'Secondary multiply WBTC promo card',
+          protocol: protocol.aavev3Optimism,
+          pills: [pill.neutral, pill.neutral],
+          data: [data.neutral('4.33x')],
+        },
+        oasisCreatePromoCardGeneric,
+      ],
+      USDC: [
+        oasisCreatePromoCardMultiplyUsdc,
+        {
+          icon: getToken('USDC').iconCircle,
+          title: 'Secondary multiply USDC promo card',
+          protocol: protocol.aavev3Arbitrum,
+          pills: [pill.neutral, pill.positive],
+          data: [data.positive('101.96%')],
+        },
+        {
+          icon: getToken('USDC').iconCircle,
+          title: 'Secondary multiply USDC promo card',
+          protocol: protocol.aavev3,
+          pills: [pill.neutral, pill.positive],
+          data: [data.positive('12.68%')],
+        },
+      ],
+    },
+  },
+  [ProductType.Earn]: {
+    default: [
+      oasisCreatePromoCardEarnDai,
+      oasisCreatePromoCardEarnWsteth,
+      oasisCreatePromoCardGeneric,
+    ],
+    tokens: {
+      ETH: [
+        oasisCreatePromoCardEarnWsteth,
+        {
+          icon: getToken('CBETH').iconCircle,
+          title: 'Secondary earn cbETH promo card',
+          protocol: protocol.aavev2,
+          pills: [pill.neutral, pill.negative],
+          data: [data.negative('$133.78')],
+        },
+        {
+          icon: getToken('RETH').iconCircle,
+          title: 'Secondary earn rETH promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.neutral],
+          data: [data.neutral('n/a')],
+        },
+      ],
+      WBTC: [
+        {
+          icon: getToken('WBTC').iconCircle,
+          title: 'Secondary earn WBTC promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.positive],
+          data: [data.positive('5.33%')],
+        },
+        oasisCreatePromoCardGeneric,
+        oasisCreatePromoCardGeneric,
+      ],
+      DAI: [
+        oasisCreatePromoCardEarnDai,
+        oasisCreatePromoCardGeneric,
+        oasisCreatePromoCardGeneric
+      ],
+      USDC: [
+        {
+          icon: getToken('USDC').iconCircle,
+          title: 'Secondary earn USDC promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.neutral],
+          data: [data.neutral('0.00% - 0.21%')],
+        },
+        {
+          icon: getToken('USDC').iconCircle,
+          title: 'Secondary earn USDC promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.negative],
+          data: [data.negative('-14.54')],
+        },
+        {
+          icon: getToken('USDC').iconCircle,
+          title: 'Secondary earn USDC promo card',
+          protocol: protocol.ajna,
+          pills: [pill.neutral, pill.negative],
+          data: [data.negative('$0.98')],
+        },
+      ]
+    },
+  },
+}
+
+const oasisCreateTable: OasisCreateItem[] = [
   {
     product: [ProductType.Borrow, ProductType.Multiply],
     primaryToken: 'ETH',
@@ -459,3 +732,8 @@ export const oasisCreateData: OasisCreateItem[] = [
     managementType: 'active',
   },
 ]
+
+export const oasisCreateData: OasisCreateData = {
+  promoCards: oasisCreatePromoCards,
+  table: oasisCreateTable,
+}

--- a/helpers/mocks/oasisCreateData.mock.ts
+++ b/helpers/mocks/oasisCreateData.mock.ts
@@ -246,11 +246,7 @@ const oasisCreatePromoCards: OasisCreatePromoCards = {
         oasisCreatePromoCardGeneric,
         oasisCreatePromoCardGeneric,
       ],
-      DAI: [
-        oasisCreatePromoCardEarnDai,
-        oasisCreatePromoCardGeneric,
-        oasisCreatePromoCardGeneric
-      ],
+      DAI: [oasisCreatePromoCardEarnDai, oasisCreatePromoCardGeneric, oasisCreatePromoCardGeneric],
       USDC: [
         {
           icon: getToken('USDC').iconCircle,
@@ -273,7 +269,7 @@ const oasisCreatePromoCards: OasisCreatePromoCards = {
           pills: [pill.neutral, pill.negative],
           data: [data.negative('$0.98')],
         },
-      ]
+      ],
     },
   },
 }


### PR DESCRIPTION
# [Filtering promo cards on Oasis Create page](https://app.shortcut.com/oazo-apps/story/9295/filtering-promo-cards)

[Tab-1684848152246.webm](https://github.com/OasisDEX/oasis-borrow/assets/16230404/17d63c1f-af31-4b9a-b23e-3cb59ade7389)
  
## Changes 👷‍♀️

- Created `OasisCreateData` interface that should be used as a Oasis Create API response type,
- created mechanism for filtering promo cards on Oasis Create page,
- added some dummy data as promo cards content.
  
## How to test 🧪

Go to `/oasis-create/borrow` and see if promo cards are updating along while natural language selector is changed.
