### PR TITLE
Protocol versionin the name/symbol of Aave strategies/tokens

### DIFF
--- a/blockchain/token-metadata-list/aave-v2.ts
+++ b/blockchain/token-metadata-list/aave-v2.ts
@@ -5,7 +5,7 @@ import { LendingProtocol } from 'lendingProtocols'
 
 export const aaveV2TokensMetadata: TokenConfig[] = [
   {
-    symbol: 'stETHeth',
+    symbol: 'stETHethV2',
     precision: 18,
     digits: 5,
     digitsInstant: 2,
@@ -22,7 +22,7 @@ export const aaveV2TokensMetadata: TokenConfig[] = [
     chain: MainNetworkNames.ethereumMainnet,
   },
   {
-    symbol: 'stETHusdc',
+    symbol: 'stETHusdcV2',
     precision: 18,
     digits: 5,
     digitsInstant: 2,
@@ -39,7 +39,7 @@ export const aaveV2TokensMetadata: TokenConfig[] = [
     chain: MainNetworkNames.ethereumMainnet,
   },
   {
-    symbol: 'ethusdc',
+    symbol: 'ethusdcV2',
     precision: 18,
     digits: 5,
     digitsInstant: 2,
@@ -56,7 +56,7 @@ export const aaveV2TokensMetadata: TokenConfig[] = [
     chain: MainNetworkNames.ethereumMainnet,
   },
   {
-    symbol: 'wBTCusdc',
+    symbol: 'wBTCusdcV2',
     precision: 18,
     digits: 5,
     digitsInstant: 2,

--- a/blockchain/token-metadata-list/aave-v3.ts
+++ b/blockchain/token-metadata-list/aave-v3.ts
@@ -5,7 +5,7 @@ import { LendingProtocol } from 'lendingProtocols'
 
 export const aaveV3TokensMetadata: TokenConfig[] = [
   {
-    symbol: 'wstETHeth',
+    symbol: 'wstETHethV3',
     precision: 18,
     digits: 5,
     digitsInstant: 2,
@@ -39,7 +39,7 @@ export const aaveV3TokensMetadata: TokenConfig[] = [
     chain: MainNetworkNames.ethereumMainnet,
   },
   {
-    symbol: 'wBTCusdc',
+    symbol: 'wBTCusdcV3',
     precision: 18,
     digits: 5,
     digitsInstant: 2,

--- a/blockchain/token-metadata-list/aave-v3.ts
+++ b/blockchain/token-metadata-list/aave-v3.ts
@@ -22,7 +22,7 @@ export const aaveV3TokensMetadata: TokenConfig[] = [
     chain: MainNetworkNames.ethereumMainnet,
   },
   {
-    symbol: 'cbETHusdc',
+    symbol: 'cbETHusdcV3',
     precision: 18,
     digits: 5,
     digitsInstant: 2,

--- a/features/aave/strategy-config.ts
+++ b/features/aave/strategy-config.ts
@@ -232,8 +232,8 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
+    name: 'wstETHethV3',
     urlSlug: 'wstETHeth',
-    name: 'wstETHeth',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
       headerOpen: headerWithDetails(adjustRiskSliders.wstethEth.riskRatios.minimum),
@@ -262,8 +262,8 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
+    name: 'stETHethV2',
     urlSlug: 'stETHeth',
-    name: 'stETHeth',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
       headerOpen: headerWithDetails(adjustRiskSliders.stethEth.riskRatios.minimum),
@@ -291,7 +291,7 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
-    name: 'ethusdc',
+    name: 'ethusdcV2',
     urlSlug: 'ethusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
@@ -320,7 +320,7 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
-    name: 'stETHusdc',
+    name: 'stETHusdcV2',
     urlSlug: 'stETHusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
@@ -349,7 +349,7 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
-    name: 'wBTCusdc',
+    name: 'wBTCusdcV2',
     urlSlug: 'wBTCusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
@@ -378,7 +378,7 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
-    name: 'ethusdc',
+    name: 'ethusdcV3',
     urlSlug: 'ethusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
@@ -436,7 +436,7 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
-    name: 'wBTCusdc',
+    name: 'wBTCusdcV2',
     urlSlug: 'wBTCusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
@@ -465,8 +465,8 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
+    name: 'wstETHethV3',
     urlSlug: 'wstETHeth',
-    name: 'wstETHeth',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {
       headerOpen: AaveOpenHeader,

--- a/features/aave/strategy-config.ts
+++ b/features/aave/strategy-config.ts
@@ -407,7 +407,7 @@ const ethereumStrategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
     networkId: NetworkIds.MAINNET,
-    name: 'cbETHusdc',
+    name: 'cbETHusdcV3',
     urlSlug: 'cbETHusdc',
     proxyType: ProxyType.DpmProxy,
     viewComponents: {

--- a/features/asset/AssetView.tsx
+++ b/features/asset/AssetView.tsx
@@ -21,14 +21,16 @@ const aaveAssets = {
       { strategy: 'optimism-wstethusdc', featureToggle: 'AaveV3Optimism' },
       { strategy: 'arbitrum-ethusdc', featureToggle: 'AaveV3Arbitrum' },
       { strategy: 'arbitrum-wstethusdc', featureToggle: 'AaveV3Arbitrum' },
-      { strategy: 'ethusdc' },
-      { strategy: 'stETHusdc' },
+      { strategy: 'ethusdcV2', featureToggle: 'AaveV2ProductCard' },
+      { strategy: 'stETHusdcV2', featureToggle: 'AaveV2ProductCard' },
     ]),
-    earn: getAaveEnabledStrategies([{ strategy: 'stETHeth' }]),
+    earn: getAaveEnabledStrategies([
+      { strategy: 'stETHethV2', featureToggle: 'AaveV2ProductCard' },
+    ]),
   },
   btc: {
     multiply: getAaveEnabledStrategies([
-      { strategy: 'wBTCusdc' },
+      { strategy: 'wBTCusdcV2', featureToggle: 'AaveV2ProductCard' },
       { strategy: 'optimism-wbtcusdc', featureToggle: 'AaveV3Optimism' },
       { strategy: 'arbitrum-wbtcusdc', featureToggle: 'AaveV3Arbitrum' },
     ]),

--- a/features/earn/aave/components/AavePositionHeader.tsx
+++ b/features/earn/aave/components/AavePositionHeader.tsx
@@ -17,11 +17,19 @@ import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 const tokenPairList = {
-  stETHeth: {
+  stETHethV2: {
     translationKey: 'open-earn.aave.product-header.token-pair-list.aave-steth-eth',
     tokenList: ['AAVE', 'STETH', 'ETH'],
   },
-  wstETHeth: {
+  stETHethV3: {
+    translationKey: 'open-earn.aave.product-header.token-pair-list.aave-steth-eth',
+    tokenList: ['AAVE', 'STETH', 'ETH'],
+  },
+  wstETHethV2: {
+    translationKey: 'open-earn.aave.product-header.token-pair-list.aave-wsteth-eth',
+    tokenList: ['AAVE', 'WSTETH', 'ETH'],
+  },
+  wstETHethV3: {
     translationKey: 'open-earn.aave.product-header.token-pair-list.aave-wsteth-eth',
     tokenList: ['AAVE', 'WSTETH', 'ETH'],
   },

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -292,6 +292,9 @@ export const productCardsConfig: {
         { strategy: 'borrow-against-ETH', featureToggle: 'AaveBorrow' },
       ]),
       multiply: getAaveEnabledStrategies([
+        { strategy: 'stETHusdcV2', featureToggle: 'AaveV2ProductCard' },
+        { strategy: 'ethusdcV2', featureToggle: 'AaveV2ProductCard' },
+        { strategy: 'wBTCusdcV2', featureToggle: 'AaveV2ProductCard' },
         { strategy: 'optimism-ethusdc', featureToggle: 'AaveV3Optimism' },
         { strategy: 'optimism-wstethusdc', featureToggle: 'AaveV3Optimism' },
         { strategy: 'optimism-wbtcusdc', featureToggle: 'AaveV3Optimism' },
@@ -300,8 +303,8 @@ export const productCardsConfig: {
         { strategy: 'arbitrum-wbtcusdc', featureToggle: 'AaveV3Arbitrum' },
       ]),
       earn: getAaveEnabledStrategies([
-        { strategy: 'wstETHeth', featureToggle: 'AaveV3EarnWSTETH' },
-        { strategy: 'stETHeth' },
+        { strategy: 'wstETHethV3', featureToggle: 'AaveV3EarnWSTETH' },
+        { strategy: 'stETHethV2', featureToggle: 'AaveV2ProductCard' },
       ]),
     },
   },
@@ -392,16 +395,19 @@ export const productCardsConfig: {
     'CRVV1ETHSTETH-A': {
       link: EXTERNAL_LINKS.KB.TOKENS.CRVV1ETHSTETH,
     },
-    stETHeth: {
+    stETHethV2: {
       link: EXTERNAL_LINKS.KB.WHAT_YOU_SHOULD_KNOW_ABOUT_STETH,
     },
-    stETHusdc: {
+    stETHusdcV2: {
       link: EXTERNAL_LINKS.KB.WHAT_YOU_SHOULD_KNOW_ABOUT_STETH,
     },
     'RETH-A': {
       link: EXTERNAL_LINKS.KB.TOKENS.ETH,
     },
-    wstETHeth: {
+    wstETHethV2: {
+      link: EXTERNAL_LINKS.KB.STETH_AAVE_V3_EMODE,
+    },
+    wstETHethV3: {
       link: EXTERNAL_LINKS.KB.STETH_AAVE_V3_EMODE,
     },
   },

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -72,7 +72,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   UseNetworkRowProductCard: false,
   AaveV3Optimism: false,
   AaveV3Arbitrum: false,
-  AaveV2ProductCard: false,
+  AaveV2ProductCard: true,
   AaveV3MultiplycbETHusdc: false,
   AaveV3MultiplywBTCusdc: false,
   AaveV3MultiplywstETHeth: false,

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -931,19 +931,35 @@
     "lowest-annual-fee-cheapest-vault": "此为使用质押 ETH 借贷选项中，最低年费和最便宜的金库",
     "unprofitable-position": "此仓位目前无法获利，但只要您明白现况，仍可以开启金库。",
     "aave": {
-      "stETHeth": {
+      "stETHethV2": {
         "title": "stETH/ETH AAVE",
         "description": "通过增加质押奖励赚取你的 ETH，在 AAVE 上借贷 ETH 来得到更多 stETH 的风险敞口。"
       },
-      "stETHusdc": {
+      "stETHethV3": {
+        "title": "stETH/ETH AAVE",
+        "description": "通过增加质押奖励赚取你的 ETH，在 AAVE 上借贷 ETH 来得到更多 stETH 的风险敞口。"
+      },
+      "stETHusdcV2": {
         "title": "最大的 stETH 杠杆倍率",
         "description": "通过 AAVE 和 USDC 最大化你的 stETH 敞口。"
       },
-      "ethusdc": {
+      "stETHusdcV3": {
+        "title": "最大的 stETH 杠杆倍率",
+        "description": "通过 AAVE 和 USDC 最大化你的 stETH 敞口。"
+      },
+      "ethusdcV2": {
         "title": "最大的 ETH 杠杆倍率",
         "description": "通过 AAVE 和 USDC 最大化你的 ETH 敞口。"
       },
-      "wBTCusdc": {
+      "ethusdcV3": {
+        "title": "最大的 ETH 杠杆倍率",
+        "description": "通过 AAVE 和 USDC 最大化你的 ETH 敞口。"
+      },
+      "wBTCusdcV2": {
+        "title": "最大的 WBTC 杠杆倍率",
+        "description": "通过 AAVE 和 USDC 最大化你的 WBTC 敞口。"
+      },
+      "wBTCusdcV3": {
         "title": "最大的 WBTC 杠杆倍率",
         "description": "通过 AAVE 和 USDC 最大化你的 WBTC 敞口。"
       }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1717,7 +1717,11 @@
         "title": "High wBTC multiple option",
         "description": "The biggest possible Multiple to maximize your exposure to WBTC"
       },
-      "cbETHusdc": {
+      "cbETHusdcV2": {
+        "title": "High cbETH multiple option",
+        "description": "The biggest possible Multiple to maximize your exposure to cbETH"
+      },
+      "cbETHusdcV3": {
         "title": "High cbETH multiple option",
         "description": "The biggest possible Multiple to maximize your exposure to cbETH"
       },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1677,23 +1677,43 @@
       "GUNIV3DAIUSDC1-A": "Earn on your Dai with exposure to the DAI/USDC 5bps pool on UNI V3"
     },
     "aave": {
-      "stETHeth": {
+      "stETHethV2": {
         "title": "stETH/ETH Aave",
         "description": "Earn on your ETH with increased staking rewards. Borrow ETH on Aave to get more exposure to stETH."
       },
-      "wstETHeth": {
+      "stETHethV3": {
+        "title": "stETH/ETH Aave",
+        "description": "Earn on your ETH with increased staking rewards. Borrow ETH on Aave to get more exposure to stETH."
+      },
+      "wstETHethV2": {
         "title": "wstETH/ETH Aave",
         "description": "Enter with ETH, and get up to 9.99x Multiple on stETH staking rewards."
       },
-      "stETHusdc": {
+      "wstETHethV3": {
+        "title": "wstETH/ETH Aave",
+        "description": "Enter with ETH, and get up to 9.99x Multiple on stETH staking rewards."
+      },
+      "stETHusdcV2": {
         "title": "Highest stETH multiple option",
         "description": "Maximise your stETH exposure with Aave and USDC."
       },
-      "ethusdc": {
+      "stETHusdcV3": {
+        "title": "Highest stETH multiple option",
+        "description": "Maximise your stETH exposure with Aave and USDC."
+      },
+      "ethusdcV2": {
         "title": "Highest ETH multiple option",
         "description": "Maximise your ETH exposure with Aave and USDC."
       },
-      "wBTCusdc": {
+      "ethusdcV3": {
+        "title": "Highest ETH multiple option",
+        "description": "Maximise your ETH exposure with Aave and USDC."
+      },
+      "wBTCusdcV2": {
+        "title": "High wBTC multiple option",
+        "description": "The biggest possible Multiple to maximize your exposure to WBTC"
+      },
+      "wBTCusdcV3": {
         "title": "High wBTC multiple option",
         "description": "The biggest possible Multiple to maximize your exposure to WBTC"
       },
@@ -1750,8 +1770,10 @@
       "GUNIV3DAIUSDC1-A": "Get up to {{value}} exposure to the DAI/USDC UNI V3 5bps pool"
     },
     "aave": {
-      "stETHeth": "Get up to {{value}} ETH exposure to stETH",
-      "wstETHeth": "Get up to {{value}} ETH exposure to wstETH",
+      "stETHethV2": "Get up to {{value}} ETH exposure to stETH",
+      "stETHethV3": "Get up to {{value}} ETH exposure to stETH",
+      "wstETHethV2": "Get up to {{value}} ETH exposure to wstETH",
+      "wstETHethV3": "Get up to {{value}} ETH exposure to wstETH",
       "borrow-against-ETH": "Borrow up to ${{value}}"
     }
   },

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1165,19 +1165,35 @@
       "GUNIV3DAIUSDC1-A": "Gane rendimientos a partir de su Dai con exposición al pool DAI/USDC 5bps de UNI V3"
     },
     "aave": {
-      "stETHeth": {
+      "stETHethV2": {
         "title": "stETH/ETH AAVE",
         "description": "Gana con tu ETH con aumentando las recompenzas de staking. Pide prestado ETH en AAVE para obtener más exposición a stETH."
       },
-      "stETHusdc": {
+      "stETHethV3": {
+        "title": "stETH/ETH AAVE",
+        "description": "Gana con tu ETH con aumentando las recompenzas de staking. Pide prestado ETH en AAVE para obtener más exposición a stETH."
+      },
+      "stETHusdcV2": {
         "title": "Mayor multiple de stETH ",
         "description": "Maximiza tu exposición a stETH con AAVE y USDC."
       },
-      "ethusdc": {
+      "stETHusdcV3": {
+        "title": "Mayor multiple de stETH ",
+        "description": "Maximiza tu exposición a stETH con AAVE y USDC."
+      },
+      "ethusdcV2": {
         "title": "Mayor multiple de ETH ",
         "description": "Maximiza tu exposición a ETH con AAVE y USDC.."
       },
-      "wBTCusdc": {
+      "ethusdcV3": {
+        "title": "Mayor multiple de ETH ",
+        "description": "Maximiza tu exposición a ETH con AAVE y USDC.."
+      },
+      "wBTCusdcV2": {
+        "title": "Mayor multiple de WBTC",
+        "description": "Maximiza tu exposición a WBTC con AAVE y USDC."
+      },
+      "wBTCusdcV3": {
         "title": "Mayor multiple de WBTC",
         "description": "Maximiza tu exposición a WBTC con AAVE y USDC."
       }


### PR DESCRIPTION
Every strategy has a protocol version in the name/symbol (and token def in `tokens: TokenConfig[]`), for example theres now `wBTCusdcV2` and `wBTCusdcV3`.

This fixes couple of UI bugs and clears confusion.