### PR TITLE
🧬 [Oasis Create Data] Create a main endpoint

### DIFF
--- a/handlers/product-hub/index.ts
+++ b/handlers/product-hub/index.ts
@@ -1,4 +1,4 @@
-import { oasisCreateData as data } from 'helpers/mocks/oasisCreateData.mock'
+import { productHubData as data } from 'helpers/mocks/productHubData.mock'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 export async function handleProductHubData(req: NextApiRequest, res: NextApiResponse) {

--- a/handlers/product-hub/index.ts
+++ b/handlers/product-hub/index.ts
@@ -1,0 +1,10 @@
+import { oasisCreateData as data } from 'helpers/mocks/oasisCreateData.mock'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export async function handleProductHubData(req: NextApiRequest, res: NextApiResponse) {
+  return res.status(200).json(data)
+}
+
+export async function updateProductHubData(req: NextApiRequest, res: NextApiResponse) {
+  return res.status(200).json({})
+}

--- a/pages/api/product-hub.tsx
+++ b/pages/api/product-hub.tsx
@@ -1,0 +1,14 @@
+import { handleProductHubData, updateProductHubData } from 'handlers/product-hub'
+import { NextApiHandler } from 'next'
+
+const handler: NextApiHandler = async (req, res) => {
+  switch (req.method) {
+    case 'POST':
+      return await handleProductHubData(req, res)
+    case 'UPDATE':
+      return await updateProductHubData(req, res)
+    default:
+      return res.status(405).end()
+  }
+}
+export default handler


### PR DESCRIPTION
# [[Oasis Create Data] Create a main endpoint](https://app.shortcut.com/oazo-apps/story/9100/oasis-create-data-breaking-ground-create-a-main-endpoint)

## Changes 👷‍♀️
- instead of "Oasis Create" we choose to use "product-hub" name as more general alternative
- dummy data endpoint `/api/product-hub`
  
## How to test 🧪
- POST `/api/product-hub`
