### PR TITLE
🧿 Ajna Earn price slider validation

### DIFF
--- a/components/MessageCard.tsx
+++ b/components/MessageCard.tsx
@@ -4,7 +4,7 @@ import { Card, Flex, Grid, Text } from 'theme-ui'
 
 interface NoticeCardProps {
   messages: (TranslateStringType | JSX.Element)[]
-  type: 'error' | 'warning' | 'ok'
+  type: 'error' | 'warning' | 'ok' | 'notice'
   withBullet?: boolean
   handleClick?: () => void
 }
@@ -17,6 +17,10 @@ const cardStyles = {
   warning: {
     cardVariant: 'warning',
     textColor: 'warning100',
+  },
+  notice: {
+    cardVariant: 'notice',
+    textColor: 'primary100',
   },
   ok: {
     cardVariant: 'ok',

--- a/features/ajna/positions/common/components/AjnaValidationMessages.tsx
+++ b/features/ajna/positions/common/components/AjnaValidationMessages.tsx
@@ -6,7 +6,7 @@ import React, { FC } from 'react'
 
 interface AjnaValidationMessagesProps {
   validations: AjnaValidationItem[]
-  type: 'warning' | 'error'
+  type: 'warning' | 'error' | 'notice' | 'success'
 }
 
 export const AjnaValidationMessages: FC<AjnaValidationMessagesProps> = ({ validations, type }) => {
@@ -35,7 +35,7 @@ export const AjnaValidationMessages: FC<AjnaValidationMessagesProps> = ({ valida
   return (
     <MessageCard
       messages={messagesWithTranslations}
-      type={type}
+      type={type === 'success' ? 'ok' : type}
       withBullet={validations.length > 1}
     />
   )

--- a/features/ajna/positions/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaProductContext.tsx
@@ -85,6 +85,8 @@ interface AjnaProductContext<P, F, A> {
     hasErrors: boolean
     isFormFrozen: boolean
     isFormValid: boolean
+    notices: AjnaValidationItem[]
+    successes: AjnaValidationItem[]
     warnings: AjnaValidationItem[]
   }
   notifications: DetailsSectionNotificationItem[]
@@ -188,6 +190,8 @@ export function AjnaProductContextProvider({
         quoteBalance,
         simulationErrors: simulation?.errors,
         simulationWarnings: simulation?.warnings,
+        simulationNotices: simulation?.notices,
+        simulationSuccesses: simulation?.successes,
         state,
         position,
         positionAuction,

--- a/features/ajna/positions/common/sidebars/AjnaFormContentSummary.tsx
+++ b/features/ajna/positions/common/sidebars/AjnaFormContentSummary.tsx
@@ -17,7 +17,7 @@ export function AjnaFormContentSummary({
   } = useAjnaGeneralContext()
   const {
     form: { dispatch },
-    validation: { errors, warnings },
+    validation: { errors, notices, successes, warnings },
   } = useAjnaProductContext(product)
 
   return (
@@ -25,6 +25,8 @@ export function AjnaFormContentSummary({
       {showReset && <SidebarResetButton clear={() => dispatch({ type: 'reset' })} />}
       <AjnaValidationMessages validations={errors} type="error" />
       <AjnaValidationMessages validations={warnings} type="warning" />
+      <AjnaValidationMessages validations={notices} type="notice" />
+      <AjnaValidationMessages validations={successes} type="success" />
       {children}
     </>
   )

--- a/features/ajna/positions/common/validation.tsx
+++ b/features/ajna/positions/common/validation.tsx
@@ -59,6 +59,8 @@ interface GetAjnaBorrowValidationsParams {
   quoteBalance: BigNumber
   simulationErrors?: AjnaSimulationValidationItem[]
   simulationWarnings?: AjnaSimulationValidationItem[]
+  simulationNotices?: AjnaSimulationValidationItem[]
+  simulationSuccesses?: AjnaSimulationValidationItem[]
   state: AjnaFormState
   position: AjnaGenericPosition
   positionAuction: AjnaPositionAuction
@@ -204,6 +206,8 @@ export function getAjnaValidation({
   quoteBalance,
   simulationErrors = [],
   simulationWarnings = [],
+  simulationNotices = [],
+  simulationSuccesses = [],
   state,
   txError,
   position,
@@ -214,9 +218,13 @@ export function getAjnaValidation({
   hasErrors: boolean
   errors: AjnaValidationItem[]
   warnings: AjnaValidationItem[]
+  notices: AjnaValidationItem[]
+  successes: AjnaValidationItem[]
 } {
   const localErrors: AjnaValidationItem[] = []
   const localWarnings: AjnaValidationItem[] = []
+  const localNotices: AjnaValidationItem[] = []
+  const localSuccesses: AjnaValidationItem[] = []
   const isEarnProduct = product === 'earn'
   const depositBalance = isEarnProduct ? quoteBalance : collateralBalance
   const token = product === 'earn' ? quoteToken : collateralToken
@@ -285,6 +293,14 @@ export function getAjnaValidation({
     ...localWarnings,
     ...mapSimulationValidation({ items: simulationWarnings, collateralToken, quoteToken, token }),
   ]
+  const notices = [
+    ...localNotices,
+    ...mapSimulationValidation({ items: simulationNotices, collateralToken, quoteToken, token }),
+  ]
+  const successes = [
+    ...localSuccesses,
+    ...mapSimulationValidation({ items: simulationSuccesses, collateralToken, quoteToken, token }),
+  ]
 
   const isFormFrozen =
     product === 'earn' && (positionAuction as AjnaEarnPositionAuction).isBucketFrozen
@@ -295,5 +311,7 @@ export function getAjnaValidation({
     isFormFrozen,
     errors,
     warnings,
+    notices,
+    successes,
   }
 }

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -112,6 +112,10 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
 
   const resolvedValue = price || lowestUtilizedPrice
 
+  console.log(` htp: ${position.pool.highestThresholdPrice}`)
+  console.log(`lup: ${position.pool.lowestUtilizedPrice}`)
+  console.log(`momp: ${position.pool.mostOptimisticMatchingPrice}`)
+
   const maxLtv = position.getMaxLtv(price)
 
   const { min, max, range } = useMemo(

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -112,10 +112,6 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
 
   const resolvedValue = price || lowestUtilizedPrice
 
-  console.log(` htp: ${position.pool.highestThresholdPrice}`)
-  console.log(`lup: ${position.pool.lowestUtilizedPrice}`)
-  console.log(`momp: ${position.pool.mostOptimisticMatchingPrice}`)
-
   const maxLtv = position.getMaxLtv(price)
 
   const { min, max, range } = useMemo(

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.18",
     "@oasisdex/automation": "1.4.0",
-    "@oasisdex/dma-library": "0.3.17",
+    "@oasisdex/dma-library": "0.3.19",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/oasis-actions": "0.2.16",
     "@oasisdex/transactions": "0.1.4-alpha.0",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2728,8 +2728,6 @@
       "withdraw-undercollateralized": "You cannot withdraw more than {{amount}} {{collateralToken}}, as this would take your position below the minimum LTV. Please enter a lower amount.",
       "borrow-undercollateralized": "You cannot generate more than {{amount}} {{quoteToken}}, as this would take your position below the minimum LTV. Please enter a lower amount.",
       "earning-no-apy": "You will be lending without earning any yield.",
-      "price-below-htp": "You will be lending without earning any yield.",
-      "price-above-momp": "Your selected price is too close to market price. In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}. You are selecting a riskier level for lending.",
       "withdraw-more-than-available": "You cannot withdraw more than {{amount}} {{token}}, please select a lower amount.",
       "after-lup-index-bigger-than-htp-index": "You cannot withdraw this amount, please try to withdraw less.",
       "debt-less-then-dust-limit": "Minimum debt amount you can draw is {{minDebtAmount}}, as this is the dust limit of the pool. Please enter an amount at least equal to dust limit.",
@@ -2739,7 +2737,11 @@
       "generate-close-to-max-ltv": "Generating {{amount}} {{quoteToken}} of debt, would take your position close to the maximum LTV. To reduce your risk of liquidation, please enter a lower amount.",
       "is-during-grace-time": "Your position has been moved to liquidation. 90 days of interest have been added as penalty. You still have some time to <1>Deposit Collateral</1> or <1>Repay your Debt</1> to save it from Liquidation. <2>Read more about <1>Ajna Liquidations →</1></2>",
       "is-being-liquidated": "Your position is currently being liquidated. A penalty has been applied increasing your debt. You still can <1>Deposit Collateral</1> or <1>Repay your Debt</1> to remove it from the liquidation auction. <2>Read more about <1>Ajna Liquidations →</1></2>",
-      "collateral-to-claim": "There is collateral tokens for you to claim. These tokens don't earn any yield. <2>Read more about <1>Ajna Lending →</1></2>"
+      "collateral-to-claim": "There is collateral tokens for you to claim. These tokens don't earn any yield. <2>Read more about <1>Ajna Lending →</1></2>",
+      "price-below-htp": "Unutilized Liquidity: Lending at this price means you are not earning any yield. <1>A deposit fee of 1 day's interest applies to all deposits below the active liquidity range.</1> <2><1>Help me pick correctly →</1></2>",
+      "price-between-htp-and-lup": "Available Liquidity: Your deposit is earning yield but is not currently utilised by borrowers. <1>A deposit fee of 1 day's interest applies to all deposits below the active liquidity range.</1> <2><1>Help me pick correctly →</1></2>",
+      "price-between-lup-and-momp": "Active liquidity: You are actively lending and will earn a yield whenever there are loans above {{lup}} {{collateralToken}}/{{quoteToken}}. <2><1>Help me pick correctly →</1></2>",
+      "price-above-momp": "Boundary Liquidity: Your selected price is too close to market price. In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}. You are selecting a riskier level for lending. <2><1>Help me pick correctly →</1></2>"
     },
     "rewards": {
       "title": "Your Ajna token rewards",

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -350,6 +350,11 @@ export const oasisBaseTheme = {
       borderColor: 'success100',
       bg: 'success10',
     },
+    notice: {
+      variant: 'cards.primary',
+      borderColor: 'secondary60',
+      bg: 'secondary60',
+    },
     vaultFormContainer: {
       variant: 'cards.primary',
       boxShadow: ['none', 'card'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,10 +3867,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.17.tgz#9691982b7420bfcb89c463273bc8dd97dccf1913"
-  integrity sha512-fxEPJBcdGQ6kS9ghZJJqUkfavtnonfhsiFPjcPyLSj7WZR5wAo4WBKeUoCPtMsyqaXdQlukCF5wo7mLJZSB5BQ==
+"@oasisdex/dma-library@0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.19.tgz#6e1d4f01eecb8d47305f39ed212438c2a5717020"
+  integrity sha512-UPR7Kz0mTdDSRTwDmxWtJTXF8szkvV8Rk58AoAHP9jbLpxc3zOKVQmV2uucnTvqTmDaWnht60vh9hSgIbDjDAA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Ajna Earn price slider validation](https://app.shortcut.com/oazo-apps/story/9066)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/301bf668-0bab-4346-b901-536a5844387d)
![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/61a743a9-3945-4692-b9b0-2ed7521ae3b0)
![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/2c51fea0-a76b-4b8f-bdba-8aa8274bf9af)
![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/8421c556-fcdb-452c-9171-da2b1ed92d6d)

  
## Changes 👷‍♀️

- Added two new types of message to `AjnaValidationMessages` component: `notice` and `success`,
- added handling to new types of validations returned from library to UI,
- added support for links in validation message for non-local Ajna validations.
  
## How to test 🧪

Go to Ajna Earn UI (either open or manage is fine) and try putting price in all four color ranges to see different messages.
