### PR TITLE
:bug: Wrong strategy for aave v2

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -1031,7 +1031,11 @@ export function setupAppContext() {
   const lastCreatedPositionForProxy$ = memoize(curry(getLastCreatedPositionForProxy$)(context$))
 
   const strategyConfig$ = memoize(
-    curry(getStrategyConfig$)(proxiesRelatedWithPosition$, lastCreatedPositionForProxy$),
+    curry(getStrategyConfig$)(
+      proxiesRelatedWithPosition$,
+      aaveV2.aaveProxyConfiguration$,
+      lastCreatedPositionForProxy$,
+    ),
     (positionId: PositionId, networkName: NetworkNames) =>
       `${positionId.walletAddress}-${positionId.vaultId}-${networkName}`,
   )

--- a/features/aave/helpers/getStrategyConfig.test.ts
+++ b/features/aave/helpers/getStrategyConfig.test.ts
@@ -1,0 +1,35 @@
+import { NetworkNames } from 'blockchain/networks'
+import { PositionCreated } from 'features/aave/services/readPositionCreatedEvents'
+import { PositionId } from 'features/aave/types'
+import { AaveUserConfigurationResults } from 'lendingProtocols/aave-v2/pipelines'
+import { Observable, of } from 'rxjs'
+
+import { ProxiesRelatedWithPosition } from './getProxiesRelatedWithPosition'
+import { getStrategyConfig$ } from './getStrategyConfig'
+
+describe('getStrategyConfig', () => {
+  const proxiesForPosition$ = jest.fn<Observable<ProxiesRelatedWithPosition>, [PositionId]>()
+  const lastCreatedPositionForProxy$ = jest.fn<Observable<PositionCreated | undefined>, [string]>()
+  const aaveUserConfiguration$ = jest.fn<Observable<AaveUserConfigurationResults>, [string]>()
+
+  it('should return strategy based on assets when there is not PositionCreated Event', (done) => {
+    lastCreatedPositionForProxy$.mockReturnValue(of<PositionCreated | undefined>(undefined))
+    proxiesForPosition$.mockReturnValue(
+      of({ dsProxy: '0x123', dpmProxy: undefined, walletAddress: '0x123' }),
+    )
+    aaveUserConfiguration$.mockReturnValue(of(Object.assign([], { hasAssets: () => true })))
+
+    const observable$ = getStrategyConfig$(
+      proxiesForPosition$,
+      aaveUserConfiguration$,
+      lastCreatedPositionForProxy$,
+      { walletAddress: '0x123' },
+      NetworkNames.ethereumMainnet,
+    )
+
+    observable$.subscribe((strategy) => {
+      expect(strategy).toBeDefined()
+      done()
+    })
+  })
+})

--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -3,28 +3,36 @@ import { loadStrategyFromTokens } from 'features/aave'
 import { IStrategyConfig } from 'features/aave/common/StrategyConfigTypes'
 import { PositionCreated } from 'features/aave/services/readPositionCreatedEvents'
 import { PositionId } from 'features/aave/types'
+import { AaveUserConfigurationResults } from 'lendingProtocols/aave-v2/pipelines'
 import { isEqual } from 'lodash'
-import { Observable, of } from 'rxjs'
+import { combineLatest, iif, Observable, of } from 'rxjs'
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators'
 
 import { ProxiesRelatedWithPosition } from './getProxiesRelatedWithPosition'
 
 export function getStrategyConfig$(
   proxiesForPosition$: (positionId: PositionId) => Observable<ProxiesRelatedWithPosition>,
-  lastCreatedPositionForProxy$: (proxyAddress: string) => Observable<PositionCreated>,
+  aaveUserConfiguration$: (proxyAddress: string) => Observable<AaveUserConfigurationResults>,
+  lastCreatedPositionForProxy$: (proxyAddress: string) => Observable<PositionCreated | undefined>,
   positionId: PositionId,
   networkName: NetworkNames,
-): Observable<IStrategyConfig | undefined> {
+): Observable<IStrategyConfig> {
   return proxiesForPosition$(positionId).pipe(
     switchMap(({ dsProxy, dpmProxy }) => {
       const effectiveProxyAddress = dsProxy || dpmProxy?.proxy
-      if (effectiveProxyAddress === undefined) {
-        return of(undefined)
-      } else {
-        return lastCreatedPositionForProxy$(effectiveProxyAddress)
-      }
+      return combineLatest(
+        iif(
+          () => effectiveProxyAddress !== undefined,
+          aaveUserConfiguration$(effectiveProxyAddress!),
+          of(undefined),
+        ),
+        effectiveProxyAddress && effectiveProxyAddress === dpmProxy?.proxy
+          ? lastCreatedPositionForProxy$(effectiveProxyAddress)
+          : of(undefined),
+      )
     }),
-    map((lastCreatedPosition) => {
+    map(([aaveUserConfigurations, lastCreatedPosition]) => {
+      // event has a higher priority than assets
       if (lastCreatedPosition !== undefined) {
         return loadStrategyFromTokens(
           lastCreatedPosition.collateralTokenSymbol,
@@ -32,7 +40,22 @@ export function getStrategyConfig$(
           networkName,
         )
       }
-      return undefined
+      if (aaveUserConfigurations === undefined) {
+        throw new Error(`There is no PositionCreatedEvent and AaveUserConfiguration`)
+      }
+
+      switch (true) {
+        case aaveUserConfigurations.hasAssets(['STETH'], ['ETH', 'WETH']):
+          return loadStrategyFromTokens('STETH', 'ETH', networkName)
+        case aaveUserConfigurations.hasAssets(['ETH', 'WETH'], ['USDC']):
+          return loadStrategyFromTokens('ETH', 'USDC', networkName)
+        case aaveUserConfigurations.hasAssets(['WBTC'], ['USDC']):
+          return loadStrategyFromTokens('WBTC', 'USDC', networkName)
+        case aaveUserConfigurations.hasAssets(['STETH'], ['USDC']):
+          return loadStrategyFromTokens('STETH', 'USDC', networkName)
+        default:
+          throw new Error(`User doesn't have assets supported in the app`)
+      }
     }),
     distinctUntilChanged(isEqual),
   )

--- a/pages/[network]/aave/[version]/[vault].tsx
+++ b/pages/[network]/aave/[version]/[vault].tsx
@@ -54,6 +54,7 @@ function WithStrategy({
   protocol: AaveLendingProtocol
   network: NetworkNames
 }) {
+  const { push } = useRouter()
   const { t } = useTranslation()
   const { strategyConfig$, aaveManageStateMachine, proxiesRelatedWithPosition$ } = useAaveContext(
     protocol,
@@ -63,6 +64,15 @@ function WithStrategy({
   const [proxiesRelatedWithPosition, proxiesRelatedWithPositionError] = useObservable(
     proxiesRelatedWithPosition$(positionId),
   )
+  if (strategyConfigError) {
+    console.warn(
+      `Strategy config not found for network: ${network} and positionId`,
+      positionId,
+      strategyConfigError,
+    )
+    void push(INTERNAL_LINKS.notFound)
+    return <></>
+  }
   return (
     <WithErrorHandler error={[strategyConfigError, proxiesRelatedWithPositionError]}>
       <WithLoadingIndicator


### PR DESCRIPTION
# Changes
- Fix infinite loader on Aave manage position. Right now we have proper error logging and redirect to 404.
- Possibility to view DS Proxy position on AAVE
