### PR TITLE
🧿 Additional Ajna pools

### DIFF
--- a/blockchain/contracts/arbitrum.ts
+++ b/blockchain/contracts/arbitrum.ts
@@ -151,6 +151,12 @@ export const arbitrumContracts: MainnetContracts = {
   ajnaPoolPairs: {
     'ETH-USDC': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_ETHUSDC),
     'WBTC-USDC': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_WBTCUSDC),
+    'WSTETH-DAI': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_WSTETHDAI),
+    'RETH-DAI': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_RETHDAI),
+    'WBTC-DAI': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_WBTCDAI),
+    'USDC-ETH': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_USDCWETH),
+    'USDC-WBTC': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_USDCWBTC),
+    'USDC-DAI': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_USDCDAI),
   },
   ajnaRewardsManager: contractDesc(ajnaRewardsManager, arbitrum.ajna.AjnaRewardsManager),
   // TODO update address

--- a/blockchain/contracts/goerli.ts
+++ b/blockchain/contracts/goerli.ts
@@ -165,6 +165,12 @@ export const goerliContracts: MainnetContracts = {
   ajnaPoolPairs: {
     'ETH-USDC': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_ETHUSDC),
     'WBTC-USDC': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_WBTCUSDC),
+    'WSTETH-DAI': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_WSTETHDAI),
+    'RETH-DAI': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_RETHDAI),
+    'WBTC-DAI': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_WBTCDAI),
+    'USDC-ETH': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_USDCWETH),
+    'USDC-WBTC': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_USDCWBTC),
+    'USDC-DAI': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_USDCDAI),
   },
   ajnaRewardsManager: contractDesc(ajnaRewardsManager, goerli.ajna.AjnaRewardsManager),
   // TODO update address

--- a/blockchain/contracts/mainnet.ts
+++ b/blockchain/contracts/mainnet.ts
@@ -157,6 +157,12 @@ export const mainnetContracts = {
   ajnaPoolPairs: {
     'ETH-USDC': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_ETHUSDC),
     'WBTC-USDC': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_WBTCUSDC),
+    'WSTETH-DAI': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_WSTETHDAI),
+    'RETH-DAI': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_RETHDAI),
+    'WBTC-DAI': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_WBTCDAI),
+    'USDC-ETH': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_USDCWETH),
+    'USDC-WBTC': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_USDCWBTC),
+    'USDC-DAI': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_USDCDAI),
   },
   ajnaRewardsManager: contractDesc(ajnaRewardsManager, mainnet.ajna.AjnaRewardsManager),
   // TODO update address

--- a/blockchain/contracts/optimism.ts
+++ b/blockchain/contracts/optimism.ts
@@ -167,6 +167,12 @@ export const optimismContracts: MainnetContracts = {
   ajnaPoolPairs: {
     'ETH-USDC': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_ETHUSDC),
     'WBTC-USDC': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_WBTCUSDC),
+    'WSTETH-DAI': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_WSTETHDAI),
+    'RETH-DAI': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_RETHDAI),
+    'WBTC-DAI': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_WBTCDAI),
+    'USDC-ETH': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_USDCWETH),
+    'USDC-WBTC': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_USDCWBTC),
+    'USDC-DAI': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_USDCDAI),
   },
   ajnaRewardsManager: contractDesc(ajnaRewardsManager, optimism.ajna.AjnaRewardsManager),
   // TODO update address

--- a/features/ajna/common/helpers/filterPoolData.tsx
+++ b/features/ajna/common/helpers/filterPoolData.tsx
@@ -21,7 +21,12 @@ export function filterPoolData({ data, pair, product }: FilterPoolDataParams) {
 
         return {
           minPositionSize: `$${formatFiatBalance(payload.minPositionSize)}`,
-          maxLtv: formatDecimalAsPercent(payload.maxLtv),
+          maxLtv:
+            payload.lowestUtilizedPriceIndex > 0 ? (
+              formatDecimalAsPercent(payload.maxLtv)
+            ) : (
+              <AssetsTableDataCellInactive />
+            ),
           liquidityAvaliable: `$${formatFiatBalance(payload.liquidityAvaliable)}`,
           annualFee: formatDecimalAsPercent(payload.annualFee),
         }
@@ -40,7 +45,12 @@ export function filterPoolData({ data, pair, product }: FilterPoolDataParams) {
           '90DayNetApy': formatDecimalAsPercent(payload['90DayNetApy']),
           '7DayNetApy': formatDecimalAsPercent(payload['7DayNetApy']),
           tvl: `$${formatFiatBalance(payload.tvl)}`,
-          minLtv: formatDecimalAsPercent(payload.minLtv),
+          minLtv:
+            payload.lowestUtilizedPriceIndex > 0 ? (
+              formatDecimalAsPercent(payload.minLtv)
+            ) : (
+              <AssetsTableDataCellInactive />
+            ),
         }
       } else
         return {
@@ -55,8 +65,18 @@ export function filterPoolData({ data, pair, product }: FilterPoolDataParams) {
         const payload = data[pair as keyof typeof data]
 
         return {
-          with50Tokens: `${formatCryptoBalance(payload.with50Tokens)} ${pair.split('-')[0]}`,
-          maxMultiple: `${payload.maxMultiply.toFixed(2)}`,
+          with50Tokens:
+            payload.lowestUtilizedPriceIndex > 0 ? (
+              `${formatCryptoBalance(payload.with50Tokens)} ${pair.split('-')[0]}`
+            ) : (
+              <AssetsTableDataCellInactive />
+            ),
+          maxMultiple:
+            payload.lowestUtilizedPriceIndex > 0 ? (
+              `${payload.maxMultiply.toFixed(2)}`
+            ) : (
+              <AssetsTableDataCellInactive />
+            ),
           liquidityAvaliable: `$${formatFiatBalance(payload.liquidityAvaliable)}`,
           annualFee: formatDecimalAsPercent(payload.annualFee),
         }

--- a/features/ajna/common/types.ts
+++ b/features/ajna/common/types.ts
@@ -55,6 +55,7 @@ export type AjnaPoolData = {
     '90DayNetApy': BigNumber
     annualFee: BigNumber
     liquidityAvaliable: BigNumber
+    lowestUtilizedPriceIndex: number
     maxLtv: BigNumber
     maxMultiply: BigNumber
     minLtv: BigNumber

--- a/features/ajna/positions/common/helpers/getAjnaPoolsTableData.ts
+++ b/features/ajna/positions/common/helpers/getAjnaPoolsTableData.ts
@@ -11,7 +11,9 @@ export interface AjnaPoolsDataResponse {
   dailyPercentageRate30dAverage: string
   poolMinDebtAmount: string
   lup: string
+  lupIndex: string
   htp: string
+  htpIndex: string
 }
 
 interface AjnaPoolsTableData {
@@ -23,7 +25,9 @@ interface AjnaPoolsTableData {
   dailyPercentageRate30dAverage: BigNumber
   poolMinDebtAmount: BigNumber
   lowestUtilizedPrice: BigNumber
+  lowestUtilizedPriceIndex: number
   highestThresholdPrice: BigNumber
+  highestThresholdPriceIndex: number
 }
 
 export const getAjnaPoolsTableData = async (): Promise<AjnaPoolsTableData[]> => {
@@ -42,7 +46,9 @@ export const getAjnaPoolsTableData = async (): Promise<AjnaPoolsTableData[]> => 
         dailyPercentageRate30dAverage,
         poolMinDebtAmount,
         lup,
+        lupIndex,
         htp,
+        htpIndex,
       }) => ({
         collateralAddress,
         quoteTokenAddress,
@@ -54,7 +60,9 @@ export const getAjnaPoolsTableData = async (): Promise<AjnaPoolsTableData[]> => 
           .shiftedBy(2),
         poolMinDebtAmount: new BigNumber(poolMinDebtAmount).shiftedBy(negativeWadPrecision),
         lowestUtilizedPrice: new BigNumber(lup).shiftedBy(negativeWadPrecision),
+        lowestUtilizedPriceIndex: parseInt(lupIndex, 10),
         highestThresholdPrice: new BigNumber(htp).shiftedBy(negativeWadPrecision),
+        highestThresholdPriceIndex: parseInt(htpIndex, 10),
       }),
     )
   }

--- a/features/ajna/positions/common/observables/getAjnaPoolsTableContent.ts
+++ b/features/ajna/positions/common/observables/getAjnaPoolsTableContent.ts
@@ -44,6 +44,7 @@ export function getAjnaPoolsTableContent$(
                   dailyPercentageRate30dAverage,
                   poolMinDebtAmount,
                   lowestUtilizedPrice,
+                  lowestUtilizedPriceIndex,
                   highestThresholdPrice,
                 } = curr
 
@@ -72,9 +73,10 @@ export function getAjnaPoolsTableContent$(
                       ),
                       annualFee: interestRate,
                       liquidityAvaliable: depositSize.minus(debt),
+                      lowestUtilizedPriceIndex,
                       maxLtv,
-                      minLtv: highestThresholdPrice.div(marketPrice),
                       maxMultiply,
+                      minLtv: highestThresholdPrice.div(marketPrice),
                       minPositionSize: poolMinDebtAmount,
                       tvl: depositSize,
                       with50Tokens: maxMultiply.times(50),

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -92,7 +92,9 @@ export const subgraphMethodsRecord: {
         interestRate
         poolMinDebtAmount
         lup
+        lupIndex
         htp
+        htpIndex
       }
     }
   `,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@next/font": "^13.1.6",
     "@next/mdx": "12.0.4",
-    "@oasisdex/addresses": "0.0.18",
+    "@oasisdex/addresses": "0.0.22",
     "@oasisdex/automation": "1.4.0",
     "@oasisdex/dma-library": "0.3.19",
     "@oasisdex/multiply": "^0.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,10 +3855,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oasisdex/addresses@0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.0.18.tgz#4507462d792fc9da0f5ebd0cdab606f597901124"
-  integrity sha512-UOEu8E8Cd0MbShziAM4Dkcgo7M2+o6V+jmdyb4w919hy6J1sl3KjWh0ZMynb7QMVT59Wtdp3fpIKwOMxhkQe4Q==
+"@oasisdex/addresses@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.0.22.tgz#1e855acf99a519bd719b1b47f35bd5065db52d4c"
+  integrity sha512-pYL06JuRe7p0/DNb8+yAf49z+oz+lebvjI7aDesDMXdYF76j80zhIwPGEcHsJUH5mJaaTXN2jmaVNRqxcDr30A==
 
 "@oasisdex/automation@1.4.0":
   version "1.4.0"


### PR DESCRIPTION
# [Additional Ajna pools](https://app.shortcut.com/oazo-apps/story/9072/general-add-support-for-dai-pools)

This PR adds general support for newly added pools and displays them in the table selector. It does not contain fixes for infinity in Multiply selector, two quadrillion max LTV etc.
  
## Changes 👷‍♀️

- Added support for: `WSTETH/DAI`, `RETH/DAI`, `WBTC/DAI`, `USDC/WETH` and `USDC/WBTC`.
  
## How to test 🧪

Go to Ajna pool selector and check if new pools are available across all product types.
