### PR TITLE
Ajna earn slider range adjust

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -48,3 +48,5 @@ export const ajnaFormExternalSteps: AjnaSidebarStep[] = ['dpm']
 export const ajnaFormStepsWithTransaction: AjnaSidebarStep[] = ['transaction']
 
 export const LTVWarningThreshold = new BigNumber(0.05)
+
+export const ajnaLastIndexBucketPrice = new BigNumber(99836282890)

--- a/features/ajna/positions/common/helpers/getAjnaPoolData.ts
+++ b/features/ajna/positions/common/helpers/getAjnaPoolData.ts
@@ -1,7 +1,9 @@
 import { Bucket, GetPoolData } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
-import { WAD_PRECISION } from 'components/constants'
+import { NEGATIVE_WAD_PRECISION } from 'components/constants'
+import { ajnaLastIndexBucketPrice } from 'features/ajna/common/consts'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+import { zero } from 'helpers/zero'
 
 export interface AjnaPoolDataResponse {
   address: string
@@ -34,8 +36,6 @@ export const getAjnaPoolData: GetPoolData = async (poolAddress: string) => {
     poolAddress: poolAddress.toLowerCase(),
   })
 
-  const negativeWadPrecision = WAD_PRECISION * -1
-
   if (response && 'pool' in response) {
     const {
       address,
@@ -63,46 +63,52 @@ export const getAjnaPoolData: GetPoolData = async (poolAddress: string) => {
       buckets,
     } = response.pool
 
+    const htpBigNumber = new BigNumber(htp)
+    // we are mapping 7388 htp index to actual bucket price since contracts returns zero when pool does not contain any borrowers
+    const resolvedHighestThresholdPrice = htpBigNumber.eq(zero)
+      ? ajnaLastIndexBucketPrice
+      : htpBigNumber
+
     return {
       poolAddress: address,
       quoteToken: quoteTokenAddress,
       collateralToken: collateralAddress,
 
-      lup: new BigNumber(lup).shiftedBy(negativeWadPrecision),
-      lowestUtilizedPrice: new BigNumber(lup).shiftedBy(negativeWadPrecision),
+      lup: new BigNumber(lup).shiftedBy(NEGATIVE_WAD_PRECISION),
+      lowestUtilizedPrice: new BigNumber(lup).shiftedBy(NEGATIVE_WAD_PRECISION),
       lowestUtilizedPriceIndex: new BigNumber(lupIndex),
 
-      htp: new BigNumber(htp).shiftedBy(negativeWadPrecision),
-      highestThresholdPrice: new BigNumber(htp).shiftedBy(negativeWadPrecision),
+      htp: new BigNumber(resolvedHighestThresholdPrice).shiftedBy(NEGATIVE_WAD_PRECISION),
+      highestThresholdPrice: resolvedHighestThresholdPrice.shiftedBy(NEGATIVE_WAD_PRECISION),
       highestThresholdPriceIndex: new BigNumber(htpIndex),
 
-      highestPriceBucket: new BigNumber(hpb).shiftedBy(negativeWadPrecision),
+      highestPriceBucket: new BigNumber(hpb).shiftedBy(NEGATIVE_WAD_PRECISION),
       highestPriceBucketIndex: new BigNumber(hpbIndex),
 
-      mostOptimisticMatchingPrice: new BigNumber(momp).shiftedBy(negativeWadPrecision),
+      mostOptimisticMatchingPrice: new BigNumber(momp).shiftedBy(NEGATIVE_WAD_PRECISION),
 
-      poolMinDebtAmount: new BigNumber(poolMinDebtAmount).shiftedBy(negativeWadPrecision),
-      poolCollateralization: new BigNumber(poolCollateralization).shiftedBy(negativeWadPrecision),
-      poolActualUtilization: new BigNumber(poolActualUtilization).shiftedBy(negativeWadPrecision),
-      poolTargetUtilization: new BigNumber(poolTargetUtilization).shiftedBy(negativeWadPrecision),
-      interestRate: new BigNumber(interestRate).shiftedBy(negativeWadPrecision),
+      poolMinDebtAmount: new BigNumber(poolMinDebtAmount).shiftedBy(NEGATIVE_WAD_PRECISION),
+      poolCollateralization: new BigNumber(poolCollateralization).shiftedBy(NEGATIVE_WAD_PRECISION),
+      poolActualUtilization: new BigNumber(poolActualUtilization).shiftedBy(NEGATIVE_WAD_PRECISION),
+      poolTargetUtilization: new BigNumber(poolTargetUtilization).shiftedBy(NEGATIVE_WAD_PRECISION),
+      interestRate: new BigNumber(interestRate).shiftedBy(NEGATIVE_WAD_PRECISION),
 
-      debt: new BigNumber(debt).shiftedBy(negativeWadPrecision),
-      depositSize: new BigNumber(depositSize).shiftedBy(negativeWadPrecision),
-      apr30dAverage: new BigNumber(apr30dAverage).shiftedBy(negativeWadPrecision),
+      debt: new BigNumber(debt).shiftedBy(NEGATIVE_WAD_PRECISION),
+      depositSize: new BigNumber(depositSize).shiftedBy(NEGATIVE_WAD_PRECISION),
+      apr30dAverage: new BigNumber(apr30dAverage).shiftedBy(NEGATIVE_WAD_PRECISION),
       dailyPercentageRate30dAverage: new BigNumber(dailyPercentageRate30dAverage)
-        .shiftedBy(negativeWadPrecision)
+        .shiftedBy(NEGATIVE_WAD_PRECISION)
         .shiftedBy(2),
       monthlyPercentageRate30dAverage: new BigNumber(monthlyPercentageRate30dAverage)
-        .shiftedBy(negativeWadPrecision)
+        .shiftedBy(NEGATIVE_WAD_PRECISION)
         .shiftedBy(2),
       currentBurnEpoch: new BigNumber(currentBurnEpoch),
-      pendingInflator: new BigNumber(pendingInflator).shiftedBy(negativeWadPrecision),
+      pendingInflator: new BigNumber(pendingInflator).shiftedBy(NEGATIVE_WAD_PRECISION),
       buckets: buckets.map((bucket) => ({
         index: new BigNumber(bucket.index),
-        price: new BigNumber(bucket.price).shiftedBy(negativeWadPrecision),
-        quoteTokens: new BigNumber(bucket.quoteTokens).shiftedBy(negativeWadPrecision),
-        collateral: new BigNumber(bucket.collateral).shiftedBy(negativeWadPrecision),
+        price: new BigNumber(bucket.price).shiftedBy(NEGATIVE_WAD_PRECISION),
+        quoteTokens: new BigNumber(bucket.quoteTokens).shiftedBy(NEGATIVE_WAD_PRECISION),
+        collateral: new BigNumber(bucket.collateral).shiftedBy(NEGATIVE_WAD_PRECISION),
         bucketLPs: new BigNumber(bucket.bucketLPs),
       })),
     }


### PR DESCRIPTION
# Ajna earn slider range adjust

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added handling for case where pool is not initialized yet (there is only liquidity (or not) without borrowers)
- fixed slider step
- overwrite htpPrice when index is 7388 (from zero to minimum value from buckets price list)
  
## How to test 🧪
  <Please explain how to test your changes>

- on fresh pool where  there is no liquidity or there is liquidity but without borrowers slider range should be from min price from buckets to market price
