### PR TITLE
:loud_sound: Make smaller sample. Make larger `largePageDataBytes`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -182,7 +182,9 @@ const baseConfig = {
     ]
   },
   transpilePackages: ['@lifi/widget', '@lifi/wallet-management'],
-  largePageDataBytes: 200 * 1024, // 200 KB. The default one is 128 KB, but we have a lot of that kind of errors, so we increase it.
+  experimental: {
+    largePageDataBytes: 256 * 1024, // 256 KB. The default one is 128 KB, but we have a lot of that kind of errors, so we increase it.
+  },
 }
 
 module.exports = withBundleAnalyzer(withMDX(baseConfig))

--- a/sentry.base.config.ts
+++ b/sentry.base.config.ts
@@ -17,9 +17,9 @@ export const sentryBaseConfig: BaseConfig = {
   // so ensure that SENTRY_RELEASE is the same at build time.
   release: process.env.SENTRY_RELEASE || getConfig()?.publicRuntimeConfig?.sentryRelease,
   enabled: process.env.NEXT_PUBLIC_SENTRY_ENV !== 'development',
-  tracesSampleRate: 0.3,
+  tracesSampleRate: 0.2,
   sampleRate: 0.3,
-  profilesSampleRate: 0.3,
+  profilesSampleRate: 0.1,
   integrations: [
     new CaptureConsoleIntegration({ levels: ['error', 'warn', 'info', 'assets'] }),
     new HttpClientIntegration(),


### PR DESCRIPTION
# Changes
- Make smaller sampling to Sentry. Reason: we have a lot of transactions in Sentry. We don't need it so we are reducing sampling.
- `largePageDataBytes` change. Reason: Nearly all pages exceed the standard limit. We need to identify which page we should prioritize to address first.