### PR TITLE
Max withdraw when lup above htp copy update

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2732,7 +2732,7 @@
       "borrow-undercollateralized": "You cannot generate more than {{amount}} {{quoteToken}}, as this would take your position below the minimum LTV. Please enter a lower amount.",
       "earning-no-apy": "You will be lending without earning any yield.",
       "withdraw-more-than-available": "You cannot withdraw more than {{amount}} {{token}}, please select a lower amount.",
-      "after-lup-index-bigger-than-htp-index": "You cannot withdraw this amount, please try to withdraw less.",
+      "after-lup-index-bigger-than-htp-index": "You cannot withdraw this amount as there is not enough available liquidity in the pool. Please withdraw a lower amount or wait for more available liquidity.",
       "debt-less-then-dust-limit": "Minimum debt amount you can draw is {{minDebtAmount}}, as this is the minimum required by the pool. Please enter an amount at least equal to the minimum borrow amount.",
       "repay-more-then-debt": "You cannot repay more than the total debt amount {{amount}} {{quoteToken}}.",
       "not-enough-liquidity": "You cannot generate more debt than is available in the pool {{amount}} {{collateralToken}}/{{quoteToken}}.",


### PR DESCRIPTION
# [Max withdraw when lup above htp copy update](https://app.shortcut.com/oazo-apps/story/9139/earn-cannot-withdraw-update-copy-for-error?vc_group_by=day&ct_workflow=all&cf_workflow=500000053)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated copy
  
## How to test 🧪
  <Please explain how to test your changes>

- use earn position ETH/USDC, try to withdraw USDC
