### PR TITLE
Fix the GUNI fee to use the no fee exchange

### DIFF
--- a/blockchain/calls/proxyActions/proxyActions.ts
+++ b/blockchain/calls/proxyActions/proxyActions.ts
@@ -517,11 +517,11 @@ function getGuniCloseVaultData(data: CloseGuniMultiplyData, context: ContextConn
     fmm,
     guniResolver,
     guniRouter,
-    lowerFeesExchange,
+    noFeesExchange,
   } = getNetworkContracts(NetworkIds.MAINNET, context.chainId)
   const { contract } = context
 
-  const exchange = lowerFeesExchange
+  const exchange = noFeesExchange
 
   const { token0: token0Symbol, token1: token1Symbol } = getToken(data.token)
 


### PR DESCRIPTION
# Bug: we noticed that we started to take a fee for closing GUNI, whilst this should not be the case.

## Changes 👷‍♀️
- Fixed the fees for closing GUNI -> should not take any fees on closing. This bug was introduced with the network configuration update
  
## How to test 🧪
- Confirm that the address used is the noFeesExchange