### PR TITLE
🧿 Manual price bucket selector

### DIFF
--- a/components/constants.ts
+++ b/components/constants.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js'
 
+export const FIAT_PRECISION = 2
 export const WAD_PRECISION = 18
 export const NEGATIVE_WAD_PRECISION = -18
 export const RAY_PRECISION = 27

--- a/components/vault/VaultActionInput.tsx
+++ b/components/vault/VaultActionInput.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { BigNumber } from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
+import { FIAT_PRECISION } from 'components/constants'
 import { BigNumberInput } from 'helpers/BigNumberInput'
 import { formatAmount, formatBigNumber, formatCryptoBalance } from 'helpers/formatters/format'
 import { calculateTokenPrecisionByValue } from 'helpers/tokens'
@@ -20,7 +21,6 @@ export type VaultAction =
   | 'Sell'
   | 'Withdraw'
   | TranslateStringType
-const FIAT_PRECISION = 2
 
 export const PlusIcon = () => (
   <Icon

--- a/features/ajna/positions/earn/components/AjnaEarnInput.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnInput.tsx
@@ -15,14 +15,16 @@ import { Box, Button, Text } from 'theme-ui'
 type AjnaEarnInputButtonVariant = '-' | '+'
 
 interface AjnaEarnInputButtonProps {
+  disabled?: boolean
   variant: AjnaEarnInputButtonVariant
   onClick: (variant: AjnaEarnInputButtonVariant) => void
 }
 interface AjnaEarnInputProps {
+  disabled?: boolean
   range: BigNumber[]
 }
 
-const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ variant, onClick }) => {
+const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ disabled, variant, onClick }) => {
   return (
     <Button
       sx={{
@@ -46,6 +48,7 @@ const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ variant, onClick })
         fontWeight: 'regular',
         lineHeight: '26px',
         transition: 'border-color 200ms',
+        pointerEvents: disabled ? 'none' : 'auto',
         '&:hover': {
           borderColor: 'neutral70',
           bg: 'neutral10',
@@ -80,7 +83,7 @@ const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ variant, onClick })
   )
 }
 
-export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ range }) => {
+export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, range }) => {
   const { t } = useTranslation()
   const {
     environment: { priceFormat, quoteToken },
@@ -112,7 +115,12 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ range }) => {
   }, [price])
 
   return (
-    <>
+    <Box
+      sx={{
+        opacity: disabled ? 0.5 : 1,
+        transition: 'opacity 200ms',
+      }}
+    >
       <Text as="p" variant="paragraph4" sx={{ textAlign: 'center' }}>
         {t('ajna.position-page.earn.common.form.input-lending-price', { quoteToken })}
       </Text>
@@ -124,8 +132,9 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ range }) => {
           borderColor: isFocus ? 'neutral70' : 'neutral20',
           borderRadius: 'medium',
           transition: 'border-color 200ms',
+          cursor: disabled ? 'not-allowed' : 'default',
           '&:hover': {
-            borderColor: 'neutral70',
+            borderColor: disabled ? 'neutral20' : 'neutral70',
           },
         }}
         onBlur={(e) => {
@@ -154,7 +163,15 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ range }) => {
             setManualAmount(n)
           })}
           value={manualAmount ? formatBigNumber(manualAmount, FIAT_PRECISION) : ''}
-          sx={{ px: 5, pt: 3, pb: '40px', border: 'none', fontSize: 4, textAlign: 'center' }}
+          sx={{
+            px: 5,
+            pt: 3,
+            pb: '40px',
+            border: 'none',
+            fontSize: 4,
+            textAlign: 'center',
+            pointerEvents: disabled ? 'none' : 'auto',
+          }}
         />
         <Text
           as="span"
@@ -171,9 +188,9 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ range }) => {
         >
           {priceFormat} {t('ajna.position-page.earn.common.form.lending-price')}
         </Text>
-        <AjnaEarnInputButton variant="-" onClick={clickHandler} />
-        <AjnaEarnInputButton variant="+" onClick={clickHandler} />
+        <AjnaEarnInputButton disabled={disabled} variant="-" onClick={clickHandler} />
+        <AjnaEarnInputButton disabled={disabled} variant="+" onClick={clickHandler} />
       </Box>
-    </>
+    </Box>
   )
 }

--- a/features/ajna/positions/earn/components/AjnaEarnInput.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnInput.tsx
@@ -1,0 +1,146 @@
+import BigNumber from 'bignumber.js'
+import { FIAT_PRECISION } from 'components/constants'
+import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
+import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { BigNumberInput } from 'helpers/BigNumberInput'
+import { formatBigNumber } from 'helpers/formatters/format'
+import { handleNumericInput } from 'helpers/input'
+import { zero } from 'helpers/zero'
+import { useTranslation } from 'next-i18next'
+import React, { FC, useState } from 'react'
+import { createNumberMask } from 'text-mask-addons'
+import { Box, Button, Text } from 'theme-ui'
+
+interface AjnaEarnInputButtonProps {
+  variant: '-' | '+'
+}
+
+const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ variant }) => {
+  return (
+    <Button
+      sx={{
+        position: 'absolute',
+        top: '12px',
+        ...(variant === '-' && {
+          left: '20px',
+        }),
+        ...(variant === '+' && {
+          right: '20px',
+        }),
+        height: '28px',
+        width: '28px',
+        p: 0,
+        color: 'primary100',
+        border: '1px solid',
+        borderColor: 'neutral20',
+        borderRadius: 'ellipse',
+        bg: 'neutral10',
+        fontSize: 6,
+        fontWeight: 'regular',
+        lineHeight: '26px',
+        transition: 'border-color 200ms',
+        '&:hover': {
+          borderColor: 'neutral70',
+          bg: 'neutral10',
+          '&::before, &::after': {
+            width: '12px',
+          },
+        },
+        '&::before, &::after': {
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          width: '10px',
+          height: '2px',
+          m: 'auto',
+          borderRadius: '2px',
+          bg: 'primary100',
+        },
+        '&::before': {
+          content: '""',
+        },
+        '&::after': {
+          transform: 'rotate(90deg)',
+          ...(variant === '+' && {
+            content: '""',
+          }),
+        },
+      }}
+    />
+  )
+}
+
+export const AjnaEarnInput: FC = () => {
+  const { t } = useTranslation()
+  const {
+    environment: { priceFormat, quoteToken },
+  } = useAjnaGeneralContext()
+  const {
+    form: {
+      state: { price },
+    },
+  } = useAjnaProductContext('earn')
+  console.log('refreshed')
+  const [isFocus, setIsFocus] = useState<boolean>(false)
+  const [manualAmount, setManualAmount] = useState<BigNumber>(price || zero)
+
+  return (
+    <>
+      <Text as="p" variant="paragraph4" sx={{ textAlign: 'center' }}>
+        {t('ajna.position-page.earn.common.form.input-lending-price', { quoteToken })}
+      </Text>
+      <Box
+        sx={{
+          position: 'relative',
+          mt: 2,
+          border: '1px solid',
+          borderColor: isFocus ? 'neutral70' : 'neutral20',
+          borderRadius: 'medium',
+          transition: 'border-color 200ms',
+          '&:hover': {
+            borderColor: 'neutral70',
+          },
+        }}
+      >
+        <BigNumberInput
+          type="text"
+          mask={createNumberMask({
+            allowDecimal: true,
+            decimalLimit: FIAT_PRECISION,
+            prefix: '$',
+          })}
+          onFocus={() => {
+            setIsFocus(true)
+          }}
+          onBlur={() => {
+            setIsFocus(false)
+          }}
+          onChange={handleNumericInput((n) => {
+            console.log(`value: ${n}`)
+          })}
+          value={manualAmount ? formatBigNumber(manualAmount, FIAT_PRECISION) : ''}
+          sx={{ px: 5, pt: 3, pb: '40px', border: 'none', fontSize: 4, textAlign: 'center' }}
+        />
+        <Text
+          as="span"
+          variant="paragraph4"
+          sx={{
+            position: 'absolute',
+            right: 0,
+            bottom: 3,
+            left: 0,
+            textAlign: 'center',
+            color: 'neutral80',
+            pointerEvents: 'none',
+          }}
+        >
+          {priceFormat} {t('ajna.position-page.earn.common.form.lending-price')}
+        </Text>
+        <AjnaEarnInputButton variant="-" />
+        <AjnaEarnInputButton variant="+" />
+      </Box>
+    </>
+  )
+}

--- a/features/ajna/positions/earn/components/AjnaEarnInput.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnInput.tsx
@@ -21,6 +21,8 @@ interface AjnaEarnInputButtonProps {
 }
 interface AjnaEarnInputProps {
   disabled?: boolean
+  max: BigNumber
+  min: BigNumber
   range: BigNumber[]
 }
 
@@ -47,13 +49,15 @@ const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ disabled, variant, 
         fontSize: 6,
         fontWeight: 'regular',
         lineHeight: '26px',
-        transition: 'border-color 200ms',
-        pointerEvents: disabled ? 'none' : 'auto',
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? 'not-allowed' : 'default',
+        transition: 'border-color 200ms, opacity 200ms',
         '&:hover': {
-          borderColor: 'neutral70',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          borderColor: disabled ? 'neutral20' : 'neutral70',
           bg: 'neutral10',
           '&::before, &::after': {
-            width: '12px',
+            width: disabled ? '10px' : '12px',
           },
         },
         '&::before, &::after': {
@@ -78,12 +82,14 @@ const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ disabled, variant, 
           }),
         },
       }}
-      onClick={() => onClick(variant)}
+      onClick={() => {
+        if (!disabled) onClick(variant)
+      }}
     />
   )
 }
 
-export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, range }) => {
+export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, max, min, range }) => {
   const { t } = useTranslation()
   const {
     environment: { priceFormat, quoteToken },
@@ -115,13 +121,12 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, range }) => {
   }, [price])
 
   return (
-    <Box
-      sx={{
-        opacity: disabled ? 0.5 : 1,
-        transition: 'opacity 200ms',
-      }}
-    >
-      <Text as="p" variant="paragraph4" sx={{ textAlign: 'center' }}>
+    <Box>
+      <Text
+        as="p"
+        variant="paragraph4"
+        sx={{ textAlign: 'center', opacity: disabled ? 0.5 : 1, transition: 'opacity 200ms' }}
+      >
         {t('ajna.position-page.earn.common.form.input-lending-price', { quoteToken })}
       </Text>
       <Box
@@ -151,7 +156,7 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, range }) => {
           mask={createNumberMask({
             allowDecimal: true,
             decimalLimit: FIAT_PRECISION,
-            prefix: '$',
+            prefix: '',
           })}
           onFocus={() => {
             setIsFocus(true)
@@ -170,7 +175,9 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, range }) => {
             border: 'none',
             fontSize: 4,
             textAlign: 'center',
+            opacity: disabled ? 0.5 : 1,
             pointerEvents: disabled ? 'none' : 'auto',
+            transition: 'opacity 200ms',
           }}
         />
         <Text
@@ -183,13 +190,23 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, range }) => {
             left: 0,
             textAlign: 'center',
             color: 'neutral80',
+            opacity: disabled ? 0.5 : 1,
             pointerEvents: 'none',
+            transition: 'opacity 200ms',
           }}
         >
           {priceFormat} {t('ajna.position-page.earn.common.form.lending-price')}
         </Text>
-        <AjnaEarnInputButton disabled={disabled} variant="-" onClick={clickHandler} />
-        <AjnaEarnInputButton disabled={disabled} variant="+" onClick={clickHandler} />
+        <AjnaEarnInputButton
+          disabled={disabled || manualAmount.lte(min)}
+          variant="-"
+          onClick={clickHandler}
+        />
+        <AjnaEarnInputButton
+          disabled={disabled || manualAmount.gte(max)}
+          variant="+"
+          onClick={clickHandler}
+        />
       </Box>
     </Box>
   )

--- a/features/ajna/positions/earn/components/AjnaEarnInput.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnInput.tsx
@@ -121,7 +121,7 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, max, min, rang
   }, [price])
 
   return (
-    <Box>
+    <>
       <Text
         as="p"
         variant="paragraph4"
@@ -208,6 +208,6 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, max, min, rang
           onClick={clickHandler}
         />
       </Box>
-    </Box>
+    </>
   )
 }

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -118,7 +118,7 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
           priceFormat,
         })}
       >
-        <AjnaEarnInput />
+        <AjnaEarnInput range={range} />
       </PillAccordion>
     </>
   )

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -11,9 +11,15 @@ import { snapToPredefinedValues } from 'features/ajna/positions/earn/helpers/sna
 import { formatAmount, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
-import React, { useEffect, useMemo } from 'react'
+import React, { FC, useEffect, useMemo } from 'react'
+import { Box } from 'theme-ui'
 
-export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
+interface AjnaEarnSliderProps {
+  isDisabled?: boolean
+  nestedManualInput?: boolean
+}
+
+export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManualInput }) => {
   const { t } = useTranslation()
   const {
     environment: { collateralToken, priceFormat, quoteToken, isShort },
@@ -113,13 +119,19 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
         #EABE4C ${lupPercentage}% ${mompPercentage}%,
         #EE5728 ${mompPercentage}% 100%)`}
       />
-      <PillAccordion
-        title={t('ajna.position-page.earn.common.form.or-enter-specific-lending-price', {
-          priceFormat,
-        })}
-      >
-        <AjnaEarnInput disabled={isDisabled || isFormFrozen} min={min} max={max} range={range} />
-      </PillAccordion>
+      {nestedManualInput ? (
+        <PillAccordion
+          title={t('ajna.position-page.earn.common.form.or-enter-specific-lending-price', {
+            priceFormat,
+          })}
+        >
+          <AjnaEarnInput disabled={isDisabled || isFormFrozen} min={min} max={max} range={range} />
+        </PillAccordion>
+      ) : (
+        <Box sx={{ mt: 3 }}>
+          <AjnaEarnInput disabled={isDisabled || isFormFrozen} min={min} max={max} range={range} />
+        </Box>
+      )}
     </>
   )
 }

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -1,12 +1,14 @@
 import BigNumber from 'bignumber.js'
 import { WAD_PRECISION } from 'components/constants'
 import { SliderValuePicker } from 'components/dumb/SliderValuePicker'
+import { PillAccordion } from 'components/PillAccordion'
 import {
   ajnaDefaultMarketPriceOffset,
   ajnaDefaultPoolRangeMarketPriceOffset,
 } from 'features/ajna/common/consts'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { AjnaEarnInput } from 'features/ajna/positions/earn/components/AjnaEarnInput'
 import { AJNA_LUP_MOMP_OFFSET } from 'features/ajna/positions/earn/consts'
 import { formatAmount, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { one, zero } from 'helpers/zero'
@@ -125,7 +127,7 @@ function convertSliderThresholds({
 export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, quoteToken, isShort },
+    environment: { collateralToken, priceFormat, quoteToken, isShort },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -195,31 +197,40 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
   const leftBoundry = isShort ? one.div(resolvedValue) : resolvedValue
 
   return (
-    <SliderValuePicker
-      lastValue={resolvedValue}
-      minBoundry={min}
-      maxBoundry={max}
-      step={range[1].minus(range[0]).toNumber()}
-      leftBoundry={leftBoundry}
-      rightBoundry={maxLtv}
-      leftBoundryFormatter={(v) => `${t('price')} $${formatAmount(v, 'USD')}`}
-      rightBoundryFormatter={(v) =>
-        !v.isZero() ? `${t('max-ltv')} ${formatDecimalAsPercent(v)}` : '-'
-      }
-      disabled={isDisabled || isFormFrozen}
-      onChange={handleChange}
-      leftLabel={t('ajna.position-page.earn.common.form.max-lending-price', {
-        quoteToken: isShort ? collateralToken : quoteToken,
-        collateralToken: isShort ? quoteToken : collateralToken,
-      })}
-      rightLabel={t('ajna.position-page.earn.common.form.max-ltv-to-lend-at')}
-      leftBottomLabel={t('safer')}
-      rightBottomLabel={t('riskier')}
-      colorfulRanges={`linear-gradient(to right,
+    <>
+      <SliderValuePicker
+        lastValue={resolvedValue}
+        minBoundry={min}
+        maxBoundry={max}
+        step={range[1].minus(range[0]).toNumber()}
+        leftBoundry={leftBoundry}
+        rightBoundry={maxLtv}
+        leftBoundryFormatter={(v) => `${t('price')} $${formatAmount(v, 'USD')}`}
+        rightBoundryFormatter={(v) =>
+          !v.isZero() ? `${t('max-ltv')} ${formatDecimalAsPercent(v)}` : '-'
+        }
+        disabled={isDisabled || isFormFrozen}
+        onChange={handleChange}
+        leftLabel={t('ajna.position-page.earn.common.form.max-lending-price', {
+          quoteToken: isShort ? collateralToken : quoteToken,
+          collateralToken: isShort ? quoteToken : collateralToken,
+        })}
+        rightLabel={t('ajna.position-page.earn.common.form.max-ltv-to-lend-at')}
+        leftBottomLabel={t('safer')}
+        rightBottomLabel={t('riskier')}
+        colorfulRanges={`linear-gradient(to right,
         #D3D4D8 0 ${htpPercentage}%,
         #1ECBAE ${htpPercentage}% ${lupPercentage}%,
         #EABE4C ${lupPercentage}% ${mompPercentage}%,
         #EE5728 ${mompPercentage}% 100%)`}
-    />
+      />
+      <PillAccordion
+        title={t('ajna.position-page.earn.common.form.or-enter-specific-lending-price', {
+          priceFormat,
+        })}
+      >
+        <AjnaEarnInput />
+      </PillAccordion>
+    </>
   )
 }

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -1,128 +1,17 @@
 import BigNumber from 'bignumber.js'
-import { WAD_PRECISION } from 'components/constants'
 import { SliderValuePicker } from 'components/dumb/SliderValuePicker'
 import { PillAccordion } from 'components/PillAccordion'
-import {
-  ajnaDefaultMarketPriceOffset,
-  ajnaDefaultPoolRangeMarketPriceOffset,
-} from 'features/ajna/common/consts'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaEarnInput } from 'features/ajna/positions/earn/components/AjnaEarnInput'
 import { AJNA_LUP_MOMP_OFFSET } from 'features/ajna/positions/earn/consts'
+import { convertSliderThresholds } from 'features/ajna/positions/earn/helpers/convertSliderThresholds'
+import { getMinMaxAndRange } from 'features/ajna/positions/earn/helpers/getMinMaxAndRange'
+import { snapToPredefinedValues } from 'features/ajna/positions/earn/helpers/snapToPredefinedValues'
 import { formatAmount, formatDecimalAsPercent } from 'helpers/formatters/format'
-import { one, zero } from 'helpers/zero'
+import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect, useMemo } from 'react'
-
-function snapToPredefinedValues(value: BigNumber, predefinedSteps: BigNumber[]) {
-  return predefinedSteps.reduce((prev, curr) => {
-    return curr.minus(value).abs().lt(prev.minus(value).abs()) ? curr : prev
-  })
-}
-
-function getMinMaxAndRange({
-  highestThresholdPrice,
-  lowestUtilizedPrice,
-  lowestUtilizedPriceIndex,
-  mostOptimisticMatchingPrice,
-  marketPrice,
-  offset, // 0 - 1, percentage value
-}: {
-  highestThresholdPrice: BigNumber
-  lowestUtilizedPrice: BigNumber
-  lowestUtilizedPriceIndex: BigNumber
-  mostOptimisticMatchingPrice: BigNumber
-  marketPrice: BigNumber
-  offset: number
-}) {
-  // check whether pool contain liquidity and borrowers, if no generate default range from the lowest price to market price
-  if (lowestUtilizedPriceIndex.eq(zero)) {
-    const defaultRange = [marketPrice.times(one.minus(ajnaDefaultPoolRangeMarketPriceOffset))]
-
-    while (
-      defaultRange[defaultRange.length - 1].lt(
-        marketPrice.times(one.minus(ajnaDefaultMarketPriceOffset)),
-      )
-    ) {
-      defaultRange.push(
-        defaultRange[defaultRange.length - 1].times(1.005).decimalPlaces(WAD_PRECISION),
-      )
-    }
-
-    return {
-      min: defaultRange[0],
-      max: defaultRange[defaultRange.length - 1],
-      range: defaultRange,
-    }
-  }
-
-  // Generate ranges from min to lup
-  const lupNearHtpRange = [lowestUtilizedPrice]
-
-  while (lupNearHtpRange[lupNearHtpRange.length - 1].gt(highestThresholdPrice)) {
-    lupNearHtpRange.push(lupNearHtpRange[lupNearHtpRange.length - 1].div(1.005))
-  }
-
-  const nearHtpMinRange = [lupNearHtpRange[lupNearHtpRange.length - 1]]
-
-  while (
-    nearHtpMinRange[nearHtpMinRange.length - 1].gt(nearHtpMinRange[0].times(one.minus(offset)))
-  ) {
-    nearHtpMinRange.push(nearHtpMinRange[nearHtpMinRange.length - 1].div(1.005))
-  }
-
-  // Generate ranges from lup to max
-  const lupNearMompRange = [lowestUtilizedPrice]
-
-  while (lupNearMompRange[lupNearMompRange.length - 1].lt(mostOptimisticMatchingPrice)) {
-    lupNearMompRange.push(lupNearMompRange[lupNearMompRange.length - 1].times(1.005))
-  }
-
-  const nearMompMaxRange = [lupNearMompRange[lupNearMompRange.length - 1]]
-
-  while (
-    nearMompMaxRange[nearMompMaxRange.length - 1].lt(nearMompMaxRange[0].times(one.plus(offset)))
-  ) {
-    nearMompMaxRange.push(nearMompMaxRange[nearMompMaxRange.length - 1].times(1.005))
-  }
-
-  const range = [
-    ...new Set([...nearHtpMinRange, ...lupNearHtpRange, ...lupNearMompRange, ...nearMompMaxRange]),
-  ]
-    .sort((a, b) => a.toNumber() - b.toNumber())
-    .map((item) => item.decimalPlaces(18))
-
-  return {
-    min: range[0],
-    max: range[range.length - 1],
-    range,
-  }
-}
-
-function convertSliderValuesToPercents(value: BigNumber, min: BigNumber, max: BigNumber) {
-  return value.minus(min).div(max.minus(min)).times(100).toNumber()
-}
-
-function convertSliderThresholds({
-  min,
-  max,
-  highestThresholdPrice,
-  lowestUtilizedPrice,
-  mostOptimisticMatchingPrice,
-}: {
-  min: BigNumber
-  max: BigNumber
-  highestThresholdPrice: BigNumber
-  lowestUtilizedPrice: BigNumber
-  mostOptimisticMatchingPrice: BigNumber
-}) {
-  return {
-    htpPercentage: convertSliderValuesToPercents(highestThresholdPrice, min, max),
-    lupPercentage: convertSliderValuesToPercents(lowestUtilizedPrice, min, max),
-    mompPercentage: convertSliderValuesToPercents(mostOptimisticMatchingPrice, min, max),
-  }
-}
 
 export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
   const { t } = useTranslation()

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -118,7 +118,7 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
           priceFormat,
         })}
       >
-        <AjnaEarnInput range={range} />
+        <AjnaEarnInput disabled={isDisabled || isFormFrozen} range={range} />
       </PillAccordion>
     </>
   )

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -118,7 +118,7 @@ export function AjnaEarnSlider({ isDisabled }: { isDisabled?: boolean }) {
           priceFormat,
         })}
       >
-        <AjnaEarnInput disabled={isDisabled || isFormFrozen} range={range} />
+        <AjnaEarnInput disabled={isDisabled || isFormFrozen} min={min} max={max} range={range} />
       </PillAccordion>
     </>
   )

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -32,7 +32,6 @@ export function AjnaEarnOverviewManageController() {
       content={
         <DetailsSectionContentCardWrapper>
           <ContentCardCurrentEarnings
-            isLoading={isSimulationLoading}
             quoteToken={quoteToken}
             // TODO adjust once data available in subgraph
             currentEarnings={zero}

--- a/features/ajna/positions/earn/helpers/convertSliderThresholds.ts
+++ b/features/ajna/positions/earn/helpers/convertSliderThresholds.ts
@@ -1,0 +1,22 @@
+import BigNumber from 'bignumber.js'
+import { convertSliderValuesToPercents } from 'features/ajna/positions/earn/helpers/convertSliderValuesToPercents'
+
+export const convertSliderThresholds = ({
+  min,
+  max,
+  highestThresholdPrice,
+  lowestUtilizedPrice,
+  mostOptimisticMatchingPrice,
+}: {
+  min: BigNumber
+  max: BigNumber
+  highestThresholdPrice: BigNumber
+  lowestUtilizedPrice: BigNumber
+  mostOptimisticMatchingPrice: BigNumber
+}) => {
+  return {
+    htpPercentage: convertSliderValuesToPercents(highestThresholdPrice, min, max),
+    lupPercentage: convertSliderValuesToPercents(lowestUtilizedPrice, min, max),
+    mompPercentage: convertSliderValuesToPercents(mostOptimisticMatchingPrice, min, max),
+  }
+}

--- a/features/ajna/positions/earn/helpers/convertSliderValuesToPercents.ts
+++ b/features/ajna/positions/earn/helpers/convertSliderValuesToPercents.ts
@@ -1,0 +1,5 @@
+import BigNumber from 'bignumber.js'
+
+export const convertSliderValuesToPercents = (value: BigNumber, min: BigNumber, max: BigNumber) => {
+  return value.minus(min).div(max.minus(min)).times(100).toNumber()
+}

--- a/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
+++ b/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
@@ -1,0 +1,86 @@
+import BigNumber from 'bignumber.js'
+import { WAD_PRECISION } from 'components/constants'
+import {
+  ajnaDefaultMarketPriceOffset,
+  ajnaDefaultPoolRangeMarketPriceOffset,
+} from 'features/ajna/common/consts'
+import { one, zero } from 'helpers/zero'
+
+export const getMinMaxAndRange = ({
+  highestThresholdPrice,
+  lowestUtilizedPrice,
+  lowestUtilizedPriceIndex,
+  mostOptimisticMatchingPrice,
+  marketPrice,
+  offset, // 0 - 1, percentage value
+}: {
+  highestThresholdPrice: BigNumber
+  lowestUtilizedPrice: BigNumber
+  lowestUtilizedPriceIndex: BigNumber
+  mostOptimisticMatchingPrice: BigNumber
+  marketPrice: BigNumber
+  offset: number
+}) => {
+  // check whether pool contain liquidity and borrowers, if no generate default range from the lowest price to market price
+  if (lowestUtilizedPriceIndex.eq(zero)) {
+    const defaultRange = [marketPrice.times(one.minus(ajnaDefaultPoolRangeMarketPriceOffset))]
+
+    while (
+      defaultRange[defaultRange.length - 1].lt(
+        marketPrice.times(one.minus(ajnaDefaultMarketPriceOffset)),
+      )
+    ) {
+      defaultRange.push(
+        defaultRange[defaultRange.length - 1].times(1.005).decimalPlaces(WAD_PRECISION),
+      )
+    }
+
+    return {
+      min: defaultRange[0],
+      max: defaultRange[defaultRange.length - 1],
+      range: defaultRange,
+    }
+  }
+
+  // Generate ranges from min to lup
+  const lupNearHtpRange = [lowestUtilizedPrice]
+
+  while (lupNearHtpRange[lupNearHtpRange.length - 1].gt(highestThresholdPrice)) {
+    lupNearHtpRange.push(lupNearHtpRange[lupNearHtpRange.length - 1].div(1.005))
+  }
+
+  const nearHtpMinRange = [lupNearHtpRange[lupNearHtpRange.length - 1]]
+
+  while (
+    nearHtpMinRange[nearHtpMinRange.length - 1].gt(nearHtpMinRange[0].times(one.minus(offset)))
+  ) {
+    nearHtpMinRange.push(nearHtpMinRange[nearHtpMinRange.length - 1].div(1.005))
+  }
+
+  // Generate ranges from lup to max
+  const lupNearMompRange = [lowestUtilizedPrice]
+
+  while (lupNearMompRange[lupNearMompRange.length - 1].lt(mostOptimisticMatchingPrice)) {
+    lupNearMompRange.push(lupNearMompRange[lupNearMompRange.length - 1].times(1.005))
+  }
+
+  const nearMompMaxRange = [lupNearMompRange[lupNearMompRange.length - 1]]
+
+  while (
+    nearMompMaxRange[nearMompMaxRange.length - 1].lt(nearMompMaxRange[0].times(one.plus(offset)))
+  ) {
+    nearMompMaxRange.push(nearMompMaxRange[nearMompMaxRange.length - 1].times(1.005))
+  }
+
+  const range = [
+    ...new Set([...nearHtpMinRange, ...lupNearHtpRange, ...lupNearMompRange, ...nearMompMaxRange]),
+  ]
+    .sort((a, b) => a.toNumber() - b.toNumber())
+    .map((item) => item.decimalPlaces(18))
+
+  return {
+    min: range[0],
+    max: range[range.length - 1],
+    range,
+  }
+}

--- a/features/ajna/positions/earn/helpers/snapToPredefinedValues.ts
+++ b/features/ajna/positions/earn/helpers/snapToPredefinedValues.ts
@@ -1,0 +1,7 @@
+import BigNumber from 'bignumber.js'
+
+export const snapToPredefinedValues = (value: BigNumber, predefinedSteps: BigNumber[]) => {
+  return predefinedSteps.reduce((prev, curr) => {
+    return curr.minus(value).abs().lt(prev.minus(value).abs()) ? curr : prev
+  })
+}

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormContentAdjust.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormContentAdjust.tsx
@@ -11,7 +11,7 @@ export function AjnaEarnFormContentAdjust() {
 
   return (
     <>
-      <AjnaEarnSlider />
+      <AjnaEarnSlider nestedManualInput={true} />
       {isFormValid && (
         <AjnaFormContentSummary>
           <AjnaEarnFormOrder />

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormContentOpen.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormContentOpen.tsx
@@ -27,7 +27,10 @@ export function AjnaEarnFormContentOpen() {
         maxAmount={quoteBalance}
         resetOnClear
       />
-      <AjnaEarnSlider isDisabled={!depositAmount || depositAmount?.lte(0)} />
+      <AjnaEarnSlider
+        isDisabled={!depositAmount || depositAmount?.lte(0)}
+        nestedManualInput={true}
+      />
       {isFormValid && (
         <AjnaFormContentSummary>
           <AjnaEarnFormOrder />

--- a/helpers/input.tsx
+++ b/helpers/input.tsx
@@ -82,7 +82,7 @@ export function InputWithMax({
 
 export function handleNumericInput(fn: (n?: BigNumber) => void) {
   return (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/,/g, '')
+    const value = e.target.value.replace(/,|\$/g, '')
     const amount = value !== '' ? new BigNumber(value) : undefined
     fn(amount)
   }

--- a/helpers/input.tsx
+++ b/helpers/input.tsx
@@ -82,7 +82,7 @@ export function InputWithMax({
 
 export function handleNumericInput(fn: (n?: BigNumber) => void) {
   return (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/,|\$/g, '')
+    const value = e.target.value.replace(/,/g, '')
     const amount = value !== '' ? new BigNumber(value) : undefined
     fn(amount)
   }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2647,7 +2647,10 @@
             "ajna-fee": "Ajna fee",
             "deposit-fee-tooltip": "Ajna has deposit fee for deposits below current utilized liquidity as to incentivize lenders to actively lend out. The deposit fee is 1 day of interest: {{value}} of deposit",
             "total-deposited-into-position": "Total deposited into Position",
-            "collateral-available-to-withdraw": "Collateral available to withdraw"
+            "collateral-available-to-withdraw": "Collateral available to withdraw",
+            "input-lending-price": "Input {{quoteToken}} Lending Price",
+            "or-enter-specific-lending-price": "Or enter specific {{priceFormat}} Lending Price",
+            "lending-price": "Lending Price"
           }
         },
         "open": {


### PR DESCRIPTION
# [Manual price bucket selector](https://app.shortcut.com/oazo-apps/story/9543/earn-price-bucket-input-box)

Added ability to manually put a desired price for Ajna Earn form.
  
[Tab-1686581749966.webm](https://github.com/OasisDEX/oasis-borrow/assets/16230404/624b3e22-72bc-4c16-b275-038573cf8daf)

## Changes 👷‍♀️

- Created `AjnaEarnInput` and `AjnaEarnInputButton` components manually selecting price,
- extracted all helpers functions from `AjnaEarnSlider` from component file and moved them to separated directory along with other helpers as some of them were also used in `AjnaEarnInput`.
  
## How to test 🧪

Test implementation in following scenarios:
- opening new position,
- managing existing position on Adjust step where slider is always visible,
- managing existing position on Manage quote step, where slider is initially hidden.
