### PR TITLE
Fork network: add to wallet only once.

### DIFF
--- a/blockchain/networks/use-custom-fork-parameter.ts
+++ b/blockchain/networks/use-custom-fork-parameter.ts
@@ -2,7 +2,7 @@ import { useLocalStorage } from 'helpers/useLocalStorage'
 
 import { NetworkNames } from './network-names'
 
-export type CustomForkParameterFieldsType = 'url' | 'id'
+export type CustomForkParameterFieldsType = 'url' | 'id' | 'isAddedToWallet'
 export type CustomForkParameterType = Partial<
   Record<NetworkNames, Record<CustomForkParameterFieldsType, string>>
 >


### PR DESCRIPTION
# Changes
- if we are using forks and MetaMask we want to add Fork to the wallet.
- After the action we save information about fork in wallet in Local Storage to avoid re-adding that fork. 