### PR TITLE
As/link local subgraph

### DIFF
--- a/features/subgraphLoader/useSubgraphLoader.ts
+++ b/features/subgraphLoader/useSubgraphLoader.ts
@@ -1,6 +1,7 @@
 import { NetworkIds } from 'blockchain/networks'
 import { SubgraphBaseResponse, Subgraphs, SubgraphsResponses } from 'features/subgraphLoader/types'
 import { getNetworkId } from 'features/web3Context'
+import { useLocalStorage } from 'helpers/useLocalStorage'
 import { useEffect, useState } from 'react'
 
 interface UseSubgraphLoader<R> {
@@ -17,6 +18,7 @@ export async function loadSubgraph<
   subgraph: S,
   method: M,
   params: P = {} as P,
+  customUrl: string | undefined = undefined,
 ): Promise<SubgraphsResponses[S][keyof SubgraphsResponses[S]]> {
   const networkId = getNetworkId() as NetworkIds
   const response = await fetch(`/api/subgraph`, {
@@ -26,6 +28,7 @@ export async function loadSubgraph<
       method,
       params,
       networkId,
+      customUrl,
     }),
   })
 
@@ -38,6 +41,7 @@ export function useSubgraphLoader<
   P extends Subgraphs[S][M],
 >(subgraph: S, method: M, params: P) {
   const stringifiedParams = JSON.stringify(params)
+  const [customUrl,] = useLocalStorage<string | undefined>(`SubgraphCustomUrl`, undefined)
   const [state, setState] = useState<
     UseSubgraphLoader<SubgraphsResponses[S][keyof SubgraphsResponses[S]]>
   >({
@@ -52,7 +56,7 @@ export function useSubgraphLoader<
       isLoading: true,
     }))
 
-    loadSubgraph(subgraph, method, params)
+    loadSubgraph(subgraph, method, params, customUrl)
       // @ts-ignore
       // TODO adjust types
       .then(({ success, response }) => {

--- a/features/subgraphLoader/useSubgraphLoader.ts
+++ b/features/subgraphLoader/useSubgraphLoader.ts
@@ -1,7 +1,6 @@
 import { NetworkIds } from 'blockchain/networks'
 import { SubgraphBaseResponse, Subgraphs, SubgraphsResponses } from 'features/subgraphLoader/types'
 import { getNetworkId } from 'features/web3Context'
-import { useLocalStorage } from 'helpers/useLocalStorage'
 import { useEffect, useState } from 'react'
 
 interface UseSubgraphLoader<R> {
@@ -18,9 +17,10 @@ export async function loadSubgraph<
   subgraph: S,
   method: M,
   params: P = {} as P,
-  customUrl: string | undefined = undefined,
 ): Promise<SubgraphsResponses[S][keyof SubgraphsResponses[S]]> {
   const networkId = getNetworkId() as NetworkIds
+  const customUrl = localStorage.getItem('SubgraphCustomUrl')
+
   const response = await fetch(`/api/subgraph`, {
     method: 'POST',
     body: JSON.stringify({
@@ -41,7 +41,6 @@ export function useSubgraphLoader<
   P extends Subgraphs[S][M],
 >(subgraph: S, method: M, params: P) {
   const stringifiedParams = JSON.stringify(params)
-  const [customUrl] = useLocalStorage<string | undefined>(`SubgraphCustomUrl`, undefined)
   const [state, setState] = useState<
     UseSubgraphLoader<SubgraphsResponses[S][keyof SubgraphsResponses[S]]>
   >({
@@ -56,7 +55,7 @@ export function useSubgraphLoader<
       isLoading: true,
     }))
 
-    loadSubgraph(subgraph, method, params, customUrl)
+    loadSubgraph(subgraph, method, params)
       // @ts-ignore
       // TODO adjust types
       .then(({ success, response }) => {

--- a/features/subgraphLoader/useSubgraphLoader.ts
+++ b/features/subgraphLoader/useSubgraphLoader.ts
@@ -41,7 +41,7 @@ export function useSubgraphLoader<
   P extends Subgraphs[S][M],
 >(subgraph: S, method: M, params: P) {
   const stringifiedParams = JSON.stringify(params)
-  const [customUrl,] = useLocalStorage<string | undefined>(`SubgraphCustomUrl`, undefined)
+  const [customUrl] = useLocalStorage<string | undefined>(`SubgraphCustomUrl`, undefined)
   const [state, setState] = useState<
     UseSubgraphLoader<SubgraphsResponses[S][keyof SubgraphsResponses[S]]>
   >({

--- a/pages/api/subgraph.tsx
+++ b/pages/api/subgraph.tsx
@@ -5,9 +5,9 @@ import { NextApiHandler, NextApiRequest } from 'next'
 
 async function get({ req: { body } }: { req: NextApiRequest }) {
   try {
-    const { subgraph, method, params, networkId } = JSON.parse(body)
+    const { subgraph, method, params, networkId, customUrl } = JSON.parse(body)
     const response = await request(
-      subgraphsRecord[subgraph as keyof typeof subgraphsRecord][Number(networkId) as NetworkIds],
+      customUrl??subgraphsRecord[subgraph as keyof typeof subgraphsRecord][Number(networkId) as NetworkIds],
       subgraphMethodsRecord[method as keyof typeof subgraphMethodsRecord],
       params,
     )

--- a/pages/api/subgraph.tsx
+++ b/pages/api/subgraph.tsx
@@ -7,7 +7,8 @@ async function get({ req: { body } }: { req: NextApiRequest }) {
   try {
     const { subgraph, method, params, networkId, customUrl } = JSON.parse(body)
     const response = await request(
-      customUrl??subgraphsRecord[subgraph as keyof typeof subgraphsRecord][Number(networkId) as NetworkIds],
+      customUrl ??
+        subgraphsRecord[subgraph as keyof typeof subgraphsRecord][Number(networkId) as NetworkIds],
       subgraphMethodsRecord[method as keyof typeof subgraphMethodsRecord],
       params,
     )


### PR DESCRIPTION
Enables connecting oasis-borrow to local instance of subgraph

by setting the storage variable of `SubgraphCustomUrl`