### PR TITLE
🧿 Add origination fee to debt simulation

### DIFF
--- a/features/ajna/positions/borrow/controls/AjnaBorrowOriginationFee.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOriginationFee.tsx
@@ -2,8 +2,8 @@ import { getToken } from 'blockchain/tokensMetadata'
 import { HighlightedOrderInformation } from 'components/HighlightedOrderInformation'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { getOriginationFee } from 'features/ajna/positions/common/helpers/getOriginationFee'
 import { formatAmount, formatCryptoBalance } from 'helpers/formatters/format'
-import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -13,14 +13,11 @@ export const AjnaBorrowOriginationFee = () => {
     environment: { quoteToken, quotePrice },
   } = useAjnaGeneralContext()
   const {
-    form: {
-      state: { generateAmount },
-    },
     position: {
-      currentPosition: { position },
+      currentPosition: { position, simulation },
     },
   } = useAjnaProductContext('borrow')
-  const originationFee = position.originationFee(generateAmount || zero)
+  const originationFee = getOriginationFee(position, simulation)
   const originationFeeFormatted = `${formatCryptoBalance(
     originationFee,
   )} ${quoteToken} ($${formatAmount(originationFee.times(quotePrice), 'USD')})`

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -1,4 +1,5 @@
 import { normalizeValue } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
@@ -11,7 +12,7 @@ import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/A
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaTokensBannerController } from 'features/ajna/positions/common/controls/AjnaTokensBannerController'
 import { getBorrowishChangeVariant } from 'features/ajna/positions/common/helpers/getBorrowishChangeVariant'
-import { one } from 'helpers/zero'
+import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -86,7 +87,11 @@ export function AjnaBorrowOverviewController() {
               quoteToken={quoteToken}
               positionDebt={position.debtAmount}
               positionDebtUSD={position.debtAmount.times(quotePrice)}
-              afterPositionDebt={simulation?.debtAmount}
+              afterPositionDebt={simulation?.debtAmount.plus(
+                position.originationFee(
+                  BigNumber.max(zero, simulation.debtAmount.minus(position.debtAmount)),
+                ),
+              )}
               changeVariant={changeVariant}
             />
           </DetailsSectionContentCardWrapper>

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -1,5 +1,4 @@
 import { normalizeValue } from '@oasisdex/dma-library'
-import BigNumber from 'bignumber.js'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
@@ -12,7 +11,8 @@ import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/A
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaTokensBannerController } from 'features/ajna/positions/common/controls/AjnaTokensBannerController'
 import { getBorrowishChangeVariant } from 'features/ajna/positions/common/helpers/getBorrowishChangeVariant'
-import { one, zero } from 'helpers/zero'
+import { getOriginationFee } from 'features/ajna/positions/common/helpers/getOriginationFee'
+import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -88,9 +88,7 @@ export function AjnaBorrowOverviewController() {
               positionDebt={position.debtAmount}
               positionDebtUSD={position.debtAmount.times(quotePrice)}
               afterPositionDebt={simulation?.debtAmount.plus(
-                position.originationFee(
-                  BigNumber.max(zero, simulation.debtAmount.minus(position.debtAmount)),
-                ),
+                getOriginationFee(position, simulation),
               )}
               changeVariant={changeVariant}
             />

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -1,4 +1,5 @@
 import { normalizeValue } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
@@ -9,7 +10,7 @@ import {
   formatCryptoBalance,
   formatDecimalAsPercent,
 } from 'helpers/formatters/format'
-import { one } from 'helpers/zero'
+import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -58,7 +59,13 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
     debt: `${formatCryptoBalance(positionData.debtAmount)} ${quoteToken}`,
     afterDebt:
       simulationData?.debtAmount &&
-      `${formatCryptoBalance(simulationData.debtAmount)} ${quoteToken}`,
+      `${formatCryptoBalance(
+        simulationData.debtAmount.plus(
+          positionData.originationFee(
+            BigNumber.max(zero, simulationData.debtAmount.minus(positionData.debtAmount)),
+          ),
+        ),
+      )} ${quoteToken}`,
     availableToWithdraw: `${formatCryptoBalance(
       positionData.collateralAvailable,
     )} ${collateralToken}`,

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -1,16 +1,16 @@
 import { normalizeValue } from '@oasisdex/dma-library'
-import BigNumber from 'bignumber.js'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
+import { getOriginationFee } from 'features/ajna/positions/common/helpers/getOriginationFee'
 import { resolveIfCachedPosition } from 'features/ajna/positions/common/helpers/resolveIfCachedPosition'
 import {
   formatAmount,
   formatCryptoBalance,
   formatDecimalAsPercent,
 } from 'helpers/formatters/format'
-import { one, zero } from 'helpers/zero'
+import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -60,11 +60,7 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
     afterDebt:
       simulationData?.debtAmount &&
       `${formatCryptoBalance(
-        simulationData.debtAmount.plus(
-          positionData.originationFee(
-            BigNumber.max(zero, simulationData.debtAmount.minus(positionData.debtAmount)),
-          ),
-        ),
+        simulationData.debtAmount.plus(getOriginationFee(positionData, simulationData)),
       )} ${quoteToken}`,
     availableToWithdraw: `${formatCryptoBalance(
       positionData.collateralAvailable,

--- a/features/ajna/positions/common/helpers/getOriginationFee.ts
+++ b/features/ajna/positions/common/helpers/getOriginationFee.ts
@@ -1,0 +1,9 @@
+import { AjnaPosition } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
+import { zero } from 'helpers/zero'
+
+export function getOriginationFee(position: AjnaPosition, simulation?: AjnaPosition) {
+  return simulation
+    ? position.originationFee(BigNumber.max(zero, simulation.debtAmount.minus(position.debtAmount)))
+    : zero
+}


### PR DESCRIPTION
# [Add origination fee to debt simulation](https://app.shortcut.com/oazo-apps/story/9461/origination-fee-is-not-part-of-the-debt-increase-total-origination-fee-value-is-not-precise)

Origination fee had to be calculated on the front-end instead of library, because library doesn't have a context of if the position is actual existing position or just a simulation.
![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/1d34d9c3-421f-47db-a2aa-b45b6fda8cbc)
  
## Changes 👷‍♀️

- Created `getOriginationFee` method that is added to debt simulation in overview section and order information.
  
## How to test 🧪

- Try simulating drawing debt in both open and manage flows for Ajna Borrow position.
