### PR TITLE
Update Maker rate up notification copy

### DIFF
--- a/content/dsr-notification.tsx
+++ b/content/dsr-notification.tsx
@@ -14,8 +14,7 @@ const DsrNotificationWithLink: FC<DsrNotificationWithLinkProps> = ({ translation
     i18nKey={translationKey}
     values={values}
     components={{
-      1: <strong />,
-      2: (
+      1: (
         <AppLink
           sx={{ fontSize: 'inherit', color: 'inherit', fontWeight: 'regular' }}
           href={EXTERNAL_LINKS.BLOG.MAKER_STABILITY_FEE_CHANGES}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2486,8 +2486,8 @@
       "amountBiggerThanDeposit": "You cannot withdraw more than {{totalValue}} DAI"
     },
     "notification": {
-      "title": "Maker vaults cost going up!",
-      "message": "Learn more <2><1>here</1></2>."
+      "title": " The borrowing rate for Maker positions is increasing!",
+      "message": "<1>Learn more →</1>"
     },
     "landing-page-banner": {
       "title": "NEW DSR RATE! Earn 3.49% on your DAI. <1>Get started</1>"


### PR DESCRIPTION
# Update Maker rate up notification copy

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/5254deda-3259-4bca-b29c-16efd1222ed0)
  
## Changes 👷‍♀️

- Updated copy for notification of rate up message on Maker vaults.
  
## How to test 🧪

Check any maker vault.
