### PR TITLE
🧿 Delay Ajna rewards

### DIFF
--- a/features/ajna/common/components/AjnaRewardCard.tsx
+++ b/features/ajna/common/components/AjnaRewardCard.tsx
@@ -28,7 +28,7 @@ const AjnaRewardCardListBox: FC<AjnaRewardCardListBoxProps> = ({ title, list, li
   const { t } = useTranslation()
 
   return (
-    <>
+    <Box sx={{ mb: [2, 4] }}>
       <Heading
         sx={{
           mb: [0, 3],
@@ -66,33 +66,30 @@ const AjnaRewardCardListBox: FC<AjnaRewardCardListBoxProps> = ({ title, list, li
           </Text>
         ))}
       </Box>
-      <AppLink href={link.href} sx={{ display: ['none', 'block'] }}>
+      <AppLink href={link.href} sx={{ display: ['none', 'block'], textAlign: 'center' }}>
         <WithArrow gap={1} sx={{ ...getAjnaWithArrowColorScheme() }}>
           {t(link.title)}
         </WithArrow>
       </AppLink>
-    </>
+    </Box>
   )
 }
 
 interface EarningOnPositionsLinkProps {
-  ownerPageLink: Link
   numberOfPositions: number
+  ownerPageLink: Link
   walletAddress: string
-  mobileOnly?: boolean
 }
 
 const EarningOnPositionsLink: FC<EarningOnPositionsLinkProps> = ({
-  ownerPageLink,
   numberOfPositions,
+  ownerPageLink,
   walletAddress,
-  mobileOnly,
 }) => {
   return (
     <Box
       sx={{
-        display: mobileOnly ? ['block', 'none'] : ['none', 'block'],
-        mt: [0, 3],
+        mt: 3,
         fontSize: [1, 2],
         color: 'neutral80',
         transform: 'translateX(-8px)',
@@ -130,24 +127,41 @@ interface Rewards {
   numberOfPositions: number
 }
 
-interface AjnaRewardCardBannerProps {
-  banner: BannerProps
-  rewards: Rewards
-  gradient: string
+interface AjnaRewardCardBannerPropsAvailable {
+  notAvailable?: never
   ownerPageLink: Link
+  rewards: Rewards
+  txStatus?: TxStatus
   walletAddress: string
   onBtnClick?: () => void
-  txStatus?: TxStatus
+}
+
+interface AjnaRewardCardBannerPropsUnavailable {
+  notAvailable: true
+  ownerPageLink?: never
+  rewards?: never
+  txStatus?: never
+  walletAddress?: never
+  onBtnClick?: never
+}
+
+type AjnaRewardCardBannerProps = (
+  | AjnaRewardCardBannerPropsAvailable
+  | AjnaRewardCardBannerPropsUnavailable
+) & {
+  banner: BannerProps
+  gradient: string
 }
 
 const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
   banner,
-  rewards,
   gradient,
-  ownerPageLink,
-  walletAddress,
+  notAvailable,
   onBtnClick,
+  ownerPageLink,
+  rewards,
   txStatus,
+  walletAddress,
 }) => {
   const { t } = useTranslation()
 
@@ -155,10 +169,9 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
     <Card
       sx={{
         width: '100%',
-        mt: [0, 4],
-        p: 4,
-        pb: 4,
-        pt: [0, 4],
+        mt: 'auto',
+        px: 4,
+        py: [0, 4],
         border: 'none',
         borderRadius: 'large',
         background: ['none', gradient],
@@ -168,69 +181,81 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
         <Heading variant="boldParagraph3" sx={{ display: ['none', 'block'] }}>
           {t(banner.title)}
         </Heading>
-        <Text as="p" sx={{ color: 'primary100', fontSize: '36px', fontWeight: 'regular' }}>
-          {formatCryptoBalance(rewards.tokens)}
-          <Text as="span" sx={{ fontSize: '28px', pl: 2 }}>
-            AJNA
-          </Text>
+        <Text as="p" sx={{ color: 'primary100', fontSize: '36px', fontWeight: 'semiBold' }}>
+          {notAvailable ? (
+            <Text as="span" sx={{ fontSize: '28px', pl: 2 }}>
+              {t('coming-soon')}
+            </Text>
+          ) : (
+            <>
+              {formatCryptoBalance(rewards.tokens)}
+              <Text as="span" sx={{ fontSize: '28px', pl: 2 }}>
+                AJNA
+              </Text>
+            </>
+          )}
         </Text>
         {/* TODO uncomment once ajna token usdc price will be available*/}
         {/*<Text as="p" variant="paragraph2" sx={{ color: 'neutral80' }}>*/}
         {/*  ${(rewards.usd)}*/}
         {/*</Text>*/}
-        {rewards.tokens.gt(zero) && (
-          <Button
-            sx={{ mb: [0, banner.footer ? 3 : 0], mt: [4, 4], fontSize: 1, p: 0 }}
-            disabled={txStatus && progressStatuses.includes(txStatus)}
-            onClick={onBtnClick}
-          >
-            <Flex
-              sx={{
-                p: 2,
-              }}
-            >
-              {txStatus && progressStatuses.includes(txStatus) ? (
-                <Flex sx={{ px: 3, alignItems: 'center', gap: 2 }}>
-                  <Text
-                    as="span"
-                    variant="paragraph3"
-                    sx={{ color: 'inherit', fontSize: 'inherit' }}
-                  >
-                    {t('system.in-progress')}
-                  </Text>
-                  <Spinner
-                    variant="styles.spinner.medium"
-                    size={14}
-                    sx={{
-                      color: 'white',
-                      boxSizing: 'content-box',
-                    }}
-                  />
-                </Flex>
-              ) : (
-                <WithArrow
-                  gap={1}
+        {!notAvailable && (
+          <>
+            {rewards.tokens.gt(zero) && (
+              <Button
+                sx={{ mb: [0, banner.footer ? 3 : 0], mt: [4, 4], fontSize: 1, p: 0 }}
+                disabled={txStatus && progressStatuses.includes(txStatus)}
+                onClick={onBtnClick}
+              >
+                <Flex
                   sx={{
-                    color: 'inherit',
-                    fontSize: 'inherit',
-                    pl: 3,
-                    pr: '24px',
-                    alignItems: 'center',
+                    p: 2,
                   }}
                 >
-                  {txStatus && failedStatuses.includes(txStatus)
-                    ? t('retry')
-                    : t(banner.button.title)}
-                </WithArrow>
-              )}
-            </Flex>
-          </Button>
+                  {txStatus && progressStatuses.includes(txStatus) ? (
+                    <Flex sx={{ px: 3, alignItems: 'center', gap: 2 }}>
+                      <Text
+                        as="span"
+                        variant="paragraph3"
+                        sx={{ color: 'inherit', fontSize: 'inherit' }}
+                      >
+                        {t('system.in-progress')}
+                      </Text>
+                      <Spinner
+                        variant="styles.spinner.medium"
+                        size={14}
+                        sx={{
+                          color: 'white',
+                          boxSizing: 'content-box',
+                        }}
+                      />
+                    </Flex>
+                  ) : (
+                    <WithArrow
+                      gap={1}
+                      sx={{
+                        color: 'inherit',
+                        fontSize: 'inherit',
+                        pl: 3,
+                        pr: '24px',
+                        alignItems: 'center',
+                      }}
+                    >
+                      {txStatus && failedStatuses.includes(txStatus)
+                        ? t('retry')
+                        : t(banner.button.title)}
+                    </WithArrow>
+                  )}
+                </Flex>
+              </Button>
+            )}
+            <EarningOnPositionsLink
+              ownerPageLink={ownerPageLink}
+              numberOfPositions={rewards.numberOfPositions}
+              walletAddress={walletAddress}
+            />
+          </>
         )}
-        <EarningOnPositionsLink
-          ownerPageLink={ownerPageLink}
-          numberOfPositions={rewards.numberOfPositions}
-          walletAddress={walletAddress}
-        />
       </Flex>
     </Card>
   )
@@ -272,7 +297,7 @@ export function AjnaRewardCard({
   return (
     <Card p={4} sx={{ height: '100%', borderRadius: 'large', position: 'relative' }}>
       {floatingLabel}
-      <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
+      <Flex sx={{ flexDirection: 'column', alignItems: 'center', height: '100%' }}>
         <Flex
           sx={{
             width: '100px',
@@ -287,25 +312,23 @@ export function AjnaRewardCard({
           <Image src={staticFilesRuntimeUrl(image)} />
         </Flex>
         <AjnaRewardCardListBox title={title} list={list} link={link} />
-        {walletAddress && !isLoading && !notAvailable && (
-          <AjnaRewardCardBanner
-            rewards={rewards}
-            banner={banner}
-            gradient={gradient}
-            onBtnClick={onBtnClick}
-            txStatus={txStatus}
-            ownerPageLink={ownerPageLink}
-            walletAddress={walletAddress}
-          />
-        )}
-        {isConnected && isLoading && !notAvailable && <Skeleton sx={{ mt: 4, height: '202px' }} />}
-        {rewards && walletAddress && (
-          <EarningOnPositionsLink
-            ownerPageLink={ownerPageLink}
-            numberOfPositions={rewards.numberOfPositions}
-            walletAddress={walletAddress}
-            mobileOnly
-          />
+        {notAvailable ? (
+          <AjnaRewardCardBanner banner={banner} gradient={gradient} notAvailable />
+        ) : (
+          <>
+            {walletAddress && !isLoading && (
+              <AjnaRewardCardBanner
+                banner={banner}
+                gradient={gradient}
+                onBtnClick={onBtnClick}
+                ownerPageLink={ownerPageLink}
+                rewards={rewards}
+                txStatus={txStatus}
+                walletAddress={walletAddress}
+              />
+            )}
+            {isConnected && isLoading && <Skeleton sx={{ mt: 4, height: '202px' }} />}
+          </>
         )}
       </Flex>
     </Card>

--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -35,7 +35,7 @@ export const steps: {
     manage: ['manage', 'dpm', 'transaction', 'transition'],
   },
   earn: {
-    open: ['risk', 'setup', 'dpm', 'nft', 'transaction'],
+    open: ['risk', 'setup', 'dpm', 'transaction'],
     manage: ['manage', 'dpm', 'transaction', 'transition'],
   },
   multiply: {

--- a/features/ajna/common/controls/AjnaRewardsController.tsx
+++ b/features/ajna/common/controls/AjnaRewardsController.tsx
@@ -91,19 +91,20 @@ export function AjnaRewardsController() {
       )}
       <ProductCardsWrapper gap={24} desktopWidthOfCard={448} sx={{ mt: 5 }}>
         <AjnaRewardCard
-          {...miningRewardsCard}
-          onBtnClick={userNftsData.handler}
-          txStatus={userNftsData.txDetails?.txStatus}
-          rewards={userNftsData.rewards}
-          isLoading={userNftsData.isLoading}
           key="miningRewards"
+          isLoading={userNftsData.isLoading}
+          notAvailable
+          onBtnClick={userNftsData.handler}
+          rewards={userNftsData.rewards}
+          txStatus={userNftsData.txDetails?.txStatus}
+          {...miningRewardsCard}
         />
         <AjnaRewardCard
-          {...oasisRewardsCard}
           key="oasisRewards"
-          notAvailable
           isLoading={false}
+          notAvailable
           rewards={{ tokens: zero, usd: zero, numberOfPositions: 0 }}
+          {...oasisRewardsCard}
           floatingLabel={
             <FloatingLabel
               text={t('ajna.rewards.cards.token.floatingLabel')}

--- a/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
@@ -115,7 +115,12 @@ export function AjnaGeneralContextProvider({
     return {
       currentStep,
       steps,
-      editingStep: getAjnaEditingStep({ currentStep, product, flow }),
+      editingStep: getAjnaEditingStep({
+        currentStep,
+        flow,
+        product,
+        steps,
+      }),
       isExternalStep: isExternalStep({ currentStep }),
       isFlowStateReady,
       isStepWithTransaction: isStepWithTransaction({ currentStep }),

--- a/features/ajna/positions/common/contexts/ajnaStepManager.ts
+++ b/features/ajna/positions/common/contexts/ajnaStepManager.ts
@@ -22,13 +22,15 @@ export function isStepWithTransaction({ currentStep }: GeneralStepManager) {
 }
 
 export const getAjnaEditingStep = ({
-  flow,
   currentStep,
+  flow,
   product,
+  steps,
 }: {
-  flow: AjnaFlow
   currentStep: AjnaSidebarStep
+  flow: AjnaFlow
   product: AjnaProduct
+  steps: AjnaSidebarStep[]
 }) => {
   const defaultEditingStep = flow === 'open' ? 'setup' : 'manage'
 
@@ -38,7 +40,7 @@ export const getAjnaEditingStep = ({
       return defaultEditingStep
     case 'earn':
       if (flow === 'open') {
-        return currentStep === 'transaction' ? 'nft' : 'setup'
+        return currentStep === 'transaction' && steps.includes('nft') ? 'nft' : 'setup'
       }
 
       return defaultEditingStep

--- a/features/ajna/positions/earn/state/ajnaEarnFormReducto.ts
+++ b/features/ajna/positions/earn/state/ajnaEarnFormReducto.ts
@@ -35,7 +35,7 @@ export const ajnaEarnReset = {
   depositAmountUSD: undefined,
   withdrawAmount: undefined,
   withdrawAmountUSD: undefined,
-  isStakingNft: undefined,
+  isStakingNft: false,
 }
 
 export const ajnaEarnDefault: AjnaEarnFormState = {


### PR DESCRIPTION
# [Delay Ajna rewards](https://app.shortcut.com/oazo-apps/story/9744/front-end-ajna-lm-rewards-delay-handling)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/d9a57e0b-bb73-4bb9-93e3-367b8434fa0b)
  
## Changes 👷‍♀️

- Disabled NFT opt-in/out step on Ajna Earn open flow,
- replaced Ajna token amount with "coming soon" on rewards page.
  
## How to test 🧪

- Try opening Earn position and see if NFT step is skipped,
- check if rewards page displays "coming soon" properly.
