### PR TITLE
🧿 Fix repeated allowance request

### DIFF
--- a/features/ajna/positions/common/helpers/getPrimaryButtonLabelKey.ts
+++ b/features/ajna/positions/common/helpers/getPrimaryButtonLabelKey.ts
@@ -1,6 +1,15 @@
-import { AjnaFlow, AjnaProduct, AjnaSidebarStep } from 'features/ajna/common/types'
+import {
+  AjnaFlow,
+  AjnaFormState,
+  AjnaGenericPosition,
+  AjnaProduct,
+  AjnaSidebarStep,
+} from 'features/ajna/common/types'
+import { isFormEmpty } from 'features/ajna/positions/common/helpers/isFormEmpty'
 
 interface GetPrimaryButtonLabelKeyParams {
+  state: AjnaFormState
+  position: AjnaGenericPosition
   currentStep: AjnaSidebarStep
   flow: AjnaFlow
   hasAllowance: boolean
@@ -20,6 +29,9 @@ export function getPrimaryButtonLabelKey({
   isTransitionInProgress,
   isTxError,
   isTxSuccess,
+  position,
+  product,
+  state,
   walletAddress,
 }: GetPrimaryButtonLabelKeyParams): string {
   switch (currentStep) {
@@ -35,7 +47,11 @@ export function getPrimaryButtonLabelKey({
       if (isTransitionInProgress) return 'borrow-to-multiply.button-progress'
       else return 'confirm'
     default:
-      if (walletAddress && hasDpmAddress && hasAllowance) return 'confirm'
+      if (
+        isFormEmpty({ product, state, position, currentStep }) ||
+        (walletAddress && hasDpmAddress && hasAllowance)
+      )
+        return 'confirm'
       else if (walletAddress && hasDpmAddress) return 'set-token-allowance'
       else if (walletAddress) return 'dpm.create-flow.welcome-screen.create-button'
       else return 'connect-wallet-button'

--- a/features/ajna/positions/common/views/AjnaFormView.tsx
+++ b/features/ajna/positions/common/views/AjnaFormView.tsx
@@ -122,7 +122,9 @@ export function AjnaFormView({
     isTransitionInProgress,
     isTxError,
     isTxSuccess,
+    position,
     product,
+    state,
     walletAddress,
   })
   const primaryButtonActions = getAjnaSidebarPrimaryButtonActions({


### PR DESCRIPTION
# [Fix repeated allowance request](https://app.shortcut.com/oazo-apps/story/9443/borrow-repeated-allowance-request-bug-for-wbtc)

The issue was never about asking for allowance, just about button label. By default, primary button label was set to match action of asking user for collateral token allowance.
  
## Changes 👷‍♀️

- Added check if form is empty to `getPrimaryButtonLabelKey` method, so if form is its original state, it is displaying default label (which is "Confirm").
  
## How to test 🧪

Go to any existing Ajna Borrow position and see if label is correct in initial state.
