### PR TITLE
🧿 Rename "Liquidation threshold" to "Dynamic Max LTV"

### DIFF
--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -71,7 +71,7 @@ export function AjnaBorrowOverviewController() {
               isLoading={isSimulationLoading}
               loanToValue={position.riskRatio.loanToValue}
               afterLoanToValue={simulation?.riskRatio.loanToValue}
-              liquidationThreshold={position.maxRiskRatio.loanToValue}
+              dynamicMaxLtv={position.maxRiskRatio.loanToValue}
               changeVariant={changeVariant}
             />
             <ContentCardCollateralLocked

--- a/features/ajna/positions/common/components/contentCards/ContentCardLoanToValue.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardLoanToValue.tsx
@@ -13,7 +13,7 @@ interface ContentCardLoanToValueProps {
   isLoading?: boolean
   loanToValue: BigNumber
   afterLoanToValue?: BigNumber
-  liquidationThreshold: BigNumber
+  dynamicMaxLtv: BigNumber
   changeVariant?: ChangeVariantType
 }
 
@@ -21,7 +21,7 @@ export function ContentCardLoanToValue({
   isLoading,
   loanToValue,
   afterLoanToValue,
-  liquidationThreshold,
+  dynamicMaxLtv,
   changeVariant = 'positive',
 }: ContentCardLoanToValueProps) {
   const { t } = useTranslation()
@@ -29,7 +29,7 @@ export function ContentCardLoanToValue({
   const formatted = {
     loanToValue: formatDecimalAsPercent(loanToValue),
     afterLoanToValue: afterLoanToValue && formatDecimalAsPercent(afterLoanToValue),
-    liquidationThreshold: liquidationThreshold && formatDecimalAsPercent(liquidationThreshold),
+    liquidationThreshold: dynamicMaxLtv && formatDecimalAsPercent(dynamicMaxLtv),
   }
 
   const contentCardSettings: ContentCardProps = {

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
@@ -73,7 +73,7 @@ export function AjnaMultiplyOverviewController() {
               isLoading={isSimulationLoading}
               loanToValue={position.riskRatio.loanToValue}
               afterLoanToValue={simulation?.riskRatio.loanToValue}
-              liquidationThreshold={position.maxRiskRatio.loanToValue}
+              dynamicMaxLtv={position.maxRiskRatio.loanToValue}
               changeVariant={changeVariant}
             />
             <ContentCardNetBorrowCost

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2650,7 +2650,7 @@
             "below-current-price": "{{priceRatio}} below current price",
             "loan-to-value": "Loan to value",
             "loan-to-value-modal-desc": "Your Loan to Value ratio represents how much you have borrowed based on your collateral supplied.",
-            "liquidation-threshold": "Liquidation Threshold: {{liquidationThreshold}}",
+            "liquidation-threshold": "Dynamic Max LTV: {{liquidationThreshold}}",
             "collateral-locked": "Collateral locked",
             "collateral-locked-modal-desc": "This is the amount of tokens you have as collateral for your debt.",
             "position-debt": "Position debt",


### PR DESCRIPTION
# [Rename "Liquidation threshold" to "Dynamic Max LTV"](https://app.shortcut.com/oazo-apps/story/9438/liquidation-threshold-shows-max-ltv?vc_group_by=day&ct_workflow=all&cf_workflow=500000053)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/e503fe7d-895f-4a8f-803e-42bc35d2a356)
  
## Changes 👷‍♀️

- As in title.
  
## How to test 🧪

- Check it on borrow/multiply overview section.
