### PR TITLE
🧿 Add AJNA_RC5 to protocol types

### DIFF
--- a/features/aave/services/readPositionCreatedEvents.ts
+++ b/features/aave/services/readPositionCreatedEvents.ts
@@ -72,10 +72,6 @@ function mapEvent(
 function extractLendingProtocolFromPositionCreatedEvent(
   positionCreatedChainEvent: CreatePositionEvent,
 ): LendingProtocol {
-  console.log('---')
-  console.log(positionCreatedChainEvent.args.protocol)
-  console.log(positionCreatedChainEvent)
-
   switch (positionCreatedChainEvent.args.protocol) {
     case 'AAVE':
     case 'AaveV2':

--- a/features/aave/services/readPositionCreatedEvents.ts
+++ b/features/aave/services/readPositionCreatedEvents.ts
@@ -72,6 +72,10 @@ function mapEvent(
 function extractLendingProtocolFromPositionCreatedEvent(
   positionCreatedChainEvent: CreatePositionEvent,
 ): LendingProtocol {
+  console.log('---')
+  console.log(positionCreatedChainEvent.args.protocol)
+  console.log(positionCreatedChainEvent)
+
   switch (positionCreatedChainEvent.args.protocol) {
     case 'AAVE':
     case 'AaveV2':
@@ -79,6 +83,7 @@ function extractLendingProtocolFromPositionCreatedEvent(
     case 'AAVE_V3':
       return LendingProtocol.AaveV3
     case 'Ajna':
+    case 'AJNA_RC5':
       return LendingProtocol.Ajna
     default:
       throw new Error(


### PR DESCRIPTION
# Add AJNA_RC5 to protocol types

After connecting to Ajna RC5 contracts, protocol name in `CreatePosition` event is changed from `Ajna` to `AJNA_RC5` which made loading any new position fail.
  
## Changes 👷‍♀️

- Added `AJNA_RC5` to acceptable protocols list in filters.
  
## How to test 🧪

- Open new Ajna position and see if it is loading. 