### PR TITLE
🧬/🧿 Clickable promo cards on Product Hub

### DIFF
--- a/components/PromoCard.tsx
+++ b/components/PromoCard.tsx
@@ -3,7 +3,6 @@ import { AppLink } from 'components/Links'
 import { ProtocolLabel, ProtocolLabelProps } from 'components/ProtocolLabel'
 import { Skeleton } from 'components/Skeleton'
 import { TokensGroup } from 'components/TokensGroup'
-import { WithArrow } from 'components/WithArrow'
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Box, Flex, Heading, Image, SxStyleProp, Text } from 'theme-ui'
@@ -11,7 +10,7 @@ import { Box, Flex, Heading, Image, SxStyleProp, Text } from 'theme-ui'
 export type PromoCardVariant = 'neutral' | 'positive' | 'negative'
 
 export interface PromoCardWrapperProps {
-  withHover?: boolean
+  link?: string
 }
 
 export interface PromoCardTranslationProps {
@@ -51,7 +50,7 @@ export type PromoCardProps = (
   }[]
   link?: {
     href: string
-    label: string | PromoCardTranslationProps
+    label?: string | PromoCardTranslationProps
   }
   data?: {
     label: string | PromoCardTranslationProps
@@ -72,34 +71,44 @@ export const dataColors: { [key in PromoCardVariant]: SxStyleProp } = {
   neutral: { color: 'primary100' },
 }
 
-export const PromoCardWrapper: FC<PromoCardWrapperProps> = ({ children, withHover = true }) => {
+export const PromoCardWrapper: FC<PromoCardWrapperProps> = ({ children, link }) => {
+  const sx: SxStyleProp = {
+    position: 'relative',
+    px: 3,
+    py: '24px',
+    textAlign: 'center',
+    border: '1px solid',
+    borderColor: 'neutral20',
+    borderRadius: 'large',
+    bg: 'neutral10',
+  }
+
   return (
-    <Box
-      sx={{
-        position: 'relative',
-        px: 3,
-        py: '24px',
-        textAlign: 'center',
-        border: '1px solid',
-        borderColor: 'neutral20',
-        borderRadius: 'large',
-        bg: 'neutral10',
-        transition: 'border-color 200ms',
-        ...(withHover && {
-          '&:hover': {
-            borderColor: 'primary100',
-          },
-        }),
-      }}
-    >
-      {children}
-    </Box>
+    <>
+      {link ? (
+        <AppLink
+          href={link}
+          sx={{
+            ...sx,
+            fontWeight: 'inherit',
+            transition: 'border-color 200ms',
+            '&:hover': {
+              borderColor: 'neutral70',
+            },
+          }}
+        >
+          {children}
+        </AppLink>
+      ) : (
+        <Box sx={sx}>{children}</Box>
+      )}
+    </>
   )
 }
 
 export const PromoCardLoadingState: FC = () => {
   return (
-    <PromoCardWrapper withHover={false}>
+    <PromoCardWrapper>
       <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
         <Flex>
           <Box sx={{ mr: '-20px' }}>
@@ -137,7 +146,7 @@ export const PromoCard: FC<PromoCardProps> = ({
   tokens,
 }) => {
   return (
-    <PromoCardWrapper>
+    <PromoCardWrapper link={link?.href}>
       <Flex
         sx={{
           justifyContent: 'center',
@@ -225,12 +234,10 @@ export const PromoCard: FC<PromoCardProps> = ({
           ))}
         </Flex>
       )}
-      {link && (
-        <AppLink href={link.href} sx={{ display: 'inline-block', mt: 2 }}>
-          <WithArrow variant="paragraph3" sx={{ color: 'interactive100', fontWeight: 'regular' }}>
-            <PromoCardTranslation text={link.label} />
-          </WithArrow>
-        </AppLink>
+      {link?.label && (
+        <Text as="p" sx={{ mt: 2, fontSize: 2, color: 'interactive100' }}>
+          <PromoCardTranslation text={link.label} /> →
+        </Text>
       )}
     </PromoCardWrapper>
   )

--- a/features/ajna/common/controls/AjnaProductHubController.tsx
+++ b/features/ajna/common/controls/AjnaProductHubController.tsx
@@ -17,6 +17,7 @@ export function AjnaProductHubController({ product, token }: AjnaProductHubContr
       <WithFeatureToggleRedirect feature="OasisCreate">
         <AnimatedWrapper sx={{ mb: 5 }}>
           <ProductHubView
+            headerGradient={['#f154db', '#974eea']}
             initialProtocol={[LendingProtocol.Ajna]}
             product={product}
             promoCardsCollection="AjnaLP"

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -71,6 +71,7 @@ export function AjnaHomepageView() {
       </Box>
       <Box sx={{ mt: '180px', borderTop: '1px solid', borderColor: 'neutral20' }}>
         <ProductHubView
+          headerGradient={['#f154db', '#974eea']}
           initialProtocol={[LendingProtocol.Ajna]}
           product={ProductHubProductType.Borrow}
           promoCardsCollection="AjnaLP"

--- a/features/productHub/controls/ProductHubNaturalLanguageSelectorController.tsx
+++ b/features/productHub/controls/ProductHubNaturalLanguageSelectorController.tsx
@@ -7,6 +7,7 @@ import React, { FC, useEffect, useRef, useState } from 'react'
 import { Box, Heading } from 'theme-ui'
 
 interface ProductHubNaturalLanguageSelectorControllerProps {
+  gradient: [string, string],
   product: ProductHubProductType
   token?: string
   url?: string
@@ -15,7 +16,7 @@ interface ProductHubNaturalLanguageSelectorControllerProps {
 
 export const ProductHubNaturalLanguageSelectorController: FC<
   ProductHubNaturalLanguageSelectorControllerProps
-> = ({ product, token, url, onChange }) => {
+> = ({ gradient, product, token, url, onChange }) => {
   const { t } = useTranslation()
 
   const [overwriteOption, setOverwriteOption] = useState<HeaderSelectorOption>()
@@ -39,7 +40,7 @@ export const ProductHubNaturalLanguageSelectorController: FC<
         {t('product-hub.header.i-want-to')}
         <HeaderSelector
           defaultOption={productHubOptionsMap[product].product}
-          gradient={['#2a30ee', '#a4a6ff']}
+          gradient={gradient}
           options={Object.values(productHubOptionsMap).map((option) => option.product)}
           parentRef={ref}
           withHeaders={true}
@@ -69,7 +70,7 @@ export const ProductHubNaturalLanguageSelectorController: FC<
               ? productHubOptionsMap[product].tokens[token]
               : productHubOptionsMap[product].tokens.all
           }
-          gradient={['#2a30ee', '#a4a6ff']}
+          gradient={gradient}
           options={Object.values(productHubOptionsMap[selectedProduct].tokens)}
           overwriteOption={overwriteOption}
           parentRef={ref}

--- a/features/productHub/controls/ProductHubNaturalLanguageSelectorController.tsx
+++ b/features/productHub/controls/ProductHubNaturalLanguageSelectorController.tsx
@@ -7,7 +7,7 @@ import React, { FC, useEffect, useRef, useState } from 'react'
 import { Box, Heading } from 'theme-ui'
 
 interface ProductHubNaturalLanguageSelectorControllerProps {
-  gradient: [string, string],
+  gradient: [string, string]
   product: ProductHubProductType
   token?: string
   url?: string

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -23,6 +23,7 @@ import { Box, Text } from 'theme-ui'
 interface ProductHubViewProps {
   initialNetwork?: ProductHubSupportedNetworks[]
   initialProtocol?: LendingProtocol[]
+  headerGradient?: [string, string]
   product: ProductHubProductType
   promoCardsCollection: PromoCardsCollection
   token?: string
@@ -32,6 +33,7 @@ interface ProductHubViewProps {
 export const ProductHubView: FC<ProductHubViewProps> = ({
   initialNetwork,
   initialProtocol,
+  headerGradient = ['#2a30ee', '#a4a6ff'],
   product,
   promoCardsCollection,
   token,
@@ -72,6 +74,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
         }}
       >
         <ProductHubNaturalLanguageSelectorController
+          gradient={headerGradient}
           product={product}
           token={token}
           url={url}

--- a/handlers/product-hub/helpers/parseAjnaPromoCard.ts
+++ b/handlers/product-hub/helpers/parseAjnaPromoCard.ts
@@ -2,6 +2,8 @@ import BigNumber from 'bignumber.js'
 import { NetworkNames } from 'blockchain/networks'
 import { PromoCardProps, PromoCardVariant } from 'components/PromoCard'
 import { isShortPosition } from 'features/ajna/positions/common/helpers/isShortPosition'
+import { getActionUrl } from 'features/productHub/helpers'
+import { ProductHubItem, ProductHubProductType } from 'features/productHub/types'
 import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -14,7 +16,7 @@ const getAjnaTokensPill = {
 export function parseAjnaBorrowPromoCard(
   collateralToken: string,
   quoteToken: string,
-  maxLtv?: string,
+  product?: ProductHubItem,
 ): PromoCardProps {
   return {
     tokens: [collateralToken, quoteToken],
@@ -29,19 +31,24 @@ export function parseAjnaBorrowPromoCard(
         label: {
           key: 'ajna.promo-cards.max-ltv',
           props: {
-            maxLtv: maxLtv ? formatDecimalAsPercent(new BigNumber(maxLtv)) : 'n/a',
+            maxLtv: product?.maxLtv ? formatDecimalAsPercent(new BigNumber(product.maxLtv)) : 'n/a',
           },
         },
       },
       getAjnaTokensPill,
     ],
+    ...(product && {
+      link: {
+        href: getActionUrl({ ...product, product: [ProductHubProductType.Borrow] }),
+      },
+    }),
   }
 }
 
 export function parseAjnaMultiplyPromoCard(
   collateralToken: string,
   quoteToken: string,
-  maxMultiply?: string,
+  product?: ProductHubItem,
 ): PromoCardProps {
   const isShort = isShortPosition({ collateralToken })
 
@@ -61,19 +68,26 @@ export function parseAjnaMultiplyPromoCard(
         label: {
           key: 'ajna.promo-cards.up-to-multiple',
           props: {
-            maxMultiple: maxMultiply ? `${parseFloat(maxMultiply).toFixed(2)}x` : 'n/a',
+            maxMultiple: product?.maxMultiply
+              ? `${parseFloat(product.maxMultiply).toFixed(2)}x`
+              : 'n/a',
           },
         },
       },
       getAjnaTokensPill,
     ],
+    ...(product && {
+      link: {
+        href: getActionUrl({ ...product, product: [ProductHubProductType.Multiply] }),
+      },
+    }),
   }
 }
 
 export function parseAjnaEarnPromoCard(
   collateralToken: string,
   quoteToken: string,
-  weeklyNetApy?: string,
+  product?: ProductHubItem,
 ): PromoCardProps {
   return {
     tokens: [collateralToken, quoteToken],
@@ -86,17 +100,22 @@ export function parseAjnaEarnPromoCard(
     pills: [
       {
         label: {
-          key: weeklyNetApy
+          key: product?.weeklyNetApy
             ? 'ajna.promo-cards.get-weekly-apy'
             : 'ajna.promo-cards.lends-to-one-token',
           props: {
-            weeklyNetApy: weeklyNetApy
-              ? formatDecimalAsPercent(new BigNumber(weeklyNetApy))
+            weeklyNetApy: product?.weeklyNetApy
+              ? formatDecimalAsPercent(new BigNumber(product.weeklyNetApy))
               : 'n/a',
           },
         },
       },
       getAjnaTokensPill,
     ],
+    ...(product && {
+      link: {
+        href: getActionUrl({ ...product, product: [ProductHubProductType.Earn] }),
+      },
+    }),
   }
 }

--- a/handlers/product-hub/promo-card-collections-parsers/ajnaLpHandler.ts
+++ b/handlers/product-hub/promo-card-collections-parsers/ajnaLpHandler.ts
@@ -24,8 +24,8 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
 
   const ETHUSDCBorrowishProduct = findByTokenPair(borrowishProducts, ['ETH', 'USDC'])
   const ETHDAIBorrowishProduct = findByTokenPair(borrowishProducts, ['ETH', 'DAI'])
-  const WSTETHUSDCBorrowishProduct = findByTokenPair(borrowishProducts, ['WSTETH', 'WSTETH'])
-  const WBTCUSDCBorrowishProduct = findByTokenPair(borrowishProducts, ['WBTC', 'WBTC'])
+  const WSTETHUSDCBorrowishProduct = findByTokenPair(borrowishProducts, ['WSTETH', 'USDC'])
+  const WBTCUSDCBorrowishProduct = findByTokenPair(borrowishProducts, ['WBTC', 'USDC'])
   const WBTCDAIBorrowishProduct = findByTokenPair(borrowishProducts, ['WBTC', 'DAI'])
   const USDCETHBorrowishProduct = findByTokenPair(borrowishProducts, ['USDC', 'ETH'])
   const USDCWBTCBorrowishProduct = findByTokenPair(borrowishProducts, ['USDC', 'WBTC'])
@@ -66,122 +66,58 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     link: { href: EXTERNAL_LINKS.KB.AJNA, label: { key: 'Learn more' } },
   }
 
-  const promoCardETHUSDCBorrow = parseAjnaBorrowPromoCard(
-    'ETH',
-    'USDC',
-    ETHUSDCBorrowishProduct?.maxLtv,
-  )
-  const promoCardETHDAIBorrow = parseAjnaBorrowPromoCard(
-    'ETH',
-    'DAI',
-    ETHDAIBorrowishProduct?.maxLtv,
-  )
+  const promoCardETHUSDCBorrow = parseAjnaBorrowPromoCard('ETH', 'USDC', ETHUSDCBorrowishProduct)
+  const promoCardETHDAIBorrow = parseAjnaBorrowPromoCard('ETH', 'DAI', ETHDAIBorrowishProduct)
   const promoCardWSTETHUSDCBorrow = parseAjnaBorrowPromoCard(
     'WSTETH',
     'USDC',
-    WSTETHUSDCBorrowishProduct?.maxLtv,
+    WSTETHUSDCBorrowishProduct,
   )
-  const promoCardWBTCUSDCBorrow = parseAjnaBorrowPromoCard(
-    'WBTC',
-    'USDC',
-    WBTCUSDCBorrowishProduct?.maxLtv,
-  )
-  const promoCardWBTCDAICBorrow = parseAjnaBorrowPromoCard(
-    'WBTC',
-    'DAI',
-    WBTCDAIBorrowishProduct?.maxLtv,
-  )
-  const promoCardUSDCETHBorrow = parseAjnaBorrowPromoCard(
-    'USDC',
-    'ETH',
-    USDCETHBorrowishProduct?.maxLtv,
-  )
-  const promoCardUSDCWBTCBorrow = parseAjnaBorrowPromoCard(
-    'USDC',
-    'WBTC',
-    USDCWBTCBorrowishProduct?.maxLtv,
-  )
+  const promoCardWBTCUSDCBorrow = parseAjnaBorrowPromoCard('WBTC', 'USDC', WBTCUSDCBorrowishProduct)
+  const promoCardWBTCDAICBorrow = parseAjnaBorrowPromoCard('WBTC', 'DAI', WBTCDAIBorrowishProduct)
+  const promoCardUSDCETHBorrow = parseAjnaBorrowPromoCard('USDC', 'ETH', USDCETHBorrowishProduct)
+  const promoCardUSDCWBTCBorrow = parseAjnaBorrowPromoCard('USDC', 'WBTC', USDCWBTCBorrowishProduct)
   const promoCardETHUSDCMultiply = parseAjnaMultiplyPromoCard(
     'ETH',
     'USDC',
-    ETHUSDCBorrowishProduct?.maxMultiply,
+    ETHUSDCBorrowishProduct,
   )
   const promoCardWSTETHUSDCMultiply = parseAjnaMultiplyPromoCard(
     'WSTETH',
     'USDC',
-    WSTETHUSDCBorrowishProduct?.maxMultiply,
+    WSTETHUSDCBorrowishProduct,
   )
   const promoCardWBTCUSDCMultiply = parseAjnaMultiplyPromoCard(
     'WBTC',
     'USDC',
-    WBTCUSDCBorrowishProduct?.maxMultiply,
+    WBTCUSDCBorrowishProduct,
   )
   const promoCardWBTCDAIMultiply = parseAjnaMultiplyPromoCard(
     'WBTC',
     'DAI',
-    WBTCDAIBorrowishProduct?.maxMultiply,
+    WBTCDAIBorrowishProduct,
   )
   const promoCardUSDCETHMultiply = parseAjnaMultiplyPromoCard(
     'USDC',
     'ETH',
-    USDCETHBorrowishProduct?.maxMultiply,
+    USDCETHBorrowishProduct,
   )
   const promoCardUSDCWBTCMultiply = parseAjnaMultiplyPromoCard(
     'USDC',
     'WBTC',
-    USDCWBTCBorrowishProduct?.maxMultiply,
+    USDCWBTCBorrowishProduct,
   )
-  const promoCardETHUSDCEarn = parseAjnaEarnPromoCard(
-    'ETH',
-    'USDC',
-    ETHUSDCEarnProduct?.weeklyNetApy,
-  )
-  const promoCardWSTETHUSDCEarn = parseAjnaEarnPromoCard(
-    'WSTETH',
-    'USDC',
-    WSTETHUSDCEarnProduct?.weeklyNetApy,
-  )
-  const promoCardWSTETHDAIEarn = parseAjnaEarnPromoCard(
-    'WSTETH',
-    'DAI',
-    WSTETHDAIEarnProduct?.weeklyNetApy,
-  )
-  const promoCardRETHDAIEarn = parseAjnaEarnPromoCard(
-    'RETH',
-    'DAI',
-    RETHDAIEarnProduct?.weeklyNetApy,
-  )
-  const promoCardETHDAIEarn = parseAjnaEarnPromoCard('ETH', 'DAI', ETHDAIEarnProduct?.weeklyNetApy)
-  const promoCardWBTCUSDCEarn = parseAjnaEarnPromoCard(
-    'WBTC',
-    'USDC',
-    WBTCUSDCEarnProduct?.weeklyNetApy,
-  )
-  const promoCardWBTCDAIEarn = parseAjnaEarnPromoCard(
-    'WBTC',
-    'DAI',
-    WBTCDAIEarnProduct?.weeklyNetApy,
-  )
-  const promoCardUSDCETHEarn = parseAjnaEarnPromoCard(
-    'USDC',
-    'ETH',
-    USDCETHEarnProduct?.weeklyNetApy,
-  )
-  const promoCardUSDCWSTETHEarn = parseAjnaEarnPromoCard(
-    'USDC',
-    'WSTETH',
-    USDCWSTETHEarnProduct?.weeklyNetApy,
-  )
-  const promoCardUSDCRETHEarn = parseAjnaEarnPromoCard(
-    'USDC',
-    'RETH',
-    USDCRETHEarnProduct?.weeklyNetApy,
-  )
-  const promoCardUSDCWBTCEarn = parseAjnaEarnPromoCard(
-    'USDC',
-    'WBTC',
-    USDCWBTCEarnProduct?.weeklyNetApy,
-  )
+  const promoCardETHUSDCEarn = parseAjnaEarnPromoCard('ETH', 'USDC', ETHUSDCEarnProduct)
+  const promoCardWSTETHUSDCEarn = parseAjnaEarnPromoCard('WSTETH', 'USDC', WSTETHUSDCEarnProduct)
+  const promoCardWSTETHDAIEarn = parseAjnaEarnPromoCard('WSTETH', 'DAI', WSTETHDAIEarnProduct)
+  const promoCardRETHDAIEarn = parseAjnaEarnPromoCard('RETH', 'DAI', RETHDAIEarnProduct)
+  const promoCardETHDAIEarn = parseAjnaEarnPromoCard('ETH', 'DAI', ETHDAIEarnProduct)
+  const promoCardWBTCUSDCEarn = parseAjnaEarnPromoCard('WBTC', 'USDC', WBTCUSDCEarnProduct)
+  const promoCardWBTCDAIEarn = parseAjnaEarnPromoCard('WBTC', 'DAI', WBTCDAIEarnProduct)
+  const promoCardUSDCETHEarn = parseAjnaEarnPromoCard('USDC', 'ETH', USDCETHEarnProduct)
+  const promoCardUSDCWSTETHEarn = parseAjnaEarnPromoCard('USDC', 'WSTETH', USDCWSTETHEarnProduct)
+  const promoCardUSDCRETHEarn = parseAjnaEarnPromoCard('USDC', 'RETH', USDCRETHEarnProduct)
+  const promoCardUSDCWBTCEarn = parseAjnaEarnPromoCard('USDC', 'WBTC', USDCWBTCEarnProduct)
 
   return {
     [ProductHubProductType.Borrow]: {


### PR DESCRIPTION
# [Clickable promo cards on Product Hub](https://app.shortcut.com/oazo-apps/story/9819)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/b2e8a90d-4369-40a2-ad19-d440933af1b5)
  
## Changes 👷‍♀️

- Modified `PromoCard` component to be entirely clickable when link is provided,
- added links to products for `ajnaLPHandler`.
  
## How to test 🧪

Check promo cards on `/ajna`.