### PR TITLE
🧬 Support for tooltips on Product Hub

### DIFF
--- a/components/PromoCard.tsx
+++ b/components/PromoCard.tsx
@@ -3,19 +3,14 @@ import { AppLink } from 'components/Links'
 import { ProtocolLabel, ProtocolLabelProps } from 'components/ProtocolLabel'
 import { Skeleton } from 'components/Skeleton'
 import { TokensGroup } from 'components/TokensGroup'
+import { Translatable, TranslatableType } from 'components/Translatable'
 import React, { FC } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Box, Flex, Heading, Image, SxStyleProp, Text } from 'theme-ui'
 
 export type PromoCardVariant = 'neutral' | 'positive' | 'negative'
 
 export interface PromoCardWrapperProps {
   link?: string
-}
-
-export interface PromoCardTranslationProps {
-  key: string
-  props?: { [key: string]: string }
 }
 
 interface PromoCardPropsWithIcon {
@@ -41,20 +36,20 @@ export type PromoCardProps = (
   | PromoCardPropsWithImage
   | PromoCardPropsWithTokens
 ) & {
-  title: string | PromoCardTranslationProps
+  title: TranslatableType
   protocol?: ProtocolLabelProps
-  description?: string | PromoCardTranslationProps
+  description?: TranslatableType
   pills?: {
-    label: string | PromoCardTranslationProps
+    label: TranslatableType
     variant?: PromoCardVariant
   }[]
   link?: {
     href: string
-    label?: string | PromoCardTranslationProps
+    label?: TranslatableType
   }
   data?: {
-    label: string | PromoCardTranslationProps
-    value: string | PromoCardTranslationProps
+    label: TranslatableType
+    value: TranslatableType
     variant?: PromoCardVariant
   }[]
 }
@@ -126,14 +121,6 @@ export const PromoCardLoadingState: FC = () => {
   )
 }
 
-export const PromoCardTranslation: FC<{ text: string | PromoCardTranslationProps }> = ({
-  text,
-}) => {
-  const { t } = useTranslation()
-
-  return <>{typeof text === 'object' ? t(text.key, text.props) : text}</>
-}
-
 export const PromoCard: FC<PromoCardProps> = ({
   data,
   description,
@@ -174,11 +161,11 @@ export const PromoCard: FC<PromoCardProps> = ({
         </Box>
       )}
       <Heading as="h3" variant="boldParagraph2">
-        <PromoCardTranslation text={title} />
+        <Translatable text={title} />
       </Heading>
       {description && (
         <Text as="p" variant="paragraph3" sx={{ mt: 2 }}>
-          <PromoCardTranslation text={description} />
+          <Translatable text={description} />
         </Text>
       )}
       {pills && (
@@ -209,7 +196,7 @@ export const PromoCard: FC<PromoCardProps> = ({
                 ...pillColors[variant],
               }}
             >
-              <PromoCardTranslation text={label} />
+              <Translatable text={label} />
             </Flex>
           ))}
         </Flex>
@@ -223,7 +210,7 @@ export const PromoCard: FC<PromoCardProps> = ({
               sx={{ justifyContent: 'space-between', width: '100%' }}
             >
               <Text as="span" variant="paragraph3" sx={{ color: 'neutral80' }}>
-                <PromoCardTranslation text={label} />
+                <Translatable text={label} />
               </Text>
               <Text as="span" variant="boldParagraph3" sx={dataColors[variant]}>
                 {variant === 'negative' && <Icon name="arrow_decrease" size={12} sx={{ mr: 1 }} />}
@@ -236,7 +223,7 @@ export const PromoCard: FC<PromoCardProps> = ({
       )}
       {link?.label && (
         <Text as="p" sx={{ mt: 2, fontSize: 2, color: 'interactive100' }}>
-          <PromoCardTranslation text={link.label} /> →
+          <Translatable text={link.label} /> →
         </Text>
       )}
     </PromoCardWrapper>

--- a/components/Translatable.tsx
+++ b/components/Translatable.tsx
@@ -1,12 +1,18 @@
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
+export type TranslatableType =
+  | string
+  | {
+      key: string
+      props?: { [key: string]: string }
+    }
+
 export interface TranslatableProps {
-  key: string
-  props?: { [key: string]: string }
+  text: TranslatableType
 }
 
-export const Translatable: FC<{ text: string | TranslatableProps }> = ({ text }) => {
+export const Translatable: FC<TranslatableProps> = ({ text }) => {
   const { t } = useTranslation()
 
   return <>{typeof text === 'object' ? t(text.key, text.props) : text}</>

--- a/components/Translatable.tsx
+++ b/components/Translatable.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface TranslatableProps {
+  key: string
+  props?: { [key: string]: string }
+}
+
+export const Translatable: FC<{ text: string | TranslatableProps }> = ({ text }) => {
+  const { t } = useTranslation()
+
+  return <>{typeof text === 'object' ? t(text.key, text.props) : text}</>
+}

--- a/components/assetsTable/cellComponents/AssetsTableDataCellInactive.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellInactive.tsx
@@ -2,5 +2,9 @@ import React, { PropsWithChildren } from 'react'
 import { Text } from 'theme-ui'
 
 export function AssetsTableDataCellInactive({ children = 'n/a' }: PropsWithChildren<{}>) {
-  return <Text as="span" sx={{ color: 'neutral80' }}>{children}</Text>
+  return (
+    <Text as="span" sx={{ color: 'neutral80' }}>
+      {children}
+    </Text>
+  )
 }

--- a/components/assetsTable/cellComponents/AssetsTableDataCellInactive.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellInactive.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react'
-import { Box } from 'theme-ui'
+import { Text } from 'theme-ui'
 
 export function AssetsTableDataCellInactive({ children = 'n/a' }: PropsWithChildren<{}>) {
-  return <Box sx={{ color: 'neutral80' }}>{children}</Box>
+  return <Text as="span" sx={{ color: 'neutral80' }}>{children}</Text>
 }

--- a/components/assetsTable/cellComponents/AssetsTableTooltip.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableTooltip.tsx
@@ -9,11 +9,13 @@ export interface AssetsTableTooltipProps {
     description: string
   }
   icon: string
+  iconColor?: string
 }
 
 export function AssetsTableTooltip({
   content: { title, description },
   icon,
+  iconColor,
 }: AssetsTableTooltipProps) {
   return (
     <StatefulTooltip
@@ -38,7 +40,7 @@ export function AssetsTableTooltip({
         boxShadow: 'buttonMenu',
       }}
     >
-      <Icon size={16} name={icon} color="interactive100" />
+      <Icon size={16} name={icon} color={iconColor || 'interactive100'} />
     </StatefulTooltip>
   )
 }

--- a/components/assetsTable/cellComponents/AssetsTableTooltip.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableTooltip.tsx
@@ -1,12 +1,13 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { StatefulTooltip } from 'components/Tooltip'
+import { Translatable, TranslatableType } from 'components/Translatable'
 import React from 'react'
 import { Text } from 'theme-ui'
 
 export interface AssetsTableTooltipProps {
   content: {
-    title?: string
-    description: string
+    title?: TranslatableType
+    description: TranslatableType
   }
   icon: string
   iconColor?: string
@@ -23,10 +24,10 @@ export function AssetsTableTooltip({
         <>
           {title && (
             <Text as="span" sx={{ display: 'block', mb: 1, fontWeight: 'semiBold' }}>
-              {title}
+              <Translatable text={title} />
             </Text>
           )}
-          {description}
+          <Translatable text={description} />
         </>
       }
       containerSx={{ position: 'relative', top: '2px', display: 'inline-flex', ml: 1 }}

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -41,121 +41,107 @@ function parseProduct(
     case ProductHubProductType.Borrow:
       return {
         maxLtv: {
-          sortable: maxLtv ? maxLtv.toNumber() : 0,
-          value: maxLtv ? (
+          sortable: maxLtv?.toNumber() || 0,
+          value: (
             <>
-              {formatDecimalAsPercent(maxLtv)}
+              {maxLtv ? formatDecimalAsPercent(maxLtv) : <AssetsTableDataCellInactive />}
               {tooltips?.maxLtv && <AssetsTableTooltip {...tooltips.maxLtv} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
         liquidityAvaliable: {
-          sortable: liquidity ? liquidity.toNumber() : 0,
-          value: liquidity ? (
+          sortable: liquidity?.toNumber() || 0,
+          value: (
             <>
-              ${formatFiatBalance(liquidity)}
+              {liquidity ? `$${formatFiatBalance(liquidity)}` : <AssetsTableDataCellInactive />}
               {tooltips?.liquidity && <AssetsTableTooltip {...tooltips.liquidity} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
         borrowRate: {
-          sortable: fee ? fee.toNumber() : 0,
-          value: fee ? (
+          sortable: fee?.toNumber() || 0,
+          value: (
             <>
-              {formatDecimalAsPercent(fee)}
+              {fee ? formatDecimalAsPercent(fee) : <AssetsTableDataCellInactive />}
               {tooltips?.fee && <AssetsTableTooltip {...tooltips.fee} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
       }
     case ProductHubProductType.Multiply:
       return {
-        strategy: multiplyStrategy ? (
+        strategy: (
           <>
-            {multiplyStrategy}
+            {multiplyStrategy || <AssetsTableDataCellInactive />}
             {tooltips?.multiplyStrategy && <AssetsTableTooltip {...tooltips.multiplyStrategy} />}
           </>
-        ) : (
-          <AssetsTableDataCellInactive />
         ),
         maxMultiple: {
-          sortable: maxMultiply ? maxMultiply.toNumber() : 0,
-          value: maxMultiply ? (
+          sortable: maxMultiply?.toNumber() || 0,
+          value: (
             <>
-              {maxMultiply.toFixed(2)}x
+              {maxMultiply ? `${maxMultiply.toFixed(2)}x` : <AssetsTableDataCellInactive />}
               {tooltips?.maxMultiply && <AssetsTableTooltip {...tooltips.maxMultiply} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
         liquidityAvaliable: {
-          sortable: liquidity ? liquidity.toNumber() : 0,
-          value: liquidity ? (
+          sortable: liquidity?.toNumber() || 0,
+          value: (
             <>
-              ${formatFiatBalance(liquidity)}
+              {liquidity ? `$${formatFiatBalance(liquidity)}` : <AssetsTableDataCellInactive />}
               {tooltips?.liquidity && <AssetsTableTooltip {...tooltips.liquidity} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
-        variableFeeYr: {
+        borrowRate: {
           sortable: fee ? fee.toNumber() : 0,
-          value: fee ? (
+          value: (
             <>
-              {formatDecimalAsPercent(fee)}
+              {fee ? formatDecimalAsPercent(fee) : <AssetsTableDataCellInactive />}
               {tooltips?.fee && <AssetsTableTooltip {...tooltips.fee} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
       }
     case ProductHubProductType.Earn:
       return {
-        strategy: earnStrategy ? (
+        strategy: (
           <>
-            {earnStrategy}
+            {earnStrategy || <AssetsTableDataCellInactive />}
             {tooltips?.earnStrategy && <AssetsTableTooltip {...tooltips.earnStrategy} />}
           </>
-        ) : (
-          <AssetsTableDataCellInactive />
         ),
-        management: managementType ? (
+        management: (
           <>
-            <Trans i18nKey={`product-hub.table.${managementType}`} />
+            {managementType ? (
+              <Trans i18nKey={`product-hub.table.${managementType}`} />
+            ) : (
+              <AssetsTableDataCellInactive />
+            )}
             {tooltips?.managementType && <AssetsTableTooltip {...tooltips.managementType} />}
           </>
-        ) : (
-          <AssetsTableDataCellInactive />
         ),
         '7DayNetApy': {
-          sortable: weeklyNetApy ? weeklyNetApy.toNumber() : 0,
-          value: weeklyNetApy ? (
+          sortable: weeklyNetApy?.toNumber() || 0,
+          value: (
             <>
-              {formatDecimalAsPercent(weeklyNetApy)}
+              {weeklyNetApy ? (
+                formatDecimalAsPercent(weeklyNetApy)
+              ) : (
+                <AssetsTableDataCellInactive />
+              )}
               {tooltips?.weeklyNetApy && <AssetsTableTooltip {...tooltips.weeklyNetApy} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
         liquidityAvaliable: {
-          sortable: liquidity ? liquidity.toNumber() : 0,
-          value: liquidity ? (
+          sortable: liquidity?.toNumber() || 0,
+          value: (
             <>
-              ${formatFiatBalance(liquidity)}
+              {liquidity ? `$${formatFiatBalance(liquidity)}` : <AssetsTableDataCellInactive />}
               {tooltips?.liquidity && <AssetsTableTooltip {...tooltips.liquidity} />}
             </>
-          ) : (
-            <AssetsTableDataCellInactive />
           ),
         },
       }

--- a/features/productHub/types.ts
+++ b/features/productHub/types.ts
@@ -56,6 +56,10 @@ export interface ProductHubItemTooltips {
 
 export type ProductHubItem = ProductHubItemBasics & ProductHubItemDetails & ProductHubItemTooltips
 
+export type ProductHubItemWithFlattenTooltip = Omit<ProductHubItem, 'tooltips'> & {
+  tooltips: string
+}
+
 export type ProductHubPromoCards = {
   [key in ProductHubProductType]: {
     default: PromoCardProps[]

--- a/handlers/product-hub/index.ts
+++ b/handlers/product-hub/index.ts
@@ -1,6 +1,6 @@
 import { Protocol } from '@prisma/client'
 import { networks } from 'blockchain/networks'
-import { ProductHubItem } from 'features/productHub/types'
+import { ProductHubItem, ProductHubItemWithFlattenTooltip } from 'features/productHub/types'
 import { checkIfAllHandlersExist, filterTableData, measureTime } from 'handlers/product-hub/helpers'
 import { PROMO_CARD_COLLECTIONS_PARSERS } from 'handlers/product-hub/promo-card-collections-parsers'
 import {
@@ -130,7 +130,9 @@ export async function updateProductHubData(
       })
     }
 
-    const createData = flatten([...dataHandlersPromiseList.map(({ data }) => data)])
+    const createData = flatten([
+      ...dataHandlersPromiseList.map(({ data }) => data),
+    ]) as ProductHubItemWithFlattenTooltip[]
     try {
       await prisma.productHubItems.createMany({
         data: createData,

--- a/server/database/migrations/024-product-hub-add-tooltips.sql
+++ b/server/database/migrations/024-product-hub-add-tooltips.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "product_hub_items"
+  ADD COLUMN "tooltips" JSONB;

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -247,6 +247,7 @@ model ProductHubItems {
   multiplyStrategyType ProductHubStrategy?
   reverseTokens Boolean?
   updatedAt DateTime @updatedAt
+  tooltips Json?
 
   @@unique([label, network, product, protocol, primaryToken, secondaryToken], name: "product_hub_item_id")
   @@map("product_hub_items")


### PR DESCRIPTION
# Support for tooltips on Product Hub

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/552204b9-eccf-43e5-8834-32580643301a)
  
## Changes 👷‍♀️

- Added migration altering Product Hub database table to add `tooltips` column,
- extracted `PromoCardTranslation` component from `PromoCards` and renamed it into `Translatable` so it can be reused anywhere else (as tooltips need it),
- added support for tooltips for columns, that doesn't have any content.
  
## How to test 🧪

Add some tooltips to any product hub patch api handler and check if they are on the front-end.
