### PR TITLE
🧿 Fix Ajna layout after redesign changes

### DIFF
--- a/features/ajna/common/layout.tsx
+++ b/features/ajna/common/layout.tsx
@@ -1,13 +1,13 @@
 import { isAppContextAvailable } from 'components/AppContextProvider'
 import { WithFeatureToggleRedirect } from 'components/FeatureToggleRedirect'
 import { PageSEOTags } from 'components/HeadTags'
-import { BasicLayout } from 'components/Layouts'
+import { WithAnnouncementLayout } from 'components/Layouts'
 import { AnjaFooter } from 'features/ajna/common/components/AnjaFooter'
 import { AjnaNavigationController } from 'features/navigation/controls/AjnaNavigationController'
 import React, { PropsWithChildren } from 'react'
 import { ajnaExtensionTheme } from 'theme'
 import { ThemeProvider } from 'theme-ui'
-import { Background } from 'theme/Background'
+import { BackgroundLight } from 'theme/BackgroundLight'
 
 interface AjnaLayoutProps {}
 
@@ -20,14 +20,15 @@ export function AjnaLayout({ children }: PropsWithChildren<{}>) {
 
   return (
     <ThemeProvider theme={ajnaExtensionTheme}>
-      <BasicLayout
-        header={<AjnaNavigationController />}
+      <WithAnnouncementLayout
+        sx={{ zIndex: 2, position: 'relative' }}
+        showAnnouncement={false}
         footer={<AnjaFooter />}
-        sx={{ position: 'relative' }}
-        bg={<Background short />}
+        header={<AjnaNavigationController />}
+        bg={<BackgroundLight />}
       >
         {children}
-      </BasicLayout>
+      </WithAnnouncementLayout>
     </ThemeProvider>
   )
 }

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -52,24 +52,23 @@ export function AjnaHomepageView() {
 
   return (
     <AnimatedWrapper>
-      <Box sx={{ maxWidth: '670px', mt: 5, mx: 'auto' }}>
-        <Hero
-          isConnected={context?.status === 'connected'}
-          heading="landing.hero.ajna.headline"
-          subheading={
-            <Trans
-              i18nKey="landing.hero.ajna.subheader"
-              components={[
-                <AppLink
-                  sx={{ fontSize: 'inherit', fontWeight: 'regular' }}
-                  href={EXTERNAL_LINKS.KB.AJNA}
-                />,
-              ]}
-            />
-          }
-          showButton={false}
-        />
-      </Box>
+      <Hero
+        isConnected={context?.status === 'connected'}
+        heading="landing.hero.ajna.headline"
+        headingWidth="980px"
+        subheading={
+          <Trans
+            i18nKey="landing.hero.ajna.subheader"
+            components={[
+              <AppLink
+                sx={{ fontSize: 'inherit', fontWeight: 'regular' }}
+                href={EXTERNAL_LINKS.KB.AJNA}
+              />,
+            ]}
+          />
+        }
+        subheadingWidth="740px"
+      />
       <Box sx={{ mt: '180px', borderTop: '1px solid', borderColor: 'neutral20' }}>
         <ProductHubView
           headerGradient={['#f154db', '#974eea']}

--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -95,7 +95,7 @@ export function HomepageView() {
           primaryText={t('landing.why-oasis.sub-headers.security.primary')}
           secondaryText={t('landing.why-oasis.sub-headers.security.secondary')}
           ctaLabel={t('find-your-defi-product')}
-          ctaOnClick={scrollTo('homepage-table')}
+          ctaOnClick={scrollTo('product-hub')}
           sx={{ alignSelf: 'center', mb: [5, 0] }}
         />
         <Image
@@ -166,7 +166,6 @@ export function HomepageView() {
           promoCardsCollection="Home"
           token="ETH"
           limitRows={10}
-          id="homepage-table"
         />
       </Box>
       <Box

--- a/features/homepage/common/Hero.tsx
+++ b/features/homepage/common/Hero.tsx
@@ -10,13 +10,17 @@ export function Hero({
   sx,
   isConnected,
   heading,
+  headingWidth = '700px',
   subheading,
+  subheadingWidth = '450px',
   showButton = true,
 }: {
   sx?: SxStyleProp
   isConnected: boolean
   heading: string
+  headingWidth?: string
   subheading: ReactNode
+  subheadingWidth?: string
   showButton?: boolean
 }) {
   const { t } = useTranslation()
@@ -38,10 +42,18 @@ export function Hero({
         ...sx,
       }}
     >
-      <Heading as="h1" variant="heroHeader" sx={{ mt: [2, 5], mb: 3, maxWidth: ['100%', '700px'] }}>
+      <Heading
+        as="h1"
+        variant="heroHeader"
+        sx={{ mt: [2, 5], mb: 3, maxWidth: ['100%', headingWidth] }}
+      >
         {t(heading)}
       </Heading>
-      <Text variant="paragraph1" sx={{ mb: 4, color: 'neutral80', maxWidth: ['100%', '450px'] }}>
+      <Text
+        variant="paragraph1"
+        as="p"
+        sx={{ mb: 4, color: 'neutral80', maxWidth: ['100%', subheadingWidth] }}
+      >
         {subheading}
       </Text>
       {showButton && (
@@ -58,7 +70,7 @@ export function Hero({
             },
           }}
           onClick={
-            isConnected ? scrollTo('homepage-table') : async () => connecting || (await connect())
+            isConnected ? scrollTo('product-hub') : async () => connecting || (await connect())
           }
         >
           {isConnected ? t('find-your-defi-product') : t('connect-wallet')}

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -29,7 +29,6 @@ interface ProductHubViewProps {
   token?: string
   url?: string
   limitRows?: number
-  id?: string
 }
 
 export const ProductHubView: FC<ProductHubViewProps> = ({
@@ -41,7 +40,6 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   token,
   url,
   limitRows,
-  id,
 }) => {
   const { t } = useTranslation()
   const { data } = useProductHubData({
@@ -70,7 +68,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   return (
     <Fragment key={product}>
       <Box
-        id={id}
+        id="product-hub"
         sx={{
           position: 'relative',
           my: [3, null, '48px'],


### PR DESCRIPTION
# [Fix Ajna layout after redesign changes](https://app.shortcut.com/oazo-apps/story/9976/fix-ajna-layout-after-redesign-changes)

Latest redesign changes broke Ajna layout, this PR brings it back.
  
## Changes 👷‍♀️

- Updated `AjnaLayout` to use the same layout as rest of the pages (except for color scheme),
- updated `Hero` on Ajna landing page to match the one on homepage.
  
## How to test 🧪

Check all `/ajna` pages to see if layout is updated everywhere.
