### PR TITLE
🧿 Update Ajna Rewards banner

### DIFF
--- a/components/LandingBanner.tsx
+++ b/components/LandingBanner.tsx
@@ -26,7 +26,7 @@ export function LandingBanner({
   link,
 }: LandingBannerProps) {
   return (
-    <Box sx={{ borderRadius: '32px', background }}>
+    <Box sx={{ borderRadius: 'round', background }}>
       <Grid
         sx={{
           gridTemplateColumns: ['1fr', '1fr 316px'],
@@ -51,10 +51,12 @@ export function LandingBanner({
           />
         </Box>
         <Flex sx={{ p: [4, 5], flexDirection: 'column', justifyContent: 'space-between' }}>
-          <Heading as="h2" sx={{ mb: 2, fontSize: '28px' }}>
+          <Heading as="h2" variant="header4" sx={{ mb: '12px' }}>
             {title}
           </Heading>
-          <Text sx={{ color: 'neutral80', fontSize: 4 }}>{description}</Text>
+          <Text as="p" variant="paragraph1" sx={{ color: 'neutral80' }}>
+            {description}
+          </Text>
           <Flex
             sx={{
               mt: [5, 4],

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@makerdao/dai-ui-icons'
 import { AnimatedWrapper } from 'components/AnimatedWrapper'
 import { useAppContext } from 'components/AppContextProvider'
 import { BenefitCard, BenefitCardsWrapper } from 'components/BenefitCard'
@@ -7,12 +6,14 @@ import { AppLink } from 'components/Links'
 import { AjnaHaveSomeQuestions } from 'features/ajna/common/components/AjnaHaveSomeQuestions'
 import { ProductHubProductType } from 'features/productHub/types'
 import { ProductHubView } from 'features/productHub/views'
-import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
+import { useConnection } from 'features/web3OnBoard'
+import { EXTERNAL_LINKS, INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useObservable } from 'helpers/observableHook'
+import { useAccount } from 'helpers/useAccount'
 import { LendingProtocol } from 'lendingProtocols'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
-import { Box, Flex, Text } from 'theme-ui'
+import { Box, Button, Flex, Text } from 'theme-ui'
 
 import { Hero } from './common/Hero'
 
@@ -49,6 +50,10 @@ export function AjnaHomepageView() {
   const { t } = useTranslation()
   const { context$ } = useAppContext()
   const [context] = useObservable(context$)
+  const { connecting, connect } = useConnection({
+    initialConnect: false,
+  })
+  const { isConnected } = useAccount()
 
   return (
     <AnimatedWrapper>
@@ -113,37 +118,23 @@ export function AjnaHomepageView() {
           src: '/static/img/setup-banner/anja-landing-banner.png',
         }}
         link={{
-          href: 'link',
-          label: t('ajna.landing-banner.linkLabel'),
+          href: EXTERNAL_LINKS.AJNA.HOME,
+          label: t('ajna.landing-banner.link-label'),
         }}
         button={
-          context?.status !== 'connected' ? (
-            <AppLink
-              variant="primary"
-              href="/connect"
-              sx={{
-                display: 'flex',
-                px: '40px',
-                py: 2,
-                color: 'offWhite',
-                alignItems: 'center',
-                '&:hover svg': {
-                  transform: 'translateX(10px)',
-                },
-              }}
-            >
-              {t('connect-wallet-button')}
-              <Icon
-                name="arrow_right"
-                sx={{
-                  ml: 2,
-                  position: 'relative',
-                  left: 2,
-                  transition: '0.2s',
-                }}
-              />
+          isConnected ? (
+            <AppLink variant="primary" href={INTERNAL_LINKS.ajnaRewards} sx={{ px: '40px' }}>
+              {t('ajna.landing-banner.button-label')}
             </AppLink>
-          ) : null
+          ) : (
+            <Button
+              variant="primary"
+              sx={{ px: '40px' }}
+              onClick={async () => connecting || (await connect())}
+            >
+              {t('connect-wallet')} →
+            </Button>
+          )
         }
       />
       <AjnaHaveSomeQuestions />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2480,7 +2480,7 @@
     "other-assets": "Other assets you can borrow against",
     "landing-banner": {
       "title": "Get Ajna token when you use Ajna protocol",
-      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sollicitudin mollis fringilla. Nunc bibendum ultricies mi. Donec vitae elementum turpis.",
+      "description": "summer.fi users are eligible for exclusive Ajna token rewards! Open and Ajna position through summer.fi and automatically earn Ajna tokens.",
       "button-label": "See my rewards →",
       "link-label": "Visit Anja website →"
     },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2481,7 +2481,8 @@
     "landing-banner": {
       "title": "Get Ajna token when you use Ajna protocol",
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sollicitudin mollis fringilla. Nunc bibendum ultricies mi. Donec vitae elementum turpis.",
-      "linkLabel": "Visit Anja website ->"
+      "button-label": "See my rewards →",
+      "link-label": "Visit Anja website →"
     },
     "learn": {
       "ajna-website": "Ajna website",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2482,7 +2482,7 @@
       "title": "Get Ajna token when you use Ajna protocol",
       "description": "summer.fi users are eligible for exclusive Ajna token rewards! Open and Ajna position through summer.fi and automatically earn Ajna tokens.",
       "button-label": "See my rewards →",
-      "link-label": "Visit Anja website →"
+      "link-label": "Visit Ajna website →"
     },
     "learn": {
       "ajna-website": "Ajna website",


### PR DESCRIPTION
# [Update Ajna Rewards banner](https://app.shortcut.com/oazo-apps/story/9870/update-ajna-rewards-button-on-landing-page)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/bd019b3c-946f-4d4f-85ed-0588c028b3fa)
  
## Changes 👷‍♀️

- Fixed connect button when user is disconnected,
- added "See my rewards" when user has connected wallet,
- tiny adjustments to banner styles so it matches design and utilizes theme ui predefined themes.
  
## How to test 🧪

Use banner as connected and disconnected user.
