### PR TITLE
Assets table entire row active

### DIFF
--- a/components/assetsTable/AssetsTable.tsx
+++ b/components/assetsTable/AssetsTable.tsx
@@ -248,6 +248,7 @@ export function AssetsTableDataRow({ row, rowKeys }: AssetsTableDataRowProps) {
     <Box
       as="tr"
       sx={{
+        position: 'relative',
         borderRadius: 'medium',
         transition: 'box-shadow 200ms',
         '&:hover': {

--- a/components/assetsTable/AssetsTable.tsx
+++ b/components/assetsTable/AssetsTable.tsx
@@ -13,7 +13,7 @@ import { ExpandableArrow } from 'components/dumb/ExpandableArrow'
 import { StatefulTooltip } from 'components/Tooltip'
 import { kebabCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
-import React, { Fragment, useMemo, useState } from 'react'
+import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Flex } from 'theme-ui'
 
 interface AssetsTableHeaderCellProps {
@@ -239,16 +239,41 @@ export function AssetsTableHeaderCell({
 }
 
 export function AssetsTableDataRow({ row, rowKeys }: AssetsTableDataRowProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [hasUndisabledButton, setHasUndisabledButton] = useState<boolean>(false)
+
+  useEffect(() => {
+    setHasUndisabledButton(
+      ref.current?.querySelector('.table-action-button:not(:disabled') !== null,
+    )
+  }, [ref])
+
   return (
     <Box
+      ref={ref}
       as="tr"
       sx={{
         position: 'relative',
         borderRadius: 'medium',
         transition: 'box-shadow 200ms',
-        '&:hover': {
-          boxShadow: 'buttonMenu',
-        },
+        ...(hasUndisabledButton && {
+          cursor: 'pointer',
+          '&:hover': {
+            boxShadow: 'buttonMenu',
+            '.table-action-button': {
+              bg: 'secondary100',
+            },
+          },
+        }),
+      }}
+      {...{
+        ...(hasUndisabledButton && {
+          role: 'link',
+          onClick: () => {
+            if (ref.current && ref.current.querySelector('.table-action-button'))
+              (ref.current.querySelector('.table-action-button') as HTMLButtonElement).click()
+          },
+        }),
       }}
     >
       {rowKeys.map((label, i) => (

--- a/components/assetsTable/AssetsTable.tsx
+++ b/components/assetsTable/AssetsTable.tsx
@@ -21,7 +21,6 @@ interface AssetsTableHeaderCellProps {
   headerTranslationProps?: AssetsTableHeaderTranslationProps
   isSortable: boolean
   isSticky: boolean
-  isWithFollow: boolean
   label: string
   last: boolean
   sortingSettings?: AssetsTableSortingSettings
@@ -44,7 +43,6 @@ export function AssetsTable({
   headerTranslationProps,
   isLoading = false,
   isSticky = false,
-  isWithFollow = false,
   rows,
   tooltips = [],
 }: AssetsTableProps) {
@@ -99,7 +97,6 @@ export function AssetsTable({
                 headerTranslationProps={headerTranslationProps}
                 isSortable={(rows[0][label] as AssetsTableSortableCell).sortable !== undefined}
                 isSticky={isSticky}
-                isWithFollow={isWithFollow}
                 label={label}
                 last={i + 1 === rowKeys.length}
                 sortingSettings={sortingSettings}
@@ -140,7 +137,6 @@ export function AssetsTableHeaderCell({
   headerTranslationProps,
   isSortable,
   isSticky,
-  isWithFollow,
   label,
   last,
   sortingSettings,
@@ -158,7 +154,6 @@ export function AssetsTableHeaderCell({
         px: '12px',
         pt: '28px',
         pb: isSticky ? '48px' : '20px',
-        ...(first && isWithFollow && { pl: '80px' }),
         fontSize: 1,
         fontWeight: 'semiBold',
         color: 'neutral80',

--- a/components/assetsTable/AssetsTable.tsx
+++ b/components/assetsTable/AssetsTable.tsx
@@ -11,6 +11,7 @@ import {
 } from 'components/assetsTable/types'
 import { ExpandableArrow } from 'components/dumb/ExpandableArrow'
 import { StatefulTooltip } from 'components/Tooltip'
+import { getRandomString } from 'helpers/getRandomString'
 import { kebabCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react'
@@ -116,7 +117,7 @@ export function AssetsTable({
         >
           {sortedRows.map((row, i) => (
             <Fragment key={getRowKey(i, row)}>
-              <AssetsTableDataRow row={row} rowKeys={rowKeys} />
+              <AssetsTableDataRow key={getRandomString()} row={row} rowKeys={rowKeys} />
               {banner && i === Math.floor(bannerRows / 2) && (
                 <tr>
                   <td colSpan={Object.keys(row).length}>

--- a/components/assetsTable/cellComponents/AssetsTableDataCellAction.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellAction.tsx
@@ -7,7 +7,7 @@ import {
 } from 'features/follow/common/ShareButton'
 import getConfig from 'next/config'
 import React from 'react'
-import { Button, Flex } from 'theme-ui'
+import { Box, Button, Flex } from 'theme-ui'
 
 const basePath = getConfig()?.publicRuntimeConfig?.basePath
 
@@ -73,6 +73,7 @@ export function AssetsTableDataCellAction({
           disabled={disabled}
           onClick={onClick}
         >
+          <Box sx={{ display: ['none', null, null, 'block'], position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }} />
           {cta}
         </Button>
       )}

--- a/components/assetsTable/cellComponents/AssetsTableDataCellAction.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellAction.tsx
@@ -1,6 +1,6 @@
 import { AppLink } from 'components/Links'
 import React from 'react'
-import { Box, Button, Flex } from 'theme-ui'
+import { Button, Flex } from 'theme-ui'
 
 interface AssetsTableDataCellActionProps {
   cta?: string
@@ -29,21 +29,12 @@ export function AssetsTableDataCellAction({
         </AppLink>
       ) : (
         <Button
+          className="table-action-button"
           variant="tertiary"
           sx={{ width: ['100%', null, null, 'auto'] }}
           disabled={disabled}
           onClick={onClick}
         >
-          <Box
-            sx={{
-              display: ['none', null, null, 'block'],
-              position: 'absolute',
-              top: 0,
-              right: 0,
-              bottom: 0,
-              left: 0,
-            }}
-          />
           {cta}
         </Button>
       )}

--- a/components/assetsTable/cellComponents/AssetsTableDataCellAction.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellAction.tsx
@@ -1,22 +1,12 @@
-import { Icon } from '@makerdao/dai-ui-icons'
 import { AppLink } from 'components/Links'
-import {
-  getTwitterShareUrl,
-  twitterSharePositionText,
-  twitterSharePositionVia,
-} from 'features/follow/common/ShareButton'
-import getConfig from 'next/config'
 import React from 'react'
 import { Box, Button, Flex } from 'theme-ui'
-
-const basePath = getConfig()?.publicRuntimeConfig?.basePath
 
 interface AssetsTableDataCellActionProps {
   cta?: string
   disabled?: boolean
   link?: string
   newTab?: boolean
-  shareButton?: boolean
   onClick?: () => void
 }
 
@@ -25,47 +15,18 @@ export function AssetsTableDataCellAction({
   disabled = false,
   link,
   newTab = false,
-  shareButton,
   onClick,
 }: AssetsTableDataCellActionProps) {
   return (
     <Flex sx={{ justifyContent: 'flex-end' }}>
       {link ? (
-        <>
-          <AppLink
-            href={link}
-            sx={{ flexGrow: [1, null, null, 'initial'], pointerEvents: disabled ? 'none' : 'auto' }}
-            internalInNewTab={newTab}
-          >
-            <AssetsTableDataCellAction cta={cta} disabled={disabled} onClick={onClick} />
-          </AppLink>
-          {shareButton && (
-            <AppLink
-              href={getTwitterShareUrl({
-                text: twitterSharePositionText,
-                url: `${basePath}${link}`,
-                via: twitterSharePositionVia,
-              })}
-              sx={{ ml: 2 }}
-            >
-              <Button
-                variant="tertiary"
-                sx={{
-                  width: '36px',
-                  height: '36px',
-                  pt: '3px',
-                  pr: 0,
-                  pb: 0,
-                  pl: '2px',
-                  mr: '1px',
-                  mb: '3px',
-                }}
-              >
-                <Icon name="share" size={18} />
-              </Button>
-            </AppLink>
-          )}
-        </>
+        <AppLink
+          href={link}
+          sx={{ flexGrow: [1, null, null, 'initial'], pointerEvents: disabled ? 'none' : 'auto' }}
+          internalInNewTab={newTab}
+        >
+          <AssetsTableDataCellAction cta={cta} disabled={disabled} onClick={onClick} />
+        </AppLink>
       ) : (
         <Button
           variant="tertiary"
@@ -73,7 +34,16 @@ export function AssetsTableDataCellAction({
           disabled={disabled}
           onClick={onClick}
         >
-          <Box sx={{ display: ['none', null, null, 'block'], position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }} />
+          <Box
+            sx={{
+              display: ['none', null, null, 'block'],
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              bottom: 0,
+              left: 0,
+            }}
+          />
           {cta}
         </Button>
       )}

--- a/components/assetsTable/cellComponents/AssetsTableDataCellAsset.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellAsset.tsx
@@ -1,7 +1,4 @@
-import BigNumber from 'bignumber.js'
-import { AssetsTableFollowButtonProps } from 'components/assetsTable/types'
 import { TokensGroup } from 'components/TokensGroup'
-import { FollowButtonControl } from 'features/follow/controllers/FollowButtonControl'
 import { allDefined } from 'helpers/allDefined'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -9,7 +6,6 @@ import { Flex, Text } from 'theme-ui'
 
 interface AssetsTableDataCellAssetProps {
   asset: string
-  followButton?: AssetsTableFollowButtonProps
   icons?: string[]
   positionId?: string
   prefix?: string
@@ -18,7 +14,6 @@ interface AssetsTableDataCellAssetProps {
 
 export function AssetsTableDataCellAsset({
   asset,
-  followButton,
   icons = [],
   positionId,
   prefix,
@@ -28,20 +23,6 @@ export function AssetsTableDataCellAsset({
 
   return (
     <Flex sx={{ alignItems: 'center' }}>
-      {followButton && positionId && (
-        <FollowButtonControl
-          chainId={followButton.chainId}
-          followerAddress={followButton.followerAddress}
-          vaultId={new BigNumber(positionId)}
-          short
-          sx={{
-            position: ['absolute', null, null, 'relative'],
-            right: [0, null, null, 'auto'],
-            mr: ['24px', null, null, 4],
-          }}
-          protocol="maker" //TODO ŁW - update when follow other protocols will be supported
-        />
-      )}
       {icons.length > 0 && allDefined(...icons) && <TokensGroup tokens={icons} />}
       <Flex sx={{ flexDirection: 'column', ml: '10px' }}>
         <Text as="span" sx={{ fontSize: 4, fontWeight: 'semiBold' }}>

--- a/components/assetsTable/types.tsx
+++ b/components/assetsTable/types.tsx
@@ -37,12 +37,6 @@ export interface AssetsTableProps {
   headerTranslationProps?: AssetsTableHeaderTranslationProps
   isLoading?: boolean
   isSticky?: boolean
-  isWithFollow?: boolean
   rows: AssetsTableRowData[]
   tooltips?: string[]
-}
-
-export interface AssetsTableFollowButtonProps {
-  followerAddress: string
-  chainId: number
 }

--- a/features/discover/common/DiscoverData.tsx
+++ b/features/discover/common/DiscoverData.tsx
@@ -3,7 +3,6 @@ import { AssetsTableBannerProps, AssetsTableRowData } from 'components/assetsTab
 import { DiscoverDataResponseError } from 'features/discover/api'
 import { DiscoverError } from 'features/discover/common/DiscoverError'
 import { DiscoverPreloader } from 'features/discover/common/DiscoverPreloader'
-import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 import { Box } from 'theme-ui'
 
@@ -16,8 +15,6 @@ interface DiscoverDataProps {
 }
 
 export function DiscoverData({ banner, error, isLoading, isSticky, rows }: DiscoverDataProps) {
-  const { chainId, walletAddress } = useAccount()
-
   return (
     <Box sx={{ position: 'relative' }}>
       {rows ? (
@@ -28,10 +25,6 @@ export function DiscoverData({ banner, error, isLoading, isSticky, rows }: Disco
             isLoading={isLoading}
             isSticky={isSticky}
             rows={rows}
-            {...(!!chainId &&
-              !!walletAddress && {
-                isWithFollow: true,
-              })}
           />
         </>
       ) : isLoading ? (

--- a/features/discover/helpers/parseDiscoverRowData.tsx
+++ b/features/discover/helpers/parseDiscoverRowData.tsx
@@ -37,14 +37,7 @@ interface parseDiscoverRowDataParams {
   walletAddress?: string
 }
 
-function ParseDiscoverCellData({
-  chainId,
-  kind,
-  label,
-  lang,
-  row,
-  walletAddress,
-}: ParseDiscoverCellDataParams): ReactNode {
+function ParseDiscoverCellData({ kind, label, lang, row }: ParseDiscoverCellDataParams): ReactNode {
   const stringified = Object.keys(row)
     .filter((item) => typeof row[item] === 'string' || typeof row[item] === 'number')
     .reduce<{ [key: string]: string }>((a, v) => ({ ...a, [v]: row[v] as string }), {})
@@ -55,13 +48,6 @@ function ParseDiscoverCellData({
         <AssetsTableDataCellAsset
           asset={stringified.asset}
           positionId={stringified.cdpId}
-          {...(!!chainId &&
-            !!walletAddress && {
-              followButton: {
-                chainId,
-                followerAddress: walletAddress,
-              },
-            })}
           icons={[stringified.asset]}
         />
       )
@@ -126,7 +112,6 @@ function ParseDiscoverCellData({
         <AssetsTableDataCellAction
           link={`/${stringified.cdpId}`}
           newTab={true}
-          shareButton={true}
           onClick={() => trackingEvents.discover.viewPosition(kind, stringified.cdpId)}
         />
       )

--- a/features/vaultsOverview/containers/FollowedTable.tsx
+++ b/features/vaultsOverview/containers/FollowedTable.tsx
@@ -23,12 +23,11 @@ import React from 'react'
 export function FollowedTable({ address }: { address: string }) {
   const { t } = useTranslation()
   const { followedList$ } = useAppContext()
-  const { chainId, walletAddress } = useAccount()
+  const { walletAddress } = useAccount()
   const checksumAddress = getAddress(address.toLocaleLowerCase())
   const [followedListData, followedListError] = useObservable(followedList$(checksumAddress))
 
   const isOwner = address === walletAddress
-  const showFollowButton = !!chainId && !!walletAddress
 
   return (
     <WithErrorHandler error={[followedListError]}>
@@ -36,24 +35,12 @@ export function FollowedTable({ address }: { address: string }) {
         {([followedMakerPositions]) => {
           const borrowPositions = getMakerBorrowPositions({
             positions: followedMakerPositions,
-            shareButton: true,
-            ...(showFollowButton && {
-              followButton: { chainId, followerAddress: walletAddress },
-            }),
           })
           const multiplyPositions = getMakerMultiplyPositions({
             positions: followedMakerPositions,
-            shareButton: true,
-            ...(showFollowButton && {
-              followButton: { chainId, followerAddress: walletAddress },
-            }),
           })
           const earnPositions = getMakerEarnPositions({
             positions: followedMakerPositions,
-            shareButton: true,
-            ...(showFollowButton && {
-              followButton: { chainId, followerAddress: walletAddress },
-            }),
           })
 
           return followedMakerPositions.length ? (
@@ -67,11 +54,7 @@ export function FollowedTable({ address }: { address: string }) {
                   <AssetsTableHeading>
                     Summer.fi {t('nav.borrow')} ({borrowPositions.length})
                   </AssetsTableHeading>
-                  <AssetsResponsiveTable
-                    rows={borrowPositions}
-                    tooltips={positionsTableTooltips}
-                    isWithFollow={showFollowButton}
-                  />
+                  <AssetsResponsiveTable rows={borrowPositions} tooltips={positionsTableTooltips} />
                 </>
               )}
               {multiplyPositions.length > 0 && (
@@ -82,7 +65,6 @@ export function FollowedTable({ address }: { address: string }) {
                   <AssetsResponsiveTable
                     rows={multiplyPositions}
                     tooltips={positionsTableTooltips}
-                    isWithFollow={showFollowButton}
                   />
                 </>
               )}
@@ -91,11 +73,7 @@ export function FollowedTable({ address }: { address: string }) {
                   <AssetsTableHeading>
                     Summer.fi {t('nav.earn')} ({earnPositions.length})
                   </AssetsTableHeading>
-                  <AssetsResponsiveTable
-                    rows={earnPositions}
-                    tooltips={positionsTableTooltips}
-                    isWithFollow={showFollowButton}
-                  />
+                  <AssetsResponsiveTable rows={earnPositions} tooltips={positionsTableTooltips} />
                 </>
               )}
             </AssetsTableContainer>

--- a/features/vaultsOverview/helpers.tsx
+++ b/features/vaultsOverview/helpers.tsx
@@ -4,7 +4,7 @@ import { AssetsTableDataCellAsset } from 'components/assetsTable/cellComponents/
 import { AssetsTableDataCellInactive } from 'components/assetsTable/cellComponents/AssetsTableDataCellInactive'
 import { AssetsTableDataCellProtection } from 'components/assetsTable/cellComponents/AssetsTableDataCellRiskProtection'
 import { AssetsTableDataCellRiskRatio } from 'components/assetsTable/cellComponents/AssetsTableDataCellRiskRatio'
-import { AssetsTableFollowButtonProps, AssetsTableRowData } from 'components/assetsTable/types'
+import { AssetsTableRowData } from 'components/assetsTable/types'
 import { AjnaPositionDetails } from 'features/ajna/positions/common/observables/getAjnaPosition'
 import { AutoBSTriggerData } from 'features/automation/common/state/autoBSTriggerData'
 import { StopLossTriggerData } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
@@ -30,26 +30,14 @@ export const positionsTableTooltips = [
   'variable',
   'vaultDebt',
 ]
-export const followTableSkippedHeaders = [
-  'icon',
-  'ilk',
-  'liquidityToken',
-  'protection',
-  'sameTab',
-  'url',
-]
 
-interface GetPositionParams {
-  followButton?: AssetsTableFollowButtonProps
-  shareButton?: boolean
-}
-interface GetMakerPositionParams extends GetPositionParams {
+interface GetMakerPositionParams {
   positions: MakerPositionDetails[]
 }
-interface GetAavePositionParams extends GetPositionParams {
+interface GetAavePositionParams {
   positions: AavePosition[]
 }
-interface GetDsrPositionParams extends GetPositionParams {
+interface GetDsrPositionParams {
   address: string
   dsr?: Dsr
 }
@@ -138,8 +126,6 @@ export function getAjnaPositionOfType(positions: AjnaPositionDetails[]) {
 
 export function getMakerBorrowPositions({
   positions,
-  followButton,
-  shareButton,
 }: GetMakerPositionParams): AssetsTableRowData[] {
   return getMakerPositionOfType(positions).borrow.map(
     ({
@@ -156,14 +142,7 @@ export function getMakerBorrowPositions({
       stopLossData,
       token,
     }) => ({
-      asset: (
-        <AssetsTableDataCellAsset
-          asset={ilk}
-          icons={[token]}
-          positionId={id.toString()}
-          followButton={followButton}
-        />
-      ),
+      asset: <AssetsTableDataCellAsset asset={ilk} icons={[token]} positionId={id.toString()} />,
       colRatio: (
         <AssetsTableDataCellRiskRatio
           level={collateralizationRatio.times(100).toNumber()}
@@ -181,20 +160,13 @@ export function getMakerBorrowPositions({
           link={`/ethereum/maker/${id.toString()}`}
         />
       ),
-      action: (
-        <AssetsTableDataCellAction
-          link={`/ethereum/maker/${id.toString()}`}
-          shareButton={shareButton}
-        />
-      ),
+      action: <AssetsTableDataCellAction link={`/ethereum/maker/${id.toString()}`} />,
     }),
   )
 }
 
 export function getMakerMultiplyPositions({
   positions,
-  followButton,
-  shareButton,
 }: GetMakerPositionParams): AssetsTableRowData[] {
   return getMakerPositionOfType(positions).multiply.map(
     ({
@@ -210,14 +182,7 @@ export function getMakerMultiplyPositions({
       token,
       value,
     }) => ({
-      asset: (
-        <AssetsTableDataCellAsset
-          asset={ilk}
-          icons={[token]}
-          positionId={id.toString()}
-          followButton={followButton}
-        />
-      ),
+      asset: <AssetsTableDataCellAsset asset={ilk} icons={[token]} positionId={id.toString()} />,
       netUSDValue: `$${formatFiatBalance(value)}`,
       currentMultiple: `${calculateMultiply({ debt, lockedCollateralUSD }).toFixed(2)}x`,
       liquidationPrice: `$${formatFiatBalance(liquidationPrice)}`,
@@ -229,44 +194,23 @@ export function getMakerMultiplyPositions({
           link={`/ethereum/maker/${id.toString()}`}
         />
       ),
-      action: (
-        <AssetsTableDataCellAction
-          link={`/ethereum/maker/${id.toString()}`}
-          shareButton={shareButton}
-        />
-      ),
+      action: <AssetsTableDataCellAction link={`/ethereum/maker/${id.toString()}`} />,
     }),
   )
 }
 
-export function getMakerEarnPositions({
-  positions,
-  followButton,
-  shareButton,
-}: GetMakerPositionParams): AssetsTableRowData[] {
+export function getMakerEarnPositions({ positions }: GetMakerPositionParams): AssetsTableRowData[] {
   return getMakerPositionOfType(positions).earn.map(
     ({ debt, history, id, ilk, ilkDebtAvailable, lockedCollateralUSD, token, value }) => {
       return {
-        asset: (
-          <AssetsTableDataCellAsset
-            asset={ilk}
-            icons={[token]}
-            positionId={id.toString()}
-            followButton={followButton}
-          />
-        ),
+        asset: <AssetsTableDataCellAsset asset={ilk} icons={[token]} positionId={id.toString()} />,
         netUSDValue: `$${formatFiatBalance(value)}`,
         pnl: `${formatPercent(calculatePNL(history, lockedCollateralUSD.minus(debt)).times(100), {
           precision: 2,
         })}`,
         liquidity: `${formatCryptoBalance(ilkDebtAvailable)} DAI`,
         protection: <AssetsTableDataCellInactive />,
-        action: (
-          <AssetsTableDataCellAction
-            link={`/ethereum/maker/${id.toString()}`}
-            shareButton={shareButton}
-          />
-        ),
+        action: <AssetsTableDataCellAction link={`/ethereum/maker/${id.toString()}`} />,
       }
     },
   )
@@ -274,7 +218,6 @@ export function getMakerEarnPositions({
 
 export function getAaveMultiplyPositions({
   positions,
-  shareButton,
 }: GetAavePositionParams): AssetsTableRowData[] {
   return getAavePositionOfType(positions).multiply.map(
     ({ fundingCost, id, liquidationPrice, multiple, netValue, title, token, url }) => {
@@ -285,16 +228,13 @@ export function getAaveMultiplyPositions({
         liquidationPrice: `$${formatFiatBalance(liquidationPrice)}`,
         fundingCost: `${fundingCost.toFixed(2)}%`,
         protection: <AssetsTableDataCellInactive />,
-        action: <AssetsTableDataCellAction link={url} shareButton={shareButton} />,
+        action: <AssetsTableDataCellAction link={url} />,
       }
     },
   )
 }
 
-export function getAaveEarnPositions({
-  positions,
-  shareButton,
-}: GetAavePositionParams): AssetsTableRowData[] {
+export function getAaveEarnPositions({ positions }: GetAavePositionParams): AssetsTableRowData[] {
   return getAavePositionOfType(positions).earn.map(
     ({ id, liquidity, netValue, title, token, url }) => {
       return {
@@ -303,17 +243,13 @@ export function getAaveEarnPositions({
         pnl: <AssetsTableDataCellInactive />,
         liquidity: `${formatCryptoBalance(liquidity)} USDC`,
         protection: <AssetsTableDataCellInactive />,
-        action: <AssetsTableDataCellAction link={url} shareButton={shareButton} />,
+        action: <AssetsTableDataCellAction link={url} />,
       }
     },
   )
 }
 
-export function getDsrPosition({
-  address,
-  dsr,
-  shareButton,
-}: GetDsrPositionParams): AssetsTableRowData[] {
+export function getDsrPosition({ address, dsr }: GetDsrPositionParams): AssetsTableRowData[] {
   const netValue = getDsrValue(dsr)
 
   const dsrPosition = [
@@ -323,7 +259,7 @@ export function getDsrPosition({
       pnl: <AssetsTableDataCellInactive />,
       liquidity: 'Unlimited',
       protection: <AssetsTableDataCellInactive />,
-      action: <AssetsTableDataCellAction link={`/earn/dsr/${address}`} shareButton={shareButton} />,
+      action: <AssetsTableDataCellAction link={`/earn/dsr/${address}`} />,
     },
   ]
 

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -89,9 +89,9 @@ async function getAjnaPoolData(
           const liquidity = buckets
             .filter((bucket) => new BigNumber(bucket.index).lte(highestThresholdPriceIndex))
             .reduce((acc, bucket) => acc.plus(bucket.quoteTokens), zero)
+            .minus(debt)
             .times(prices[quoteToken])
             .shiftedBy(negativeWadPrecision)
-            .minus(debt)
             .toString()
           const fee = interestRate.toString()
           const multiplyStrategy = isShort ? `Short ${quoteToken}` : `Long ${collateralToken}`

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -89,9 +89,9 @@ async function getAjnaPoolData(
           const liquidity = buckets
             .filter((bucket) => new BigNumber(bucket.index).lte(highestThresholdPriceIndex))
             .reduce((acc, bucket) => acc.plus(bucket.quoteTokens), zero)
-            .minus(debt)
             .times(prices[quoteToken])
             .shiftedBy(negativeWadPrecision)
+            .minus(debt)
             .toString()
           const fee = interestRate.toString()
           const multiplyStrategy = isShort ? `Short ${quoteToken}` : `Long ${collateralToken}`


### PR DESCRIPTION
# [Assets table entire row active](https://app.shortcut.com/oazo-apps/story/9087/on-the-create-table-make-the-entire-row-clickable-not-just-the-button)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/8e6256a1-6f86-4499-b2c4-5e7ac5bb621b)
  
## Changes 👷‍♀️

- Made entire row covered by action button,
- removed follow vault and share button from the table.
  
## How to test 🧪

- Check if entire row is clickable in Product Finder, Discover and on owner's page,
- check if owner's page doesn't have follow and share buttons anymore.
