### PR TITLE
🧿 Ajna Borrow liquidity available number is invalid

### DIFF
--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -89,9 +89,9 @@ async function getAjnaPoolData(
           const liquidity = buckets
             .filter((bucket) => new BigNumber(bucket.index).lte(highestThresholdPriceIndex))
             .reduce((acc, bucket) => acc.plus(bucket.quoteTokens), zero)
+            .shiftedBy(negativeWadPrecision)
             .minus(debt)
             .times(prices[quoteToken])
-            .shiftedBy(negativeWadPrecision)
             .toString()
           const fee = interestRate.toString()
           const multiplyStrategy = isShort ? `Short ${quoteToken}` : `Long ${collateralToken}`


### PR DESCRIPTION
# [Ajna Borrow liquidity available number is invalid](https://app.shortcut.com/oazo-apps/story/9168/borrow-the-liquidity-available-number-is-invalid)

Debt and bucket liquidity were returned with different precision.
  
## Changes 👷‍♀️

- Fixed precision error.