### PR TITLE
Center navigation

### DIFF
--- a/components/navigation/Navigation.tsx
+++ b/components/navigation/Navigation.tsx
@@ -23,7 +23,10 @@ interface NavigationProps {
   pill?: NavigationBrandingPill
 }
 
-export const navigationBreakpoints = ['531px', '744px', '1025px', '1279px']
+export const navigationBreakpoints = [531, 744, 1025, 1279]
+export const navigationBreakpointsWithPixels = navigationBreakpoints.map(
+  (breakpoint) => `${breakpoint}px`,
+)
 
 export function Navigation({
   actions,
@@ -34,18 +37,19 @@ export function Navigation({
 }: NavigationProps) {
   const [isMobileMenuOpen, toggleIsMobileMenuOpen, setIsMobileMenuOpen] = useToggle(false)
   const ref = useOutsideElementClickHandler(() => setIsMobileMenuOpen(false))
-  const isViewBelowL = useMediaQuery(`(max-width: ${navigationBreakpoints[2]})`)
+  const isViewBelowL = useMediaQuery(`(max-width: ${navigationBreakpoints[2] - 1}px)`)
 
   return (
-    <ThemeProvider theme={{ breakpoints: navigationBreakpoints }}>
+    <ThemeProvider theme={{ breakpoints: navigationBreakpointsWithPixels }}>
       <Container
         as="header"
         variant="navigation"
         sx={{
           position: 'relative',
-          display: 'flex',
+          display: 'grid',
+          gridTemplateColumns: ['auto auto', null, null, 'auto auto auto', '30% 40% 30%'],
           alignItems: 'center',
-          justifyContent: 'space-between',
+          // justifyContent: 'space-between',
           mt: '24px',
           mb: '64px',
           zIndex: 3,

--- a/components/navigation/NavigationActions.tsx
+++ b/components/navigation/NavigationActions.tsx
@@ -4,5 +4,16 @@ import { Flex } from 'theme-ui'
 interface NavigationActionsProps {}
 
 export function NavigationActions({ children }: PropsWithChildren<NavigationActionsProps>) {
-  return <Flex sx={{ flexShrink: 0, columnGap: 2, zIndex: 2 }}>{children}</Flex>
+  return (
+    <Flex
+      sx={{
+        flexShrink: 0,
+        columnGap: 2,
+        ml: 'auto',
+        zIndex: 2,
+      }}
+    >
+      {children}
+    </Flex>
+  )
 }

--- a/components/navigation/NavigationBranding.tsx
+++ b/components/navigation/NavigationBranding.tsx
@@ -1,5 +1,5 @@
 import { AppLink } from 'components/Links'
-import { navigationBreakpoints } from 'components/navigation/Navigation'
+import { navigationBreakpointsWithPixels } from 'components/navigation/Navigation'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import React from 'react'
@@ -26,7 +26,7 @@ export function NavigationBranding({
   link = INTERNAL_LINKS.homepage,
   pill,
 }: NavigationBrandingProps) {
-  const isViewBelowS = useMediaQuery(`(max-width: ${navigationBreakpoints[0]})`)
+  const isViewBelowS = useMediaQuery(`(max-width: ${navigationBreakpointsWithPixels[0]})`)
 
   return (
     <AppLink

--- a/components/navigation/NavigationMenu.tsx
+++ b/components/navigation/NavigationMenu.tsx
@@ -28,7 +28,7 @@ export function NavigationMenu({ links, panels }: NavigationMenuProps) {
 
   return (
     <Box
-      sx={{ position: ['static', null, null, null, 'relative'], flexGrow: 1, zIndex: 2 }}
+      sx={{ position: ['static', null, null, null, 'relative'], zIndex: 2 }}
       onMouseLeave={() => closeDropdown()}
     >
       {((links && links.length > 0) || (panels && panels.length > 0)) && (
@@ -36,10 +36,10 @@ export function NavigationMenu({ links, panels }: NavigationMenuProps) {
           as="ul"
           sx={{
             listStyle: 'none',
-            columnGap: ['24px', null, null, null, '40px'],
+            columnGap: '40px',
             justifyContent: 'center',
             px: '20px',
-            py: 2,
+            py: 1,
           }}
         >
           {panels?.map((panel) => (

--- a/features/navigation/controls/AjnaNavigationController.tsx
+++ b/features/navigation/controls/AjnaNavigationController.tsx
@@ -15,7 +15,7 @@ import { useMediaQuery } from 'usehooks-ts'
 export function AjnaNavigationController() {
   const { uiChanges } = useAppContext()
   const { isConnected, walletAddress } = useAccount()
-  const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3]})`)
+  const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3] - 1}px)`)
 
   return (
     <>

--- a/features/navigation/controls/NavigationActionsController.tsx
+++ b/features/navigation/controls/NavigationActionsController.tsx
@@ -15,9 +15,9 @@ interface NavigationActionsControllerProps {
 }
 
 export function NavigationActionsController({ isConnected }: NavigationActionsControllerProps) {
-  const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3]})`)
-  const isViewBelowL = useMediaQuery(`(max-width: ${navigationBreakpoints[2]})`)
-  const isViewBelowM = useMediaQuery(`(max-width: ${navigationBreakpoints[1]})`)
+  const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3] - 1}px)`)
+  const isViewBelowL = useMediaQuery(`(max-width: ${navigationBreakpoints[2] - 1}px)`)
+  const isViewBelowM = useMediaQuery(`(max-width: ${navigationBreakpoints[1] - 1}px)`)
 
   const useNetworkSwitcher = useFeatureToggle('UseNetworkSwitcher')
   const swapWidgetFeatureToggle = useFeatureToggle('SwapWidget')

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -15,7 +15,7 @@ import { useMediaQuery } from 'usehooks-ts'
 export function NavigationController() {
   const { uiChanges } = useAppContext()
   const { isConnected, walletAddress } = useAccount()
-  const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3]})`)
+  const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3] - 1}px)`)
 
   return (
     <>


### PR DESCRIPTION
# [Center navigation](https://app.shortcut.com/oazo-apps/story/10008/center-navigation-links)

From now on, navigation in centered relatively to the window, not in between logo and user actions.

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/667f959e-c8df-40ac-b363-835d2dcaa300)
  
## Changes 👷‍♀️
- Centered navigation,
- fixed couple edge case rwd nav related bugs.
  
## How to test 🧪
Self explanatory.