### PR TITLE
Get is form empty method fix

### DIFF
--- a/features/ajna/positions/common/helpers/getIsFormEmpty.ts
+++ b/features/ajna/positions/common/helpers/getIsFormEmpty.ts
@@ -37,6 +37,8 @@ export function getIsFormEmpty({
         case 'setup':
           return !depositAmount && !withdrawAmount
         case 'nft':
+        case 'dpm':
+        case 'transaction':
           return false
         case 'manage':
           if ((position as AjnaEarnPosition).quoteTokenAmount.isZero()) {
@@ -59,6 +61,9 @@ export function getIsFormEmpty({
       switch (currentStep) {
         case 'setup':
           return !depositAmount
+        case 'dpm':
+        case 'transaction':
+          return false
         case 'manage':
           if (action === 'close-multiply') {
             return false

--- a/features/ajna/positions/common/hooks/useAjnaTxHandler.ts
+++ b/features/ajna/positions/common/hooks/useAjnaTxHandler.ts
@@ -58,7 +58,7 @@ export function useAjnaTxHandler(): () => void {
     } else {
       setIsLoadingSimulation(true)
     }
-  }, [context?.chainId, dpmAddress, state])
+  }, [context?.chainId, state, isFormEmpty])
 
   useDebouncedEffect(
     () => {
@@ -101,7 +101,7 @@ export function useAjnaTxHandler(): () => void {
           })
       }
     },
-    [context?.chainId, dpmAddress, state, isExternalStep],
+    [context?.chainId, state, isExternalStep],
     250,
   )
 


### PR DESCRIPTION
# [Get is form empty method fix](https://app.shortcut.com/oazo-apps/story/9939/deposit-liquidity-order-information-shows-0)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted conditions inside `getIsFormEmpty` method
- adjusted dependencies arrays in `useAjnaTxHandler`
  
## How to test 🧪
  <Please explain how to test your changes>

- while opening earn / multiply position, after dpm. & allowance step order informations should display correct data
