### PR TITLE
Remove long / short wording in setup & manage flow

### DIFF
--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -11,7 +11,6 @@ import { useAjnaBorrowFormReducto } from 'features/ajna/positions/borrow/state/a
 import { AjnaGeneralContextProvider } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { AjnaProductContextProvider } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { getAjnaHeadlineProps } from 'features/ajna/positions/common/helpers/getAjnaHeadlineProps'
-import { isShortPosition } from 'features/ajna/positions/common/helpers/isShortPosition'
 import { getAjnaHistory$ } from 'features/ajna/positions/common/observables/getAjnaHistory'
 import {
   AjnaBorrowishPositionAuction,
@@ -181,13 +180,6 @@ export function AjnaProductController({
                     {...getAjnaHeadlineProps({
                       collateralToken: dpmPositionData?.collateralToken,
                       flow,
-                      strategy: dpmPositionData
-                        ? t(
-                            isShortPosition({ collateralToken: dpmPositionData?.collateralToken })
-                              ? 'short'
-                              : 'long',
-                          )
-                        : '',
                       product: dpmPositionData?.product as AjnaProduct,
                       quoteToken: dpmPositionData?.quoteToken,
                       id,

--- a/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
+++ b/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
@@ -8,7 +8,6 @@ interface AjnaBorrowHeadlinePropsParams {
   id?: string
   product?: AjnaProduct
   quoteToken?: string
-  strategy: string
 }
 
 export function getAjnaHeadlineProps({
@@ -17,7 +16,6 @@ export function getAjnaHeadlineProps({
   id,
   product,
   quoteToken,
-  strategy,
 }: AjnaBorrowHeadlinePropsParams) {
   const { t } = useTranslation()
 
@@ -28,7 +26,6 @@ export function getAjnaHeadlineProps({
           collateralToken,
           id,
           product: upperFirst(product),
-          strategy,
           quoteToken,
         }),
         token: [collateralToken, quoteToken],

--- a/features/ajna/positions/common/sidebars/AjnaFormContentTransaction.tsx
+++ b/features/ajna/positions/common/sidebars/AjnaFormContentTransaction.tsx
@@ -16,7 +16,7 @@ export function AjnaFormContentTransaction({
 }: AjnaFormContentTransactionProps) {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, isShort, product, quoteToken },
+    environment: { collateralToken, product, quoteToken },
     tx: { isTxStarted, isTxError, isTxWaitingForApproval, isTxInProgress, isTxSuccess },
   } = useAjnaGeneralContext()
 
@@ -29,7 +29,6 @@ export function AjnaFormContentTransaction({
               collateralToken,
               product: upperFirst(product),
               quoteToken,
-              strategy: t(isShort ? 'short' : 'long'),
             })}
           </Text>
           <OrderInformation />

--- a/features/ajna/positions/common/views/AjnaFormView.tsx
+++ b/features/ajna/positions/common/views/AjnaFormView.tsx
@@ -39,7 +39,7 @@ export function AjnaFormView({
   const [context] = useObservable(context$)
   const { walletAddress } = useAccount()
   const {
-    environment: { collateralToken, dpmProxy, flow, isOwner, isShort, product, quoteToken },
+    environment: { collateralToken, dpmProxy, flow, isOwner, product, quoteToken },
     steps: {
       currentStep,
       editingStep,
@@ -163,7 +163,7 @@ export function AjnaFormView({
       isTxSuccess
         ? `ajna.position-page.common.form.transaction.success-${flow}`
         : `ajna.position-page.common.form.transaction.progress-${flow}`,
-      { collateralToken, quoteToken, strategy: t(isShort ? 'short' : 'long') },
+      { collateralToken, quoteToken },
     ),
     txDetails,
   })

--- a/features/ajna/positions/common/views/AjnaPositionView.tsx
+++ b/features/ajna/positions/common/views/AjnaPositionView.tsx
@@ -58,7 +58,6 @@ export function AjnaPositionView({
           id,
           product,
           quoteToken,
-          strategy: t(isShort ? 'short' : 'long'),
         })}
         {...(flow === 'manage' && { shareButton: true })}
         details={[

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2529,8 +2529,8 @@
     "position-page": {
       "common": {
         "headline": {
-          "open": "{{collateralToken}}/{{quoteToken}} {{strategy}} {{product}} Position",
-          "manage": "{{collateralToken}}/{{quoteToken}} {{strategy}} {{product}} #{{id}}",
+          "open": "{{collateralToken}}/{{quoteToken}} {{product}} Position",
+          "manage": "{{collateralToken}}/{{quoteToken}} {{product}} #{{id}}",
           "current-market-price": "Current Market Price"
         },
         "banners": {
@@ -2591,11 +2591,11 @@
             }
           },
           "transaction": {
-            "confirm": "Here you can review the details of the changes of your {{collateralToken}}/{{quoteToken}} Ajna {{strategy}} {{product}} Position.",
-            "progress-open": "Creating your {{collateralToken}}/{{quoteToken}} {{strategy}} Ajna Position",
-            "progress-manage": "Updating your {{collateralToken}}/{{quoteToken}} {{strategy}} Ajna Position",
-            "success-open": "Your {{collateralToken}}/{{quoteToken}} {{strategy}} Ajna Position was created",
-            "success-manage": "Your {{collateralToken}}/{{quoteToken}} {{strategy}} Ajna Position was updated"
+            "confirm": "Here you can review the details of the changes of your {{collateralToken}}/{{quoteToken}} Ajna {{product}} Position.",
+            "progress-open": "Creating your {{collateralToken}}/{{quoteToken}} Ajna Position",
+            "progress-manage": "Updating your {{collateralToken}}/{{quoteToken}} Ajna Position",
+            "success-open": "Your {{collateralToken}}/{{quoteToken}} Ajna Position was created",
+            "success-manage": "Your {{collateralToken}}/{{quoteToken}} Ajna Position was updated"
           }
         },
         "notifications": {


### PR DESCRIPTION
# [Remove long / short wording in setup & manage flow](https://app.shortcut.com/oazo-apps/story/9562/remove-word-long-from-pool-namek)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted copies and params so we no longer use long / short in the position open & manage flow
  
## How to test 🧪
  <Please explain how to test your changes>

- no short / long wording
