### PR TITLE
🧿 Ajna safety switch

### DIFF
--- a/features/ajna/common/controls/AjnaProductHubController.tsx
+++ b/features/ajna/common/controls/AjnaProductHubController.tsx
@@ -2,6 +2,7 @@ import { AnimatedWrapper } from 'components/AnimatedWrapper'
 import { WithConnection } from 'components/connectWallet'
 import { ProductHubProductType } from 'features/productHub/types'
 import { ProductHubView } from 'features/productHub/views'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { LendingProtocol } from 'lendingProtocols'
 import React from 'react'
 
@@ -11,6 +12,8 @@ interface AjnaProductHubControllerProps {
 }
 
 export function AjnaProductHubController({ product, token }: AjnaProductHubControllerProps) {
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
+
   return (
     <WithConnection>
       <AnimatedWrapper sx={{ mb: 5 }}>
@@ -18,7 +21,7 @@ export function AjnaProductHubController({ product, token }: AjnaProductHubContr
           headerGradient={['#f154db', '#974eea']}
           initialProtocol={[LendingProtocol.Ajna]}
           product={product}
-          promoCardsCollection="AjnaLP"
+          promoCardsCollection={ajnaSafetySwitchOn ? 'Home' : 'AjnaLP'}
           token={token}
           url="/ajna/"
         />

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -31,11 +31,11 @@ export function AjnaBorrowOverviewController() {
     },
   } = useAjnaGeneralContext()
   const {
+    notifications,
     position: {
       isSimulationLoading,
       currentPosition: { position, simulation },
     },
-    notifications,
   } = useAjnaProductContext('borrow')
 
   const liquidationPrice = isShort

--- a/features/ajna/positions/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaProductContext.tsx
@@ -189,6 +189,7 @@ export function AjnaProductContextProvider({
     () =>
       getAjnaValidation({
         ajnaSafetySwitchOn,
+        flow,
         collateralBalance,
         collateralToken,
         quoteToken,

--- a/features/ajna/positions/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaProductContext.tsx
@@ -26,6 +26,7 @@ import {
 } from 'features/ajna/positions/multiply/state/ajnaMultiplyFormReducto'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React, {
   Dispatch,
   PropsWithChildren,
@@ -153,6 +154,7 @@ export function AjnaProductContextProvider({
   positionAuction,
   positionHistory,
 }: PropsWithChildren<AjnaProductDetailsContextProviderProps>) {
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
   const { walletAddress } = useAccount()
   const gasEstimation = useGasEstimationContext()
   const { positionIdFromDpmProxy$ } = useAppContext()
@@ -161,10 +163,11 @@ export function AjnaProductContextProvider({
     environment: {
       collateralBalance,
       collateralToken,
-      quoteToken,
       ethBalance,
       ethPrice,
+      flow,
       quoteBalance,
+      quoteToken,
     },
     steps: { currentStep },
     tx: { txDetails },
@@ -221,6 +224,8 @@ export function AjnaProductContextProvider({
   const notifications = useMemo(
     () =>
       getAjnaNotifications({
+        ajnaSafetySwitchOn,
+        flow,
         position,
         positionAuction,
         product,

--- a/features/ajna/positions/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaProductContext.tsx
@@ -188,6 +188,7 @@ export function AjnaProductContextProvider({
   const validation = useMemo(
     () =>
       getAjnaValidation({
+        ajnaSafetySwitchOn,
         collateralBalance,
         collateralToken,
         quoteToken,

--- a/features/ajna/positions/common/helpers/getAjnaSidebarButtonsStatus.tsx
+++ b/features/ajna/positions/common/helpers/getAjnaSidebarButtonsStatus.tsx
@@ -1,8 +1,10 @@
-import { AjnaSidebarEditingStep, AjnaSidebarStep } from 'features/ajna/common/types'
+import { AjnaFlow, AjnaSidebarEditingStep, AjnaSidebarStep } from 'features/ajna/common/types'
 
 export function getAjnaSidebarButtonsStatus({
+  ajnaSafetySwitchOn,
   currentStep,
   editingStep,
+  flow,
   hasErrors,
   isFormFrozen,
   isAllowanceLoading,
@@ -17,11 +19,13 @@ export function getAjnaSidebarButtonsStatus({
   isTxWaitingForApproval,
   walletAddress,
 }: {
+  ajnaSafetySwitchOn: boolean
   currentStep: AjnaSidebarStep
   editingStep: AjnaSidebarEditingStep
+  flow: AjnaFlow
   hasErrors: boolean
-  isFormFrozen: boolean
   isAllowanceLoading: boolean
+  isFormFrozen: boolean
   isFormValid: boolean
   isOwner: boolean
   isSimulationLoading?: boolean
@@ -52,7 +56,9 @@ export function getAjnaSidebarButtonsStatus({
       isTxWaitingForApproval ||
       isTransitionInProgress)
 
-  const isPrimaryButtonHidden = !!(walletAddress && !isOwner && currentStep === editingStep)
+  const isPrimaryButtonHidden =
+    !!(walletAddress && !isOwner && currentStep === editingStep) ||
+    (ajnaSafetySwitchOn && flow === 'open' && currentStep !== 'risk')
   const isTextButtonHidden =
     !(
       (currentStep === 'transaction' && (!isTxStarted || isTxError)) ||

--- a/features/ajna/positions/common/notifications.tsx
+++ b/features/ajna/positions/common/notifications.tsx
@@ -345,7 +345,5 @@ export function getAjnaNotifications({
       break
   }
 
-  console.log(notifications)
-
   return notifications
 }

--- a/features/ajna/positions/common/notifications.tsx
+++ b/features/ajna/positions/common/notifications.tsx
@@ -293,48 +293,50 @@ export function getAjnaNotifications({
       }
       break
     case 'earn': {
-      const {
-        price,
-        pool: { highestThresholdPrice, mostOptimisticMatchingPrice },
-        quoteTokenAmount,
-      } = position as AjnaEarnPosition
-      const earningNoApy = price.lt(highestThresholdPrice) && price.gt(zero)
-      const priceAboveMomp = price.gt(mostOptimisticMatchingPrice)
-      const emptyPosition = quoteTokenAmount.isZero()
-      const earnPositionAuction = positionAuction as AjnaEarnPositionAuction
+      if (flow === 'manage') {
+        const {
+          price,
+          pool: { highestThresholdPrice, mostOptimisticMatchingPrice },
+          quoteTokenAmount,
+        } = position as AjnaEarnPosition
+        const earningNoApy = price.lt(highestThresholdPrice) && price.gt(zero)
+        const priceAboveMomp = price.gt(mostOptimisticMatchingPrice)
+        const emptyPosition = quoteTokenAmount.isZero()
+        const earnPositionAuction = positionAuction as AjnaEarnPositionAuction
 
-      const moveToAdjust = () => {
-        dispatch({ type: 'reset' })
-        updateState('uiDropdown', 'adjust')
-        updateState('uiPill', 'deposit-earn')
-      }
+        const moveToAdjust = () => {
+          dispatch({ type: 'reset' })
+          updateState('uiDropdown', 'adjust')
+          updateState('uiPill', 'deposit-earn')
+        }
 
-      if (priceAboveMomp) {
-        notifications.push(
-          ajnaNotifications.priceAboveMomp({
-            message: { collateralToken, quoteToken },
-            action: moveToAdjust,
-          }),
-        )
-      }
-      if (earningNoApy) {
-        notifications.push(
-          ajnaNotifications.earningNoApy({
-            action: !quoteTokenAmount.isZero() ? moveToAdjust : undefined,
-          }),
-        )
-      }
+        if (priceAboveMomp) {
+          notifications.push(
+            ajnaNotifications.priceAboveMomp({
+              message: { collateralToken, quoteToken },
+              action: moveToAdjust,
+            }),
+          )
+        }
+        if (earningNoApy) {
+          notifications.push(
+            ajnaNotifications.earningNoApy({
+              action: !quoteTokenAmount.isZero() ? moveToAdjust : undefined,
+            }),
+          )
+        }
 
-      if (emptyPosition) {
-        notifications.push(ajnaNotifications.emptyPosition({ quoteToken }))
-      }
+        if (emptyPosition) {
+          notifications.push(ajnaNotifications.emptyPosition({ quoteToken }))
+        }
 
-      if (earnPositionAuction.isBucketFrozen) {
-        notifications.push(ajnaNotifications.lendingPriceFrozen({ quoteToken }))
-      }
+        if (earnPositionAuction.isBucketFrozen) {
+          notifications.push(ajnaNotifications.lendingPriceFrozen({ quoteToken }))
+        }
 
-      if (earnPositionAuction.isCollateralToWithdraw) {
-        notifications.push(ajnaNotifications.collateralToWithdraw(null))
+        if (earnPositionAuction.isCollateralToWithdraw) {
+          notifications.push(ajnaNotifications.collateralToWithdraw(null))
+        }
       }
 
       break
@@ -342,6 +344,8 @@ export function getAjnaNotifications({
     default:
       break
   }
+
+  console.log(notifications)
 
   return notifications
 }

--- a/features/ajna/positions/common/notifications.tsx
+++ b/features/ajna/positions/common/notifications.tsx
@@ -1,7 +1,12 @@
 import { AjnaEarnPosition } from '@oasisdex/dma-library'
 import { DetailsSectionNotificationItem } from 'components/DetailsSectionNotification'
 import { AppLink } from 'components/Links'
-import { AjnaGenericPosition, AjnaProduct, AjnaUpdateState } from 'features/ajna/common/types'
+import {
+  AjnaFlow,
+  AjnaGenericPosition,
+  AjnaProduct,
+  AjnaUpdateState,
+} from 'features/ajna/common/types'
 import {
   AjnaBorrowFormAction,
   AjnaBorrowFormState,
@@ -70,15 +75,16 @@ type LendingPriceFrozenParams = {
 type NotificationCallbackWithParams<P> = (params: P) => DetailsSectionNotificationItem
 
 const ajnaNotifications: {
-  priceAboveMomp: NotificationCallbackWithParams<PriceAboveMompParams>
+  beingLiquidated: NotificationCallbackWithParams<null>
+  collateralToWithdraw: NotificationCallbackWithParams<null>
   earningNoApy: NotificationCallbackWithParams<EarningNoApyParams>
   emptyPosition: NotificationCallbackWithParams<EmptyPositionParams>
-  timeToLiquidation: NotificationCallbackWithParams<TimeToLiquidationParams>
-  beingLiquidated: NotificationCallbackWithParams<null>
   gotLiquidated: NotificationCallbackWithParams<null>
   gotPartiallyLiquidated: NotificationCallbackWithParams<null>
   lendingPriceFrozen: NotificationCallbackWithParams<LendingPriceFrozenParams>
-  collateralToWithdraw: NotificationCallbackWithParams<null>
+  priceAboveMomp: NotificationCallbackWithParams<PriceAboveMompParams>
+  safetySwichOn: NotificationCallbackWithParams<null>
+  timeToLiquidation: NotificationCallbackWithParams<TimeToLiquidationParams>
 } = {
   priceAboveMomp: ({ action, message }) => ({
     title: {
@@ -206,9 +212,31 @@ const ajnaNotifications: {
     type: 'error',
     closable: true,
   }),
+  safetySwichOn: () => ({
+    title: {
+      translationKey: 'ajna.position-page.common.notifications.safety-switch-on.title',
+    },
+    message: {
+      component: (
+        <Trans
+          i18nKey={'ajna.position-page.common.notifications.safety-switch-on.message'}
+          components={[
+            <AppLink
+              sx={{ fontSize: 'inherit', color: 'inherit' }}
+              href={EXTERNAL_LINKS.DISCORD}
+            />,
+          ]}
+        />
+      ),
+    },
+    icon: 'liquidation',
+    type: 'error',
+  }),
 }
 
 export function getAjnaNotifications({
+  ajnaSafetySwitchOn,
+  flow,
   position,
   positionAuction,
   collateralToken,
@@ -217,6 +245,8 @@ export function getAjnaNotifications({
   updateState,
   product,
 }: {
+  ajnaSafetySwitchOn: boolean
+  flow: AjnaFlow
   position: AjnaGenericPosition
   positionAuction: AjnaPositionAuction
   collateralToken: string
@@ -232,6 +262,10 @@ export function getAjnaNotifications({
   product: AjnaProduct
 }) {
   const notifications: DetailsSectionNotificationItem[] = []
+
+  if (ajnaSafetySwitchOn && flow === 'open') {
+    notifications.push(ajnaNotifications.safetySwichOn(null))
+  }
 
   switch (product) {
     case 'multiply':

--- a/features/ajna/positions/common/validation.tsx
+++ b/features/ajna/positions/common/validation.tsx
@@ -268,6 +268,17 @@ export function getAjnaValidation({
         message: { component: <AjnaSafetyOnMessage /> },
       })
     }
+    if (
+      product === 'earn' &&
+      'quoteTokenAmount' in position &&
+      position.quoteTokenAmount?.isZero() &&
+      'depositAmount' in state &&
+      state.depositAmount?.gt(zero)
+    ) {
+      localErrors.push({
+        message: { component: <AjnaSafetyOnMessage /> },
+      })
+    }
   }
 
   const hasPotentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({

--- a/features/ajna/positions/common/validation.tsx
+++ b/features/ajna/positions/common/validation.tsx
@@ -47,7 +47,17 @@ const AjnaValidationWithLink: FC<AjnaValidationWithLinkProps> = ({ translationKe
   />
 )
 
+const AjnaSafetyOnMessage: FC = () => (
+  <Trans
+    i18nKey={'ajna.validations.safety-switch-on'}
+    components={[
+      <AppLink sx={{ fontSize: 'inherit', color: 'inherit' }} href={EXTERNAL_LINKS.DISCORD} />,
+    ]}
+  />
+)
+
 interface GetAjnaBorrowValidationsParams {
+  ajnaSafetySwitchOn: boolean
   collateralBalance: BigNumber
   collateralToken: string
   quoteToken: string
@@ -195,6 +205,7 @@ function isFormValid({
 }
 
 export function getAjnaValidation({
+  ajnaSafetySwitchOn,
   collateralBalance,
   collateralToken,
   quoteToken,
@@ -242,6 +253,21 @@ export function getAjnaValidation({
   }
   if ('paybackAmount' in state && state.paybackAmount?.gt(quoteBalance)) {
     localErrors.push({ message: { translationKey: 'payback-amount-exceeds-debt-token-balance' } })
+  }
+
+  if (ajnaSafetySwitchOn) {
+    if (
+      product === 'borrow' &&
+      'debtAmount' in position &&
+      position.debtAmount?.isZero() &&
+      (('depositAmount' in state && state.depositAmount?.gt(zero)) ||
+        ('paybackAmount' in state && state.paybackAmount?.gt(zero)) ||
+        ('generateAmount' in state && state.generateAmount?.gt(zero)))
+    ) {
+      localErrors.push({
+        message: { component: <AjnaSafetyOnMessage /> },
+      })
+    }
   }
 
   const hasPotentialInsufficientEthFundsForTx = notEnoughETHtoPayForTx({

--- a/features/ajna/positions/common/validation.tsx
+++ b/features/ajna/positions/common/validation.tsx
@@ -259,28 +259,36 @@ export function getAjnaValidation({
   }
 
   if (ajnaSafetySwitchOn && flow === 'manage') {
-    if (
-      product === 'borrow' &&
-      'debtAmount' in position &&
-      position.debtAmount?.isZero() &&
-      (('depositAmount' in state && state.depositAmount?.gt(zero)) ||
-        ('paybackAmount' in state && state.paybackAmount?.gt(zero)) ||
-        ('generateAmount' in state && state.generateAmount?.gt(zero)))
-    ) {
-      localErrors.push({
-        message: { component: <AjnaSafetyOnMessage /> },
-      })
-    }
-    if (
-      product === 'earn' &&
-      'quoteTokenAmount' in position &&
-      position.quoteTokenAmount?.isZero() &&
-      'depositAmount' in state &&
-      state.depositAmount?.gt(zero)
-    ) {
-      localErrors.push({
-        message: { component: <AjnaSafetyOnMessage /> },
-      })
+    switch (product) {
+      case 'borrow':
+      case 'multiply':
+        if (
+          'debtAmount' in position &&
+          position.debtAmount?.isZero() &&
+          (('loanToValue' in state && state.loanToValue?.gt(zero)) ||
+            ('depositAmount' in state && state.depositAmount?.gt(zero)) ||
+            ('paybackAmount' in state && state.paybackAmount?.gt(zero)) ||
+            ('generateAmount' in state && state.generateAmount?.gt(zero)))
+        ) {
+          localErrors.push({
+            message: { component: <AjnaSafetyOnMessage /> },
+          })
+        }
+
+        break
+      case 'earn':
+        if (
+          'quoteTokenAmount' in position &&
+          position.quoteTokenAmount?.isZero() &&
+          'depositAmount' in state &&
+          state.depositAmount?.gt(zero)
+        ) {
+          localErrors.push({
+            message: { component: <AjnaSafetyOnMessage /> },
+          })
+        }
+
+        break
     }
   }
 

--- a/features/ajna/positions/common/validation.tsx
+++ b/features/ajna/positions/common/validation.tsx
@@ -3,6 +3,7 @@ import { AjnaSimulationValidationItem } from 'actions/ajna/types'
 import BigNumber from 'bignumber.js'
 import { AppLink } from 'components/Links'
 import {
+  AjnaFlow,
   AjnaFormState,
   AjnaGenericPosition,
   AjnaProduct,
@@ -58,6 +59,7 @@ const AjnaSafetyOnMessage: FC = () => (
 
 interface GetAjnaBorrowValidationsParams {
   ajnaSafetySwitchOn: boolean
+  flow: AjnaFlow
   collateralBalance: BigNumber
   collateralToken: string
   quoteToken: string
@@ -206,6 +208,7 @@ function isFormValid({
 
 export function getAjnaValidation({
   ajnaSafetySwitchOn,
+  flow,
   collateralBalance,
   collateralToken,
   quoteToken,
@@ -255,7 +258,7 @@ export function getAjnaValidation({
     localErrors.push({ message: { translationKey: 'payback-amount-exceeds-debt-token-balance' } })
   }
 
-  if (ajnaSafetySwitchOn) {
+  if (ajnaSafetySwitchOn && flow === 'manage') {
     if (
       product === 'borrow' &&
       'debtAmount' in position &&

--- a/features/ajna/positions/common/views/AjnaFormView.tsx
+++ b/features/ajna/positions/common/views/AjnaFormView.tsx
@@ -18,6 +18,7 @@ import { useProductTypeTransition } from 'features/ajna/positions/common/hooks/u
 import { useConnection } from 'features/web3OnBoard'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useFlowState } from 'helpers/useFlowState'
 import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
@@ -34,6 +35,7 @@ export function AjnaFormView({
   children,
   txSuccessAction,
 }: PropsWithChildren<AjnaFormViewProps>) {
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
   const { t } = useTranslation()
   const { context$ } = useAppContext()
   const [context] = useObservable(context$)
@@ -98,8 +100,10 @@ export function AjnaFormView({
     isPrimaryButtonLoading,
     isTextButtonHidden,
   } = getAjnaSidebarButtonsStatus({
+    ajnaSafetySwitchOn,
     currentStep,
     editingStep,
+    flow,
     hasErrors,
     isFormFrozen,
     isAllowanceLoading: flowState.isLoading,

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -27,8 +27,8 @@ export function AjnaEarnOverviewManageController() {
 
   return (
     <DetailsSection
-      notifications={notifications}
       title={t('system.overview')}
+      notifications={notifications}
       content={
         <DetailsSectionContentCardWrapper>
           <ContentCardCurrentEarnings

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
@@ -18,6 +18,7 @@ export function AjnaEarnOverviewOpenController() {
     form: {
       state: { depositAmount },
     },
+    notifications,
     position: {
       currentPosition: { simulation, position },
     },
@@ -41,6 +42,7 @@ export function AjnaEarnOverviewOpenController() {
   return (
     <DetailsSection
       title={<SimulateTitle token={quoteToken} depositAmount={depositAmount} />}
+      notifications={notifications}
       content={
         <>
           <DetailsSectionContentTable

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
@@ -31,6 +31,7 @@ export function AjnaMultiplyOverviewController() {
   } = useAjnaGeneralContext()
 
   const {
+    notifications,
     position: {
       isSimulationLoading,
       currentPosition: { position, simulation },
@@ -59,6 +60,7 @@ export function AjnaMultiplyOverviewController() {
     <Grid gap={2}>
       <DetailsSection
         title={t('system.overview')}
+        notifications={notifications}
         content={
           <DetailsSectionContentCardWrapper>
             <ContentCardLiquidationPrice

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -10,6 +10,7 @@ import { useConnection } from 'features/web3OnBoard'
 import { EXTERNAL_LINKS, INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { LendingProtocol } from 'lendingProtocols'
 import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
@@ -47,6 +48,7 @@ export const benefitCardsAnja = [
 ]
 
 export function AjnaHomepageView() {
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
   const { t } = useTranslation()
   const { context$ } = useAppContext()
   const [context] = useObservable(context$)
@@ -79,7 +81,7 @@ export function AjnaHomepageView() {
           headerGradient={['#f154db', '#974eea']}
           initialProtocol={[LendingProtocol.Ajna]}
           product={ProductHubProductType.Borrow}
-          promoCardsCollection="AjnaLP"
+          promoCardsCollection={ajnaSafetySwitchOn ? 'Home' : 'AjnaLP'}
         />
       </Box>
       <Flex

--- a/features/homepage/HomepageView.tsx
+++ b/features/homepage/HomepageView.tsx
@@ -9,6 +9,7 @@ import { formatAsShorthandNumbers } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
 import { scrollTo } from 'helpers/scrollTo'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Box, Flex, Grid, Image, Text } from 'theme-ui'
@@ -72,6 +73,7 @@ function WhyOasisStats({ oasisStatsValue }: { oasisStatsValue?: OasisStats }) {
 }
 
 export function HomepageView() {
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
   const { t } = useTranslation()
   const { getOasisStats$ } = useAppContext()
   const [oasisStatsValue] = useObservable(getOasisStats$())
@@ -163,7 +165,7 @@ export function HomepageView() {
       <Box sx={{ mt: 7 }}>
         <ProductHubView
           product={ProductHubProductType.Multiply}
-          promoCardsCollection="Home"
+          promoCardsCollection={ajnaSafetySwitchOn ? 'Home' : 'HomeWithAjna'}
           token="ETH"
           limitRows={10}
         />

--- a/features/productHub/controls/ProductHubContentController.tsx
+++ b/features/productHub/controls/ProductHubContentController.tsx
@@ -34,14 +34,15 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
   limitRows,
 }) => {
   const ajnaEnabled = useFeatureToggle('Ajna')
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
 
   const dataMatchedToFeatureFlags = useMemo(
     () =>
       tableData.filter((row) => {
-        if (row.protocol === LendingProtocol.Ajna) return ajnaEnabled
+        if (row.protocol === LendingProtocol.Ajna) return ajnaEnabled && !ajnaSafetySwitchOn
         else return true
       }),
-    [ajnaEnabled, tableData],
+    [ajnaEnabled, ajnaSafetySwitchOn, tableData],
   )
   const dataMatchedByNL = useMemo(
     () => matchRowsByNL(dataMatchedToFeatureFlags, selectedProduct, selectedToken),

--- a/features/productHub/views/ProductHubRouteHandler.tsx
+++ b/features/productHub/views/ProductHubRouteHandler.tsx
@@ -10,6 +10,7 @@ import {
 import { ProductHubProductType } from 'features/productHub/types'
 import { ProductHubView } from 'features/productHub/views'
 import { WithChildren } from 'helpers/types'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import React from 'react'
 
@@ -20,10 +21,17 @@ function ProductHubRouteHandler({
   product: ProductHubProductType
   token?: string
 }) {
+  const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
+
   return (
     <WithConnection>
       <AnimatedWrapper sx={{ mb: 5 }}>
-        <ProductHubView product={product} promoCardsCollection="Home" token={token} url="/" />
+        <ProductHubView
+          product={product}
+          promoCardsCollection={ajnaSafetySwitchOn ? 'Home' : 'HomeWithAjna'}
+          token={token}
+          url="/"
+        />
       </AnimatedWrapper>
     </WithConnection>
   )

--- a/handlers/product-hub/promo-card-collections-parsers/index.ts
+++ b/handlers/product-hub/promo-card-collections-parsers/index.ts
@@ -8,4 +8,6 @@ export const PROMO_CARD_COLLECTIONS_PARSERS: {
 } = {
   AjnaLP: ajnaLpHandler,
   Home: home,
+  // TODO: replace with proper hander when available
+  HomeWithAjna: home,
 }

--- a/handlers/product-hub/types.ts
+++ b/handlers/product-hub/types.ts
@@ -2,7 +2,7 @@ import { ProductHubItem } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 import { NextApiRequest } from 'next'
 
-export type PromoCardsCollection = 'Home' | 'AjnaLP'
+export type PromoCardsCollection = 'Home' | 'HomeWithAjna' | 'AjnaLP'
 
 export type ProductHubDataParams = {
   protocols: LendingProtocol[]

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -26,6 +26,7 @@ export type Feature =
   | 'AaveProtection'
   | 'AaveProtectionWrite'
   | 'Ajna'
+  | 'AjnaSafetySwitch'
   | 'DaiSavingsRate'
   | 'FollowAAVEVaults'
   | 'Sillyness'
@@ -70,6 +71,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   AaveProtection: false,
   AaveProtectionWrite: false,
   Ajna: false,
+  AjnaSafetySwitch: false,
   DaiSavingsRate: true,
   FollowAAVEVaults: false,
   Sillyness: false,

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2615,6 +2615,10 @@
             "title": "This position was partially liquidated. Some part of your collateral was sold to cover your debt",
             "message": "Your debt was increased by 90 days before liquidation as a penalty. During the liquidation your position recollateralized and was removed from liquidation. <0>Read more about Ajna Liquidations →</0>"
           },
+          "safety-switch-on": {
+            "title": "Opening Ajna positions temporary disabled",
+            "message": "Due to a technical issue we have currently disabled opening new Ajna positions, as they might not result in the expected outcome for our users. We are working on a resolution. Further announcements will be made via <0>our discord →</0>"
+          },
           "read-more": "Read more about Ajna Liquidations"
         }
       },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2761,7 +2761,8 @@
       "price-below-htp": "Unutilized Liquidity: Lending at this price means you are not earning any yield. <1>A deposit fee of 1 day's interest applies to all deposits below the active liquidity range.</1> <2><1>Help me pick correctly →</1></2>",
       "price-between-htp-and-lup": "Available Liquidity: Your deposit is earning yield but is not currently utilised by borrowers. <1>A deposit fee of 1 day's interest applies to all deposits below the active liquidity range.</1> <2><1>Help me pick correctly →</1></2>",
       "price-between-lup-and-momp": "Active liquidity: You are actively lending and will earn a yield whenever there are loans above {{lup}} {{collateralToken}}/{{quoteToken}}. <2><1>Help me pick correctly →</1></2>",
-      "price-above-momp": "Boundary Liquidity: Your selected price is too close to market price. In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}. You are selecting a riskier level for lending. <2><1>Help me pick correctly →</1></2>"
+      "price-above-momp": "Boundary Liquidity: Your selected price is too close to market price. In case {{collateralToken}} price reaches your selected price you might be left with collateral tokens instead of {{quoteToken}}. You are selecting a riskier level for lending. <2><1>Help me pick correctly →</1></2>",
+      "safety-switch-on": "Due to a technical issue we have currently disabled depositing tokens into empty Ajna positions, as they might not result in the expected outcome for our users. We are working on a resolution. Further announcements will be made via <0>our discord →</0>"
     },
     "rewards": {
       "title": "Your Ajna token rewards",


### PR DESCRIPTION
# [Ajna safety switch](https://app.shortcut.com/oazo-apps/story/9999/ajna-safety-switch)

A safety switch that can be turn on to prevent users from dumping tokens in Ajna.
  
## Changes 👷‍♀️

Whenever `AjnaSafetySwitch` is turned on:
- All Ajna open flow forms are locked, primary button is hidden, there is special notification displayed at the top of overview section,
- empty borrow positions are preventing user from depositing more collateral or generating or paying back debt (which isn't a case since position is empty, but still message will appear),
- empty earn positions are preventing user from depositing more quote,
- all Ajna products and promo cards are hidden from Product Finder.
  
## How to test 🧪

Turn on `AjnaSafetySwitch` and go through the list.