### PR TITLE
🧿 Hide access to Ajna Multiply

### DIFF
--- a/features/ajna/common/components/AjnaProductHubIntro.tsx
+++ b/features/ajna/common/components/AjnaProductHubIntro.tsx
@@ -1,0 +1,72 @@
+import { AppLink } from 'components/Links'
+import { WithArrow } from 'components/WithArrow'
+import { productHubLinksMap } from 'features/productHub/meta'
+import { ProductHubProductType } from 'features/productHub/types'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
+import React, { FC } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { Box, Text } from 'theme-ui'
+
+interface AjnaProductHubIntroProps {
+  selectedProduct: ProductHubProductType
+  selectedToken: string
+}
+
+export const AjnaProductHubIntro: FC<AjnaProductHubIntroProps> = ({ selectedProduct }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ my: 5 }}>
+      {selectedProduct === ProductHubProductType.Multiply ? (
+        <>
+          <Text as="p" variant="header5" sx={{ mb: 1 }}>
+            {t('ajna.product-finder.multiply-soon-title')}
+          </Text>
+          <Text as="p" variant="paragraph2">
+            <Trans
+              i18nKey="ajna.product-finder.multiply-soon-intro"
+              components={{
+                1: (
+                  <AppLink
+                    href={INTERNAL_LINKS.ajnaBorrow}
+                    sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+                  />
+                ),
+                2: (
+                  <AppLink
+                    href={INTERNAL_LINKS.ajnaEarn}
+                    sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+                  />
+                ),
+              }}
+            />
+          </Text>
+        </>
+      ) : (
+        <Text
+          as="p"
+          variant="paragraph2"
+          sx={{
+            mx: 'auto',
+            mt: '24px',
+          }}
+        >
+          {t(`product-hub.intro.${selectedProduct}`)}{' '}
+          <AppLink href={productHubLinksMap[selectedProduct]}>
+            <WithArrow
+              variant="paragraph2"
+              sx={{
+                display: 'inline-block',
+                fontSize: 3,
+                color: 'interactive100',
+                fontWeight: 'regular',
+              }}
+            >
+              Summer.fi {t(`nav.${selectedProduct}`)}
+            </WithArrow>
+          </AppLink>
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/features/ajna/common/controls/AjnaProductHubController.tsx
+++ b/features/ajna/common/controls/AjnaProductHubController.tsx
@@ -20,7 +20,7 @@ export function AjnaProductHubController({ product, token }: AjnaProductHubContr
           initialProtocol={[LendingProtocol.Ajna]}
           product={product}
           promoCardsCollection="AjnaLP"
-          subtext={(selectedProduct, selectedToken) => (
+          intro={(selectedProduct, selectedToken) => (
             <AjnaProductHubIntro selectedProduct={selectedProduct} selectedToken={selectedToken} />
           )}
           token={token}

--- a/features/ajna/common/controls/AjnaProductHubController.tsx
+++ b/features/ajna/common/controls/AjnaProductHubController.tsx
@@ -1,5 +1,6 @@
 import { AnimatedWrapper } from 'components/AnimatedWrapper'
 import { WithConnection } from 'components/connectWallet'
+import { AjnaProductHubIntro } from 'features/ajna/common/components/AjnaProductHubIntro'
 import { ProductHubProductType } from 'features/productHub/types'
 import { ProductHubView } from 'features/productHub/views'
 import { LendingProtocol } from 'lendingProtocols'
@@ -19,6 +20,9 @@ export function AjnaProductHubController({ product, token }: AjnaProductHubContr
           initialProtocol={[LendingProtocol.Ajna]}
           product={product}
           promoCardsCollection="AjnaLP"
+          subtext={(selectedProduct, selectedToken) => (
+            <AjnaProductHubIntro selectedProduct={selectedProduct} selectedToken={selectedToken} />
+          )}
           token={token}
           url="/ajna/"
         />

--- a/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
@@ -60,17 +60,18 @@ export function AjnaBorrowFormController() {
                 updateState('action', 'generate-borrow')
               },
             },
-            {
-              label: t('system.actions.borrow.switch-to-multiply'),
-              icon: 'circle_exchange',
-              iconShrink: 2,
-              panel: 'switch',
-              action: () => {
-                dispatch({ type: 'reset' })
-                updateState('uiDropdown', 'switch')
-                updateState('action', 'switch-borrow')
-              },
-            },
+            // TODO: uncomment on multiply release
+            // {
+            //   label: t('system.actions.borrow.switch-to-multiply'),
+            //   icon: 'circle_exchange',
+            //   iconShrink: 2,
+            //   panel: 'switch',
+            //   action: () => {
+            //     dispatch({ type: 'reset' })
+            //     updateState('uiDropdown', 'switch')
+            //     updateState('action', 'switch-borrow')
+            //   },
+            // },
           ],
         },
       })}

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -81,11 +81,8 @@ export function AjnaHomepageView() {
           initialProtocol={[LendingProtocol.Ajna]}
           product={ProductHubProductType.Borrow}
           promoCardsCollection="AjnaLP"
-          subtext={(selectedProduct, selectedToken) => (
-            <AjnaProductHubIntro
-              selectedProduct={selectedProduct}
-              selectedToken={selectedToken}
-            />
+          intro={(selectedProduct, selectedToken) => (
+            <AjnaProductHubIntro selectedProduct={selectedProduct} selectedToken={selectedToken} />
           )}
         />
       </Box>

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -4,6 +4,7 @@ import { BenefitCard, BenefitCardsWrapper } from 'components/BenefitCard'
 import { LandingBanner } from 'components/LandingBanner'
 import { AppLink } from 'components/Links'
 import { AjnaHaveSomeQuestions } from 'features/ajna/common/components/AjnaHaveSomeQuestions'
+import { AjnaProductHubIntro } from 'features/ajna/common/components/AjnaProductHubIntro'
 import { ProductHubProductType } from 'features/productHub/types'
 import { ProductHubView } from 'features/productHub/views'
 import { useConnection } from 'features/web3OnBoard'
@@ -80,6 +81,12 @@ export function AjnaHomepageView() {
           initialProtocol={[LendingProtocol.Ajna]}
           product={ProductHubProductType.Borrow}
           promoCardsCollection="AjnaLP"
+          subtext={(selectedProduct, selectedToken) => (
+            <AjnaProductHubIntro
+              selectedProduct={selectedProduct}
+              selectedToken={selectedToken}
+            />
+          )}
         />
       </Box>
       <Flex

--- a/features/productHub/components/ProductHubIntro.tsx
+++ b/features/productHub/components/ProductHubIntro.tsx
@@ -1,0 +1,42 @@
+import { AppLink } from 'components/Links'
+import { WithArrow } from 'components/WithArrow'
+import { productHubLinksMap } from 'features/productHub/meta'
+import { ProductHubProductType } from 'features/productHub/types'
+import React, { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Text } from 'theme-ui'
+
+interface ProductHubIntroProps {
+  selectedProduct: ProductHubProductType
+  selectedToken: string
+}
+
+export const ProductHubIntro: FC<ProductHubIntroProps> = ({ selectedProduct }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Text
+      as="p"
+      variant="paragraph2"
+      sx={{
+        mx: 'auto',
+        mt: '24px',
+      }}
+    >
+      {t(`product-hub.intro.${selectedProduct}`)}{' '}
+      <AppLink href={productHubLinksMap[selectedProduct]}>
+        <WithArrow
+          variant="paragraph2"
+          sx={{
+            display: 'inline-block',
+            fontSize: 3,
+            color: 'interactive100',
+            fontWeight: 'regular',
+          }}
+        >
+          Summer.fi {t(`nav.${selectedProduct}`)}
+        </WithArrow>
+      </AppLink>
+    </Text>
+  )
+}

--- a/features/productHub/controls/ProductHubPromoCardsController.tsx
+++ b/features/productHub/controls/ProductHubPromoCardsController.tsx
@@ -23,10 +23,14 @@ export const ProductHubPromoCardsController: FC<ProductHubPromoCardsControllerPr
   )
 
   return (
-    <Grid columns={[1, null, 2, 3]} gap={3} sx={{ mb: 4 }}>
-      {promoCards.map((promoCard, i) => (
-        <PromoCard key={`${selectedProduct}-${i}`} {...promoCard} />
-      ))}
-    </Grid>
+    <>
+      {promoCards.length > 0 && (
+        <Grid columns={[1, null, 2, 3]} gap={3} sx={{ mb: 4 }}>
+          {promoCards.map((promoCard, i) => (
+            <PromoCard key={`${selectedProduct}-${i}`} {...promoCard} />
+          ))}
+        </Grid>
+      )}
+    </>
   )
 }

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -24,10 +24,10 @@ import { Box, Flex } from 'theme-ui'
 interface ProductHubViewProps {
   initialNetwork?: ProductHubSupportedNetworks[]
   initialProtocol?: LendingProtocol[]
+  intro?: (selectedProduct: ProductHubProductType, selectedToken: string) => ReactNode
   headerGradient?: [string, string, ...string[]]
   product: ProductHubProductType
   promoCardsCollection: PromoCardsCollection
-  subtext?: (selectedProduct: ProductHubProductType, selectedToken: string) => ReactNode
   token?: string
   url?: string
   limitRows?: number
@@ -39,7 +39,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   headerGradient = ['#007DA3', '#E7A77F', '#E97047'],
   product,
   promoCardsCollection,
-  subtext,
+  intro,
   token,
   url,
   limitRows,
@@ -91,8 +91,8 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
             setSelectedFilters(defaultFilters)
           }}
         />
-        {subtext ? (
-          subtext(selectedProduct, selectedToken)
+        {intro ? (
+          intro(selectedProduct, selectedToken)
         ) : (
           <ProductHubIntro selectedProduct={selectedProduct} selectedToken={selectedToken} />
         )}

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -1,13 +1,14 @@
 import { AppLink } from 'components/Links'
 import { WithArrow } from 'components/WithArrow'
 import { ProductHubLoadingState } from 'features/productHub/components'
+import { ProductHubIntro } from 'features/productHub/components/ProductHubIntro'
 import {
   ProductHubNaturalLanguageSelectorController,
   ProductHubPromoCardsController,
 } from 'features/productHub/controls'
 import { ProductHubContentController } from 'features/productHub/controls/ProductHubContentController'
 import { useProductHubData } from 'features/productHub/hooks/useProductHubData'
-import { ALL_ASSETS, productHubLinksMap } from 'features/productHub/meta'
+import { ALL_ASSETS } from 'features/productHub/meta'
 import {
   ProductHubFilters,
   ProductHubProductType,
@@ -17,8 +18,8 @@ import { PromoCardsCollection } from 'handlers/product-hub/types'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
 import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
-import React, { FC, Fragment, useMemo, useState } from 'react'
-import { Box, Flex, Text } from 'theme-ui'
+import React, { FC, Fragment, ReactNode, useMemo, useState } from 'react'
+import { Box, Flex } from 'theme-ui'
 
 interface ProductHubViewProps {
   initialNetwork?: ProductHubSupportedNetworks[]
@@ -26,6 +27,7 @@ interface ProductHubViewProps {
   headerGradient?: [string, string, ...string[]]
   product: ProductHubProductType
   promoCardsCollection: PromoCardsCollection
+  subtext?: (selectedProduct: ProductHubProductType, selectedToken: string) => ReactNode
   token?: string
   url?: string
   limitRows?: number
@@ -37,6 +39,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   headerGradient = ['#007DA3', '#E7A77F', '#E97047'],
   product,
   promoCardsCollection,
+  subtext,
   token,
   url,
   limitRows,
@@ -88,29 +91,11 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
             setSelectedFilters(defaultFilters)
           }}
         />
-        <Text
-          as="p"
-          variant="paragraph2"
-          sx={{
-            mx: 'auto',
-            mt: '24px',
-          }}
-        >
-          {t(`product-hub.intro.${selectedProduct}`)}{' '}
-          <AppLink href={productHubLinksMap[selectedProduct]}>
-            <WithArrow
-              variant="paragraph2"
-              sx={{
-                display: 'inline-block',
-                fontSize: 3,
-                color: 'interactive100',
-                fontWeight: 'regular',
-              }}
-            >
-              Summer.fi {t(`nav.${selectedProduct}`)}
-            </WithArrow>
-          </AppLink>
-        </Text>
+        {subtext ? (
+          subtext(selectedProduct, selectedToken)
+        ) : (
+          <ProductHubIntro selectedProduct={selectedProduct} selectedToken={selectedToken} />
+        )}
       </Box>
       <WithLoadingIndicator value={[data]} customLoader={<ProductHubLoadingState />}>
         {([_data]) => (

--- a/handlers/product-hub/promo-card-collections-parsers/ajnaLpHandler.ts
+++ b/handlers/product-hub/promo-card-collections-parsers/ajnaLpHandler.ts
@@ -7,7 +7,6 @@ import {
   findByTokenPair,
   parseAjnaBorrowPromoCard,
   parseAjnaEarnPromoCard,
-  parseAjnaMultiplyPromoCard,
 } from 'handlers/product-hub/helpers'
 import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import { LendingProtocol } from 'lendingProtocols'
@@ -47,14 +46,6 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     description: { key: 'product-hub.promo-cards.learn-how-to-use-borrow-and-get-liquidity' },
     link: { href: EXTERNAL_LINKS.KB.AJNA, label: { key: 'Learn more' } },
   }
-  const promoCardLearnAboutMultiply = {
-    image: lendingProtocolsByName[LendingProtocol.Ajna].icon,
-    title: { key: 'product-hub.promo-cards.get-to-know-ajna-multiply' },
-    description: {
-      key: 'product-hub.promo-cards.learn-how-to-use-multiply-to-optimize-your-position',
-    },
-    link: { href: EXTERNAL_LINKS.KB.AJNA, label: { key: 'Learn more' } },
-  }
   const promoCardWhatIsEarn = {
     image: lendingProtocolsByName[LendingProtocol.Ajna].icon,
     title: { key: 'product-hub.promo-cards.what-is-earn-on-ajna' },
@@ -81,36 +72,6 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
   const promoCardWBTCDAICBorrow = parseAjnaBorrowPromoCard('WBTC', 'DAI', WBTCDAIBorrowishProduct)
   const promoCardUSDCETHBorrow = parseAjnaBorrowPromoCard('USDC', 'ETH', USDCETHBorrowishProduct)
   const promoCardUSDCWBTCBorrow = parseAjnaBorrowPromoCard('USDC', 'WBTC', USDCWBTCBorrowishProduct)
-  const promoCardETHUSDCMultiply = parseAjnaMultiplyPromoCard(
-    'ETH',
-    'USDC',
-    ETHUSDCBorrowishProduct,
-  )
-  const promoCardWSTETHUSDCMultiply = parseAjnaMultiplyPromoCard(
-    'WSTETH',
-    'USDC',
-    WSTETHUSDCBorrowishProduct,
-  )
-  const promoCardWBTCUSDCMultiply = parseAjnaMultiplyPromoCard(
-    'WBTC',
-    'USDC',
-    WBTCUSDCBorrowishProduct,
-  )
-  const promoCardWBTCDAIMultiply = parseAjnaMultiplyPromoCard(
-    'WBTC',
-    'DAI',
-    WBTCDAIBorrowishProduct,
-  )
-  const promoCardUSDCETHMultiply = parseAjnaMultiplyPromoCard(
-    'USDC',
-    'ETH',
-    USDCETHBorrowishProduct,
-  )
-  const promoCardUSDCWBTCMultiply = parseAjnaMultiplyPromoCard(
-    'USDC',
-    'WBTC',
-    USDCWBTCBorrowishProduct,
-  )
   const promoCardETHUSDCEarn = parseAjnaEarnPromoCard('ETH', 'USDC', ETHUSDCEarnProduct)
   const promoCardWSTETHUSDCEarn = parseAjnaEarnPromoCard('WSTETH', 'USDC', WSTETHUSDCEarnProduct)
   const promoCardWSTETHDAIEarn = parseAjnaEarnPromoCard('WSTETH', 'DAI', WSTETHDAIEarnProduct)
@@ -133,12 +94,8 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
       },
     },
     [ProductHubProductType.Multiply]: {
-      default: [promoCardETHUSDCMultiply, promoCardWBTCUSDCMultiply, promoCardUSDCETHMultiply],
-      tokens: {
-        ETH: [promoCardETHUSDCMultiply, promoCardWSTETHUSDCMultiply, promoCardUSDCETHMultiply],
-        WBTC: [promoCardWBTCUSDCMultiply, promoCardWBTCDAIMultiply, promoCardUSDCWBTCMultiply],
-        USDC: [promoCardUSDCETHMultiply, promoCardUSDCWBTCMultiply, promoCardLearnAboutMultiply],
-      },
+      default: [],
+      tokens: {},
     },
     [ProductHubProductType.Earn]: {
       default: [promoCardETHUSDCEarn, promoCardWBTCUSDCEarn, promoCardETHDAIEarn],

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -131,8 +131,9 @@ async function getAjnaPoolData(
                 ...getTokenGroup(collateralToken, 'primary'),
                 product: [
                   ProductHubProductType.Borrow,
-                  ProductHubProductType.Multiply,
-                  ...(isYieldLoop ? [ProductHubProductType.Earn] : []),
+                  // TODO: uncomment on multiply release
+                  // ProductHubProductType.Multiply,
+                  // ...(isYieldLoop ? [ProductHubProductType.Earn] : []),
                 ],
                 protocol,
                 secondaryToken: quoteToken,

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2492,6 +2492,10 @@
       "oasis-discord": "Summer.fi Discord",
       "oasis-twitter": "Summer.fi Twitter"
     },
+    "product-finder": {
+      "multiply-soon-title": "Ajna Multiply coming soon",
+      "multiply-soon-intro": "We're busy building Multiply for Ajna and will be releasing it shortly. For now you can <1>Borrow</1> and <2>Earn</2> on Ajna."
+    },
     "product-cards": {
       "borrow-against-your": "Borrow against your {{token}}",
       "collaterals-you-can-borrow": "Collaterals you can borrow",


### PR DESCRIPTION
# [Hide access to Ajna Multiply](https://app.shortcut.com/oazo-apps/story/10046/ajna-multiply-on-ajna-landing-page-product-finder)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/e7b08c49-1b3c-4e84-be82-f9c8e874109b)
  
## Changes 👷‍♀️

- commented out Ajna Multiply products from Ajna Product Finder handler,
- removed Ajna Multiply promo cards from Product Finder (removed, not commented out as they are going to be different than was until now anyway),
- added dedicated intro on Product Finder on Ajna pages when user selects "Multiply" in natural language selector,
- removed "Switch to multiply" from dropdown menu on manage Ajna Borrow UI.
  
## How to test 🧪

- Patch Product Hub data with new data handler,
- go through changes list.
