### PR TITLE
Ajna earn empty position notification adjust

### DIFF
--- a/features/ajna/positions/common/notifications.tsx
+++ b/features/ajna/positions/common/notifications.tsx
@@ -301,8 +301,9 @@ export function getAjnaNotifications({
         } = position as AjnaEarnPosition
         const earningNoApy = price.lt(highestThresholdPrice) && price.gt(zero)
         const priceAboveMomp = price.gt(mostOptimisticMatchingPrice)
-        const emptyPosition = quoteTokenAmount.isZero()
         const earnPositionAuction = positionAuction as AjnaEarnPositionAuction
+        const emptyPosition =
+          quoteTokenAmount.isZero() && !earnPositionAuction.isCollateralToWithdraw
 
         const moveToAdjust = () => {
           dispatch({ type: 'reset' })

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2715,7 +2715,7 @@
             },
             "empty-position": {
               "title": "Your lending position is empty",
-              "message": "To start earning you need to provide liquidity using your quote tokens"
+              "message": "To start earning you need to provide liquidity using your tokens"
             },
             "lending-price-frozen": {
               "title": "This lending price is currently frozen and borrowers are being liquidated",


### PR DESCRIPTION
# [Ajna earn empty position notification adjust](https://app.shortcut.com/oazo-apps/story/10060/earn-withdraw-collateral-banner-appears-at-the-same-time-as-empty-position)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted notification copy and condition
  
## How to test 🧪
  <Please explain how to test your changes>

- when position have 0 quote tokens but collateral to withdraw, empty position notification shouldn't popup
