### PR TITLE
Fix the layout of the 404 page

### DIFF
--- a/pages/not-found.tsx
+++ b/pages/not-found.tsx
@@ -1,6 +1,7 @@
 import { PageSEOTags } from 'components/HeadTags'
 import { MarketingLayout } from 'components/Layouts'
 import { AppLink } from 'components/Links'
+import { WithChildren } from 'helpers/types'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
@@ -28,6 +29,8 @@ function NotFoundPage() {
   )
 }
 
-NotFoundPage.layout = MarketingLayout
+NotFoundPage.layout = ({ children }: WithChildren) => (
+  <MarketingLayout topBackground="light">{children}</MarketingLayout>
+)
 
 export default NotFoundPage


### PR DESCRIPTION
# Fix the layout of the 404 page

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- fixes the layout of the 404 page (lighter instead of home page one)
  
## How to test 🧪
- go to `/not-found`