### PR TITLE
Empty pool slider market price offset

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -53,4 +53,4 @@ export const ajnaLastIndexBucketPrice = new BigNumber(99836282890)
 
 // safe defaults which should ensure reasonable slider range for newly created pools
 export const ajnaDefaultPoolRangeMarketPriceOffset = 0.8 // 80%
-export const ajnaDefaultMarketPriceOffset = 0.45 // 45%
+export const ajnaDefaultMarketPriceOffset = 0.25 // 25%


### PR DESCRIPTION
# [Empty pool slider market price offset](https://app.shortcut.com/oazo-apps/story/10119/pool-without-borrowers)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- changed market price offset from 45% to 25%
  
## How to test 🧪
  <Please explain how to test your changes>

- on pool without borrowers when providing liquidity you should be able to set up ltv to 75%
