### PR TITLE
After lup bigger than htp copy update

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.25",
     "@oasisdex/automation": "1.4.0",
-    "@oasisdex/dma-library": "0.3.25",
+    "@oasisdex/dma-library": "0.3.26",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2753,7 +2753,7 @@
       "borrow-undercollateralized": "You cannot generate more than {{amount}} {{quoteToken}}, as this would take your position above the maximum LTV. Please enter a lower amount.",
       "earning-no-apy": "You will be lending without earning any yield.",
       "withdraw-more-than-available": "You cannot withdraw more than {{amount}} {{token}}, please select a lower amount.",
-      "after-lup-index-bigger-than-htp-index": "You cannot withdraw this amount as there is not enough available liquidity in the pool. Please withdraw a lower amount or wait for more available liquidity.",
+      "after-lup-index-bigger-than-htp-index": "You cannot adjust this position as there is not enough available liquidity in the pool. Please wait for more available liquidity.",
       "debt-less-then-dust-limit": "Minimum debt amount you can draw is {{minDebtAmount}}, as this is the minimum required by the pool. Please enter an amount at least equal to the minimum borrow amount.",
       "repay-more-then-debt": "You cannot repay more than the total debt amount {{amount}} {{quoteToken}}.",
       "not-enough-liquidity": "You cannot generate more debt than is available in the pool {{amount}} {{collateralToken}}/{{quoteToken}}.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,10 +3937,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.3.25":
-  version "0.3.25"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.25.tgz#8acb62011e2e4d060ecf21c019b7e071dd357f5b"
-  integrity sha512-1jxV/hhyG1SWEO1BK3qwNVCS4uKGv4ehzG+XeR3kneswrknTrmrthb4vWRESSj9bWcIkBcMKVExspA497vY6HQ==
+"@oasisdex/dma-library@0.3.26":
+  version "0.3.26"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.26.tgz#9b0200d673e92f968d4d6164dfccf79630814cd3"
+  integrity sha512-7/h+6sO2eJhcfMK1ENsM/Hgg2jmTpqe07xLOj5QhXDIvmlS6tpgCi+kYUD4WfWE2npTt7D4T1DWUMskxRXtSpA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [After lup bigger than htp copy update](https://app.shortcut.com/oazo-apps/story/9478/earn-validation-check-if-there-is-enough-liquidity-available-to-adjust-the-position)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated copy
- library version bump
  
## How to test 🧪
  <Please explain how to test your changes>

- when there is no enough liquidity to move user bucket to another one, error with updated copy should popup
