### PR TITLE
Usage of buckets list in ajna earn slider

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -52,5 +52,5 @@ export const LTVWarningThreshold = new BigNumber(0.05)
 export const ajnaLastIndexBucketPrice = new BigNumber(99836282890)
 
 // safe defaults which should ensure reasonable slider range for newly created pools
-export const ajnaDefaultPoolRangeMarketPriceOffset = 0.8 // 80%
+export const ajnaDefaultPoolRangeMarketPriceOffset = 0.9 // 90%
 export const ajnaDefaultMarketPriceOffset = 0.25 // 25%

--- a/features/ajna/positions/earn/components/AjnaEarnInput.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnInput.tsx
@@ -2,7 +2,10 @@ import BigNumber from 'bignumber.js'
 import { FIAT_PRECISION } from 'components/constants'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
-import { snapToPredefinedValues } from 'features/ajna/positions/earn/helpers/snapToPredefinedValues'
+import {
+  mappedAjnaBuckets,
+  snapToPredefinedValues,
+} from 'features/ajna/positions/earn/helpers/snapToPredefinedValues'
 import { BigNumberInput } from 'helpers/BigNumberInput'
 import { formatBigNumber } from 'helpers/formatters/format'
 import { handleNumericInput } from 'helpers/input'
@@ -104,13 +107,12 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, max, min, rang
   const [manualAmount, setManualAmount] = useState<BigNumber>(price || zero)
 
   const clickHandler = (variant: AjnaEarnInputButtonVariant) => {
-    const snappedValue = snapToPredefinedValues(manualAmount, range)
-    let index = range.indexOf(snappedValue)
+    const snappedValue = snapToPredefinedValues(manualAmount)
+    let index = mappedAjnaBuckets.indexOf(snappedValue)
+    if (variant === '+') index = Math.max(0, index - 1)
+    if (variant === '-') index = Math.max(range.length - 1, index + 1)
 
-    if (variant === '-') index = Math.max(0, index - 1)
-    if (variant === '+') index = Math.min(range.length - 1, index + 1)
-
-    const selectedValue = range.at(index) || zero
+    const selectedValue = mappedAjnaBuckets.at(index) || zero
 
     setManualAmount(selectedValue)
     updateState('price', selectedValue)
@@ -118,9 +120,9 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, max, min, rang
 
   const enterPressedHandler = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      const snappedValue = snapToPredefinedValues(manualAmount, range)
-      const index = range.indexOf(snappedValue)
-      const selectedValue = range.at(index) || zero
+      const snappedValue = snapToPredefinedValues(manualAmount)
+      const index = mappedAjnaBuckets.indexOf(snappedValue)
+      const selectedValue = mappedAjnaBuckets.at(index) || zero
 
       setManualAmount(selectedValue)
       updateState('price', selectedValue)
@@ -155,7 +157,7 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled, max, min, rang
         }}
         onBlur={(e) => {
           if (!e.currentTarget.contains(e.relatedTarget as Node) && manualAmount !== price) {
-            const snappedValue = snapToPredefinedValues(manualAmount, range)
+            const snappedValue = snapToPredefinedValues(manualAmount)
 
             setManualAmount(snappedValue)
             updateState('price', snappedValue)

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -62,7 +62,7 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManu
   )
 
   function handleChange(v: BigNumber) {
-    const newValue = snapToPredefinedValues(v, range)
+    const newValue = snapToPredefinedValues(v)
     updateState('price', newValue)
   }
 
@@ -97,7 +97,7 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManu
         lastValue={resolvedValue}
         minBoundry={min}
         maxBoundry={max}
-        step={range[1].minus(range[0]).toNumber()}
+        step={range.at(-1)!.minus(range.at(-2)!).toNumber()}
         leftBoundry={leftBoundry}
         rightBoundry={maxLtv}
         leftBoundryFormatter={(v) => `${t('price')} $${formatAmount(v, 'USD')}`}

--- a/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
+++ b/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
@@ -4,6 +4,7 @@ import {
   ajnaDefaultMarketPriceOffset,
   ajnaDefaultPoolRangeMarketPriceOffset,
 } from 'features/ajna/common/consts'
+import { snapToPredefinedValues } from 'features/ajna/positions/earn/helpers/snapToPredefinedValues'
 import { one, zero } from 'helpers/zero'
 
 export const getMinMaxAndRange = ({
@@ -36,8 +37,8 @@ export const getMinMaxAndRange = ({
     }
 
     return {
-      min: defaultRange[0],
-      max: defaultRange[defaultRange.length - 1],
+      min: snapToPredefinedValues(defaultRange[0]),
+      max: snapToPredefinedValues(defaultRange[defaultRange.length - 1]),
       range: defaultRange,
     }
   }
@@ -79,8 +80,8 @@ export const getMinMaxAndRange = ({
     .map((item) => item.decimalPlaces(18))
 
   return {
-    min: range[0],
-    max: range[range.length - 1],
+    min: snapToPredefinedValues(range[0]),
+    max: snapToPredefinedValues(range[range.length - 1]),
     range,
   }
 }

--- a/features/ajna/positions/earn/helpers/snapToPredefinedValues.ts
+++ b/features/ajna/positions/earn/helpers/snapToPredefinedValues.ts
@@ -1,7 +1,13 @@
+import { ajnaBuckets } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
+import { NEGATIVE_WAD_PRECISION } from 'components/constants'
 
-export const snapToPredefinedValues = (value: BigNumber, predefinedSteps: BigNumber[]) => {
-  return predefinedSteps.reduce((prev, curr) => {
+export const mappedAjnaBuckets = ajnaBuckets.map((price) =>
+  new BigNumber(price).shiftedBy(NEGATIVE_WAD_PRECISION),
+)
+
+export const snapToPredefinedValues = (value: BigNumber) => {
+  return mappedAjnaBuckets.reduce((prev, curr) => {
     return curr.minus(value).abs().lt(prev.minus(value).abs()) ? curr : prev
   })
 }


### PR DESCRIPTION
# [Usage of buckets list in ajna earn slider](https://app.shortcut.com/oazo-apps/story/10134/earn-lending-price-out-of-sync-with-slider)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- `snapToPredefinedValues` method uses predefined ajna bucket list as range
  
## How to test 🧪
  <Please explain how to test your changes>

- test slider and input, simulation price should always match price from these
