### PR TITLE
Adjust earn slider default value on fresh pool

### DIFF
--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -72,8 +72,8 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManu
 
   useEffect(() => {
     // triggered only once to initialize price on state when lup index is zero
-    if (lowestUtilizedPriceIndex.isZero()) {
-      handleChange(max)
+    if (lowestUtilizedPriceIndex.isZero() && !price) {
+      handleChange(min)
     }
   }, [])
 


### PR DESCRIPTION
# Adjust earn slider default value on fresh pool

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- set default value of earn slider to min value
- fix issue on existing earn position on pool without borrowers where slider value was updated to max even though position price existed
  
## How to test 🧪
  <Please explain how to test your changes>

- on pool without borrowers earn slider default value should be set up to min value as default
- on existing position on not utilized pool, slider value should be set to position lending price
