### PR TITLE
Bump dma-lib version to 0.3.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.27",
     "@oasisdex/automation": "1.5.0-alpha.8",
-    "@oasisdex/dma-library": "0.3.27",
+    "@oasisdex/dma-library": "0.3.28",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,10 +3937,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.3.27":
-  version "0.3.27"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.27.tgz#a9c192a229e33e7cc78ee69052b4e6125779e05f"
-  integrity sha512-mxDFm4Igxtg+mPpCqohS/NagkDp4qhwwfx6stBQ6s4UqqvcaKFj70iRxgXFEdZS6wal45oaN3A/e2UVumF6PEA==
+"@oasisdex/dma-library@0.3.28":
+  version "0.3.28"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.28.tgz#8533f2fe743c78e945dd8ec5d2bb8f696fc2231d"
+  integrity sha512-ZKlfGlYBXlC/JR1ufC3Lt4iRPBnk4vfIkckTyaKnlS5NbGYcfTOccR//Al2DJAeU8AG8jaA5HH3jXQMe9a8RQw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# Bump dma-lib version to 0.3.28

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- Bump dma-lib version to 0.3.28
  
## How to test 🧪
  <Please explain how to test your changes>

- max available to withdraw in ajna earn positions shouldn't drop below 0
