### PR TITLE
Liquidity typo fix and format negative to zero

### DIFF
--- a/features/ajna/common/types.ts
+++ b/features/ajna/common/types.ts
@@ -54,7 +54,7 @@ export type AjnaPoolData = {
     '7DayNetApy': BigNumber
     '90DayNetApy': BigNumber
     annualFee: BigNumber
-    liquidityAvaliable: BigNumber
+    liquidityAvailable: BigNumber
     lowestUtilizedPriceIndex: number
     maxLtv: BigNumber
     maxMultiply: BigNumber

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -14,7 +14,7 @@ import React from 'react'
 import { Trans } from 'react-i18next'
 
 function parseProductNumbers(stringNumbers: (string | undefined)[]): (BigNumber | undefined)[] {
-  return stringNumbers.map((number) => (number ? negativeToZero(new BigNumber(number)) : undefined))
+  return stringNumbers.map((number) => (number ? new BigNumber(number) : undefined))
 }
 
 function parseProduct(
@@ -38,6 +38,15 @@ function parseProduct(
     maxLtvString,
     maxMultiplyString,
   ])
+
+  const resolved = {
+    liquidity: liquidity ? (
+      formatFiatBalance(negativeToZero(liquidity))
+    ) : (
+      <AssetsTableDataCellInactive />
+    ),
+  }
+
   switch (product) {
     case ProductHubProductType.Borrow:
       return {
@@ -54,7 +63,7 @@ function parseProduct(
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
-              {liquidity ? `$${formatFiatBalance(liquidity)}` : <AssetsTableDataCellInactive />}
+              {resolved.liquidity}
               {tooltips?.liquidity && <AssetsTableTooltip {...tooltips.liquidity} />}
             </>
           ),
@@ -90,7 +99,7 @@ function parseProduct(
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
-              {liquidity ? `$${formatFiatBalance(liquidity)}` : <AssetsTableDataCellInactive />}
+              {resolved.liquidity}
               {tooltips?.liquidity && <AssetsTableTooltip {...tooltips.liquidity} />}
             </>
           ),
@@ -140,7 +149,7 @@ function parseProduct(
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
-              {liquidity ? `$${formatFiatBalance(liquidity)}` : <AssetsTableDataCellInactive />}
+              {resolved.liquidity}
               {tooltips?.liquidity && <AssetsTableTooltip {...tooltips.liquidity} />}
             </>
           ),

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -1,3 +1,4 @@
+import { negativeToZero } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 import { AssetsTableDataCellAction } from 'components/assetsTable/cellComponents/AssetsTableDataCellAction'
 import { AssetsTableDataCellAsset } from 'components/assetsTable/cellComponents/AssetsTableDataCellAsset'
@@ -13,7 +14,7 @@ import React from 'react'
 import { Trans } from 'react-i18next'
 
 function parseProductNumbers(stringNumbers: (string | undefined)[]): (BigNumber | undefined)[] {
-  return stringNumbers.map((number) => (number ? new BigNumber(number) : undefined))
+  return stringNumbers.map((number) => (number ? negativeToZero(new BigNumber(number)) : undefined))
 }
 
 function parseProduct(
@@ -49,7 +50,7 @@ function parseProduct(
             </>
           ),
         },
-        liquidityAvaliable: {
+        liquidityAvailable: {
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
@@ -85,7 +86,7 @@ function parseProduct(
             </>
           ),
         },
-        liquidityAvaliable: {
+        liquidityAvailable: {
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
@@ -135,7 +136,7 @@ function parseProduct(
             </>
           ),
         },
-        liquidityAvaliable: {
+        liquidityAvailable: {
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -238,7 +238,7 @@
         "earnings-to-date": "Earnings to date",
         "funding-cost": "Funding cost",
         "liquidation-price": "Liquidation price",
-        "liquidity-avaliable": "Liquidity avaliable",
+        "liquidity-available": "Liquidity available",
         "liquidity": "Liquidity",
         "long-short": "Long/Short",
         "management": "Management",


### PR DESCRIPTION
# [Liquidity typo fix and format negative to zero](https://app.shortcut.com/oazo-apps/story/10219/product-hub-liquidity-available-typo-and-formatting)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- liquidity typo fix and format negative to zero
  
## How to test 🧪
  <Please explain how to test your changes>

- in product hub table liquidity shouldn't drop below 0
- typo fixed
