### PR TITLE
Fix ajna flow config for payback actions

### DIFF
--- a/features/ajna/positions/common/helpers/getFlowStateConfig.ts
+++ b/features/ajna/positions/common/helpers/getFlowStateConfig.ts
@@ -52,6 +52,12 @@ export function getFlowStateConfig({
     case 'payback-borrow':
     case 'withdraw-borrow':
     case 'payback-multiply':
+      if (!state.paybackAmount) {
+        return {
+          amount: zero,
+          token: 'ETH',
+        }
+      }
       return {
         amount: state.paybackAmount,
         token: quoteToken,


### PR DESCRIPTION
# [Fix ajna flow config for payback actions](https://app.shortcut.com/oazo-apps/story/10232/flow-config-fix)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed ajna flow config for payback actions
  
## How to test 🧪
  <Please explain how to test your changes>

- when performing withdraw and payback action on pool i.e USDC-WBTC, when user types something into withdraw input there should be no `Set WBTC allowance` until payback input will be filled
