### PR TITLE
Ajna areEarnPricesEqual fix

### DIFF
--- a/features/ajna/positions/earn/helpers/areEarnPricesEqual.ts
+++ b/features/ajna/positions/earn/helpers/areEarnPricesEqual.ts
@@ -1,4 +1,4 @@
 import BigNumber from 'bignumber.js'
 
 export const areEarnPricesEqual = (positionPrice: BigNumber, newPrice?: BigNumber) =>
-  newPrice?.decimalPlaces(2).eq(positionPrice.decimalPlaces(2))
+  newPrice?.eq(positionPrice)


### PR DESCRIPTION
# [Ajna areEarnPricesEqual fix](https://app.shortcut.com/oazo-apps/story/10237/earn-cannot-adjust-price-bucket-on-existing-pool)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed rounding issue
  
## How to test 🧪
  <Please explain how to test your changes>

- you should be able to adjust price bucket on earn short position
