### PR TITLE
Partial Ajna earn input fix

### DIFF
--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -125,11 +125,23 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManu
             priceFormat,
           })}
         >
-          <AjnaEarnInput disabled={isDisabled || isFormFrozen} min={min} max={max} range={range} />
+          <AjnaEarnInput
+            disabled={isDisabled || isFormFrozen}
+            min={min}
+            max={max}
+            range={range}
+            fallbackValue={resolvedLup}
+          />
         </PillAccordion>
       ) : (
         <Box sx={{ mt: 3 }}>
-          <AjnaEarnInput disabled={isDisabled || isFormFrozen} min={min} max={max} range={range} />
+          <AjnaEarnInput
+            disabled={isDisabled || isFormFrozen}
+            min={min}
+            max={max}
+            range={range}
+            fallbackValue={resolvedLup}
+          />
         </Box>
       )}
     </>


### PR DESCRIPTION
# [Partial Ajna earn input fix](https://app.shortcut.com/oazo-apps/story/10237/earn-cannot-adjust-price-bucket-on-existing-pool)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- handled case for short pools
  
## How to test 🧪
  <Please explain how to test your changes>

- ajna earn input should work for short pools, if user input value out of range, on enter it should snap to fallback value (lup or max)
