### PR TITLE
🧿 Ajna Earn short position lending price

### DIFF
--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -1,4 +1,4 @@
-import { calculateAjnaMaxLiquidityWithdraw } from '@oasisdex/dma-library'
+import { calculateAjnaMaxLiquidityWithdraw, normalizeValue } from '@oasisdex/dma-library'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
@@ -16,7 +16,7 @@ import React from 'react'
 export function AjnaEarnOverviewManageController() {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, quoteToken, quotePrice },
+    environment: { collateralToken, isShort, priceFormat, quoteToken, quotePrice },
   } = useAjnaGeneralContext()
   const {
     position: {
@@ -25,6 +25,11 @@ export function AjnaEarnOverviewManageController() {
     },
     notifications,
   } = useAjnaProductContext('earn')
+
+  const liquidationToMarketPrice = position.price.div(position.marketPrice)
+  const relationToMarketPrice = one.minus(
+    isShort ? normalizeValue(one.div(liquidationToMarketPrice)) : liquidationToMarketPrice,
+  )
 
   return (
     <DetailsSection
@@ -54,12 +59,13 @@ export function AjnaEarnOverviewManageController() {
           />
           <ContentCardPositionLendingPrice
             isLoading={isSimulationLoading}
-            collateralToken={collateralToken}
             quoteToken={quoteToken}
+            priceFormat={priceFormat}
+            isShort={isShort}
             positionLendingPrice={position.price}
             highestThresholdPrice={position.pool.highestThresholdPrice}
             afterPositionLendingPrice={simulation?.price}
-            relationToMarketPrice={position.maxRiskRatio.loanToValue.minus(one)}
+            relationToMarketPrice={relationToMarketPrice}
           />
         </DetailsSectionContentCardWrapper>
       }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2698,7 +2698,9 @@
             "position-lending-price": "Position lending price",
             "position-lending-price-modal-desc": "The lending price is akin to a limit order, if the market price hits the selected price you will be left with collateral tokens. It's expected that borrowers are liquidated some time before your price is reached, and you will be able to withdraw funds in the token you deposited.",
             "minimum-yield-price-modal": "Minimum Yield Price",
+            "maximum-yield-price-modal": "Maximum Yield Price",
             "minimum-yield-price-modal-desc": "Below this lending price you will not earn any yield. Select a lending price above this level to earn.",
+            "maximum-yield-price-modal-desc": "Above this lending price you will not earn any yield. Select a lending price below this level to earn.",
             "net-value": "Net value",
             "net-value-modal-desc": "The total amount of tokens available in position, this includes the earned amount:"
           },


### PR DESCRIPTION
# [Ajna Earn short position lending price](https://app.shortcut.com/oazo-apps/story/10236/earn-short-pools-have-position-lending-price-displayed-incorrectly)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/fad378af-2e43-4925-a748-af2a27424deb)
![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/0e22554c-9f7d-45a9-aa77-89c4124487dc)
  
## Changes 👷‍♀️

- Updated `ContentCardPositionLendingPrice` content card to display properly short earn positions.
  
## How to test 🧪

Compare this card on long and short positions, e.g.: `137` and `141`.