### PR TITLE
Ajna earn slider max market price

### DIFF
--- a/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
+++ b/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
@@ -76,6 +76,7 @@ export const getMinMaxAndRange = ({
   const range = [
     ...new Set([...nearHtpMinRange, ...lupNearHtpRange, ...lupNearMompRange, ...nearMompMaxRange]),
   ]
+    .filter((item) => item.lt(marketPrice))
     .sort((a, b) => a.toNumber() - b.toNumber())
     .map((item) => item.decimalPlaces(18))
 


### PR DESCRIPTION
# [Ajna earn slider max market price](https://app.shortcut.com/oazo-apps/story/10264/earn-slider-can-go-above-100)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- limited max value of earn slider to value below market price
  
## How to test 🧪
  <Please explain how to test your changes>

- on short earn position try to move slider to max value, user shouldn't be able to move above 100%
