### PR TITLE
🧿 Fix passing earn subgraph for empty positions

### DIFF
--- a/features/ajna/positions/earn/helpers/getAjnaEarnData.ts
+++ b/features/ajna/positions/earn/helpers/getAjnaEarnData.ts
@@ -3,31 +3,45 @@ import BigNumber from 'bignumber.js'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
 import { zero } from 'helpers/zero'
 
+const defaultResponse = {
+  lps: zero,
+  priceIndex: null,
+  nftID: null,
+  cumulativeDeposit: zero,
+  cumulativeFees: zero,
+  cumulativeWithdraw: zero,
+}
+
 export const getAjnaEarnData: GetEarnData = async (proxy: string) => {
   const { response } = await loadSubgraph('Ajna', 'getEarnData', {
     dpmProxyAddress: proxy.toLowerCase(),
   })
 
-  if (response && 'account' in response && response.account) {
-    const earnPosition = response.account.earnPositions.find((position) => position.lps > 0)
+  if (
+    response &&
+    'account' in response &&
+    response.account &&
+    response.account.earnPositions.length
+  ) {
+    const earnPosition = response.account.earnPositions[0]
+    const cumulativeValues = {
+      cumulativeDeposit: new BigNumber(earnPosition.account.cumulativeDeposit),
+      cumulativeFees: new BigNumber(earnPosition.account.cumulativeFees),
+      cumulativeWithdraw: new BigNumber(earnPosition.account.cumulativeWithdraw),
+    }
 
-    if (earnPosition)
-      return {
-        lps: new BigNumber(earnPosition.lps),
-        priceIndex: new BigNumber(earnPosition.index),
-        nftID: earnPosition.nft?.id || null,
-        cumulativeDeposit: new BigNumber(earnPosition.account.cumulativeDeposit),
-        cumulativeFees: new BigNumber(earnPosition.account.cumulativeFees),
-        cumulativeWithdraw: new BigNumber(earnPosition.account.cumulativeWithdraw),
-      }
+    return earnPosition.lps > 0
+      ? {
+          lps: new BigNumber(earnPosition.lps),
+          priceIndex: new BigNumber(earnPosition.index),
+          nftID: earnPosition.nft?.id || null,
+          ...cumulativeValues,
+        }
+      : {
+          ...defaultResponse,
+          ...cumulativeValues,
+        }
   }
 
-  return {
-    lps: zero,
-    priceIndex: null,
-    nftID: null,
-    cumulativeDeposit: zero,
-    cumulativeFees: zero,
-    cumulativeWithdraw: zero,
-  }
+  return defaultResponse
 }


### PR DESCRIPTION
# Fix passing earn subgraph for empty positions

Fixed an issue where all cumulative values for emptied position were equal to zero.

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/55b09dd6-7285-4b8b-8cbb-7913f0e82d40)
  
## Changes 👷‍♀️

- Fixed condition that decides on passing empty response from subgraph.
  
## How to test 🧪

Can be tested on position `137` (until I deposit something again 😏).
