### PR TITLE
🧿 Add balances to Ajna rewards page

### DIFF
--- a/features/ajna/common/components/AjnaRewardCard.tsx
+++ b/features/ajna/common/components/AjnaRewardCard.tsx
@@ -163,7 +163,7 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
           <>
             {rewards.tokens.gt(zero) && (
               <Button
-                sx={{ mb: [0, banner.footer ? 3 : 0], mt: [4, 4], fontSize: 1, p: 0 }}
+                sx={{ mb: [0, banner.footer ? 3 : 0], mt: [4, 4], fontSize: 1, py: 0 }}
                 disabled={claimingDisabled || (txStatus && progressStatuses.includes(txStatus))}
                 onClick={onBtnClick}
               >
@@ -290,7 +290,7 @@ export function AjnaRewardCard({
                 walletAddress={walletAddress}
               />
             )}
-            {isConnected && isLoading && <Skeleton sx={{ mt: 4, height: '202px' }} />}
+            {isConnected && isLoading && <Skeleton sx={{ mt: 4, height: '220px' }} />}
           </>
         )}
       </Flex>

--- a/features/ajna/common/components/AjnaRewardCard.tsx
+++ b/features/ajna/common/components/AjnaRewardCard.tsx
@@ -290,7 +290,9 @@ export function AjnaRewardCard({
                 walletAddress={walletAddress}
               />
             )}
-            {isConnected && isLoading && <Skeleton sx={{ mt: 4, height: '220px' }} />}
+            {isConnected && isLoading && (
+              <Skeleton sx={{ height: '220px', borderRadius: 'large' }} />
+            )}
           </>
         )}
       </Flex>

--- a/features/ajna/common/components/AjnaRewardCard.tsx
+++ b/features/ajna/common/components/AjnaRewardCard.tsx
@@ -241,7 +241,6 @@ interface AjnaRewardCardProps {
 
 export function AjnaRewardCard({
   banner,
-  claimingDisabled,
   floatingLabel,
   gradient,
   image,

--- a/features/ajna/common/components/AjnaRewardCard.tsx
+++ b/features/ajna/common/components/AjnaRewardCard.tsx
@@ -9,7 +9,7 @@ import { formatCryptoBalance } from 'helpers/formatters/format'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { useAccount } from 'helpers/useAccount'
 import { zero } from 'helpers/zero'
-import { Trans, useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next'
 import React, { FC, ReactNode } from 'react'
 import { Box, Button, Card, Flex, Heading, Image, Spinner, Text } from 'theme-ui'
 
@@ -75,46 +75,6 @@ const AjnaRewardCardListBox: FC<AjnaRewardCardListBoxProps> = ({ title, list, li
   )
 }
 
-interface EarningOnPositionsLinkProps {
-  numberOfPositions: number
-  ownerPageLink: Link
-  walletAddress: string
-}
-
-const EarningOnPositionsLink: FC<EarningOnPositionsLinkProps> = ({
-  numberOfPositions,
-  ownerPageLink,
-  walletAddress,
-}) => {
-  return (
-    <Box
-      sx={{
-        mt: 3,
-        fontSize: [1, 2],
-        color: 'neutral80',
-        transform: 'translateX(-8px)',
-      }}
-    >
-      <Trans
-        i18nKey={ownerPageLink.title}
-        values={{ value: numberOfPositions || 0 }}
-        components={{
-          1: (
-            <AppLink
-              href={`${ownerPageLink.href}/${walletAddress}`}
-              sx={{
-                mt: [0, 3],
-              }}
-              key="card-link"
-            />
-          ),
-          2: <WithArrow as="span" gap={1} sx={{ color: 'inherit', fontWeight: 'regular' }} />,
-        }}
-      />
-    </Box>
-  )
-}
-
 interface BannerProps {
   title: string
   button: { title: string }
@@ -124,7 +84,6 @@ interface BannerProps {
 interface Rewards {
   tokens: BigNumber
   usd: BigNumber
-  numberOfPositions: number
 }
 
 interface AjnaRewardCardBannerPropsAvailable {
@@ -158,10 +117,8 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
   gradient,
   notAvailable,
   onBtnClick,
-  ownerPageLink,
   rewards,
   txStatus,
-  walletAddress,
 }) => {
   const { t } = useTranslation()
 
@@ -249,11 +206,6 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
                 </Flex>
               </Button>
             )}
-            <EarningOnPositionsLink
-              ownerPageLink={ownerPageLink}
-              numberOfPositions={rewards.numberOfPositions}
-              walletAddress={walletAddress}
-            />
           </>
         )}
       </Flex>

--- a/features/ajna/common/components/AjnaRewardCard.tsx
+++ b/features/ajna/common/components/AjnaRewardCard.tsx
@@ -81,7 +81,7 @@ interface BannerProps {
   footer?: string
 }
 
-interface Rewards {
+export interface Rewards {
   tokens: BigNumber
   usd: BigNumber
 }
@@ -109,11 +109,13 @@ type AjnaRewardCardBannerProps = (
   | AjnaRewardCardBannerPropsUnavailable
 ) & {
   banner: BannerProps
+  claimingDisabled: boolean
   gradient: string
 }
 
 const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
   banner,
+  claimingDisabled,
   gradient,
   notAvailable,
   onBtnClick,
@@ -126,6 +128,7 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
     <Card
       sx={{
         width: '100%',
+        minHeight: '220px',
         mt: 'auto',
         px: 4,
         py: [0, 4],
@@ -161,7 +164,7 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
             {rewards.tokens.gt(zero) && (
               <Button
                 sx={{ mb: [0, banner.footer ? 3 : 0], mt: [4, 4], fontSize: 1, p: 0 }}
-                disabled={txStatus && progressStatuses.includes(txStatus)}
+                disabled={claimingDisabled || (txStatus && progressStatuses.includes(txStatus))}
                 onClick={onBtnClick}
               >
                 <Flex
@@ -169,39 +172,45 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
                     p: 2,
                   }}
                 >
-                  {txStatus && progressStatuses.includes(txStatus) ? (
-                    <Flex sx={{ px: 3, alignItems: 'center', gap: 2 }}>
-                      <Text
-                        as="span"
-                        variant="paragraph3"
-                        sx={{ color: 'inherit', fontSize: 'inherit' }}
-                      >
-                        {t('system.in-progress')}
-                      </Text>
-                      <Spinner
-                        variant="styles.spinner.medium"
-                        size={14}
-                        sx={{
-                          color: 'white',
-                          boxSizing: 'content-box',
-                        }}
-                      />
-                    </Flex>
+                  {claimingDisabled ? (
+                    t('ajna.rewards.cards.button-disabled')
                   ) : (
-                    <WithArrow
-                      gap={1}
-                      sx={{
-                        color: 'inherit',
-                        fontSize: 'inherit',
-                        pl: 3,
-                        pr: '24px',
-                        alignItems: 'center',
-                      }}
-                    >
-                      {txStatus && failedStatuses.includes(txStatus)
-                        ? t('retry')
-                        : t(banner.button.title)}
-                    </WithArrow>
+                    <>
+                      {txStatus && progressStatuses.includes(txStatus) ? (
+                        <Flex sx={{ px: 3, alignItems: 'center', gap: 2 }}>
+                          <Text
+                            as="span"
+                            variant="paragraph3"
+                            sx={{ color: 'inherit', fontSize: 'inherit' }}
+                          >
+                            {t('system.in-progress')}
+                          </Text>
+                          <Spinner
+                            variant="styles.spinner.medium"
+                            size={14}
+                            sx={{
+                              color: 'white',
+                              boxSizing: 'content-box',
+                            }}
+                          />
+                        </Flex>
+                      ) : (
+                        <WithArrow
+                          gap={1}
+                          sx={{
+                            color: 'inherit',
+                            fontSize: 'inherit',
+                            pl: 3,
+                            pr: '24px',
+                            alignItems: 'center',
+                          }}
+                        >
+                          {txStatus && failedStatuses.includes(txStatus)
+                            ? t('retry')
+                            : t(banner.button.title)}
+                        </WithArrow>
+                      )}
+                    </>
                   )}
                 </Flex>
               </Button>
@@ -214,35 +223,37 @@ const AjnaRewardCardBanner: FC<AjnaRewardCardBannerProps> = ({
 }
 
 interface AjnaRewardCardProps {
-  title: string
-  image: string
-  list: string[]
-  link: Link
-  ownerPageLink: Link
   banner: BannerProps
-  gradient: string
-  isLoading: boolean
-  rewards: Rewards
-  onBtnClick?: () => void
-  txStatus?: TxStatus
-  notAvailable?: boolean
+  claimingDisabled?: boolean
   floatingLabel?: ReactNode
+  gradient: string
+  image: string
+  isLoading: boolean
+  link: Link
+  list: string[]
+  notAvailable?: boolean
+  onBtnClick?: () => void
+  ownerPageLink: Link
+  rewards: Rewards
+  title: string
+  txStatus?: TxStatus
 }
 
 export function AjnaRewardCard({
-  title,
-  image,
-  list,
-  link,
-  ownerPageLink,
   banner,
-  gradient,
-  onBtnClick,
-  txStatus,
-  isLoading,
-  rewards,
-  notAvailable,
+  claimingDisabled,
   floatingLabel,
+  gradient,
+  image,
+  isLoading,
+  link,
+  list,
+  notAvailable,
+  onBtnClick,
+  ownerPageLink,
+  rewards,
+  title,
+  txStatus,
 }: AjnaRewardCardProps) {
   const { isConnected, walletAddress } = useAccount()
 
@@ -265,12 +276,13 @@ export function AjnaRewardCard({
         </Flex>
         <AjnaRewardCardListBox title={title} list={list} link={link} />
         {notAvailable ? (
-          <AjnaRewardCardBanner banner={banner} gradient={gradient} notAvailable />
+          <AjnaRewardCardBanner banner={banner} gradient={gradient} notAvailable claimingDisabled />
         ) : (
           <>
             {walletAddress && !isLoading && (
               <AjnaRewardCardBanner
                 banner={banner}
+                claimingDisabled
                 gradient={gradient}
                 onBtnClick={onBtnClick}
                 ownerPageLink={ownerPageLink}

--- a/features/ajna/common/controls/AjnaRewardsController.tsx
+++ b/features/ajna/common/controls/AjnaRewardsController.tsx
@@ -75,7 +75,6 @@ export function AjnaRewardsController() {
 
   return (
     <AnimatedWrapper>
-      <Button onClick={userAjnaRewards.refetch}>userAjnaRewards</Button>
       <AjnaHeader title={t('ajna.rewards.title')} intro={t('ajna.rewards.intro')} />
       {!isConnected && (
         <Flex sx={{ justifyContent: 'center', mb: 5 }}>

--- a/features/ajna/common/controls/AjnaRewardsController.tsx
+++ b/features/ajna/common/controls/AjnaRewardsController.tsx
@@ -75,6 +75,7 @@ export function AjnaRewardsController() {
 
   return (
     <AnimatedWrapper>
+      <Button onClick={userAjnaRewards.refetch}>userAjnaRewards</Button>
       <AjnaHeader title={t('ajna.rewards.title')} intro={t('ajna.rewards.intro')} />
       {!isConnected && (
         <Flex sx={{ justifyContent: 'center', mb: 5 }}>

--- a/features/ajna/common/controls/AjnaRewardsController.tsx
+++ b/features/ajna/common/controls/AjnaRewardsController.tsx
@@ -102,8 +102,8 @@ export function AjnaRewardsController() {
         <AjnaRewardCard
           key="oasisRewards"
           isLoading={false}
-          notAvailable
-          rewards={{ tokens: zero, usd: zero, numberOfPositions: 0 }}
+          // notAvailable
+          rewards={{ tokens: zero, usd: zero, }}
           {...oasisRewardsCard}
           floatingLabel={
             <FloatingLabel

--- a/features/ajna/common/controls/AjnaRewardsController.tsx
+++ b/features/ajna/common/controls/AjnaRewardsController.tsx
@@ -5,10 +5,10 @@ import { WithArrow } from 'components/WithArrow'
 import { AjnaHaveSomeQuestions } from 'features/ajna/common/components/AjnaHaveSomeQuestions'
 import { AjnaHeader } from 'features/ajna/common/components/AjnaHeader'
 import { AjnaRewardCard } from 'features/ajna/common/components/AjnaRewardCard'
+import { useAjnaRewards } from 'features/ajna/rewards/useAjnaRewards'
 import { useAjnaUserNfts } from 'features/ajna/rewards/useAjnaUserNfts'
 import { useConnection } from 'features/web3OnBoard'
 import { useAccount } from 'helpers/useAccount'
-import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React, { useCallback } from 'react'
 import { Button, Flex } from 'theme-ui'
@@ -63,9 +63,9 @@ const oasisRewardsCard = {
 export function AjnaRewardsController() {
   const { t } = useTranslation()
   const userNftsData = useAjnaUserNfts()
+  const userAjnaRewards = useAjnaRewards()
 
   const { isConnected } = useAccount()
-
   const { connect } = useConnection({ initialConnect: false })
 
   const handleConnect = useCallback(async () => {
@@ -101,9 +101,8 @@ export function AjnaRewardsController() {
         />
         <AjnaRewardCard
           key="oasisRewards"
-          isLoading={false}
-          // notAvailable
-          rewards={{ tokens: zero, usd: zero, }}
+          isLoading={userAjnaRewards.isLoading}
+          rewards={userAjnaRewards.rewards}
           {...oasisRewardsCard}
           floatingLabel={
             <FloatingLabel

--- a/features/ajna/common/controls/AjnaRewardsController.tsx
+++ b/features/ajna/common/controls/AjnaRewardsController.tsx
@@ -20,7 +20,6 @@ const miningRewardsCard = {
     'ajna.rewards.cards.mining.list-1',
     'ajna.rewards.cards.mining.list-2',
     'ajna.rewards.cards.mining.list-3',
-    'ajna.rewards.cards.mining.list-4',
   ],
   // TODO update link once available
   link: { title: 'ajna.rewards.cards.mining.link', href: '/' },

--- a/features/ajna/positions/common/helpers/getAjnaRewards.ts
+++ b/features/ajna/positions/common/helpers/getAjnaRewards.ts
@@ -1,0 +1,22 @@
+import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+
+export interface AjnaClaimedReward {
+  id: number
+  user: string
+  week: number
+  amount: number
+}
+
+type GetAjnaRewards = (walletAddress: string) => Promise<AjnaClaimedReward[]>
+
+export const getAjnaRewards: GetAjnaRewards = async (walletAddress: string) => {
+  const { response } = await loadSubgraph('Ajna', 'getClaimedRewards', {
+    walletAddress: walletAddress.toLowerCase(),
+  })
+
+  if (response && 'claimeds' in response) {
+    return response.claimeds
+  }
+
+  throw new Error('No claimed rewards data found')
+}

--- a/features/ajna/rewards/useAjnaRewards.ts
+++ b/features/ajna/rewards/useAjnaRewards.ts
@@ -1,0 +1,85 @@
+import BigNumber from 'bignumber.js'
+import { useCustomNetworkParameter } from 'blockchain/networks'
+import { Rewards } from 'features/ajna/common/components/AjnaRewardCard'
+import { getAjnaRewardsData } from 'handlers/ajna-rewards/getAjnaRewardsData'
+import { useAccount } from 'helpers/useAccount'
+import { zero } from 'helpers/zero'
+import { useCallback, useEffect, useState } from 'react'
+
+interface AjnaRewardsParamsState {
+  rewards: Rewards
+  isError: boolean
+  isLoading: boolean
+  refetch(): void
+}
+
+const defaultRewards = {
+  tokens: zero,
+  usd: zero,
+}
+const errorState = {
+  rewards: defaultRewards,
+  isError: true,
+  isLoading: false,
+}
+
+export const useAjnaRewards = (): AjnaRewardsParamsState => {
+  const { walletAddress } = useAccount()
+  const [networkParameter] = useCustomNetworkParameter()
+  const [state, setState] = useState<AjnaRewardsParamsState>({
+    rewards: defaultRewards,
+    isError: false,
+    isLoading: true,
+    refetch: () => {},
+  })
+
+  const fetchData = useCallback(async (): Promise<void> => {
+    setState({
+      ...state,
+      isLoading: true,
+    })
+
+    if (walletAddress && networkParameter) {
+      Promise.all([
+        fetch(`/api/ajna-rewards?address=${walletAddress}&networkId=${networkParameter.id}`),
+        // getAjnaPoolData(NetworkIds.GOERLI, tickers),
+      ])
+        .then(async ([apiResponse]) => {
+          const parseApiResponse = (await apiResponse.json()) as Awaited<
+            ReturnType<typeof getAjnaRewardsData>
+          >
+
+          if (parseApiResponse.amount) {
+            setState({
+              ...state,
+              rewards: {
+                tokens: new BigNumber(parseApiResponse.amount),
+                usd: zero,
+              },
+              isError: false,
+              isLoading: false,
+            })
+          }
+          if (parseApiResponse.error) {
+            setState({
+              ...state,
+              ...errorState,
+            })
+          }
+        })
+        .catch(() => {
+          setState({
+            ...state,
+            ...errorState,
+          })
+        })
+    }
+  }, [walletAddress, networkParameter?.id])
+
+  useEffect(() => void fetchData(), [fetchData])
+
+  return {
+    ...state,
+    refetch: useCallback(() => fetchData(), [fetchData]),
+  }
+}

--- a/features/ajna/rewards/useAjnaRewards.ts
+++ b/features/ajna/rewards/useAjnaRewards.ts
@@ -42,7 +42,11 @@ export const useAjnaRewards = (): AjnaRewardsParamsState => {
 
     if (walletAddress && networkParameter) {
       Promise.all([
-        fetch(`/api/ajna-rewards?address=${walletAddress}&networkId=${networkParameter.id}`),
+        fetch(
+          `/api/ajna-rewards?address=${walletAddress.toLocaleLowerCase()}&networkId=${
+            networkParameter.id
+          }`,
+        ),
         getAjnaRewards(walletAddress),
       ])
         .then(async ([apiResponse, subgraphResponse]) => {
@@ -56,6 +60,7 @@ export const useAjnaRewards = (): AjnaRewardsParamsState => {
               ...state,
               rewards: {
                 tokens: new BigNumber(parseApiResponse.amount).minus(claimed),
+                // TODO: recalculate when Ajna Token value is available
                 usd: zero,
               },
               isError: false,
@@ -82,6 +87,6 @@ export const useAjnaRewards = (): AjnaRewardsParamsState => {
 
   return {
     ...state,
-    refetch: useCallback(() => fetchData(), [fetchData]),
+    refetch: fetchData,
   }
 }

--- a/features/content/faqs/ajna/borrow/en.mdx
+++ b/features/content/faqs/ajna/borrow/en.mdx
@@ -74,7 +74,7 @@ process you can repay your debt or add more collateral to recollateralize your p
 
 ##### What are the token rewards?
 
-Selected pools receive Summer.fi x Ajna rewards weekly. These rewards incentivize early adopters of
+Selected pools receive Summer.fi × Ajna rewards weekly. These rewards incentivize early adopters of
 Ajna who use Summer.fi Smart DeFi Account. It accrues automatically with no staking needed and can
 be claimed weekly after tokens are released.
 

--- a/features/content/faqs/ajna/earn/en.mdx
+++ b/features/content/faqs/ajna/earn/en.mdx
@@ -55,7 +55,7 @@ liquidity goes up the rate will go up and if it has little use the rate will go 
 
 ##### What are the token rewards?
 
-Selected pools receive Summer.fi x Ajna rewards weekly. These rewards incentivize early adopters of
+Selected pools receive Summer.fi × Ajna rewards weekly. These rewards incentivize early adopters of
 Ajna who use Summer.fi Smart DeFi Account. It accrues automatically with no staking needed and can
 be claimed weekly after tokens are released.
 

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -187,5 +187,12 @@ export const subgraphMethodsRecord: {
       }
     }
   `,
+  getClaimedRewards: gql`
+    query getClaimed($walletAddress: ID!) {
+      claimeds(where: { user: $walletAddress }) {
+        amount
+      }
+    }
+  `,
   tempMethod: '',
 }

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -2,6 +2,7 @@ import { NetworkIds } from 'blockchain/networks'
 import { AjnaHistoryResponse } from 'features/ajna/positions/common/helpers/getAjnaHistory'
 import { AjnaPoolDataResponse } from 'features/ajna/positions/common/helpers/getAjnaPoolData'
 import { AjnaPoolsDataResponse } from 'features/ajna/positions/common/helpers/getAjnaPoolsTableData'
+import { AjnaClaimedReward } from 'features/ajna/positions/common/helpers/getAjnaRewards'
 import { AjnaPositionAuctionResponse } from 'features/ajna/rewards/helpers/getAjnaPositionAuction'
 import { AjnaUserNftsResponse } from 'features/ajna/rewards/helpers/getAjnaUserNfts'
 
@@ -13,6 +14,7 @@ export type Subgraphs = {
     getNftIds: { walletAddress: string }
     getPositionAuction: { dpmProxyAddress: string }
     getHistory: { dpmProxyAddress: string }
+    getClaimedRewards: { walletAddress: string }
   }
   TempGraph: {
     tempMethod: undefined
@@ -50,6 +52,7 @@ export type SubgraphsResponses = {
     getNftIds: SubgraphBaseResponse<{ nfts: AjnaUserNftsResponse[] }>
     getPositionAuction: SubgraphBaseResponse<{ auctions: AjnaPositionAuctionResponse[] }>
     getAjnaHistory: SubgraphBaseResponse<{ oasisEvents: AjnaHistoryResponse[] }>
+    getClaimedRewards: SubgraphBaseResponse<{ claimeds: AjnaClaimedReward[] }>
   }
   TempGraph: {
     tempMethod: SubgraphBaseResponse<undefined>

--- a/handlers/ajna-rewards/get.tsx
+++ b/handlers/ajna-rewards/get.tsx
@@ -1,0 +1,8 @@
+import { getAjnaRewardsData } from 'handlers/ajna-rewards/getAjnaRewardsData'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export async function get(req: NextApiRequest, res: NextApiResponse) {
+  const response = await getAjnaRewardsData(req.query)
+
+  return res.status(response.error ? 500 : 200).json(response)
+}

--- a/handlers/ajna-rewards/getAjnaRewardsData.ts
+++ b/handlers/ajna-rewards/getAjnaRewardsData.ts
@@ -1,0 +1,45 @@
+import BigNumber from 'bignumber.js'
+import { NEGATIVE_WAD_PRECISION } from 'components/constants'
+import { zero } from 'helpers/zero'
+import { NextApiRequest } from 'next'
+import { prisma } from 'server/prisma'
+import * as z from 'zod'
+
+const querySchema = z.object({
+  address: z.string(),
+  networkId: z.string(),
+})
+
+export async function getAjnaRewardsData(query: NextApiRequest['query']) {
+  try {
+    querySchema.parse(query)
+  } catch (error) {
+    return {
+      errorMessage: 'Invalid GET parameters',
+      error: String(error),
+    }
+  }
+
+  const { address, networkId } = querySchema.parse(query)
+
+  try {
+    return {
+      amount: (
+        await prisma.ajnaRewardsWeeklyClaim.findMany({
+          where: {
+            user_address: address,
+            chain_id: parseInt(networkId, 10),
+          },
+        })
+      )
+        .reduce<BigNumber>((total, current) => total.plus(new BigNumber(current.amount)), zero)
+        .shiftedBy(NEGATIVE_WAD_PRECISION)
+        .toString(),
+    }
+  } catch (error) {
+    return {
+      errorMessage: 'Unknown error occured',
+      error: String(error),
+    }
+  }
+}

--- a/pages/api/ajna-rewards/index.tsx
+++ b/pages/api/ajna-rewards/index.tsx
@@ -1,0 +1,12 @@
+import { get } from 'handlers/ajna-rewards/get'
+import { NextApiHandler } from 'next'
+
+const handler: NextApiHandler = async (req, res) => {
+  switch (req.method) {
+    case 'GET':
+      return await get(req, res)
+    default:
+      return res.status(405).end()
+  }
+}
+export default handler

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2778,9 +2778,8 @@
         "mining": {
           "title": "AJNA Protocol Rewards",
           "list-1": "Rewards Earn Positions only",
-          "list-2": "Fortnightly Claim period",
-          "list-3": "Earn proportionally to % of pool interest generated",
-          "list-4": "You need to opt-in to stake your positions",
+          "list-2": "Earn proportionally to % of pool interest generated",
+          "list-3": "You need to opt-in to stake your positions",
           "link": "Learn more about Ajna Liquidity Mining Rewards",
           "banner": {
             "title": "AJNA Liquidity Mining Rewards "

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2576,7 +2576,7 @@
           },
           "nft": {
             "intro": "The Ajna rewards this position is eligible for",
-            "token-rewards": "Summer.fi x AJNA Token Rewards",
+            "token-rewards": "Summer.fi × AJNA Token Rewards",
             "protocol-rewards": "AJNA Protocol Rewards",
             "opt": "Ajna Protocol Rewards are switched off by default as the gas fees could cost more than the rewards.",
             "bullet-points": {
@@ -2787,7 +2787,7 @@
           }
         },
         "token": {
-          "title": "Summer.fi x Ajna Token Rewards",
+          "title": "Summer.fi × Ajna Token Rewards",
           "list-1": "Rewards exclusive to Summer.fi users!",
           "list-2": "Rewards for Borrowing, Lending and Multiplying",
           "list-3": "Tokens will be claimable weekly in the near future",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2798,7 +2798,8 @@
           "floatingLabel": "Exclusive to Summer.fi"
         },
         "earning-across": "Earning across <1><2>{{value}} Ajna positions</2></1>",
-        "button": "Claim AJNA tokens"
+        "button": "Claim AJNA tokens",
+        "button-disabled": "Claiming available soon"
       }
     },
     "product-hub-tooltips": {


### PR DESCRIPTION
# [Add balances to Ajna rewards page](https://app.shortcut.com/oazo-apps/story/10016/remove-fortnightly-claim-period-add-balance-from-ajna-rewards)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/bba16b89-26a8-42bc-be93-3ab74762e560)
  
## Changes 👷‍♀️

- Created `/api/ajna-rewards` endpoint for loading rewards data from database,
- created `getClaimedRewards` query for loading data from subgraph,
- created `useAjnaRewards` hook for handling rewards data,
- added allowing to disable claiming button on demand,
- removed "Earning on {{amount}} of positions".
  
## How to test 🧪

This has to be thoroughly tested when actual data is available. Currently, both database and subgraph response are empty, so some tweaking around formatting, precision etc. might be required.
