### PR TITLE
🧿 Various copy updates and typo fixes

### DIFF
--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -100,10 +100,8 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManu
         step={range.at(-1)!.minus(range.at(-2)!).toNumber()}
         leftBoundry={leftBoundry}
         rightBoundry={maxLtv}
-        leftBoundryFormatter={(v) => `${t('price')} $${formatAmount(v, 'USD')}`}
-        rightBoundryFormatter={(v) =>
-          !v.isZero() ? `${t('max-ltv')} ${formatDecimalAsPercent(v)}` : '-'
-        }
+        leftBoundryFormatter={(v) => `$${formatAmount(v, 'USD')}`}
+        rightBoundryFormatter={(v) => (!v.isZero() ? formatDecimalAsPercent(v) : '-')}
         disabled={isDisabled || isFormFrozen}
         onChange={handleChange}
         leftLabel={t('ajna.position-page.earn.common.form.token-pair-lending-price', {

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -59,7 +59,7 @@ function parseProduct(
             </>
           ),
         },
-        liquidityAvailable: {
+        liquidity: {
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
@@ -95,7 +95,7 @@ function parseProduct(
             </>
           ),
         },
-        liquidityAvailable: {
+        liquidity: {
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>
@@ -145,7 +145,7 @@ function parseProduct(
             </>
           ),
         },
-        liquidityAvailable: {
+        liquidity: {
           sortable: liquidity?.toNumber() || 0,
           value: (
             <>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2479,8 +2479,8 @@
     },
     "other-assets": "Other assets you can borrow against",
     "landing-banner": {
-      "title": "Get Ajna token when you use Ajna protocol",
-      "description": "summer.fi users are eligible for exclusive Ajna token rewards! Open and Ajna position through summer.fi and automatically earn Ajna tokens.",
+      "title": "Get exclusive Ajna tokens when you use Summer.fi",
+      "description": "Summer.fi users are eligible for exclusive Ajna token rewards! Open Ajna position through Summer.fi and automatically earn Ajna tokens.",
       "button-label": "See my rewards →",
       "link-label": "Visit Ajna website →"
     },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2693,7 +2693,7 @@
             "early-withdrawal-ends-in": "{{earlyWithdrawalPenalty}} (ends {{earlyWithdrawalPeriod}})",
             "early-withdrawal-period": "Early withdrawal period",
             "max-lending-ltv": "Max lending LTV",
-            "max-lending-ltv-modal-desc": "The max lending LTV represents the % of {{quoteToken}} you are willing to lend for each unit of {{collateralToken}}. This value moves as the price of {{collateralToken}}/{{quoteToken}} changes. You should adjust your position as the price changes to earn yield in a safe way:",
+            "max-lending-ltv-modal-desc": "The max lending LTV represents the terms you are offering to borrowers. Your selected price divided the market price represents the maximum LTV you are allowing others to borrow against their collateral for your lent asset.",
             "net-pnl": "Net PnL: {{netPnL}}",
             "position-lending-price": "Position lending price",
             "position-lending-price-modal-desc": "The lending price is akin to a limit order, if the market price hits the selected price you will be left with collateral tokens. It's expected that borrowers are liquidated some time before your price is reached, and you will be able to withdraw funds in the token you deposited.",


### PR DESCRIPTION
# Various copy updates and typo fixes

Covers:
https://app.shortcut.com/oazo-apps/story/10302/change-max-lending-price-tooltip-text
https://app.shortcut.com/oazo-apps/story/10269/typo-on-landing-page
https://discord.com/channels/837076147694207067/1127946676783558777/1127953189568786472
https://discord.com/channels/837076147694207067/839063661884080128/1127959896193761363
  
## Changes 👷‍♀️

- Updated Max LTV modal copy,
- fixed typos on Ajna landing page,
- removed redundant labels from Earn price slider,
- renamed "Available liquidity" to just "Liquidity" in product finder.
  
## How to test 🧪

Self explanatory.
