### PR TITLE
Adjust Ajna liquidation condition

### DIFF
--- a/features/ajna/positions/common/observables/getAjnaPositionAuction.ts
+++ b/features/ajna/positions/common/observables/getAjnaPositionAuction.ts
@@ -54,12 +54,12 @@ export const getAjnaPositionAuction$ = ({
             auction.collateral.gt(zero) &&
             auction.debtToCover.gt(zero) &&
             !auction.inLiquidation &&
-            !!auction.endOfGracePeriod
+            !isDuringGraceTime
 
           const isLiquidated =
             auction.debtToCover.isZero() &&
             !auction.inLiquidation &&
-            !!auction.endOfGracePeriod &&
+            !isDuringGraceTime &&
             !isPartiallyLiquidated
 
           const graceTimeRemaining = timeAgo({


### PR DESCRIPTION
# [Adjust Ajna liquidation condition](https://app.shortcut.com/oazo-apps/story/10322/borrow-position-is-showing-liquidated-when-it-is-not)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- partially handled case from story, adjusted condition so it verify whether position is in grace period and if so, liquidation notifications are not displayed
  
## How to test 🧪
  <Please explain how to test your changes>

- there should be no situation where grace period notification and notifications that position has been liquidated are visible in the same time
