### PR TITLE
Fix owner page if someone use dpm proxy address instead of wallet address

### DIFF
--- a/features/ajna/positions/common/observables/getAjnaPosition.ts
+++ b/features/ajna/positions/common/observables/getAjnaPosition.ts
@@ -100,6 +100,9 @@ export function getAjnaPositionsWithDetails$(
         (a, v) => ({ ...a, [v.proxy]: v.vaultId }),
         {},
       )
+
+      if (positionCreatedEvents.length === 0) return of([])
+
       const tokens: string[] = uniq(
         positionCreatedEvents
           .map(({ collateralTokenSymbol, debtTokenSymbol }) => [


### PR DESCRIPTION
# [Fix owner page if someone use dpm proxy address instead of wallet address](https://app.shortcut.com/oazo-apps/story/10318/my-portfolio-breaks-when-a-liquidation-is-active-in-a-loan)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added condition which verifies length of position created events in ajna observable
  
## How to test 🧪
  <Please explain how to test your changes>

- there should be no infinity loading on owner page when someone use dpm proxy address in url instead of wallet address
