### PR TITLE
🧿 Fix Ajna Earn weekly APY calculcation in Product Finder

### DIFF
--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -4,7 +4,7 @@ import { getNetworkContracts } from 'blockchain/contracts'
 import { NetworkIds, networksById } from 'blockchain/networks'
 import { getTokenPrice, Tickers } from 'blockchain/prices'
 import { getTokenSymbolFromAddress } from 'blockchain/tokensMetadata'
-import { WAD_PRECISION } from 'components/constants'
+import { NEGATIVE_WAD_PRECISION, WAD_PRECISION } from 'components/constants'
 import {
   AjnaPoolsTableData,
   getAjnaPoolsTableData,
@@ -74,7 +74,7 @@ async function getAjnaPoolData(
             },
           },
         ) => {
-          const negativeWadPrecision = WAD_PRECISION * -1
+          const isPoolNotEmpty = lowestUtilizedPriceIndex > 0
           const isShort = isShortPosition({ collateralToken })
           const isYieldLoop = isYieldLoopPool({ collateralToken, quoteToken })
           const collateralPrice = prices[collateralToken]
@@ -93,7 +93,7 @@ async function getAjnaPoolData(
             debt: debt.shiftedBy(WAD_PRECISION),
             highestThresholdPriceIndex: new BigNumber(highestThresholdPriceIndex),
           })
-            .shiftedBy(negativeWadPrecision)
+            .shiftedBy(NEGATIVE_WAD_PRECISION)
             .times(prices[quoteToken])
             .toString()
           const fee = interestRate.toString()
@@ -143,7 +143,7 @@ async function getAjnaPoolData(
                 ...getTokenGroup(quoteToken, 'secondary'),
                 fee,
                 liquidity,
-                ...(lowestUtilizedPriceIndex > 0 && {
+                ...(isPoolNotEmpty && {
                   maxLtv,
                   maxMultiply,
                 }),
@@ -152,16 +152,18 @@ async function getAjnaPoolData(
                 ...(isYieldLoop && {
                   earnStrategy: earnYieldLoopStrategy,
                   managementType,
-                  weeklyNetApy,
+                  ...(isPoolNotEmpty && {
+                    weeklyNetApy,
+                  }),
                 }),
                 tooltips: {
                   ...(isPoolWithRewards({ collateralToken, quoteToken }) && {
                     fee: ajnaRewardsTooltip,
+                    ...(isPoolNotEmpty && {
+                      weeklyNetApy: ajnaRewardsTooltip,
+                    }),
                   }),
-                  ...(isYieldLoop && {
-                    weeklyNetApy: ajnaRewardsTooltip,
-                  }),
-                  ...(lowestUtilizedPriceIndex === 0 && {
+                  ...(!isPoolNotEmpty && {
                     maxLtv: {
                       content: {
                         description: {
@@ -175,6 +177,15 @@ async function getAjnaPoolData(
                       content: {
                         description: {
                           key: 'ajna.product-hub-tooltips.no-max-multiple',
+                        },
+                      },
+                      icon: 'question_o',
+                      iconColor: 'neutral80',
+                    },
+                    weeklyNetApy: {
+                      content: {
+                        description: {
+                          key: 'ajna.product-hub-tooltips.no-weekly-apy',
                         },
                       },
                       icon: 'question_o',
@@ -195,11 +206,25 @@ async function getAjnaPoolData(
                 earnStrategy: earnLPStrategy,
                 liquidity,
                 managementType,
-                weeklyNetApy,
+                ...(isPoolNotEmpty && {
+                  weeklyNetApy,
+                }),
                 reverseTokens: true,
                 tooltips: {
-                  ...(isPoolWithRewards({ collateralToken, quoteToken }) && {
-                    weeklyNetApy: ajnaRewardsTooltip,
+                  ...(isPoolNotEmpty &&
+                    isPoolWithRewards({ collateralToken, quoteToken }) && {
+                      weeklyNetApy: ajnaRewardsTooltip,
+                    }),
+                  ...(!isPoolNotEmpty && {
+                    weeklyNetApy: {
+                      content: {
+                        description: {
+                          key: 'ajna.product-hub-tooltips.no-weekly-apy',
+                        },
+                      },
+                      icon: 'question_o',
+                      iconColor: 'neutral80',
+                    },
                   }),
                 },
               },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2817,6 +2817,7 @@
     "product-hub-tooltips": {
       "no-max-ltv": "There are currently no borrow or multiply positions for this pool. Max LTV will be calculated following the creation of the first position.",
       "no-max-multiple": "There are currently no borrow or multiply positions for this pool. Max multiple will be calculated following the creation of the first position.",
+      "no-weekly-apy": "There are currently no borrow or multiply positions for this pool. 7 day net APY will be calculated following the creation of the first position.",
       "rewards-available-soon": "Rewards are earned automatically and will be claimable weekly in the near future.",
       "this-pool-is-earning-ajna-tokens": "This pool is earning Summer.fi × Ajna token Rewards"
     }


### PR DESCRIPTION
# Fix Ajna Earn weekly APY calculcation in Product Finder

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/93143836-cd17-40d2-8701-b4e6dec3e26e)
  
## Changes 👷‍♀️

- Fixed an issue where `NaN` was shown as an weekly APY instead of `n/a` with tooltip with explanation.
  
## How to test 🧪

Run Product Finder PATH and check Product Finder - currently most of the pools on mainnet are empty.
