### PR TITLE
Set Ajna feature flat to `true`

### DIFF
--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -73,7 +73,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   FollowVaults: true,
   AaveV3Protection: false,
   AaveV3ProtectionWrite: false,
-  Ajna: false,
+  Ajna: true,
   AjnaSafetySwitch: false,
   AjnaSuppressValidation: false,
   DaiSavingsRate: true,


### PR DESCRIPTION
# Set Ajna feature flat to `true`

![giphy](https://github.com/OasisDEX/oasis-borrow/assets/16230404/5ff9fe4d-6e46-4085-b4f0-b2f1a334a3dc)

## Changes 👷‍♀️

- Set `Ajna` feature flag to `true` by default.

## How to test 🧪

Go to `/ajna` in incognito mode - if you didn't got redirected, it is working.