### PR TITLE
Ajna remove ajna earn market price offset

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -52,5 +52,4 @@ export const LTVWarningThreshold = new BigNumber(0.05)
 export const ajnaLastIndexBucketPrice = new BigNumber(99836282890)
 
 // safe defaults which should ensure reasonable slider range for newly created pools
-export const ajnaDefaultPoolRangeMarketPriceOffset = 0.9 // 90%
-export const ajnaDefaultMarketPriceOffset = 0.25 // 25%
+export const ajnaDefaultPoolRangeMarketPriceOffset = 0.99 // 90%

--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -52,4 +52,4 @@ export const LTVWarningThreshold = new BigNumber(0.05)
 export const ajnaLastIndexBucketPrice = new BigNumber(99836282890)
 
 // safe defaults which should ensure reasonable slider range for newly created pools
-export const ajnaDefaultPoolRangeMarketPriceOffset = 0.99 // 90%
+export const ajnaDefaultPoolRangeMarketPriceOffset = 0.99 // 99%

--- a/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
+++ b/features/ajna/positions/earn/helpers/getMinMaxAndRange.ts
@@ -1,9 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { WAD_PRECISION } from 'components/constants'
-import {
-  ajnaDefaultMarketPriceOffset,
-  ajnaDefaultPoolRangeMarketPriceOffset,
-} from 'features/ajna/common/consts'
+import { ajnaDefaultPoolRangeMarketPriceOffset } from 'features/ajna/common/consts'
 import { snapToPredefinedValues } from 'features/ajna/positions/earn/helpers/snapToPredefinedValues'
 import { one, zero } from 'helpers/zero'
 
@@ -26,11 +23,7 @@ export const getMinMaxAndRange = ({
   if (lowestUtilizedPriceIndex.eq(zero)) {
     const defaultRange = [marketPrice.times(one.minus(ajnaDefaultPoolRangeMarketPriceOffset))]
 
-    while (
-      defaultRange[defaultRange.length - 1].lt(
-        marketPrice.times(one.minus(ajnaDefaultMarketPriceOffset)),
-      )
-    ) {
+    while (defaultRange[defaultRange.length - 1].lt(marketPrice)) {
       defaultRange.push(
         defaultRange[defaultRange.length - 1].times(1.005).decimalPlaces(WAD_PRECISION),
       )


### PR DESCRIPTION
# Ajna remove ajna earn market price offset

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- remove ajna earn market price offset on slider for pools that are not utilized
  
## How to test 🧪
  <Please explain how to test your changes>

- on stable pools it should be possible to set ltv near 100% (on slider)
