### PR TITLE
Bring back max generate validations and calculations

### DIFF
--- a/features/ajna/positions/borrow/components/ContentFooterItemsBorrow.tsx
+++ b/features/ajna/positions/borrow/components/ContentFooterItemsBorrow.tsx
@@ -26,7 +26,7 @@ interface ContentFooterItemsBorrowProps {
 }
 
 export function ContentFooterItemsBorrow({
-  // isLoading,
+  isLoading,
   collateralToken,
   quoteToken,
   owner,
@@ -35,8 +35,8 @@ export function ContentFooterItemsBorrow({
   afterAvailableToBorrow,
   availableToWithdraw,
   afterAvailableToWithdraw,
-}: // changeVariant = 'positive',
-ContentFooterItemsBorrowProps) {
+  changeVariant = 'positive',
+}: ContentFooterItemsBorrowProps) {
   const { t } = useTranslation()
   const userAjnaRewards = useAjnaRewards(owner)
 
@@ -124,26 +124,26 @@ ContentFooterItemsBorrowProps) {
       {/*    />*/}
       {/*  }*/}
       {/*/>*/}
-      {/*<DetailsSectionFooterItem*/}
-      {/*  title={t('ajna.position-page.borrow.common.footer.available-to-borrow')}*/}
-      {/*  value={formatted.availableToBorrow}*/}
-      {/*  change={{*/}
-      {/*    isLoading,*/}
-      {/*    value:*/}
-      {/*      afterAvailableToBorrow &&*/}
-      {/*      `${formatted.afterAvailableToBorrow} ${t('system.cards.common.after')}`,*/}
-      {/*    variant: changeVariant,*/}
-      {/*  }}*/}
-      {/*  modal={*/}
-      {/*    <AjnaDetailsSectionContentSimpleModal*/}
-      {/*      title={t('ajna.position-page.borrow.common.footer.available-to-borrow')}*/}
-      {/*      description={t(*/}
-      {/*        'ajna.position-page.borrow.common.footer.available-to-borrow-modal-desc',*/}
-      {/*      )}*/}
-      {/*      value={formatted.availableToBorrow}*/}
-      {/*    />*/}
-      {/*  }*/}
-      {/*/>*/}
+      <DetailsSectionFooterItem
+        title={t('ajna.position-page.borrow.common.footer.available-to-borrow')}
+        value={formatted.availableToBorrow}
+        change={{
+          isLoading,
+          value:
+            afterAvailableToBorrow &&
+            `${formatted.afterAvailableToBorrow} ${t('system.cards.common.after')}`,
+          variant: changeVariant,
+        }}
+        modal={
+          <AjnaDetailsSectionContentSimpleModal
+            title={t('ajna.position-page.borrow.common.footer.available-to-borrow')}
+            description={t(
+              'ajna.position-page.borrow.common.footer.available-to-borrow-modal-desc',
+            )}
+            value={formatted.availableToBorrow}
+          />
+        }
+      />
     </>
   )
 }

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormOrder.tsx
@@ -121,12 +121,12 @@ export function AjnaBorrowFormOrder({ cached = false }: { cached?: boolean }) {
         //   change: formatted.afterAvailableToWithdraw,
         //   isLoading,
         // },
-        // {
-        //   label: t('system.available-to-borrow'),
-        //   value: formatted.availableToBorrow,
-        //   change: formatted.afterAvailableToBorrow,
-        //   isLoading,
-        // },
+        {
+          label: t('system.available-to-borrow'),
+          value: formatted.availableToBorrow,
+          change: formatted.afterAvailableToBorrow,
+          isLoading,
+        },
         ...(isTxSuccess && cached
           ? [
               {

--- a/features/ajna/positions/common/sidebars/AjnaFormFields.tsx
+++ b/features/ajna/positions/common/sidebars/AjnaFormFields.tsx
@@ -129,9 +129,7 @@ export function AjnaFormFieldGenerate({
       minAmount={minAmount}
       minAmountLabel={t(minAmountLabel)}
       minAuxiliaryAmount={minAmount?.times(quotePrice)}
-      // TODO uncomment once max amount calculated properly
-      // showMax={maxAmount?.gt(zero)}
-      showMax={false}
+      showMax={maxAmount?.gt(zero)}
       maxAmount={maxAmount}
       maxAmountLabel={t(maxAmountLabel)}
       maxAuxiliaryAmount={maxAmount?.times(quotePrice)}
@@ -258,7 +256,7 @@ export function AjnaFormFieldWithdraw({
       hasAuxiliary={true}
       hasError={false}
       disabled={isDisabled || isFormFrozen}
-      showMax={false}
+      showMax={maxAmount?.gt(zero) && product === 'earn'}
       maxAmount={maxAmount}
       maxAmountLabel={t(maxAmountLabel)}
       maxAuxiliaryAmount={maxAmount?.times(tokenPrice)}

--- a/features/ajna/positions/earn/components/ContentFooterItemsEarnManage.tsx
+++ b/features/ajna/positions/earn/components/ContentFooterItemsEarnManage.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { ChangeVariantType } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItem } from 'components/DetailsSectionFooterItem'
 import { Skeleton } from 'components/Skeleton'
 import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
@@ -15,6 +16,8 @@ interface ContentFooterItemsEarnOpenProps {
   availableToWithdraw: BigNumber
   projectedAnnualReward: BigNumber
   afterAvailableToWithdraw?: BigNumber
+  isLoading?: boolean
+  changeVariant?: ChangeVariantType
 }
 
 export function ContentFooterItemsEarnManage({
@@ -23,6 +26,8 @@ export function ContentFooterItemsEarnManage({
   owner,
   availableToWithdraw,
   afterAvailableToWithdraw,
+  isLoading,
+  changeVariant = 'positive',
 }: ContentFooterItemsEarnOpenProps) {
   const { t } = useTranslation()
   const userAjnaRewards = useAjnaRewards(owner)
@@ -46,6 +51,11 @@ export function ContentFooterItemsEarnManage({
       <DetailsSectionFooterItem
         title={t('system.available-to-withdraw')}
         value={formatted.availableToWithdraw}
+        change={{
+          isLoading,
+          value: formatted.afterAvailableToWithdraw,
+          variant: changeVariant,
+        }}
         modal={
           <AjnaDetailsSectionContentSimpleModal
             title={t('ajna.position-page.earn.manage.overview.available-to-withdraw')}

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -1,4 +1,8 @@
-import { calculateAjnaMaxLiquidityWithdraw, normalizeValue } from '@oasisdex/dma-library'
+import {
+  calculateAjnaMaxLiquidityWithdraw,
+  negativeToZero,
+  normalizeValue,
+} from '@oasisdex/dma-library'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
@@ -23,6 +27,9 @@ export function AjnaEarnOverviewManageController() {
       isSimulationLoading,
       currentPosition: { position, simulation },
     },
+    form: {
+      state: { withdrawAmount },
+    },
     notifications,
   } = useAjnaProductContext('earn')
 
@@ -30,6 +37,12 @@ export function AjnaEarnOverviewManageController() {
   const relationToMarketPrice = one.minus(
     isShort ? normalizeValue(one.div(liquidationToMarketPrice)) : liquidationToMarketPrice,
   )
+
+  const availableToWithdraw = calculateAjnaMaxLiquidityWithdraw({
+    pool: position.pool,
+    position,
+    simulation,
+  })
 
   return (
     <DetailsSection
@@ -72,17 +85,16 @@ export function AjnaEarnOverviewManageController() {
       footer={
         <DetailsSectionFooterItemWrapper>
           <ContentFooterItemsEarnManage
+            isLoading={isSimulationLoading}
             collateralToken={collateralToken}
             quoteToken={quoteToken}
             owner={owner}
-            availableToWithdraw={calculateAjnaMaxLiquidityWithdraw({
-              pool: position.pool,
-              position,
-              simulation,
-            })}
+            availableToWithdraw={availableToWithdraw}
             // TODO adjust once data available in subgraph
             projectedAnnualReward={zero}
-            afterAvailableToWithdraw={simulation?.quoteTokenAmount}
+            afterAvailableToWithdraw={
+              simulation ? negativeToZero(availableToWithdraw.minus(withdrawAmount)) : undefined
+            }
           />
         </DetailsSectionFooterItemWrapper>
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.29",
     "@oasisdex/automation": "1.5.0-alpha.8",
-    "@oasisdex/dma-library": "0.3.39",
+    "@oasisdex/dma-library": "0.3.40",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,10 +3937,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.3.39":
-  version "0.3.39"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.39.tgz#3f08f132104b22156e1507d451f3ae3954d20ff9"
-  integrity sha512-B9gUu7oZa0gwm030CXIRkXnhHMghdfVZNsZxUa49lb+X4z3ceFX8sOjvt6Uk0qYSWIPqkEeewl2FHoTL4FxgdA==
+"@oasisdex/dma-library@0.3.40":
+  version "0.3.40"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.3.40.tgz#aa885327b01bca231a3ceaf2e6de3fe5cba7191d"
+  integrity sha512-OXQOUPSD2UNg7SjgRR1YlTucO+EryDpeuNJp+WDKIRvpWM4OMkjxPOYrqz2JgK+PAYG4xGUYWiWTJRc+kmy/cg==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Bring back max generate validations and calculations](https://app.shortcut.com/oazo-apps/story/10369/fix-calculations-for-available-to-borrow-and-available-to-withdraw)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- show max generate amount on ajna borrow UI + validations
- show max withdraw in earn UI
  
## How to test 🧪
  <Please explain how to test your changes>

- test whether max generate amount indeed make sense for different pools scenarios (multiple buckets, single bucket, while generating moving lup below htp etc.)
