### PR TITLE
display a label next to the position [sc-10124]

### DIFF
--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { Heading } from '@theme-ui/components'
 import { getTokens } from 'blockchain/tokensMetadata'
+import { ProtocolLabel, ProtocolLabelProps } from 'components/ProtocolLabel'
 import { Skeleton } from 'components/Skeleton'
 import {
   ShareButton,
@@ -27,6 +28,7 @@ export type VaultHeadlineProps = {
   shareButton?: boolean
   token?: string[]
   handleClick?: () => void
+  protocol?: ProtocolLabelProps
 }
 
 export function VaultHeadline({
@@ -38,6 +40,7 @@ export function VaultHeadline({
   shareButton,
   token = [],
   handleClick,
+  protocol,
 }: VaultHeadlineProps) {
   const tokenData = getTokens(token)
   const followVaultEnabled = useFeatureToggle('FollowVaults')
@@ -67,6 +70,7 @@ export function VaultHeadline({
           wordBreak: 'break-word',
         }}
       >
+        {/* ICON */}
         {tokenData instanceof Array && tokenData.length > 0 && (
           <Box sx={{ mr: 2, flexShrink: 0 }}>
             {tokenData.map(({ iconCircle }, iconIndex) => (
@@ -84,33 +88,49 @@ export function VaultHeadline({
             ))}
           </Box>
         )}
+        {/* VAULT TYPE/PAIR */}
         {header}
         {label && <Image src={staticFilesRuntimeUrl(label)} sx={{ ml: 3 }} />}
-        {followVaultEnabled && (
-          <Flex
-            sx={{
-              flexWrap: 'wrap',
-              flexShrink: 0,
-              alignItems: 'center',
-              columnGap: 2,
-              ml: 3,
-              '&:hover': {
-                '.tooltip': {
-                  whiteSpace: 'nowrap',
+        <Flex
+          sx={{
+            flexDirection: ['column', 'row', 'row', 'row'],
+            flexWrap: 'wrap',
+            flexShrink: 0,
+            alignItems: 'center',
+            columnGap: 2,
+            rowGap: 1,
+            ml: [0, 2],
+          }}
+        >
+          {/* PROTOCOL LABEL **/}
+          {protocol && <ProtocolLabel network={protocol.network} protocol={protocol.protocol} />}
+
+          {followVaultEnabled && (
+            <Flex
+              sx={{
+                flexWrap: 'wrap',
+                flexShrink: 0,
+                alignItems: 'center',
+                columnGap: 2,
+                ml: [0, 2],
+                '&:hover': {
+                  '.tooltip': {
+                    whiteSpace: 'nowrap',
+                  },
                 },
-              },
-            }}
-          >
-            {followButton && <FollowButtonControl {...followButton} />}
-            {shareButton && (
-              <ShareButton
-                text={twitterSharePositionText}
-                url={document.location.href.replace(document.location.hash, '')}
-                via={twitterSharePositionVia}
-              />
-            )}
-          </Flex>
-        )}
+              }}
+            >
+              {followButton && <FollowButtonControl {...followButton} />}
+              {shareButton && (
+                <ShareButton
+                  text={twitterSharePositionText}
+                  url={document.location.href.replace(document.location.hash, '')}
+                  via={twitterSharePositionVia}
+                />
+              )}
+            </Flex>
+          )}
+        </Flex>
       </Heading>
       <Flex
         sx={{

--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -53,8 +53,7 @@ export function VaultHeadline({
         flexDirection: ['column', 'column', null, 'row'],
         justifyContent: 'space-between',
         alignItems: ['flex-start', null, null, 'center'],
-        mb: 4,
-        rowGap: 3,
+        gap: 3,
       }}
       onClick={handleClick}
     >
@@ -63,63 +62,61 @@ export function VaultHeadline({
         variant="heading1"
         sx={{
           display: 'flex',
+          flexWrap: 'wrap',
+          gap: 2,
+          alignItems: 'center',
           fontWeight: 'semiBold',
           fontSize: '28px',
           color: 'primary100',
-          alignItems: 'center',
           wordBreak: 'break-word',
         }}
       >
-        {/* ICON */}
-        {tokenData instanceof Array && tokenData.length > 0 && (
-          <Box sx={{ mr: 2, flexShrink: 0 }}>
-            {tokenData.map(({ iconCircle }, iconIndex) => (
-              <Icon
-                key={`VaultHeadlineIcon_${iconCircle}`}
-                name={iconCircle}
-                size="32px"
-                sx={{
-                  verticalAlign: 'text-bottom',
-                  position: 'relative',
-                  zIndex: tokenData.length - iconIndex,
-                  mr: tokenData.length - 1 === iconIndex ? 0 : '-16px',
-                }}
-              />
-            ))}
-          </Box>
-        )}
-        {/* VAULT TYPE/PAIR */}
-        {header}
-        {label && <Image src={staticFilesRuntimeUrl(label)} sx={{ ml: 3 }} />}
+        {/* tokens & title */}
         <Flex
           sx={{
-            flexDirection: ['column', 'row', 'row', 'row'],
-            flexWrap: 'wrap',
+            flexDirection: 'row',
             flexShrink: 0,
             alignItems: 'center',
             columnGap: 2,
-            rowGap: 1,
-            ml: [0, 2],
           }}
         >
-          {/* PROTOCOL LABEL **/}
+          {tokenData instanceof Array && tokenData.length > 0 && (
+            <Box sx={{ mr: 2, flexShrink: 0 }}>
+              {tokenData.map(({ iconCircle }, iconIndex) => (
+                <Icon
+                  key={`VaultHeadlineIcon_${iconCircle}`}
+                  name={iconCircle}
+                  size="32px"
+                  sx={{
+                    verticalAlign: 'text-bottom',
+                    position: 'relative',
+                    zIndex: tokenData.length - iconIndex,
+                    mr: tokenData.length - 1 === iconIndex ? 0 : '-16px',
+                  }}
+                />
+              ))}
+            </Box>
+          )}
+          {header}
+          {label && <Image src={staticFilesRuntimeUrl(label)} sx={{ ml: 3 }} />}
+        </Flex>
+        {/* protocol label & icon buttons */}
+        <Flex
+          sx={{
+            flexDirection: 'row',
+            flexShrink: 0,
+            alignItems: 'center',
+            columnGap: 2,
+            '&:hover': {
+              '.tooltip': {
+                whiteSpace: 'nowrap',
+              },
+            },
+          }}
+        >
           {protocol && <ProtocolLabel network={protocol.network} protocol={protocol.protocol} />}
-
           {followVaultEnabled && (
-            <Flex
-              sx={{
-                flexWrap: 'wrap',
-                flexShrink: 0,
-                alignItems: 'center',
-                columnGap: 2,
-                ml: [0, 2],
-                '&:hover': {
-                  '.tooltip': {
-                    whiteSpace: 'nowrap',
-                  },
-                },
-              }}
-            >
+            <>
               {followButton && <FollowButtonControl {...followButton} />}
               {shareButton && (
                 <ShareButton
@@ -128,13 +125,12 @@ export function VaultHeadline({
                   via={twitterSharePositionVia}
                 />
               )}
-            </Flex>
+            </>
           )}
         </Flex>
       </Heading>
       <Flex
         sx={{
-          mt: ['24px', null, null, 0],
           flexDirection: ['column', 'row'],
         }}
       >

--- a/features/aave/common/components/AaveHeader.tsx
+++ b/features/aave/common/components/AaveHeader.tsx
@@ -1,5 +1,6 @@
 import { Protocol } from '@prisma/client'
 import BigNumber from 'bignumber.js'
+import { ProtocolLabelProps } from 'components/ProtocolLabel'
 import { VaultHeadline } from 'components/vault/VaultHeadline'
 import { HeadlineDetailsProp } from 'components/vault/VaultHeadlineDetails'
 import { useAaveContext } from 'features/aave'
@@ -55,6 +56,11 @@ function AaveHeader({
     )
   }
 
+  const protocol: ProtocolLabelProps = {
+    network: strategyConfig.network,
+    protocol: strategyConfig.protocol,
+  }
+
   return (
     <WithErrorHandler error={[positionTokenPricesError, chainlinkUSDCUSDPriceError]}>
       <VaultHeadline
@@ -64,6 +70,7 @@ function AaveHeader({
         details={detailsList}
         followButton={followButton}
         shareButton={shareButton}
+        protocol={protocol}
       />
     </WithErrorHandler>
   )


### PR DESCRIPTION
# [[design] display a label next to the position name to indicate the network](https://app.shortcut.com/oazo-apps/story/10124/design-display-a-label-next-to-the-position-name-to-indicate-the-network)
![Screenshot 2023-07-18 134433](https://github.com/OasisDEX/oasis-borrow/assets/739075/fd66e0e3-b871-48b2-90af-a4707a857325)
![Screenshot 2023-07-18 134446](https://github.com/OasisDEX/oasis-borrow/assets/739075/115aca76-22af-4f5d-9181-2336f4518bc6)
![Screenshot 2023-07-18 134454](https://github.com/OasisDEX/oasis-borrow/assets/739075/182c9a8f-80f7-4efc-b5eb-72c258499886)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
Added Protocol label to position header with responsive design support according to figma design
  
## How to test 🧪
open the position view for each protocol and compare the view with figma design
