### PR TITLE
Fix wrong label on managing Aave positions

### DIFF
--- a/features/aave/common/components/SidebarAdjustRiskView.tsx
+++ b/features/aave/common/components/SidebarAdjustRiskView.tsx
@@ -238,6 +238,7 @@ export function adjustRiskView(viewConfig: AdjustRiskViewConfig) {
                       }),
                       debtToken,
                       liquidationPenalty,
+                      positionType: state.context.strategyConfig.type,
                     })
                   : t('open-earn.aave.vault-form.configure-multiple.vault-message-ok', {
                       collateralToken,

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2355,7 +2355,7 @@
           "increase-risk": "Increase risk",
           "decrease-risk": "Decrease risk",
           "vault-message-ok": "At the chosen risk level, the price of {{collateralToken}} needs to move over {{priceMovement}} with respect to {{debtToken}} for this position to be available for liquidation. Aave's liquidations penalty is at least {{liquidationPenalty}}.",
-          "vault-message-warning": "At the chosen risk level, if the price of {{collateralToken}} moves over {{priceMovement}} with respect to {{debtToken}} this Earn position could be liquidated. Aave's liquidations penalty is at least {{liquidationPenalty}}."
+          "vault-message-warning": "At the chosen risk level, if the price of {{collateralToken}} moves over {{priceMovement}} with respect to {{debtToken}} this {{positionType}} position could be liquidated. Aave's liquidations penalty is at least {{liquidationPenalty}}."
         }
       },
       "af-title": "Fill the gas tank",


### PR DESCRIPTION
# [Multiply LTV warning says Earn position](https://app.shortcut.com/oazo-apps/story/7516/multiply-ltv-warning-says-earn-position)
  
## Changes 👷‍♀️
- the warning label on adjusting position now includes proper position type
  
## How to test 🧪
- manage aave position
- move slider to the right
- the warning label should include proper Earn/Multiply/Borrow info position
