### PR TITLE
🧿 Update Earn overview box to make clear whats the status of the user position

### DIFF
--- a/components/DetailsSectionContentCard.tsx
+++ b/components/DetailsSectionContentCard.tsx
@@ -212,10 +212,7 @@ export function DetailsSectionContentCard({
         </Box>
       )}
       {extra && (
-        <Box
-          sx={{ pt: '12px', ...cursorStyle }}
-          {...hightlightableItemEvents}
-        >
+        <Box sx={{ pt: '12px', ...cursorStyle }} {...hightlightableItemEvents}>
           {extra}
         </Box>
       )}

--- a/components/DetailsSectionContentCard.tsx
+++ b/components/DetailsSectionContentCard.tsx
@@ -25,15 +25,17 @@ interface DetailsSectionContentCardLinkProps {
 }
 
 export interface ContentCardProps {
-  title: string
-  value?: string
-  unit?: TranslateStringType
   change?: DetailsSectionContentCardChangePillProps
+  customBackground?: string
+  customUnitStyle?: SystemStyleObject
+  customValueColor?: string
+  extra?: ReactNode
   footnote?: TranslateStringType
   link?: DetailsSectionContentCardLinkProps
   modal?: TranslateStringType | JSX.Element
-  customBackground?: string
-  customUnitStyle?: SystemStyleObject
+  title: string
+  unit?: TranslateStringType
+  value?: string
 }
 
 export function getChangeVariant(collRatioColor: CollRatioColor): ChangeVariantType {
@@ -125,15 +127,17 @@ export function DetailsSectionContentCardWrapper({ children }: { children: React
 }
 
 export function DetailsSectionContentCard({
-  title,
-  value,
-  unit,
   change,
+  customBackground = '',
+  customUnitStyle = {},
+  customValueColor,
+  extra,
   footnote,
   link,
   modal,
-  customBackground = '',
-  customUnitStyle = {},
+  title,
+  unit,
+  value,
 }: ContentCardProps) {
   const openModal = useModal()
   const [isHighlighted, setIsHighlighted] = useState(false)
@@ -185,7 +189,14 @@ export function DetailsSectionContentCard({
       <Text
         as="p"
         variant="header3"
-        sx={{ maxWidth: '100%', lineHeight: 'loose', ...cursorStyle }}
+        sx={{
+          maxWidth: '100%',
+          lineHeight: 'loose',
+          ...cursorStyle,
+          ...(customValueColor && {
+            color: customValueColor,
+          }),
+        }}
         {...hightlightableItemEvents}
       >
         {value || '-'}
@@ -198,6 +209,14 @@ export function DetailsSectionContentCard({
       {(change?.value || change?.isLoading) && (
         <Box sx={{ maxWidth: '100%', pt: 2, ...cursorStyle }} {...hightlightableItemEvents}>
           <DetailsSectionContentCardChangePill {...change} />
+        </Box>
+      )}
+      {extra && (
+        <Box
+          sx={{ pt: '12px', ...cursorStyle }}
+          {...hightlightableItemEvents}
+        >
+          {extra}
         </Box>
       )}
       {footnote && (

--- a/components/Steps.tsx
+++ b/components/Steps.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+import { Box, Flex } from 'theme-ui'
+
+interface StepsProps {
+  active?: number
+  color?: string
+  count: number
+}
+
+export const Steps: FC<StepsProps> = ({ active, color, count }) => {
+  return (
+    <Flex as="ul" sx={{ columnGap: '2px', listStyle: 'none', m: 0, p: 0 }}>
+      {[...Array(count)].map((_item, i) => (
+        <Box
+          key={`${i}${i === active ? '-is-active' : ''}`}
+          as="li"
+          sx={{
+            width: i === active ? '40px' : 2,
+            height: 1,
+            bg: i === active && color ? color : 'neutral30',
+            borderRadius: 'mediumLarge',
+            transition: 'width 200ms, background-color 200ms',
+          }}
+        />
+      ))}
+    </Flex>
+  )
+}

--- a/components/Steps.tsx
+++ b/components/Steps.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import React from 'react'
 import { Box, Flex } from 'theme-ui'
 
 interface StepsProps {

--- a/components/Steps.tsx
+++ b/components/Steps.tsx
@@ -17,7 +17,7 @@ export const Steps: FC<StepsProps> = ({ active, color, count }) => {
           sx={{
             width: i === active ? '40px' : 2,
             height: 1,
-            bg: i === active && color ? color : 'neutral30',
+            bg: i === active && color ? color : 'secondary60',
             borderRadius: 'mediumLarge',
             transition: 'width 200ms, background-color 200ms',
           }}

--- a/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
@@ -5,9 +5,10 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { Steps } from 'components/Steps'
 import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
-import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
-import { one, zero } from 'helpers/zero'
+import { formatCryptoBalance } from 'helpers/formatters/format'
+import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { Card, Heading, Text } from 'theme-ui'
@@ -71,7 +72,8 @@ interface ContentCardPositionLendingPriceProps {
   positionLendingPrice: BigNumber
   highestThresholdPrice: BigNumber
   afterPositionLendingPrice?: BigNumber
-  relationToMarketPrice: BigNumber
+  priceColor: string
+  priceColorIndex: number
   changeVariant?: ChangeVariantType
 }
 
@@ -83,7 +85,8 @@ export function ContentCardPositionLendingPrice({
   positionLendingPrice,
   highestThresholdPrice,
   afterPositionLendingPrice,
-  relationToMarketPrice,
+  priceColor,
+  priceColorIndex,
   changeVariant = 'positive',
 }: ContentCardPositionLendingPriceProps) {
   const { t } = useTranslation()
@@ -98,13 +101,16 @@ export function ContentCardPositionLendingPrice({
     highestThresholdPrice: formatCryptoBalance(
       isShort ? one.div(highestThresholdPrice) : highestThresholdPrice,
     ),
-    relationToMarketPrice: formatDecimalAsPercent(relationToMarketPrice.abs()),
   }
 
   const contentCardSettings: ContentCardProps = {
     title: t('ajna.position-page.earn.manage.overview.position-lending-price'),
     value: formatted.positionLendingPrice,
     unit: priceFormat,
+    customValueColor: priceColor,
+    extra: !isLoading && !afterPositionLendingPrice && (
+      <Steps active={priceColorIndex} color={priceColor} count={4} />
+    ),
     change: {
       isLoading,
       value:
@@ -125,17 +131,6 @@ export function ContentCardPositionLendingPrice({
         />
       </AjnaDetailsSectionContentSimpleModal>
     ),
-  }
-
-  if (!positionLendingPrice.isZero()) {
-    contentCardSettings.footnote = t(
-      `ajna.position-page.earn.manage.overview.${
-        relationToMarketPrice.gt(zero) ? 'below' : 'above'
-      }-market-price`,
-      {
-        amount: formatted.relationToMarketPrice,
-      },
-    )
   }
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnSlider.tsx
@@ -4,7 +4,7 @@ import { PillAccordion } from 'components/PillAccordion'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaEarnInput } from 'features/ajna/positions/earn/components/AjnaEarnInput'
-import { AJNA_LUP_MOMP_OFFSET } from 'features/ajna/positions/earn/consts'
+import { AJNA_LUP_MOMP_OFFSET, lendingPriceColors } from 'features/ajna/positions/earn/consts'
 import { convertSliderThresholds } from 'features/ajna/positions/earn/helpers/convertSliderThresholds'
 import { getMinMaxAndRange } from 'features/ajna/positions/earn/helpers/getMinMaxAndRange'
 import {
@@ -116,9 +116,9 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({ isDisabled, nestedManu
         rightBottomLabel={t('riskier')}
         colorfulRanges={`linear-gradient(to right,
         #D3D4D8 0 ${htpPercentage}%,
-        #1ECBAE ${htpPercentage}% ${lupPercentage}%,
-        #EABE4C ${lupPercentage}% ${mompPercentage}%,
-        #EE5728 ${mompPercentage}% 100%)`}
+        ${lendingPriceColors.belowLup} ${htpPercentage}% ${lupPercentage}%,
+        ${lendingPriceColors.belowMomp} ${lupPercentage}% ${mompPercentage}%,
+        ${lendingPriceColors.aboveMomp} ${mompPercentage}% 100%)`}
       />
       {nestedManualInput ? (
         <PillAccordion

--- a/features/ajna/positions/earn/consts.ts
+++ b/features/ajna/positions/earn/consts.ts
@@ -1,1 +1,8 @@
 export const AJNA_LUP_MOMP_OFFSET = 0.2 // 20%
+
+export const lendingPriceColors = {
+  belowHtp: 'primary60',
+  belowLup: '#1ECBAE',
+  belowMomp: '#EABE4C',
+  aboveMomp: '#EE5728',
+}

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -2,7 +2,6 @@ import {
   calculateAjnaMaxLiquidityWithdraw,
   getPoolLiquidity,
   negativeToZero,
-  normalizeValue,
 } from '@oasisdex/dma-library'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
@@ -14,7 +13,8 @@ import { ContentCardTotalEarnings } from 'features/ajna/positions/common/compone
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { ContentFooterItemsEarnManage } from 'features/ajna/positions/earn/components/ContentFooterItemsEarnManage'
-import { one, zero } from 'helpers/zero'
+import { getLendingPriceColor } from 'features/ajna/positions/earn/helpers/getLendingPriceColor'
+import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -34,16 +34,20 @@ export function AjnaEarnOverviewManageController() {
     notifications,
   } = useAjnaProductContext('earn')
 
-  const liquidationToMarketPrice = position.price.div(position.marketPrice)
-  const relationToMarketPrice = one.minus(
-    isShort ? normalizeValue(one.div(liquidationToMarketPrice)) : liquidationToMarketPrice,
-  )
+  const { highestThresholdPrice, lowestUtilizedPrice, mostOptimisticMatchingPrice } = position.pool
 
   const availableToWithdraw = calculateAjnaMaxLiquidityWithdraw({
     pool: position.pool,
     poolCurrentLiquidity: getPoolLiquidity(position.pool),
     position,
     simulation,
+  })
+
+  const lendingPriceColor = getLendingPriceColor({
+    highestThresholdPrice,
+    lowestUtilizedPrice,
+    mostOptimisticMatchingPrice,
+    price: position.price,
   })
 
   return (
@@ -80,7 +84,8 @@ export function AjnaEarnOverviewManageController() {
             positionLendingPrice={position.price}
             highestThresholdPrice={position.pool.highestThresholdPrice}
             afterPositionLendingPrice={simulation?.price}
-            relationToMarketPrice={relationToMarketPrice}
+            priceColor={lendingPriceColor.color}
+            priceColorIndex={lendingPriceColor.index}
           />
         </DetailsSectionContentCardWrapper>
       }

--- a/features/ajna/positions/earn/helpers/getLendingPriceColor.ts
+++ b/features/ajna/positions/earn/helpers/getLendingPriceColor.ts
@@ -1,0 +1,22 @@
+import BigNumber from 'bignumber.js'
+import { lendingPriceColors } from 'features/ajna/positions/earn/consts'
+
+interface GetLendingPriceColorParams {
+  highestThresholdPrice: BigNumber
+  lowestUtilizedPrice: BigNumber
+  mostOptimisticMatchingPrice: BigNumber
+  price: BigNumber
+}
+
+export const getLendingPriceColor = ({
+  highestThresholdPrice,
+  lowestUtilizedPrice,
+  mostOptimisticMatchingPrice,
+  price,
+}: GetLendingPriceColorParams): { color: string; index: number } => {
+  if (price.lte(highestThresholdPrice)) return { color: lendingPriceColors.belowHtp, index: 0 }
+  if (price.lte(lowestUtilizedPrice)) return { color: lendingPriceColors.belowLup, index: 1 }
+  if (price.lte(mostOptimisticMatchingPrice))
+    return { color: lendingPriceColors.belowMomp, index: 2 }
+  else return { color: lendingPriceColors.aboveMomp, index: 3 }
+}


### PR DESCRIPTION
# [Update Earn overview box to make clear whats the status of the user position](https://app.shortcut.com/oazo-apps/story/10428/update-earn-overview-box-to-make-clear-whats-the-status-of-the-user-position)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/41905d13-bb86-4d7f-ae9b-674a977ddffa)
  
## Changes 👷‍♀️
  <Please add short list of changes>
- item 1
  
## How to test 🧪
  <Please explain how to test your changes>
- step 1 ...
