### PR TITLE
Pass correct ETH address to Ajna Multiply Close & Adjust

### DIFF
--- a/actions/ajna/multiply.ts
+++ b/actions/ajna/multiply.ts
@@ -74,7 +74,8 @@ export const ajnaOpenMultiply = ({
       operationExecutor: getNetworkContracts(NetworkIds.MAINNET, chainId).operationExecutor.address,
       addresses: {
         DAI: getNetworkContracts(NetworkIds.MAINNET, chainId).tokens.DAI.address,
-        ETH: getNetworkContracts(NetworkIds.MAINNET, chainId).tokens.ETH.address,
+        // Currently tokens.ETH is being mapped to WETH
+        ETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.ETH_ACTUAL.address,
         WSTETH: getNetworkContracts(NetworkIds.MAINNET, chainId).tokens.WSTETH.address,
         USDC: getNetworkContracts(NetworkIds.MAINNET, chainId).tokens.USDC.address,
         WBTC: getNetworkContracts(NetworkIds.MAINNET, chainId).tokens.WBTC.address,
@@ -122,7 +123,8 @@ export const ajnaAdjustMultiply = ({
       operationExecutor: getNetworkContracts(NetworkIds.MAINNET, 1).operationExecutor.address,
       addresses: {
         DAI: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.DAI.address,
-        ETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.ETH.address,
+        // Currently tokens.ETH is being mapped to WETH
+        ETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.ETH_ACTUAL.address,
         WSTETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.WSTETH.address,
         USDC: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.USDC.address,
         WBTC: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.WBTC.address,
@@ -164,7 +166,8 @@ export const ajnaCloseMultiply = ({
       operationExecutor: getNetworkContracts(NetworkIds.MAINNET, 1).operationExecutor.address,
       addresses: {
         DAI: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.DAI.address,
-        ETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.ETH.address,
+        // Currently tokens.ETH is being mapped to WETH
+        ETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.ETH_ACTUAL.address,
         WSTETH: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.WSTETH.address,
         USDC: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.USDC.address,
         WBTC: getNetworkContracts(NetworkIds.MAINNET, 1).tokens.WBTC.address,

--- a/blockchain/tokens/mainnet.ts
+++ b/blockchain/tokens/mainnet.ts
@@ -75,6 +75,9 @@ export const tokensMainnet = {
   RENBTC: contractDesc(erc20, mainnet.common.RENBTC),
   CBETH: contractDesc(erc20, mainnet.common.CBETH),
   ETH: contractDesc(erc20, mainnet.common.WETH),
+  // Used to represent ETH as an ERC20 token
+  // See @oasisdex/addresses package for info
+  ETH_ACTUAL: contractDesc(erc20, mainnet.common.ETH),
 } as Record<string, ContractDesc>
 
 export const ilksNotSupportedOnGoerli = [


### PR DESCRIPTION
# [Return Funds from Proxy Bug | Ajna Multiply Close & Adjust](https://app.shortcut.com/oazo-apps/story/10422/bug-user-funds-stuck-on-proxy-after-closing)

Note: ETH_ACTUAL is an ugly solution. But, I've taken it as I'm unclear on how much other logic depends on ETH actually being WETH on mainnet

## Changes 👷‍♀️
- Create a new entry in mainnet tokens for our ETH native stand-in ERC20 address that's used in our smart contracts
- Pass this address to ajna close & multiply on mainnet
  
## How to test 🧪
- Tested on mainnet with testing wallet https://etherscan.io/tx/0x9a9f46c3f36df0eb6a14dc26885bdb17187824a3357efc5089058cda826d4ab4