### PR TITLE
Ajna - Update copy on action confirmed

### DIFF
--- a/features/ajna/positions/common/helpers/getPrimaryButtonLabelKey.ts
+++ b/features/ajna/positions/common/helpers/getPrimaryButtonLabelKey.ts
@@ -41,6 +41,7 @@ export function getPrimaryButtonLabelKey({
       return 'confirm'
     case 'transaction':
       if (isTxSuccess && flow === 'open') return 'system.go-to-position'
+      else if (isTxSuccess && flow === 'manage') return 'continue'
       else if (isTxError) return 'retry'
       else return 'confirm'
     case 'transition':


### PR DESCRIPTION
# [Update copy on action confirmed](https://app.shortcut.com/oazo-apps/story/10424/update-copy-on-action-confirmed)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- if you manage your Ajna position and the transaction is successful then the button should say "Continue" instead of "Confirm"
  
## How to test 🧪
- go and adjust your Ajna position