### PR TITLE
[BUG] Determine Swap Direction in Side Panel on Close/Decrease

### DIFF
--- a/features/ajna/positions/common/helpers/formatSwapData.ts
+++ b/features/ajna/positions/common/helpers/formatSwapData.ts
@@ -2,19 +2,19 @@ import { SwapData } from '@oasisdex/dma-library'
 
 export const formatSwapData = ({
   swapData,
-  quotePrecision,
-  collateralPrecision,
+  fromTokenPrecision,
+  toTokenPrecision,
 }: {
   swapData?: SwapData
-  quotePrecision: number
-  collateralPrecision: number
+  fromTokenPrecision: number
+  toTokenPrecision: number
 }) => {
   if (!swapData) return undefined
 
   return {
     ...swapData,
-    fromTokenAmount: swapData.fromTokenAmount.shiftedBy(-quotePrecision),
-    toTokenAmount: swapData.toTokenAmount.shiftedBy(-collateralPrecision),
-    minToTokenAmount: swapData.minToTokenAmount.shiftedBy(-collateralPrecision),
+    fromTokenAmount: swapData.fromTokenAmount.shiftedBy(-fromTokenPrecision),
+    toTokenAmount: swapData.toTokenAmount.shiftedBy(-toTokenPrecision),
+    minToTokenAmount: swapData.minToTokenAmount.shiftedBy(-toTokenPrecision),
   }
 }

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -124,27 +124,27 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
       items={[
         ...(withBuying
           ? [
-            {
-              label: t('vault-changes.buying-token', { token: collateralToken }),
-              value: formatted.buyingCollateral,
-              secondary: {
-                value: formatted.buyingCollateralUSD,
+              {
+                label: t('vault-changes.buying-token', { token: collateralToken }),
+                value: formatted.buyingCollateral,
+                secondary: {
+                  value: formatted.buyingCollateralUSD,
+                },
+                isLoading,
               },
-              isLoading,
-            },
-          ]
+            ]
           : []),
         ...(withSelling
           ? [
-            {
-              label: t('vault-changes.selling-token', { token: collateralToken }),
-              value: formatted.sellingCollateral,
-              secondary: {
-                value: formatted.sellingCollateralUSD,
+              {
+                label: t('vault-changes.selling-token', { token: collateralToken }),
+                value: formatted.sellingCollateral,
+                secondary: {
+                  value: formatted.sellingCollateralUSD,
+                },
+                isLoading,
               },
-              isLoading,
-            },
-          ]
+            ]
           : []),
         {
           label: t('system.total-exposure', { token: collateralToken }),
@@ -154,16 +154,16 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         },
         ...(withBuying || withSelling
           ? [
-            {
-              label: t('vault-changes.price-impact', { token: collateralToken }),
-              value: formatted.collateralPrice,
-              secondary: {
-                value: formatted.collateralPriceImpact,
-                variant: 'negative' as SecondaryVariantType,
+              {
+                label: t('vault-changes.price-impact', { token: collateralToken }),
+                value: formatted.collateralPrice,
+                secondary: {
+                  value: formatted.collateralPriceImpact,
+                  variant: 'negative' as SecondaryVariantType,
+                },
+                isLoading,
               },
-              isLoading,
-            },
-          ]
+            ]
           : []),
         {
           label: t('system.multiple'),
@@ -173,12 +173,12 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         },
         ...(withSlippage
           ? [
-            {
-              label: t('vault-changes.slippage-limit'),
-              value: formatted.slippageLimit,
-              isLoading,
-            },
-          ]
+              {
+                label: t('vault-changes.slippage-limit'),
+                value: formatted.slippageLimit,
+                isLoading,
+              },
+            ]
           : []),
         {
           label: t('system.debt'),
@@ -194,43 +194,43 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         },
         ...(positionData.pool.lowestUtilizedPriceIndex.gt(zero)
           ? [
-            {
-              label: t('system.dynamic-max-ltv'),
-              value: formatted.dynamicMaxLtv,
-              change: formatted.afterDynamicMaxLtv,
-              isLoading,
-            },
-          ]
+              {
+                label: t('system.dynamic-max-ltv'),
+                value: formatted.dynamicMaxLtv,
+                change: formatted.afterDynamicMaxLtv,
+                isLoading,
+              },
+            ]
           : []),
         ...(isTxSuccess && cached
           ? [
-            {
-              label: t('system.total-cost'),
-              value: formatted.totalCost,
-              isLoading,
-            },
-          ]
+              {
+                label: t('system.total-cost'),
+                value: formatted.totalCost,
+                isLoading,
+              },
+            ]
           : isFlowStateReady
-            ? [
+          ? [
               {
                 label: t('system.max-transaction-cost'),
-                value: <GasEstimation addition={oasisFee}/>,
+                value: <GasEstimation addition={oasisFee} />,
                 dropdownValues: oasisFee
                   ? [
-                    {
-                      label: t('vault-changes.oasis-fee'),
-                      value: formatted.oasisFee,
-                    },
-                    {
-                      label: t('max-gas-fee'),
-                      value: <GasEstimation/>,
-                    },
-                  ]
+                      {
+                        label: t('vault-changes.oasis-fee'),
+                        value: formatted.oasisFee,
+                      },
+                      {
+                        label: t('max-gas-fee'),
+                        value: <GasEstimation />,
+                      },
+                    ]
                   : undefined,
                 isLoading,
               },
             ]
-            : []),
+          : []),
       ]}
     />
   )

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -68,7 +68,12 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
       simulationData?.riskRatio.loanToValue.lt(positionData.riskRatio.loanToValue))
   const withOasisFee = withBuying || withSelling
 
-  const buyingOrSellingCollateral = swapData ? swapData.minToTokenAmount : zero
+  const buyingOrSellingCollateral = swapData
+    ? withBuying
+      ? swapData.minToTokenAmount
+      : swapData.fromTokenAmount
+    : zero
+
   const priceImpact = calculatePriceImpact(tokenPrice || zero, collateralPrice)
   const oasisFee = withOasisFee
     ? buyingOrSellingCollateral.times(OAZO_FEE.times(collateralPrice))
@@ -119,27 +124,27 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
       items={[
         ...(withBuying
           ? [
-              {
-                label: t('vault-changes.buying-token', { token: collateralToken }),
-                value: formatted.buyingCollateral,
-                secondary: {
-                  value: formatted.buyingCollateralUSD,
-                },
-                isLoading,
+            {
+              label: t('vault-changes.buying-token', { token: collateralToken }),
+              value: formatted.buyingCollateral,
+              secondary: {
+                value: formatted.buyingCollateralUSD,
               },
-            ]
+              isLoading,
+            },
+          ]
           : []),
         ...(withSelling
           ? [
-              {
-                label: t('vault-changes.selling-token', { token: collateralToken }),
-                value: formatted.sellingCollateral,
-                secondary: {
-                  value: formatted.sellingCollateralUSD,
-                },
-                isLoading,
+            {
+              label: t('vault-changes.selling-token', { token: collateralToken }),
+              value: formatted.sellingCollateral,
+              secondary: {
+                value: formatted.sellingCollateralUSD,
               },
-            ]
+              isLoading,
+            },
+          ]
           : []),
         {
           label: t('system.total-exposure', { token: collateralToken }),
@@ -149,16 +154,16 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         },
         ...(withBuying || withSelling
           ? [
-              {
-                label: t('vault-changes.price-impact', { token: collateralToken }),
-                value: formatted.collateralPrice,
-                secondary: {
-                  value: formatted.collateralPriceImpact,
-                  variant: 'negative' as SecondaryVariantType,
-                },
-                isLoading,
+            {
+              label: t('vault-changes.price-impact', { token: collateralToken }),
+              value: formatted.collateralPrice,
+              secondary: {
+                value: formatted.collateralPriceImpact,
+                variant: 'negative' as SecondaryVariantType,
               },
-            ]
+              isLoading,
+            },
+          ]
           : []),
         {
           label: t('system.multiple'),
@@ -168,12 +173,12 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         },
         ...(withSlippage
           ? [
-              {
-                label: t('vault-changes.slippage-limit'),
-                value: formatted.slippageLimit,
-                isLoading,
-              },
-            ]
+            {
+              label: t('vault-changes.slippage-limit'),
+              value: formatted.slippageLimit,
+              isLoading,
+            },
+          ]
           : []),
         {
           label: t('system.debt'),
@@ -189,43 +194,43 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         },
         ...(positionData.pool.lowestUtilizedPriceIndex.gt(zero)
           ? [
-              {
-                label: t('system.dynamic-max-ltv'),
-                value: formatted.dynamicMaxLtv,
-                change: formatted.afterDynamicMaxLtv,
-                isLoading,
-              },
-            ]
+            {
+              label: t('system.dynamic-max-ltv'),
+              value: formatted.dynamicMaxLtv,
+              change: formatted.afterDynamicMaxLtv,
+              isLoading,
+            },
+          ]
           : []),
         ...(isTxSuccess && cached
           ? [
-              {
-                label: t('system.total-cost'),
-                value: formatted.totalCost,
-                isLoading,
-              },
-            ]
+            {
+              label: t('system.total-cost'),
+              value: formatted.totalCost,
+              isLoading,
+            },
+          ]
           : isFlowStateReady
-          ? [
+            ? [
               {
                 label: t('system.max-transaction-cost'),
-                value: <GasEstimation addition={oasisFee} />,
+                value: <GasEstimation addition={oasisFee}/>,
                 dropdownValues: oasisFee
                   ? [
-                      {
-                        label: t('vault-changes.oasis-fee'),
-                        value: formatted.oasisFee,
-                      },
-                      {
-                        label: t('max-gas-fee'),
-                        value: <GasEstimation />,
-                      },
-                    ]
+                    {
+                      label: t('vault-changes.oasis-fee'),
+                      value: formatted.oasisFee,
+                    },
+                    {
+                      label: t('max-gas-fee'),
+                      value: <GasEstimation/>,
+                    },
+                  ]
                   : undefined,
                 isLoading,
               },
             ]
-          : []),
+            : []),
       ]}
     />
   )


### PR DESCRIPTION
# [[BUG] Fix side panel amts when closing/decreasing](https://app.shortcut.com/oazo-apps/story/10492/bug-fix-side-panel-amts-when-closing-decreasing)

  
## Changes 👷‍♀️
- Add in logic to determine swap direction in MultiplyForm component
  
## How to test 🧪
- Go to close multiply position view and confirm values are displaying as expected
