### PR TITLE
[BUG] Improve Slider Behaviour

### DIFF
--- a/components/dumb/SliderValuePicker.tsx
+++ b/components/dumb/SliderValuePicker.tsx
@@ -84,7 +84,6 @@ export function SliderValuePicker(props: SliderValuePickerProps) {
           max={props.maxBoundry?.toNumber()}
           value={props.lastValue?.toNumber()}
           onChange={(e) => {
-            console.log('onChange', e.target.value)
             props.onChange(new BigNumber(e.target.value))
           }}
         />

--- a/components/dumb/SliderValuePicker.tsx
+++ b/components/dumb/SliderValuePicker.tsx
@@ -84,6 +84,7 @@ export function SliderValuePicker(props: SliderValuePickerProps) {
           max={props.maxBoundry?.toNumber()}
           value={props.lastValue?.toNumber()}
           onChange={(e) => {
+            console.log('onChange', e.target.value)
             props.onChange(new BigNumber(e.target.value))
           }}
         />

--- a/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
+++ b/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
@@ -10,7 +10,7 @@ import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/A
 import { getBorrowishChangeVariant } from 'features/ajna/positions/common/helpers/getBorrowishChangeVariant'
 import { resolveSwapTokenPrice } from 'features/ajna/positions/common/helpers/resolveSwapTokenPrice'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
-import { one, zero } from 'helpers/zero'
+import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect, useState } from 'react'
 import { Flex, Text } from 'theme-ui'
@@ -75,10 +75,17 @@ export function AjnaMultiplySlider({ disabled = false }: AjnaMultiplySliderProps
           .plus(position.debtAmount)
           .div((simulation || position).collateralAmount.times(tokenPrice))
           .decimalPlaces(2, BigNumber.ROUND_DOWN)
-      : zero
+      : one
 
-  const resolvedValue =
-    loanToValue || simulation?.riskRatio.loanToValue || position.riskRatio.loanToValue || min
+  let resolvedValue = loanToValue || simulation?.riskRatio.loanToValue || min
+  if (resolvedValue.gt(max)) {
+    resolvedValue = max
+    updateState('loanToValue', max)
+  }
+  if (resolvedValue.lt(min)) {
+    resolvedValue = min
+    updateState('loanToValue', max)
+  }
 
   const percentage = resolvedValue.minus(min).div(max.minus(min)).times(100)
   const ltv = position.riskRatio.loanToValue


### PR DESCRIPTION
**CHANGES**
When maxBorrow can't be determined by calls via the pool and defaults to zero. Then I've suggested a fallback of one rather than zero. So, the slider doesn't get locked at 0 and is unmovable. Equally, if the max is one we'll still show validations messages after the fact that say that the t/x will not work.
