### PR TITLE
Update getLendingPriceColor.ts

### DIFF
--- a/features/ajna/positions/earn/helpers/getLendingPriceColor.ts
+++ b/features/ajna/positions/earn/helpers/getLendingPriceColor.ts
@@ -14,9 +14,9 @@ export const getLendingPriceColor = ({
   mostOptimisticMatchingPrice,
   price,
 }: GetLendingPriceColorParams): { color: string; index: number } => {
-  if (price.lte(highestThresholdPrice)) return { color: lendingPriceColors.belowHtp, index: 0 }
+  if (price.lt(highestThresholdPrice)) return { color: lendingPriceColors.belowHtp, index: 0 }
   if (price.lt(lowestUtilizedPrice)) return { color: lendingPriceColors.belowLup, index: 1 }
-  if (price.lte(mostOptimisticMatchingPrice))
+  if (price.lt(mostOptimisticMatchingPrice))
     return { color: lendingPriceColors.belowMomp, index: 2 }
   else return { color: lendingPriceColors.aboveMomp, index: 3 }
 }


### PR DESCRIPTION
below HTP should be gray

HTP bucket exactly: earns interest so it should be green

LUP bucket exactly: earns interest it should be orange

MOMP bucket must be red.

# [Title](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
- item 1
  
## How to test 🧪
  <Please explain how to test your changes>
- step 1 ...
