### PR TITLE
Improve ajna multiply slider

### DIFF
--- a/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
+++ b/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
@@ -77,14 +77,12 @@ export function AjnaMultiplySlider({ disabled = false }: AjnaMultiplySliderProps
           .decimalPlaces(2, BigNumber.ROUND_DOWN)
       : one
 
-  let resolvedValue = loanToValue || simulation?.riskRatio.loanToValue || min
+  let resolvedValue = loanToValue || position.riskRatio.loanToValue || min
   if (resolvedValue.gt(max)) {
     resolvedValue = max
-    updateState('loanToValue', max)
   }
   if (resolvedValue.lt(min)) {
     resolvedValue = min
-    updateState('loanToValue', max)
   }
 
   const percentage = resolvedValue.minus(min).div(max.minus(min)).times(100)

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
@@ -41,6 +41,7 @@ export function AjnaMultiplyFormController() {
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'adjust')
+                updateState('action', 'adjust')
               },
             },
             {

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -27,7 +27,7 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
   } = useAjnaGeneralContext()
   const {
     form: {
-      state: { action },
+      state: { action, loanToValue },
     },
     position: { cachedPosition, isSimulationLoading, currentPosition, swap },
   } = useAjnaProductContext('multiply')
@@ -60,11 +60,11 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
   const withBuying =
     action === 'open-multiply' ||
     (['adjust', 'deposit-collateral-multiply', 'withdraw-multiply'].includes(action as string) &&
-      simulationData?.riskRatio.loanToValue.gt(positionData.riskRatio.loanToValue))
+      loanToValue?.gt(positionData.riskRatio.loanToValue))
   const withSelling =
     action === 'close-multiply' ||
     (['adjust', 'deposit-collateral-multiply', 'withdraw-multiply'].includes(action as string) &&
-      simulationData?.riskRatio.loanToValue.lt(positionData.riskRatio.loanToValue))
+      loanToValue?.lt(positionData.riskRatio.loanToValue))
   const withOasisFee = withBuying || withSelling
 
   const buyingOrSellingCollateral = swapData

--- a/features/ajna/positions/multiply/state/ajnaMultiplyFormReducto.ts
+++ b/features/ajna/positions/multiply/state/ajnaMultiplyFormReducto.ts
@@ -50,6 +50,7 @@ export const ajnaMultiplyReset = {
   paybackAmountUSD: undefined,
   withdrawAmount: undefined,
   withdrawAmountUSD: undefined,
+  loanToValue: undefined,
 }
 
 export const ajnaMultiplyDefault: AjnaMultiplyFormState = {
@@ -105,7 +106,6 @@ export function useAjnaMultiplyFormReducto({ ...rest }: Partial<AjnaMultiplyForm
           return {
             ...state,
             ...ajnaMultiplyReset,
-            loanToValue: rest.loanToValue,
           }
         default:
           return state


### PR DESCRIPTION
# Improve ajna multiply slider

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted slider initial value handling to ensure proper UX
- fixed issue where simulation was not reseted when user switched from closing position to adjust position action using dropdown

  
## How to test 🧪
  <Please explain how to test your changes>

- use ajna multiply position, once loaded slider should show position LTV and button should be disabled, 
- change LTV using slider and click reset, slider should go to back to default state
- switch between actions in dropdown, value on slider should remain on position LTV
