### PR TITLE
Position label is not showing correct L2 network icon

### DIFF
--- a/features/aave/services/readPositionCreatedEvents.ts
+++ b/features/aave/services/readPositionCreatedEvents.ts
@@ -15,6 +15,7 @@ export type PositionCreated = {
   debtTokenSymbol: string
   positionType: 'Borrow' | 'Multiply' | 'Earn'
   protocol: LendingProtocol
+  chainId: NetworkIds
   proxyAddress: string
 }
 
@@ -64,6 +65,7 @@ function mapEvent(
         collateralTokenSymbol: getTokenSymbolBasedOnAddress(chainId, e.args.collateralToken),
         debtTokenSymbol: getTokenSymbolBasedOnAddress(chainId, e.args.debtToken),
         protocol: extractLendingProtocolFromPositionCreatedEvent(e),
+        chainId,
         proxyAddress: e.args.proxyAddress,
       }
     })
@@ -113,6 +115,7 @@ export function getLastCreatedPositionForProxy$(
         ),
         debtTokenSymbol: getTokenSymbolBasedOnAddress(context.chainId, event!.args.debtToken),
         protocol: extractLendingProtocolFromPositionCreatedEvent(event!),
+        chainId: context.chainId,
         proxyAddress: event!.args.proxyAddress,
       }
     }),

--- a/features/vaultsOverview/parsers.tsx
+++ b/features/vaultsOverview/parsers.tsx
@@ -5,7 +5,7 @@ import {
   negativeToZero,
 } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
-import { NetworkNames } from 'blockchain/networks'
+import { NetworkNames, networksById } from 'blockchain/networks'
 import { AssetsTableDataCellAction } from 'components/assetsTable/cellComponents/AssetsTableDataCellAction'
 import { AssetsTableDataCellAsset } from 'components/assetsTable/cellComponents/AssetsTableDataCellAsset'
 import { AssetsTableDataCellInactive } from 'components/assetsTable/cellComponents/AssetsTableDataCellInactive'
@@ -87,6 +87,7 @@ export function parseMakerBorrowPositionRows(
       debtToken: 'DAI',
       icons: [token, 'DAI'],
       id: id.toString(),
+      // TODO: should get chainId from the source event so it works in the generic way for all chains
       network: NetworkNames.ethereumMainnet,
       protocol: LendingProtocol.Maker,
       riskRatio: {
@@ -112,6 +113,7 @@ export function parseMakerMultiplyPositionRows(
       liquidationPrice,
       multiple: calculateMultiply({ debt, lockedCollateralUSD }),
       netValue: value,
+      // TODO: should get chainId from the source event so it works in the generic way for all chains
       network: NetworkNames.ethereumMainnet,
       protocol: LendingProtocol.Maker,
       url: `/ethereum/maker/${id}`,
@@ -130,6 +132,7 @@ export function parseMakerEarnPositionRows(
       liquidityToken: 'DAI',
       netValue: value,
       pnl: calculatePNL(history, lockedCollateralUSD.minus(debt)).times(100),
+      // TODO: should get chainId from the source event so it works in the generic way for all chains
       network: NetworkNames.ethereumMainnet,
       protocol: LendingProtocol.Maker,
       url: `/ethereum/maker/${id}`,
@@ -150,6 +153,7 @@ export function parseAaveMultiplyPositionRows(
       protocol,
       token,
       url,
+      chainId,
     }) => ({
       asset: `${token}/${debtToken}`,
       fundingCost,
@@ -158,21 +162,21 @@ export function parseAaveMultiplyPositionRows(
       liquidationPrice,
       multiple,
       netValue,
-      network: NetworkNames.ethereumMainnet,
+      network: networksById[chainId].name,
       protocol,
       url,
     }),
   )
 }
 export function parseAaveEarnPositionRows(positions: AavePosition[]): PositionTableEarnRow[] {
-  return positions.map(({ debtToken, id, liquidity, netValue, protocol, token, url }) => ({
+  return positions.map(({ debtToken, id, liquidity, netValue, protocol, token, url, chainId }) => ({
     asset: `${token}/${debtToken}`,
     icons: [token, debtToken],
     id,
     liquidity,
     liquidityToken: 'USDC',
     netValue,
-    network: NetworkNames.ethereumMainnet,
+    network: networksById[chainId].name,
     protocol,
     url,
   }))
@@ -196,6 +200,7 @@ export function parseAjnaBorrowPositionRows(
       debtToken: quoteToken,
       icons: [collateralToken, quoteToken],
       id: vaultId,
+      // TODO: should get chainId from the source event so it works in the generic way for all chains
       network: NetworkNames.ethereumMainnet,
       protocol: LendingProtocol.Ajna,
       riskRatio: {
@@ -230,6 +235,7 @@ export function parseAjnaEarnPositionRows(
       pnl: earnPosition.pnl,
       liquidity,
       liquidityToken: quoteToken,
+      // TODO: should get chainId from the source event so it works in the generic way for all chains
       network: NetworkNames.ethereumMainnet,
       protocol: LendingProtocol.Ajna,
       url: `/ethereum/ajna/${vaultId}`,
@@ -254,6 +260,7 @@ export function parseDsrEarnPosition({
           liquidity: 'Unlimited',
           liquidityToken: 'DAI',
           netValue,
+          // TODO: should get chainId from the source event so it works in the generic way for all chains
           network: NetworkNames.ethereumMainnet,
           protocol: LendingProtocol.Maker,
           url: `/earn/dsr/${address}`,

--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -82,6 +82,7 @@ export type AavePosition = Position & {
   fakePositionCreatedEvtForDsProxyUsers?: boolean
   debtToken: string
   protocol: AaveLendingProtocol
+  chainId: NetworkIds
 }
 
 export function createPositions$(
@@ -119,7 +120,8 @@ function buildAaveViewModel(
   walletAddress: string,
   observables: BuildPositionArgs,
 ): Observable<AavePosition | undefined> {
-  const { collateralTokenSymbol, debtTokenSymbol, proxyAddress, protocol } = positionCreatedEvent
+  const { collateralTokenSymbol, debtTokenSymbol, proxyAddress, protocol, chainId } =
+    positionCreatedEvent
   const aaveServiceMap: Record<AaveLendingProtocol, AaveServices> = {
     [LendingProtocol.AaveV2]: observables.aaveV2,
     [LendingProtocol.AaveV3]: observables.aaveV3,
@@ -216,6 +218,7 @@ function buildAaveViewModel(
           liquidity: liquidity,
           stopLossData: triggersData ? extractStopLossData(triggersData) : undefined,
           protocol,
+          chainId,
         }
       },
     ),
@@ -231,7 +234,8 @@ function buildAaveV3OnlyViewModel(
   strategyConfig: IStrategyConfig,
   tickerPrices$: (tokens: string[]) => Observable<Tickers>,
 ): Observable<AavePosition | undefined> {
-  const { collateralTokenSymbol, debtTokenSymbol, proxyAddress, protocol } = positionCreatedEvent
+  const { collateralTokenSymbol, debtTokenSymbol, proxyAddress, protocol, chainId } =
+    positionCreatedEvent
 
   if (!checkIfAave(protocol)) {
     return of(undefined)
@@ -316,6 +320,7 @@ function buildAaveV3OnlyViewModel(
         liquidity: liquidity,
         stopLossData: undefined,
         protocol,
+        chainId,
       }
     }),
   )
@@ -349,6 +354,7 @@ function getStethEthAaveV2DsProxyEarnPosition$(
                 debtTokenSymbol: 'ETH',
                 positionType: 'Earn',
                 protocol: LendingProtocol.AaveV2,
+                chainId: NetworkIds.MAINNET,
                 proxyAddress: dsProxyAddress,
                 fakePositionCreatedEvtForDsProxyUsers: true,
               },


### PR DESCRIPTION
# [Position label is not showing correct L2 network icon](https://app.shortcut.com/oazo-apps/story/10502/position-label-is-not-showing-correct-l2-network-icon)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>
Added chainId to the result model when parsing PositionCreated event, so I can use that chainId when creating aave positions stream and map it to the Network Name which is shown in the UI. This will allow to show the correct network icon on the positions table. Previously it was impossible as there were no network data in the position object and it was incorrectly showing ETH MAINNET network for L2's.

  
## How to test 🧪
  <Please explain how to test your changes>
1) Open multiply and earn positions on the optimism for aave.
2) Check positions table if the protocol label is showing an optimism icon.
