### PR TITLE
Ajna Earn: swap 30 day APY value on opening position view

### DIFF
--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
@@ -60,7 +60,7 @@ export function AjnaEarnOverviewOpenController() {
         <DetailsSectionFooterItemWrapper>
           <ContentFooterItemsEarnOpen
             totalValueLocked={position.pool.depositSize.times(quotePrice)}
-            apy={simulation?.apy.per30d}
+            apy={position.pool.apr30dAverage}
             days={30}
           />
         </DetailsSectionFooterItemWrapper>


### PR DESCRIPTION
# [Update yield in EARN order to match current yield and 30d yield](https://app.shortcut.com/oazo-apps/story/10467/update-yield-in-earn-order-to-match-current-yield-and-30d-yield)

  
## Changes 👷‍♀️
- Ajna Earn: changed the value of 30 day APY value on opening position view
  
## How to test 🧪
- go to `/ethereum/ajna/earn/USDC-ETH#setup` (example)
- input a value
- the header Average 30 day APY should match the bottom one

![image](https://github.com/OasisDEX/oasis-borrow/assets/5095527/0861d1c6-84f3-4ed0-98ee-0da44844716d)
