### PR TITLE
Ajna multiply price impact

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -807,7 +807,18 @@ export function setupAppContext() {
       amount: BigNumber,
       action: ExchangeAction,
       exchangeType: ExchangeType,
-    ) => createExchangeQuote$(context$, undefined, token, slippage, amount, action, exchangeType),
+      quoteToken?: string,
+    ) =>
+      createExchangeQuote$(
+        context$,
+        undefined,
+        token,
+        slippage,
+        amount,
+        action,
+        exchangeType,
+        quoteToken,
+      ),
     (token: string, slippage: BigNumber, amount: BigNumber, action: string, exchangeType: string) =>
       `${token}_${slippage.toString()}_${amount.toString()}_${action}_${exchangeType}`,
   )
@@ -1372,6 +1383,7 @@ export function setupAppContext() {
     chainContext$,
     positionIdFromDpmProxy$,
     switchChains,
+    exchangeQuote$,
   }
 }
 

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { useAppContext } from 'components/AppContextProvider'
 import { GasEstimation } from 'components/GasEstimation'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import { SecondaryVariantType } from 'components/infoSection/Item'
@@ -14,14 +15,16 @@ import {
   formatDecimalAsPercent,
 } from 'helpers/formatters/format'
 import { OAZO_FEE } from 'helpers/multiply/calculations'
-import { zero } from 'helpers/zero'
+import { useObservable } from 'helpers/observableHook'
+import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) {
   const { t } = useTranslation()
+  const { exchangeQuote$ } = useAppContext()
   const {
-    environment: { collateralPrice, collateralToken, quoteToken, slippage },
+    environment: { collateralPrice, collateralToken, quoteToken, slippage, isShort },
     steps: { isFlowStateReady },
     tx: { isTxSuccess, txDetails },
   } = useAjnaGeneralContext()
@@ -67,13 +70,28 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
       loanToValue?.lt(positionData.riskRatio.loanToValue))
   const withOasisFee = withBuying || withSelling
 
+  const initialQuote$ = exchangeQuote$(
+    collateralToken,
+    slippage,
+    one,
+    withBuying ? 'BUY_COLLATERAL' : 'SELL_COLLATERAL',
+    'defaultExchange',
+    quoteToken,
+  )
+
+  const [initialQuote] = useObservable(initialQuote$)
+
   const buyingOrSellingCollateral = swapData
     ? withBuying
       ? swapData.minToTokenAmount
       : swapData.fromTokenAmount
     : zero
 
-  const priceImpact = calculatePriceImpact(tokenPrice || zero, collateralPrice)
+  const priceImpact =
+    initialQuote?.status === 'SUCCESS' && tokenPrice
+      ? calculatePriceImpact(initialQuote.tokenPrice, tokenPrice)
+      : undefined
+
   const oasisFee = withOasisFee
     ? buyingOrSellingCollateral.times(OAZO_FEE.times(collateralPrice))
     : zero
@@ -111,8 +129,12 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
       buyingOrSellingCollateral.times(collateralPrice),
       'USD',
     )}`,
-    collateralPrice: `$${formatAmount(collateralPrice, 'USD')}`,
-    collateralPriceImpact: formatDecimalAsPercent(priceImpact),
+    marketPrice: tokenPrice
+      ? `${formatCryptoBalance(
+          isShort ? one.div(tokenPrice) : tokenPrice,
+        )} ${collateralToken}/${quoteToken}`
+      : 'n/a',
+    marketPriceImpact: priceImpact ? formatDecimalAsPercent(priceImpact) : 'n/a',
     oasisFee: `$${formatAmount(oasisFee, 'USD')}`,
     totalCost: txDetails?.txCost ? `$${formatAmount(txDetails.txCost, 'USD')}` : '-',
   }
@@ -154,10 +176,12 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
         ...(withBuying || withSelling
           ? [
               {
-                label: t('vault-changes.price-impact', { token: collateralToken }),
-                value: formatted.collateralPrice,
+                label: t('vault-changes.price-impact', {
+                  token: `${collateralToken}/${quoteToken}`,
+                }),
+                value: formatted.marketPrice,
                 secondary: {
-                  value: formatted.collateralPriceImpact,
+                  value: formatted.marketPriceImpact,
                   variant: 'negative' as SecondaryVariantType,
                 },
                 isLoading,

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder.tsx
@@ -73,7 +73,8 @@ export function AjnaMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
   const initialQuote$ = exchangeQuote$(
     collateralToken,
     slippage,
-    one,
+    // use ~1$ worth amount of collateral token
+    one.div(collateralPrice),
     withBuying ? 'BUY_COLLATERAL' : 'SELL_COLLATERAL',
     'defaultExchange',
     quoteToken,

--- a/features/earn/guni/manage/pipes/manageGuniVault.ts
+++ b/features/earn/guni/manage/pipes/manageGuniVault.ts
@@ -339,8 +339,10 @@ export function createManageGuniVault$(
                                   sharedAmount1: sharedAmount1.minus(0.01),
                                   requiredDebt,
                                   fromTokenAmount: swap.collateralAmount,
-                                  toTokenAmount: swap.daiAmount,
-                                  minToTokenAmount: swap.daiAmount.times(one.minus(state.slippage)),
+                                  toTokenAmount: swap.quoteAmount,
+                                  minToTokenAmount: swap.quoteAmount.times(
+                                    one.minus(state.slippage),
+                                  ),
                                 }
                               }),
                             )

--- a/features/earn/guni/open/pipes/openGuniMultiplyVaultTransactions.ts
+++ b/features/earn/guni/open/pipes/openGuniMultiplyVaultTransactions.ts
@@ -27,7 +27,7 @@ export function applyGuniEstimateGas(
     } = state
 
     const daiAmount =
-      swap?.status === 'SUCCESS' ? swap.daiAmount.div(one.minus(OAZO_LOWER_FEE)) : zero
+      swap?.status === 'SUCCESS' ? swap.quoteAmount.div(one.minus(OAZO_LOWER_FEE)) : zero
     const collateralAmount =
       swap?.status === 'SUCCESS' ? swap.collateralAmount.times(one.minus(SLIPPAGE)) : zero
 

--- a/features/multiply/manage/pipes/manageMultiplyVaultTransactions.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultTransactions.ts
@@ -691,11 +691,11 @@ export function applyEstimateGas(
               ? // add oazo fee because Oazo takes the fee from the pre swap amount,
                 // so that means that required debt on the vault must be increased
                 // to incorporate this fee.
-                swap.daiAmount.div(one.minus(OAZO_FEE))
+                swap.quoteAmount.div(one.minus(OAZO_FEE))
               : // remove slippage because we are selling collateral and buying DAI,
                 // and so we will only end up with the amount of DAI that is
                 // returned from the exchange minus the slippage.
-                swap.daiAmount.div(one.plus(SLIPPAGE))
+                swap.quoteAmount.div(one.plus(SLIPPAGE))
             : zero
 
         const borrowedCollateral =

--- a/features/multiply/open/pipes/openMultiplyVaultTransactions.ts
+++ b/features/multiply/open/pipes/openMultiplyVaultTransactions.ts
@@ -211,7 +211,7 @@ export function applyEstimateGas(
   return addGasEstimation$(state, ({ estimateGas }: TxHelpers) => {
     const { proxyAddress, depositAmount, ilk, token, account, swap, skipFL, isProxyStage } = state
 
-    const daiAmount = swap?.status === 'SUCCESS' ? swap.daiAmount.div(one.minus(OAZO_FEE)) : zero
+    const daiAmount = swap?.status === 'SUCCESS' ? swap.quoteAmount.div(one.minus(OAZO_FEE)) : zero
     const collateralAmount = swap?.status === 'SUCCESS' ? swap.collateralAmount : zero
 
     if (proxyAddress && depositAmount) {

--- a/helpers/mocks/exchangeQuote.mock.ts
+++ b/helpers/mocks/exchangeQuote.mock.ts
@@ -32,7 +32,7 @@ export function mockExchangeQuote$({
             logoURI: 'ETH',
           },
           collateralAmount: amount,
-          daiAmount: marketPrice.times(amount),
+          quoteAmount: marketPrice.times(amount),
           tokenPrice: marketPrice,
           toToken: {
             symbol: token,


### PR DESCRIPTION
# Ajna multiply price impact

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- refactored `exchangeQuote$` observable to be able to use any token pairs
- added initial quote handling to Ajna multiply order information and based on that and value from swap calculated price impact
- adjusted slider logic to use prices from our price feed (maybe there is a way to base it on swap data, to be investigated) so slider works ok on short pools
- adjusted price impact label in order information to show values not in $ but in coll token / quote token
  
## How to test 🧪
  <Please explain how to test your changes>

- use positions on different pools for example ETH/USDC, USDC/ETH, CBETH/ETH and verify price impact
- on short position check whether slider works as expected
