### PR TITLE
Hide after pills when tx success

### DIFF
--- a/features/ajna/positions/common/helpers/getIsFormEmpty.ts
+++ b/features/ajna/positions/common/helpers/getIsFormEmpty.ts
@@ -1,4 +1,5 @@
 import { AjnaEarnPosition } from '@oasisdex/dma-library'
+import { TxStatus } from '@oasisdex/transactions'
 import {
   AjnaFormState,
   AjnaGenericPosition,
@@ -15,6 +16,7 @@ interface GetIsFormEmptyParams {
   state: AjnaFormState
   position: AjnaGenericPosition
   currentStep: AjnaSidebarStep
+  txStatus?: TxStatus
 }
 
 export function getIsFormEmpty({
@@ -22,6 +24,7 @@ export function getIsFormEmpty({
   state,
   position,
   currentStep,
+  txStatus,
 }: GetIsFormEmptyParams): boolean {
   switch (product) {
     case 'borrow': {
@@ -39,7 +42,7 @@ export function getIsFormEmpty({
         case 'nft':
         case 'dpm':
         case 'transaction':
-          return false
+          return txStatus === 'Success'
         case 'manage':
           if ((position as AjnaEarnPosition).quoteTokenAmount.isZero()) {
             return !depositAmount && !withdrawAmount
@@ -63,7 +66,7 @@ export function getIsFormEmpty({
           return !depositAmount
         case 'dpm':
         case 'transaction':
-          return false
+          return txStatus === 'Success'
         case 'manage':
           if (action === 'close-multiply') {
             return false

--- a/features/ajna/positions/common/hooks/useAjnaTxHandler.ts
+++ b/features/ajna/positions/common/hooks/useAjnaTxHandler.ts
@@ -28,7 +28,7 @@ export function useAjnaTxHandler(): () => void {
   const [txHelpers] = useObservable(txHelpers$)
   const [context] = useObservable(context$)
   const {
-    tx: { setTxDetails },
+    tx: { setTxDetails, txDetails },
     environment: {
       collateralPrice,
       collateralToken,
@@ -58,7 +58,13 @@ export function useAjnaTxHandler(): () => void {
     useState<CancelablePromise<Strategy<typeof position> | undefined>>()
 
   const { dpmAddress } = state
-  const isFormEmpty = getIsFormEmpty({ product, state, position, currentStep })
+  const isFormEmpty = getIsFormEmpty({
+    product,
+    state,
+    position,
+    currentStep,
+    txStatus: txDetails?.txStatus,
+  })
 
   useEffect(() => {
     cancelablePromise?.cancel()


### PR DESCRIPTION
# [Hide after pills when tx success](https://app.shortcut.com/oazo-apps/story/10537/inconsistent-after-pill-behaviour)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- issue in `isEmptyForm` was causing the issue with after pills when tx was successful 
  
## How to test 🧪
  <Please explain how to test your changes>

- when tx on multiply position is successful, after pills should disappear
