### PR TITLE
Disable Withdrawal/Deposit + LTV adjustment for Ajna Multiply

### DIFF
--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDepositCollateral.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDepositCollateral.tsx
@@ -27,7 +27,7 @@ export function AjnaMultiplyFormContentDepositCollateral() {
         tokenPrice={collateralPrice}
       />
       {/* DISABLED: We're currently unable to support this operation
-       * in the library based on existing operation if the LTV increases
+       * in the library based on existing operation if the LTV decreases
        * added to product continuous improvements backlog
        * https://app.shortcut.com/oazo-apps/story/10553/multiply-deposit-ltv-decreases-are-not-supported-in-operation
        */}

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDepositCollateral.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDepositCollateral.tsx
@@ -1,9 +1,7 @@
-import { PillAccordion } from 'components/PillAccordion'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaFormContentSummary } from 'features/ajna/positions/common/sidebars/AjnaFormContentSummary'
 import { AjnaFormFieldDeposit } from 'features/ajna/positions/common/sidebars/AjnaFormFields'
-import { AjnaMultiplySlider } from 'features/ajna/positions/multiply/components/AjnaMultiplySlider'
 import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -29,9 +27,14 @@ export function AjnaMultiplyFormContentDepositCollateral() {
         token={collateralToken}
         tokenPrice={collateralPrice}
       />
-      <PillAccordion title={t('adjust-your-position-additional')}>
-        <AjnaMultiplySlider disabled={!depositAmount} />
-      </PillAccordion>
+      {/* DISABLED: We're currently unable to support this operation
+       * in the library based on existing operation if the LTV increases
+       * added to product continuous improvements backlog
+       * https://app.shortcut.com/oazo-apps/story/10553/multiply-deposit-ltv-decreases-are-not-supported-in-operation
+       */}
+      {/*<PillAccordion title={t('adjust-your-position-additional')}>*/}
+      {/*  <AjnaMultiplySlider disabled={!depositAmount} />*/}
+      {/*</PillAccordion>*/}
       {depositAmount && (
         <AjnaFormContentSummary>
           <AjnaMultiplyFormOrder />

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDepositCollateral.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentDepositCollateral.tsx
@@ -4,10 +4,9 @@ import { AjnaFormContentSummary } from 'features/ajna/positions/common/sidebars/
 import { AjnaFormFieldDeposit } from 'features/ajna/positions/common/sidebars/AjnaFormFields'
 import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 
 export function AjnaMultiplyFormContentDepositCollateral() {
-  const { t } = useTranslation()
+  // const { t } = useTranslation()
   const {
     environment: { collateralBalance, collateralPrice, collateralToken },
   } = useAjnaGeneralContext()

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentWithdrawCollateral.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentWithdrawCollateral.tsx
@@ -4,10 +4,9 @@ import { AjnaFormContentSummary } from 'features/ajna/positions/common/sidebars/
 import { AjnaFormFieldWithdraw } from 'features/ajna/positions/common/sidebars/AjnaFormFields'
 import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 
 export function AjnaMultiplyFormContentWithdrawCollateral() {
-  const { t } = useTranslation()
+  // const { t } = useTranslation()
   const {
     environment: { collateralPrice, collateralToken },
   } = useAjnaGeneralContext()

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentWithdrawCollateral.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentWithdrawCollateral.tsx
@@ -1,9 +1,7 @@
-import { PillAccordion } from 'components/PillAccordion'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaFormContentSummary } from 'features/ajna/positions/common/sidebars/AjnaFormContentSummary'
 import { AjnaFormFieldWithdraw } from 'features/ajna/positions/common/sidebars/AjnaFormFields'
-import { AjnaMultiplySlider } from 'features/ajna/positions/multiply/components/AjnaMultiplySlider'
 import { AjnaMultiplyFormOrder } from 'features/ajna/positions/multiply/sidebars/AjnaMultiplyFormOrder'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -29,9 +27,14 @@ export function AjnaMultiplyFormContentWithdrawCollateral() {
         token={collateralToken}
         tokenPrice={collateralPrice}
       />
-      <PillAccordion title={t('adjust-your-position-additional')}>
-        <AjnaMultiplySlider disabled={!withdrawAmount} />
-      </PillAccordion>
+      {/* DISABLED: We're currently unable to support this operation
+       * in the library based on existing operation if the LTV increases
+       * added to product continuous improvements backlog
+       * https://app.shortcut.com/oazo-apps/story/10552/multiply-withdrawal-ltv-increases-are-not-supported-in-operation
+       */}
+      {/*<PillAccordion title={t('adjust-your-position-additional')}>*/}
+      {/*  <AjnaMultiplySlider disabled={!withdrawAmount} />*/}
+      {/*</PillAccordion>*/}
       {withdrawAmount && (
         <AjnaFormContentSummary>
           <AjnaMultiplyFormOrder />


### PR DESCRIPTION
https://app.shortcut.com/oazo-apps/story/10552/multiply-withdrawal-ltv-increases-are-not-supported-in-operation
https://app.shortcut.com/oazo-apps/story/10553/multiply-deposit-ltv-decreases-are-not-supported-in-operation
  
## Changes 👷‍♀️
- Temporarily disabled adjust LTV + deposit/withdrawal until these operations are updated
  
## How to test 🧪
- Go to manage collateral in the UI
- Should not be able to see adjust LTV expander here
