### PR TITLE
Add Rewards + Tooltip to Multiply overview

### DIFF
--- a/components/DetailsSectionContentCard.tsx
+++ b/components/DetailsSectionContentCard.tsx
@@ -3,7 +3,7 @@ import { SystemStyleObject } from '@styled-system/css'
 import { Skeleton } from 'components/Skeleton'
 import { ModalProps, useModal } from 'helpers/modalHook'
 import { TranslateStringType } from 'helpers/translateStringType'
-import React, { ReactNode, useState } from 'react'
+import React, { ReactElement, ReactNode, useState } from 'react'
 import { Box, Flex, Grid, Text } from 'theme-ui'
 
 import { AppLink } from './Links'
@@ -35,7 +35,7 @@ export interface ContentCardProps {
   modal?: TranslateStringType | JSX.Element
   title: string
   unit?: TranslateStringType
-  value?: string
+  value?: ReactElement | string
 }
 
 export function getChangeVariant(collRatioColor: CollRatioColor): ChangeVariantType {

--- a/features/ajna/positions/common/components/contentCards/ContentCardNetBorrowCost.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardNetBorrowCost.tsx
@@ -1,12 +1,15 @@
+import { Icon } from '@makerdao/dai-ui-icons'
 import BigNumber from 'bignumber.js'
 import {
   ChangeVariantType,
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
 import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { Box } from 'theme-ui'
 
 interface ContentCardNetBorrowCostProps {
   isLoading?: boolean
@@ -30,7 +33,20 @@ export function ContentCardNetBorrowCost({
 
   const contentCardSettings: ContentCardProps = {
     title: t('ajna.position-page.multiply.common.overview.net-borrow-cost'),
-    value: `${formatted.netBorrowCost}`,
+    value: (
+      <Box sx={{ alignItems: 'center', display: 'flex' }}>
+        <Icon size={24} name="sparks" color="interactive100" />
+        <Box sx={{ mr: 1 }} />
+        {formatted.netBorrowCost}
+      </Box>
+    ),
+    modal: (
+      <AjnaDetailsSectionContentSimpleModal
+        title={t('ajna.position-page.multiply.common.overview.net-borrow-cost')}
+        description={t('ajna.position-page.multiply.common.overview.net-borrow-cost-modal-desc')}
+        value={formatted.netBorrowCost}
+      />
+    ),
     change: {
       isLoading,
       value:

--- a/features/ajna/positions/common/components/contentCards/ContentCardNetBorrowCost.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardNetBorrowCost.tsx
@@ -5,14 +5,21 @@ import {
   ContentCardProps,
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
+import { Skeleton } from 'components/Skeleton'
+import { StatefulTooltip } from 'components/Tooltip'
 import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
-import { formatDecimalAsPercent } from 'helpers/formatters/format'
+import { isPoolWithRewards } from 'features/ajna/positions/common/helpers/isPoolWithRewards'
+import { useAjnaRewards } from 'features/ajna/rewards/useAjnaRewards'
+import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { Box } from 'theme-ui'
+import { Text } from 'theme-ui'
 
 interface ContentCardNetBorrowCostProps {
   isLoading?: boolean
+  collateralToken: string
+  quoteToken: string
+  owner: string
   netBorrowCost: BigNumber
   afterNetBorrowCost?: BigNumber
   changeVariant?: ChangeVariantType
@@ -20,11 +27,15 @@ interface ContentCardNetBorrowCostProps {
 
 export function ContentCardNetBorrowCost({
   isLoading,
+  collateralToken,
+  quoteToken,
+  owner,
   netBorrowCost,
   afterNetBorrowCost,
   changeVariant = 'positive',
 }: ContentCardNetBorrowCostProps) {
   const { t } = useTranslation()
+  const userAjnaRewards = useAjnaRewards(owner)
 
   const formatted = {
     netBorrowCost: formatDecimalAsPercent(netBorrowCost),
@@ -34,11 +45,42 @@ export function ContentCardNetBorrowCost({
   const contentCardSettings: ContentCardProps = {
     title: t('ajna.position-page.multiply.common.overview.net-borrow-cost'),
     value: (
-      <Box sx={{ alignItems: 'center', display: 'flex' }}>
-        <Icon size={24} name="sparks" color="interactive100" />
-        <Box sx={{ mr: 1 }} />
+      <>
+        {isPoolWithRewards({ collateralToken, quoteToken }) && (
+          <StatefulTooltip
+            tooltip={
+              <>
+                <Text as="p">
+                  <strong>{t('ajna.position-page.borrow.common.footer.earned-ajna-tokens')}</strong>
+                  : {t('ajna.position-page.borrow.common.footer.earned-ajna-tokens-tooltip-desc')}
+                </Text>
+                <Text as="p" sx={{ mt: 2, fontWeight: 'semiBold' }}>
+                  {userAjnaRewards.isLoading ? (
+                    <Skeleton width="64px" />
+                  ) : (
+                    `${formatCryptoBalance(userAjnaRewards.rewards.tokens)} AJNA ${t('earned')}`
+                  )}
+                </Text>
+              </>
+            }
+            containerSx={{ position: 'relative', top: '2px', display: 'inline-block', mr: 1 }}
+            tooltipSx={{
+              width: '300px',
+              fontSize: 1,
+              whiteSpace: 'initial',
+              textAlign: 'left',
+              border: 'none',
+              borderRadius: 'medium',
+              boxShadow: 'buttonMenu',
+              fontWeight: 'regular',
+              lineHeight: 'body',
+            }}
+          >
+            <Icon size={24} name="sparks" color="interactive100" />
+          </StatefulTooltip>
+        )}
         {formatted.netBorrowCost}
-      </Box>
+      </>
     ),
     modal: (
       <AjnaDetailsSectionContentSimpleModal

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
@@ -22,6 +22,7 @@ export function AjnaMultiplyOverviewController() {
       collateralToken,
       quoteToken,
       flow,
+      owner,
       collateralPrice,
       priceFormat,
       quotePrice,
@@ -92,6 +93,9 @@ export function AjnaMultiplyOverviewController() {
               changeVariant={changeVariant}
             />
             <ContentCardNetBorrowCost
+              collateralToken={collateralToken}
+              quoteToken={quoteToken}
+              owner={owner}
               netBorrowCost={position.pool.interestRate}
               changeVariant={changeVariant}
             />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2764,6 +2764,7 @@
         "common": {
           "overview": {
             "net-borrow-cost": "Net Borrow Cost",
+            "net-borrow-cost-modal-desc": "The net borrow cost rate represents how much your debt will increase in one year at the current market utilization. This rate is variable, changing every 12 hours with utilization in the pool.",
             "net-value": "Net Value",
             "pnl": "P&L"
           },


### PR DESCRIPTION
# [Missing Rewards Icon](https://app.shortcut.com/oazo-apps/story/10555/missing-rewards-icon)
  
## Changes 👷‍♀️
- Add simple modal and rewards icon to Net Borrow Cost on multiply

