### PR TITLE
Remove buy collateral button

### DIFF
--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentManage.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentManage.tsx
@@ -59,15 +59,6 @@ export function AjnaMultiplyFormContentManage() {
             active={uiPill}
             items={[
               {
-                id: 'deposit-quote-multiply',
-                label: t('system.actions.multiply.buy-coll'),
-                action: () => {
-                  dispatch({ type: 'reset' })
-                  updateState('uiPill', 'deposit-quote-multiply')
-                  updateState('action', 'deposit-quote-multiply')
-                },
-              },
-              {
                 id: 'payback-multiply',
                 label: t('system.actions.multiply.reduce-debt'),
                 action: () => {


### PR DESCRIPTION
# [Title](https://app.shortcut.com/oazo-apps/story/10561/extra-buy-collateral-button)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- Remove buy collateral button from manage debt section of ajna multiply
  
## How to test 🧪
- Go to /ethereum/ajna/847
- Click manage debt in dropdown
- Confirm that the buy coll action pill is not visible
