### PR TITLE
Token identifying by contract address

### DIFF
--- a/blockchain/identifyTokens.ts
+++ b/blockchain/identifyTokens.ts
@@ -1,0 +1,76 @@
+import * as erc20 from 'blockchain/abi/erc20.json'
+import { Context } from 'blockchain/network'
+import { SimplifiedTokenConfig } from 'blockchain/tokensMetadata'
+import { combineLatest, Observable } from 'rxjs'
+import { ajax } from 'rxjs/ajax'
+import { shareReplay, switchMap } from 'rxjs/operators'
+import { Erc20 } from 'types/web3-v1-contracts'
+
+interface IdentifiedTokens {
+  [key: string]: SimplifiedTokenConfig
+}
+
+async function getErc20TokenData(context: Context, address: string) {
+  return Promise.all([
+    context.contract<Erc20>({ abi: erc20, address }).methods.decimals().call(),
+    context.contract<Erc20>({ abi: erc20, address }).methods.name().call(),
+    context.contract<Erc20>({ abi: erc20, address }).methods.symbol().call(),
+  ]).then(([decimals, name, symbol]) => ({
+    address,
+    decimals,
+    name,
+    symbol,
+  }))
+}
+
+export function identifyTokens$(
+  context$: Observable<Context>,
+  once$: Observable<unknown>,
+  tokens: string[],
+): Observable<IdentifiedTokens> {
+  const query = tokens.reduce<string>(
+    (total, token, i) => `${total}${i > 0 ? '&' : ''}token=${token}`,
+    '?',
+  )
+
+  return combineLatest(
+    ajax.getJSON<IdentifiedTokens>(`/api/token-identifier${query}`),
+    context$,
+    once$,
+  ).pipe(
+    switchMap(async ([ajaxResponse, context]) => {
+      const contractResponse = (
+        await Promise.all(
+          tokens
+            .filter((token) => !Object.keys(ajaxResponse).includes(token))
+            .map((token) => getErc20TokenData(context, token)),
+        )
+      ).reduce<IdentifiedTokens>(
+        (total, { address, decimals, name, symbol }) => ({
+          ...total,
+          [address]: {
+            precision: parseInt(decimals, 10),
+            digits: 5,
+            name,
+            symbol,
+          },
+        }),
+        {},
+      )
+
+      return tokens.reduce<IdentifiedTokens>(
+        (total, token) => ({
+          ...total,
+          ...(Object.keys(ajaxResponse).includes(token) && {
+            [token]: ajaxResponse[token],
+          }),
+          ...(Object.keys(contractResponse).includes(token) && {
+            [token]: contractResponse[token],
+          }),
+        }),
+        {},
+      )
+    }),
+    shareReplay(1),
+  )
+}

--- a/blockchain/identifyTokens.ts
+++ b/blockchain/identifyTokens.ts
@@ -52,7 +52,7 @@ export function identifyTokens$(
             precision: parseInt(decimals, 10),
             digits: 5,
             name,
-            symbol,
+            symbol: symbol.toUpperCase(),
           },
         }),
         {},

--- a/blockchain/identifyTokens.ts
+++ b/blockchain/identifyTokens.ts
@@ -1,9 +1,9 @@
 import * as erc20 from 'blockchain/abi/erc20.json'
 import { Context } from 'blockchain/network'
 import { SimplifiedTokenConfig } from 'blockchain/tokensMetadata'
-import { combineLatest, Observable } from 'rxjs'
+import { combineLatest, Observable, of } from 'rxjs'
 import { ajax } from 'rxjs/ajax'
-import { shareReplay, switchMap } from 'rxjs/operators'
+import { catchError, shareReplay, switchMap } from 'rxjs/operators'
 import { Erc20 } from 'types/web3-v1-contracts'
 
 interface IdentifiedTokens {
@@ -71,6 +71,7 @@ export function identifyTokens$(
         {},
       )
     }),
+    catchError(() => of({})),
     shareReplay(1),
   )
 }

--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -37,6 +37,8 @@ export interface TokenConfig {
   chain: MainNetworkNames
 }
 
+export type SimplifiedTokenConfig = Pick<TokenConfig, 'digits' | 'name' | 'precision' | 'symbol'>
+
 export const COIN_TAGS = ['stablecoin', 'lp-token'] as const
 export type CoinTag = ElementOf<typeof COIN_TAGS>
 

--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -85,6 +85,7 @@ import { getNetworkContracts } from 'blockchain/contracts'
 import { resolveENSName$ } from 'blockchain/ens'
 import { createTokenBalance$ } from 'blockchain/erc20'
 import { createGetRegistryCdps$ } from 'blockchain/getRegistryCdps'
+import { identifyTokens$ } from 'blockchain/identifyTokens'
 import { createIlkData$, createIlkDataList$, createIlksSupportedOnNetwork$ } from 'blockchain/ilks'
 import { createInstiVault$, InstiVault } from 'blockchain/instiVault'
 import {
@@ -1292,6 +1293,10 @@ export function setupAppContext() {
         .toString()}`,
   )
 
+  const identifiedTokens$ = memoize(curry(identifyTokens$)(context$, once$), (tokens: string[]) =>
+    tokens.join(),
+  )
+
   return {
     web3Context$,
     web3ContextConnected$,
@@ -1369,6 +1374,7 @@ export function setupAppContext() {
     contextForAddress$,
     dpmPositionData$,
     ajnaPosition$,
+    identifiedTokens$,
     chainContext$,
     positionIdFromDpmProxy$,
     switchChains,

--- a/pages/api/token-identifier/index.tsx
+++ b/pages/api/token-identifier/index.tsx
@@ -39,7 +39,7 @@ const handler: NextApiHandler = async (req, res) => {
               ? {
                   ...total,
                   [address]: {
-                    symbol,
+                    symbol: symbol.toUpperCase(),
                     name,
                     precision: decimals,
                     digits: 5,

--- a/pages/api/token-identifier/index.tsx
+++ b/pages/api/token-identifier/index.tsx
@@ -1,0 +1,65 @@
+import { SimplifiedTokenConfig } from 'blockchain/tokensMetadata'
+import { NextApiHandler } from 'next'
+import NodeCache from 'node-cache'
+
+const cache = new NodeCache({ stdTTL: 60 * 60 })
+
+interface TokensListResponse {
+  name: string
+  timestamp: string
+  tokens: {
+    chainId: number
+    address: string
+    name: string
+    symbol: string
+    decimals: number
+  }[]
+}
+
+const handler: NextApiHandler = async (req, res) => {
+  switch (req.method) {
+    case 'GET':
+      if (!req.query.token) {
+        return res.status(500).json({
+          errorMessage: 'Invalid GET parameters',
+          error: 'Missing tokens list',
+        })
+      }
+      const tokens = Array.isArray(req.query.token) ? req.query.token : [req.query.token]
+
+      try {
+        const cached = cache.get('tokensList')
+        const response = (cached ||
+          (await (
+            await fetch('https://tokens.coingecko.com/uniswap/all.json')
+          ).json())) as TokensListResponse
+        const tokensList = response.tokens.reduce<{ [key: string]: SimplifiedTokenConfig }>(
+          (total, { address, decimals, name, symbol }) =>
+            tokens.includes(address)
+              ? {
+                  ...total,
+                  [address]: {
+                    symbol,
+                    name,
+                    precision: decimals,
+                    digits: 5,
+                  },
+                }
+              : total,
+          {},
+        )
+
+        if (!cached) cache.set('tokensList', response)
+
+        return res.status(200).json(tokensList)
+      } catch (error) {
+        return res.status(500).json({
+          errorMessage: 'Unknown error occured',
+          error: String(error),
+        })
+      }
+    default:
+      return res.status(405).end()
+  }
+}
+export default handler


### PR DESCRIPTION
# [Token identifying by contract address](https://app.shortcut.com/oazo-apps/story/10587/token-identifying-by-contract-address)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- Created `identifyTokens$` observable for identifying provided tokens list,
- created `token-identifier` API endpoint that is utilized by observable mentioned above (mostly for error handlings and hiding json address).
  
## How to test 🧪

Currently, there is no usage of the observable anywhere inside of the app, so if you want to test it, paste the code from below on any page:

```typescript
  const { identifiedTokens$ } = useAppContext()
  const [identifiedTokensData, identifiedTokensError] = useObservable(
    identifiedTokens$([
      '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
      '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
      '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
    ]),
  )

  console.log('identifiedTokensData')
  console.log(identifiedTokensData)
  console.log('identifiedTokensError')
  console.log(identifiedTokensError)
```

This should load identified data for WETH, WSTETH and AAVE tokens.
