### PR TITLE
Ajna Multiply on Product Finder

### DIFF
--- a/features/ajna/common/components/AjnaProductHubIntro.tsx
+++ b/features/ajna/common/components/AjnaProductHubIntro.tsx
@@ -2,8 +2,10 @@ import { AppLink } from 'components/Links'
 import { WithArrow } from 'components/WithArrow'
 import { productHubLinksMap } from 'features/productHub/meta'
 import { ProductHubProductType } from 'features/productHub/types'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React, { FC } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Box, Text } from 'theme-ui'
 
 interface AjnaProductHubIntroProps {
@@ -14,31 +16,61 @@ interface AjnaProductHubIntroProps {
 export const AjnaProductHubIntro: FC<AjnaProductHubIntroProps> = ({ selectedProduct }) => {
   const { t } = useTranslation()
 
+  // TODO: remove when Ajna Multiply feature flag is no longer needed
+  const ajnaMultiplyEnabled = useFeatureToggle('AjnaMultiply')
+
   return (
     <Box sx={{ my: 5 }}>
-      <Text
-        as="p"
-        variant="paragraph2"
-        sx={{
-          mx: 'auto',
-          mt: '24px',
-        }}
-      >
-        {t(`product-hub.intro.${selectedProduct}`)}{' '}
-        <AppLink href={productHubLinksMap[selectedProduct]}>
-          <WithArrow
-            variant="paragraph2"
-            sx={{
-              display: 'inline-block',
-              fontSize: 3,
-              color: 'interactive100',
-              fontWeight: 'regular',
-            }}
-          >
-            Summer.fi {t(`nav.${selectedProduct}`)}
-          </WithArrow>
-        </AppLink>
-      </Text>
+      {selectedProduct === ProductHubProductType.Multiply && !ajnaMultiplyEnabled ? (
+        <>
+          <Text as="p" variant="header5" sx={{ mb: 1 }}>
+            {t('ajna.product-finder.multiply-soon-title')}
+          </Text>
+          <Text as="p" variant="paragraph2">
+            <Trans
+              i18nKey="ajna.product-finder.multiply-soon-intro"
+              components={{
+                1: (
+                  <AppLink
+                    href={INTERNAL_LINKS.ajnaBorrow}
+                    sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+                  />
+                ),
+                2: (
+                  <AppLink
+                    href={INTERNAL_LINKS.ajnaEarn}
+                    sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+                  />
+                ),
+              }}
+            />
+          </Text>
+        </>
+      ) : (
+        <Text
+          as="p"
+          variant="paragraph2"
+          sx={{
+            mx: 'auto',
+            mt: '24px',
+          }}
+        >
+          {t(`product-hub.intro.${selectedProduct}`)}{' '}
+          <AppLink href={productHubLinksMap[selectedProduct]}>
+            <WithArrow
+              variant="paragraph2"
+              sx={{
+                display: 'inline-block',
+                fontSize: 3,
+                color: 'interactive100',
+                fontWeight: 'regular',
+              }}
+            >
+              Summer.fi {t(`nav.${selectedProduct}`)}
+            </WithArrow>
+          </AppLink>
+        </Text>
+      )}
     </Box>
   )
 }

--- a/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
@@ -8,6 +8,7 @@ import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/A
 import { AjnaFormContentRisk } from 'features/ajna/positions/common/sidebars/AjnaFormContentRisk'
 import { AjnaFormContentTransaction } from 'features/ajna/positions/common/sidebars/AjnaFormContentTransaction'
 import { AjnaFormView } from 'features/ajna/positions/common/views/AjnaFormView'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
@@ -24,6 +25,9 @@ export function AjnaBorrowFormController() {
       updateState,
     },
   } = useAjnaProductContext('borrow')
+
+  // TODO: remove when Ajna Multiply feature flag is no longer needed
+  const ajnaMultiplyEnabled = useFeatureToggle('AjnaMultiply')
 
   return (
     <AjnaFormView
@@ -60,17 +64,21 @@ export function AjnaBorrowFormController() {
                 updateState('action', 'generate-borrow')
               },
             },
-            {
-              label: t('system.actions.borrow.switch-to-multiply'),
-              icon: 'circle_exchange',
-              iconShrink: 2,
-              panel: 'switch',
-              action: () => {
-                dispatch({ type: 'reset' })
-                updateState('uiDropdown', 'switch')
-                updateState('action', 'switch-borrow')
-              },
-            },
+            ...(ajnaMultiplyEnabled
+              ? [
+                  {
+                    label: t('system.actions.borrow.switch-to-multiply'),
+                    icon: 'circle_exchange',
+                    iconShrink: 2,
+                    panel: 'switch',
+                    action: () => {
+                      dispatch({ type: 'reset' })
+                      updateState('uiDropdown', 'switch')
+                      updateState('action', 'switch-borrow')
+                    },
+                  },
+                ]
+              : []),
           ],
         },
       })}

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -69,8 +69,9 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   const [selectedToken, setSelectedToken] = useState<string>(token || ALL_ASSETS)
   const [selectedFilters, setSelectedFilters] = useState<ProductHubFilters>(defaultFilters)
 
-  // TODO: remove when Ajna Multiply featuge flag is no longer needed
-  const ajnaMultiplyEnabled = useFeatureToggle('')
+  // TODO: remove when Ajna Multiply feature flag is no longer needed
+  const ajnaMultiplyEnabled = useFeatureToggle('AjnaMultiply')
+
   const filteredData = useMemo(() => {
     return !data
       ? undefined

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -118,9 +118,6 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
         }
   }, [data, ajnaMultiplyEnabled])
 
-  console.log(`ajnaMultiplyEnabled: ${ajnaMultiplyEnabled}`)
-  console.log(filteredData)
-
   return (
     <Fragment key={product}>
       <Box

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -16,6 +16,7 @@ import {
 } from 'features/productHub/types'
 import { PromoCardsCollection } from 'handlers/product-hub/types'
 import { WithLoadingIndicator } from 'helpers/AppSpinner'
+import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
 import React, { FC, Fragment, ReactNode, useMemo, useState } from 'react'
@@ -68,6 +69,58 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   const [selectedToken, setSelectedToken] = useState<string>(token || ALL_ASSETS)
   const [selectedFilters, setSelectedFilters] = useState<ProductHubFilters>(defaultFilters)
 
+  // TODO: remove when Ajna Multiply featuge flag is no longer needed
+  const ajnaMultiplyEnabled = useFeatureToggle('')
+  const filteredData = useMemo(() => {
+    return !data
+      ? undefined
+      : ajnaMultiplyEnabled
+      ? data
+      : {
+          promoCards: {
+            borrow: data.promoCards.borrow,
+            multiply: {
+              default: data.promoCards.multiply.default.filter(
+                (card) =>
+                  !(
+                    card.protocol?.protocol === LendingProtocol.Ajna &&
+                    card.link?.href.includes('multiply')
+                  ),
+              ),
+              tokens: Object.keys(data.promoCards.multiply.tokens).reduce(
+                (total, current) => ({
+                  ...total,
+                  [current]: data.promoCards.multiply.tokens[current].filter(
+                    (card) =>
+                      !(
+                        card.protocol?.protocol === LendingProtocol.Ajna &&
+                        card.link?.href.includes('multiply')
+                      ),
+                  ),
+                }),
+                {},
+              ),
+            },
+            earn: data.promoCards.earn,
+          },
+          table: data.table.map((row) => ({
+            ...row,
+            ...(row.protocol === LendingProtocol.Ajna && {
+              product: row.product.filter((product) => {
+                return (
+                  product === ProductHubProductType.Borrow ||
+                  (product === ProductHubProductType.Earn &&
+                    !row.earnStrategy?.includes('Yield Loop'))
+                )
+              }),
+            }),
+          })),
+        }
+  }, [data, ajnaMultiplyEnabled])
+
+  console.log(`ajnaMultiplyEnabled: ${ajnaMultiplyEnabled}`)
+  console.log(filteredData)
+
   return (
     <Fragment key={product}>
       <Box
@@ -97,7 +150,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
           <ProductHubIntro selectedProduct={selectedProduct} selectedToken={selectedToken} />
         )}
       </Box>
-      <WithLoadingIndicator value={[data]} customLoader={<ProductHubLoadingState />}>
+      <WithLoadingIndicator value={[filteredData]} customLoader={<ProductHubLoadingState />}>
         {([_data]) => (
           <>
             <ProductHubPromoCardsController

--- a/handlers/product-hub/promo-cards/ajnaLp.ts
+++ b/handlers/product-hub/promo-cards/ajnaLp.ts
@@ -17,6 +17,13 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     promoCardUSDCETHAjnaBorrow,
     promoCardUSDCWBTCAjnaBorrow,
     promoCardWBTCUSDCAjnaBorrow,
+    promoCardCBETHETHAjnaMultiply,
+    promoCardUSDCETHAjnaMultiply,
+    promoCardUSDCWBTCAjnaMultiply,
+    promoCardWBTCDAIAjnaMultiply,
+    promoCardWBTCUSDCAjnaMultiply,
+    promoCardWSTETHDAIAjnaMultiply,
+    promoCardWSTETHUSDCAjnaMultiply,
     promoCardETHUSDCAjnaEarn,
     promoCardUSDCETHAjnaEarn,
     promoCardUSDCWBTCAjnaEarn,
@@ -47,8 +54,33 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
       },
     },
     [ProductHubProductType.Multiply]: {
-      default: [],
-      tokens: {},
+      default: [
+        promoCardWSTETHUSDCAjnaMultiply,
+        promoCardWBTCUSDCAjnaMultiply,
+        promoCardsWhatAreAjnaRewards,
+      ],
+      tokens: {
+        ETH: [
+          promoCardWSTETHUSDCAjnaMultiply,
+          promoCardCBETHETHAjnaMultiply,
+          promoCardsWhatAreAjnaRewards,
+        ],
+        WBTC: [
+          promoCardWBTCUSDCAjnaMultiply,
+          promoCardWBTCDAIAjnaMultiply,
+          promoCardsWhatAreAjnaRewards,
+        ],
+        USDC: [
+          promoCardUSDCETHAjnaMultiply,
+          promoCardUSDCWBTCAjnaMultiply,
+          promoCardsWhatAreAjnaRewards,
+        ],
+        DAI: [
+          promoCardWBTCDAIAjnaMultiply,
+          promoCardWSTETHDAIAjnaMultiply,
+          promoCardsWhatAreAjnaRewards,
+        ]
+      },
     },
     [ProductHubProductType.Earn]: {
       default: [promoCardETHUSDCAjnaEarn, promoCardWSTETHDAIAjnaEarn, promoCardsWhatAreAjnaRewards],

--- a/handlers/product-hub/promo-cards/ajnaLp.ts
+++ b/handlers/product-hub/promo-cards/ajnaLp.ts
@@ -79,7 +79,7 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
           promoCardWBTCDAIAjnaMultiply,
           promoCardWSTETHDAIAjnaMultiply,
           promoCardsWhatAreAjnaRewards,
-        ]
+        ],
       },
     },
     [ProductHubProductType.Earn]: {

--- a/handlers/product-hub/promo-cards/collections/ajna.ts
+++ b/handlers/product-hub/promo-cards/collections/ajna.ts
@@ -3,8 +3,11 @@ import { findByTokenPair } from 'handlers/product-hub/helpers'
 import {
   getActiveManagementPill,
   getAjnaTokensPill,
+  getLongTokenPill,
+  getShortTokenPill,
   parseBorrowPromoCard,
   parseEarnLiquidityProvisionPromoCard,
+  parseMultiplyPromoCard,
 } from 'handlers/product-hub/promo-cards/parsers'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -30,11 +33,15 @@ export function getAjnaPromoCards(table: ProductHubItem[]) {
     product.includes(ProductHubProductType.Earn),
   )
 
+  const CBETHETHAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['CBETH', 'ETH'])
   const ETHDAIAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['ETH', 'DAI'])
   const ETHUSDCAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['ETH', 'USDC'])
   const USDCETHAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['USDC', 'ETH'])
   const USDCWBTCAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['USDC', 'WBTC'])
+  const WBTCDAIAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['WBTC', 'DAI'])
   const WBTCUSDCAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['WBTC', 'USDC'])
+  const WSTETHDAIAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['WSTETH', 'DAI'])
+  const WSTETHUSDCAjnaBorrowishProduct = findByTokenPair(ajnaBorrowishProducts, ['WSTETH', 'USDC'])
 
   const ETHUSDCAjnaEarnProduct = findByTokenPair(ajnaEarnProducts, ['USDC', 'ETH'])
   const USDCETHAjnaEarnProduct = findByTokenPair(ajnaEarnProducts, ['ETH', 'USDC'])
@@ -72,6 +79,56 @@ export function getAjnaPromoCards(table: ProductHubItem[]) {
     debtToken: 'USDC',
     product: WBTCUSDCAjnaBorrowishProduct,
     ...commonBorrowPromoCardPayload,
+  })
+
+  const promoCardCBETHETHAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'CBETH',
+    debtToken: 'ETH',
+    product: CBETHETHAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getLongTokenPill('ETH')],
+    ...commonPromoCardPayload,
+  })
+  const promoCardUSDCETHAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'USDC',
+    debtToken: 'ETH',
+    product: USDCETHAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getShortTokenPill('ETH')],
+    ...commonPromoCardPayload,
+  })
+  const promoCardUSDCWBTCAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'USDC',
+    debtToken: 'WBTC',
+    product: USDCWBTCAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getShortTokenPill('WBTC')],
+    ...commonPromoCardPayload,
+  })
+  const promoCardWBTCDAIAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'WBTC',
+    debtToken: 'DAI',
+    product: WBTCDAIAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getLongTokenPill('WBTC')],
+    ...commonPromoCardPayload,
+  })
+  const promoCardWBTCUSDCAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'WBTC',
+    debtToken: 'USDC',
+    product: WBTCUSDCAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getLongTokenPill('WBTC')],
+    ...commonPromoCardPayload,
+  })
+  const promoCardWSTETHDAIAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'WSTETH',
+    debtToken: 'DAI',
+    product: WSTETHDAIAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getLongTokenPill('WSTETH')],
+    ...commonPromoCardPayload,
+  })
+  const promoCardWSTETHUSDCAjnaMultiply = parseMultiplyPromoCard({
+    collateralToken: 'WSTETH',
+    debtToken: 'USDC',
+    product: WSTETHUSDCAjnaBorrowishProduct,
+    pills: [getAjnaTokensPill(), getLongTokenPill('WSTETH')],
+    ...commonPromoCardPayload,
   })
 
   const promoCardETHUSDCAjnaEarn = parseEarnLiquidityProvisionPromoCard({
@@ -117,6 +174,13 @@ export function getAjnaPromoCards(table: ProductHubItem[]) {
     promoCardUSDCETHAjnaBorrow,
     promoCardUSDCWBTCAjnaBorrow,
     promoCardWBTCUSDCAjnaBorrow,
+    promoCardCBETHETHAjnaMultiply,
+    promoCardUSDCETHAjnaMultiply,
+    promoCardUSDCWBTCAjnaMultiply,
+    promoCardWBTCDAIAjnaMultiply,
+    promoCardWBTCUSDCAjnaMultiply,
+    promoCardWSTETHDAIAjnaMultiply,
+    promoCardWSTETHUSDCAjnaMultiply,
     promoCardETHUSDCAjnaEarn,
     promoCardUSDCETHAjnaEarn,
     promoCardUSDCWBTCAjnaEarn,

--- a/handlers/product-hub/promo-cards/homeWithAjna.ts
+++ b/handlers/product-hub/promo-cards/homeWithAjna.ts
@@ -26,7 +26,6 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
   } = getMakerPromoCards(table)
   const { promoCardSTETHUSDCAaveV2Earn } = getAaveV2PromoCards(table)
   const {
-    promoCardETHUSDCAaveV3EthereumMultiply,
     promoCardWBTCUSDCAaveV3EthereumMultiply,
     promoCardWSTETHUSDCAaveV3EthereumMultiply,
     promoCardETHUSDCAaveV3OptimismMultiply,
@@ -38,6 +37,9 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     promoCardUSDCETHAjnaBorrow,
     promoCardUSDCWBTCAjnaBorrow,
     promoCardWBTCUSDCAjnaBorrow,
+    promoCardUSDCETHAjnaMultiply,
+    promoCardWBTCUSDCAjnaMultiply,
+    promoCardWSTETHUSDCAjnaMultiply,
     promoCardETHUSDCAjnaEarn,
     promoCardUSDCETHAjnaEarn,
     promoCardUSDCWBTCAjnaEarn,
@@ -56,23 +58,23 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     },
     [ProductHubProductType.Multiply]: {
       default: [
-        promoCardETHUSDCAaveV3EthereumMultiply,
+        promoCardWSTETHUSDCAjnaMultiply,
         promoCardWBTCUSDCAaveV3OptimismMultiply,
         promoCardETHBMakerMultiply,
       ],
       tokens: {
         ETH: [
-          promoCardETHUSDCAaveV3EthereumMultiply,
+          promoCardWSTETHUSDCAjnaMultiply,
           promoCardWSTETHAMakerMultiply,
           promoCardETHUSDCAaveV3OptimismMultiply,
         ],
         WBTC: [
           promoCardWBTCBMakerMultiply,
-          promoCardWBTCUSDCAaveV3EthereumMultiply,
+          promoCardWBTCUSDCAjnaMultiply,
           promoCardWBTCUSDCAaveV3OptimismMultiply,
         ],
         USDC: [
-          promoCardETHUSDCAaveV3EthereumMultiply,
+          promoCardUSDCETHAjnaMultiply,
           promoCardWSTETHUSDCAaveV3EthereumMultiply,
           promoCardWBTCUSDCAaveV3EthereumMultiply,
         ],

--- a/handlers/product-hub/promo-cards/index.ts
+++ b/handlers/product-hub/promo-cards/index.ts
@@ -1,5 +1,5 @@
 import { ProductHubItem, ProductHubPromoCards } from 'features/productHub/types'
-import ajnaLpHandler from 'handlers/product-hub/promo-cards/ajnaLpHandler'
+import ajnaLp from 'handlers/product-hub/promo-cards/ajnaLp'
 import home from 'handlers/product-hub/promo-cards/home'
 import homeWithAjna from 'handlers/product-hub/promo-cards/homeWithAjna'
 import { PromoCardsCollection } from 'handlers/product-hub/types'
@@ -7,7 +7,7 @@ import { PromoCardsCollection } from 'handlers/product-hub/types'
 export const PROMO_CARD_COLLECTIONS_PARSERS: {
   [key in PromoCardsCollection]: (table: ProductHubItem[]) => ProductHubPromoCards
 } = {
-  AjnaLP: ajnaLpHandler,
+  AjnaLP: ajnaLp,
   Home: home,
   HomeWithAjna: homeWithAjna,
 }

--- a/handlers/product-hub/promo-cards/parsers/getPromoCardsPills.ts
+++ b/handlers/product-hub/promo-cards/parsers/getPromoCardsPills.ts
@@ -66,6 +66,12 @@ export function getMaxLtvPill(maxLtv: string) {
   }
 }
 
+export function getShortTokenPill(token: string) {
+  return {
+    label: { key: 'product-hub.promo-cards.short-token', props: { token } },
+  }
+}
+
 export function getUpToYieldExposurePill(maxMultiple: string) {
   return {
     label: {

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -26,6 +26,7 @@ export type Feature =
   | 'AaveV3Protection'
   | 'AaveV3ProtectionWrite'
   | 'Ajna'
+  | 'AjnaMultiply'
   | 'AjnaSafetySwitch'
   | 'AjnaSuppressValidation'
   | 'DaiSavingsRate'
@@ -74,6 +75,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   AaveV3Protection: false,
   AaveV3ProtectionWrite: false,
   Ajna: true,
+  AjnaMultiply: true,
   AjnaSafetySwitch: false,
   AjnaSuppressValidation: false,
   DaiSavingsRate: true,


### PR DESCRIPTION
# Ajna Multiply on Product Finder

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/b24ce3d2-ea9b-44a5-bb1d-311408d3ffe4)
  
## Changes 👷‍♀️

- Added Ajna Multiply products to `homeWithAjna` and `ajnaLp` promo cards collections,
- created temporary filter that hides Ajna Multiply related stuff from Product Finder if feature flag is turned off.
- disabled possibility to switch from borrow to multiply, although multiply to borrow is still possible
- restored header with Ajna coming soon copy when flag is disabled
  
## How to test 🧪

- Check `/multiply` and `/ajna/multiply` pages with `AjnaMultiply` flag turned on and off.
- Check possibility to switch between position types with flag turned on and off

