### PR TITLE
Bump dma lib 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.33",
     "@oasisdex/automation": "1.5.0-alpha.8",
-    "@oasisdex/dma-library": "0.4.1",
+    "@oasisdex/dma-library": "0.4.2",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,10 +3937,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.4.1.tgz#790f264873e5377aee7bea32c5b08481673eeace"
-  integrity sha512-fim0yjIscWLukxvWbGlnqVE9ZgSJXN+PrQm/tC+3Tj4joJByQFQCjk9PEwFVAgNpFcTY1YlTs1Fkt4qgbdyLAA==
+"@oasisdex/dma-library@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.4.2.tgz#06316c6892922f4ac90dd1868bce7e20723ba00e"
+  integrity sha512-AoPGvSO0fNTteP9UyDR+nf9A6eb54+23HfzGF06klW2QsOvD9Q5nG6u8AFGR3J6PnvPEB7cnmC7YegcIhn1tvw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Bump dma lib 0.4.2](https://app.shortcut.com/oazo-apps/story/10598/generate-close-to-max-ltv-shows-zeros)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bump lib version which fixes issue with zero in warning regarding ltv close to max ltv
  
## How to test 🧪
  <Please explain how to test your changes>

- create either borrow or multiply position with ltv within range of 5% to dynamic max ltv. Later on try to deposit a little bit of collateral to remain within 5% range. Warning shouldn't popup
