### PR TITLE
Redirect non-multiply tokens only on multiply

### DIFF
--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -160,6 +160,7 @@ export function AjnaProductController({
     !id &&
     collateralToken &&
     quoteToken &&
+    product === 'multiply' &&
     !isPoolSupportingMultiply({ collateralToken, quoteToken })
   )
     void push(INTERNAL_LINKS.ajnaMultiply)


### PR DESCRIPTION
# Redirect non-multiply tokens only on multiply
  
## Changes 👷‍♀️

- Fixed an issue where pools that aren't supported by multiple were redirecting also on borrow and earn.