### PR TITLE
fix: [sc-10642] [Aave multiply] Last slider value is not neccesarily the shown order information

### DIFF
--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -1004,8 +1004,8 @@ export const trackingEvents = {
         product: productType.toLocaleLowerCase(),
         riskRatio: formatPrecision(riskRatio, 4),
         page: {
-          [ProductType.EARN]: Pages.ManageSTETH,
           [ProductType.MULTIPLY]: Pages.AdjustPosition,
+          [ProductType.EARN]: Pages.ManageSTETH,
           [ProductType.BORROW]: '',
         }[productType],
         section: 'AdjustRisk',

--- a/analytics/analytics.ts
+++ b/analytics/analytics.ts
@@ -994,25 +994,26 @@ export const trackingEvents = {
       }
       mixpanelInternalAPI(EventTypes.ButtonClick, eventBody)
     },
-    stETHAdjustRiskMoveSlider: (riskRatio: BigNumber) => {
+    aaveAdjustRiskSliderAction: (
+      action: 'ConfirmRisk' | 'MoveSlider',
+      riskRatio: BigNumber,
+      productType: ProductType,
+    ) => {
       const eventBody = {
-        id: 'MoveSlider',
-        product: ProductType.EARN,
+        id: action,
+        product: productType.toLocaleLowerCase(),
         riskRatio: formatPrecision(riskRatio, 4),
-        page: Pages.ManageSTETH,
+        page: {
+          [ProductType.EARN]: Pages.ManageSTETH,
+          [ProductType.MULTIPLY]: Pages.AdjustPosition,
+          [ProductType.BORROW]: '',
+        }[productType],
         section: 'AdjustRisk',
       }
-      mixpanelInternalAPI(EventTypes.InputChange, eventBody)
-    },
-    stETHAdjustRiskConfirmRisk: (riskRatio: BigNumber) => {
-      const eventBody = {
-        id: 'ConfirmRisk',
-        product: ProductType.EARN,
-        riskRatio: formatPrecision(riskRatio, 4),
-        page: Pages.ManageSTETH,
-        section: 'AdjustRisk',
-      }
-      mixpanelInternalAPI(EventTypes.ButtonClick, eventBody)
+      mixpanelInternalAPI(
+        action === 'MoveSlider' ? EventTypes.InputChange : EventTypes.ButtonClick,
+        eventBody,
+      )
     },
     stETHAdjustRiskConfirmTransaction: (riskRatio: BigNumber) => {
       const eventBody = {

--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -624,13 +624,15 @@ export function SidebarManageAaveVault() {
     },
   } = useAutomationContext()
 
-  const stopLossError =
-    isStopLossEnabled &&
-    state.context.transition?.simulation?.position.riskRatio.loanToValue.gte(stopLossLevel)
-
   function loading(): boolean {
     return isLoading(state)
   }
+
+  const stopLossError =
+    isStopLossEnabled &&
+    ((state.context.transition?.simulation?.position.riskRatio.loanToValue.gte(stopLossLevel) &&
+      !loading()) ||
+      state.context.userInput.riskRatio?.loanToValue.gte(stopLossLevel))
 
   const dropdownConfig = getDropdownConfig({ state, send })
 

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -1,6 +1,7 @@
 import { IPosition } from '@oasisdex/dma-library'
 import { AdjustAaveParameters, CloseAaveParameters, ManageAaveParameters } from 'actions/aave'
 import { trackingEvents } from 'analytics/analytics'
+import { ProductType as AnalyticsProductType } from 'analytics/common'
 import { TransactionDef } from 'blockchain/calls/callsHelpers'
 import {
   callOperationExecutorWithDpmProxy,
@@ -155,7 +156,7 @@ export function createManageAaveStateMachine(
               },
             },
             loading: {
-              entry: ['requestParameters'],
+              entry: ['requestParameters', 'riskRatioEvent'],
               on: {
                 STRATEGY_RECEIVED: {
                   target: 'idle',
@@ -215,7 +216,7 @@ export function createManageAaveStateMachine(
                 SET_RISK_RATIO: {
                   cond: 'canChangePosition',
                   target: '#manageAaveStateMachine.background.debouncing',
-                  actions: ['userInputRiskRatio', 'riskRatioEvent'],
+                  actions: ['userInputRiskRatio'],
                 },
                 RESET_RISK_RATIO: {
                   cond: 'canChangePosition',
@@ -591,10 +592,18 @@ export function createManageAaveStateMachine(
           transition: undefined,
         })),
         riskRatioEvent: (context) => {
-          trackingEvents.earn.stETHAdjustRiskMoveSlider(context.userInput.riskRatio!.loanToValue)
+          trackingEvents.earn.aaveAdjustRiskSliderAction(
+            'MoveSlider',
+            context.userInput.riskRatio!.loanToValue,
+            context.strategyConfig.type as AnalyticsProductType,
+          )
         },
         riskRatioConfirmEvent: (context) => {
-          trackingEvents.earn.stETHAdjustRiskConfirmRisk(context.userInput.riskRatio!.loanToValue)
+          trackingEvents.earn.aaveAdjustRiskSliderAction(
+            'ConfirmRisk',
+            context.userInput.riskRatio!.loanToValue,
+            context.strategyConfig.type as AnalyticsProductType,
+          )
         },
         // riskRatioConfirmTransactionEvent: (context) => {
         //   trackingEvents.earn.stETHAdjustRiskConfirmTransaction(


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/10642

Changes:
- renamed mixpanel events `stETHAdjustRiskMoveSlider` and `stETHAdjustRiskConfirmRisk` to `aaveAdjustRiskSliderAction`, to one action that handles all aave earn/multiply adjust events
- moved `riskRatioEvent` in the state machine after the debounce (so it doesn't execute like crazy)
- added `userInput` value to `stopLossError` for an instant feedback on the stop loss warning