### PR TITLE
Improve handling of dma multiple positions

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -1302,7 +1302,8 @@ export function setupAppContext() {
   // only single position should be picked to be displayed
   const dpmPositionDataV2$ = memoize(
     curry(getDpmPositionDataV2$)(proxiesRelatedWithPosition$, readPositionCreatedEvents$),
-    (positionId: PositionId) => `${positionId.walletAddress}-${positionId.vaultId}`,
+    (positionId: PositionId, collateralToken?: string, quoteToken?: string, product?: string) =>
+      `${positionId.walletAddress}-${positionId.vaultId}-${collateralToken}-${quoteToken}-${product}`,
   )
 
   const ajnaPosition$ = memoize(

--- a/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
@@ -43,6 +43,7 @@ interface AjnaGeneralContextProviderProps {
   steps: AjnaSidebarStep[]
   gasPrice: GasPriceParams
   slippage: BigNumber
+  isProxyWithManyPositions: boolean
 }
 
 type AjnaGeneralContextEnvironment = Omit<AjnaGeneralContextProviderProps, 'steps'> & {
@@ -106,6 +107,7 @@ export function AjnaGeneralContextProvider({
     owner,
     product,
     slippage,
+    isProxyWithManyPositions,
   } = props
   const { walletAddress } = useAccount()
   const [currentStep, setCurrentStep] = useState<AjnaSidebarStep>(steps[0])
@@ -152,6 +154,7 @@ export function AjnaGeneralContextProvider({
     environment: {
       ...props,
       isShort,
+      isProxyWithManyPositions,
       priceFormat: isShort
         ? `${quoteToken}/${collateralToken}`
         : `${collateralToken}/${quoteToken}`,

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -38,7 +38,7 @@ import { useAccount } from 'helpers/useAccount'
 import { upperFirst } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useMemo } from 'react'
 import { EMPTY } from 'rxjs'
 
@@ -69,6 +69,8 @@ export function AjnaProductController({
   } = useAppContext()
   const { walletAddress } = useAccount()
 
+  const { readPositionCreatedEvents$ } = useAppContext()
+
   const [userSettingsData, userSettingsError] = useObservable(userSettings$)
 
   const [gasPriceData, gasPriceError] = useObservable(gasPrice$)
@@ -83,6 +85,38 @@ export function AjnaProductController({
       [collateralToken, id, product, quoteToken],
     ),
   )
+
+  const [positionCreatedEvents] = useObservable(
+    useMemo(
+      () => (dpmPositionData ? readPositionCreatedEvents$(dpmPositionData.user) : EMPTY),
+      [dpmPositionData],
+    ),
+  )
+
+  const isProxyWithManyPositions = positionCreatedEvents
+    ? positionCreatedEvents.filter(
+        (item) => item.proxyAddress.toLowerCase() === dpmPositionData?.proxy.toLowerCase(),
+      ).length > 1
+    : false
+
+  useEffect(() => {
+    if (
+      id &&
+      isProxyWithManyPositions &&
+      dpmPositionData &&
+      !collateralToken &&
+      !quoteToken &&
+      !product
+    ) {
+      const {
+        product: dpmProduct,
+        collateralToken: dpmCollateralToken,
+        quoteToken: dpmQuoteToken,
+      } = dpmPositionData
+
+      void push(`/ethereum/ajna/${dpmProduct}/${dpmCollateralToken}-${dpmQuoteToken}/${id}`)
+    }
+  }, [isProxyWithManyPositions, dpmPositionData])
 
   const [balancesInfoArrayData, balancesInfoArrayError] = useObservable(
     useMemo(
@@ -238,6 +272,7 @@ export function AjnaProductController({
                         steps={steps[dpmPosition.product as AjnaProduct][flow]}
                         gasPrice={gasPrice}
                         slippage={slippage}
+                        isProxyWithManyPositions={isProxyWithManyPositions}
                       >
                         {dpmPosition.product === 'borrow' && (
                           <AjnaProductContextProvider

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -66,10 +66,9 @@ export function AjnaProductController({
     tokenPriceUSD$,
     gasPrice$,
     userSettings$,
+    readPositionCreatedEvents$,
   } = useAppContext()
   const { walletAddress } = useAccount()
-
-  const { readPositionCreatedEvents$ } = useAppContext()
 
   const [userSettingsData, userSettingsError] = useObservable(userSettings$)
 

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
@@ -1,5 +1,4 @@
 import { normalizeValue } from '@oasisdex/dma-library'
-import { useAppContext } from 'components/AppContextProvider'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooterItem'
@@ -11,10 +10,9 @@ import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/A
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaTokensBannerController } from 'features/ajna/positions/common/controls/AjnaTokensBannerController'
 import { ContentFooterItemsMultiply } from 'features/ajna/positions/multiply/components/ContentFooterItemsMultiply'
-import { useObservable } from 'helpers/observableHook'
 import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { Grid } from 'theme-ui'
 
 export function AjnaMultiplyOverviewController() {
@@ -29,23 +27,9 @@ export function AjnaMultiplyOverviewController() {
       priceFormat,
       quotePrice,
       isShort,
-      dpmProxy,
+      isProxyWithManyPositions,
     },
   } = useAjnaGeneralContext()
-
-  const { readPositionCreatedEvents$ } = useAppContext()
-
-  const [positionCreatedEvents] = useObservable(
-    useMemo(() => readPositionCreatedEvents$(owner), [owner]),
-  )
-
-  // For now we need to hide P&L for proxies with many positions
-  // because subgraph doesn't support it yet
-  const isProxyWithManyPositions = positionCreatedEvents
-    ? positionCreatedEvents.filter(
-        (item) => item.proxyAddress.toLowerCase() === dpmProxy?.toLowerCase(),
-      ).length > 1
-    : false
 
   const {
     notifications,
@@ -125,6 +109,8 @@ export function AjnaMultiplyOverviewController() {
                 .times(collateralPrice)
                 .minus(simulation?.debtAmount.times(quotePrice))}
               pnl={pnl}
+              // For now we need to hide P&L for proxies with many positions
+              // because subgraph doesn't support it yet
               pnlNotAvailable={isProxyWithManyPositions}
               showPnl={flow === 'manage'}
               changeVariant={changeVariant}


### PR DESCRIPTION
# [Improve handling of dma multiple positions](https://app.shortcut.com/oazo-apps/story/10643/ui-provide-support-for-many-ajna-positions-on-the-same-proxy)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- improved handling of dma multiple positions
- fixed issue with memoization
  
## How to test 🧪
  <Please explain how to test your changes>

- go to `0xd790A1516F78E3FB52338084B5C5931a75BB19CF` owner page, click view next to 963 borrow position, then go back to owner, click view next to 963 earn position, correct position should be loaded
- try to go directly to `ethereum/ajna/963`, url should be updated with token pair and product
