### PR TITLE
chore: [sc-10646] [Aave multiply] Update Stop loss max offset - validate on 2.5% of liquidation threshold.

### DIFF
--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -30,7 +30,7 @@ import {
   AutomationAddTriggerData,
   AutomationAddTriggerTxDef,
 } from 'features/automation/common/txDefinitions'
-import { aaveOffsetFromMaxDuringOpenFLow } from 'features/automation/metadata/aave/stopLossMetadata'
+import { aaveOffsets } from 'features/automation/metadata/aave/stopLossMetadata'
 import { extractStopLossDataInput } from 'features/automation/protection/stopLoss/openFlow/helpers'
 import { prepareStopLossTriggerDataV2 } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
 import { AllowanceStateMachine } from 'features/stateMachines/allowance'
@@ -861,7 +861,7 @@ export function createOpenAaveStateMachine(
           const { proxyAddress, debtTokenAddress, collateralTokenAddress } =
             extractStopLossDataInput(context)
           const stopLossLevel = context
-            .reserveConfig!.liquidationThreshold.minus(aaveOffsetFromMaxDuringOpenFLow)
+            .reserveConfig!.liquidationThreshold.minus(aaveOffsets.open.max)
             .times(100)
 
           return {

--- a/features/automation/metadata/aave/stopLossMetadata.ts
+++ b/features/automation/metadata/aave/stopLossMetadata.ts
@@ -35,8 +35,16 @@ import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { one, zero } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
 
-export const aaveOffsetFromMinAndMax = new BigNumber(0.05)
-export const aaveOffsetFromMaxDuringOpenFLow = new BigNumber(0.1)
+export const aaveOffsets = {
+  open: {
+    min: new BigNumber(0.01),
+    max: new BigNumber(0.025),
+  },
+  manage: {
+    min: new BigNumber(0.01),
+    max: new BigNumber(0.025),
+  },
+}
 
 export function createGetAaveStopLossMetadata(
   lendingProtocol: LendingProtocol,
@@ -70,9 +78,9 @@ export function createGetAaveStopLossMetadata(
     })
 
     const sliderMin = new BigNumber(
-      positionRatio.plus(aaveOffsetFromMinAndMax).times(100).toFixed(0, BigNumber.ROUND_UP),
+      positionRatio.plus(aaveOffsets.manage.min).times(100).toFixed(0, BigNumber.ROUND_UP),
     )
-    const sliderMax = liquidationRatio.minus(aaveOffsetFromMinAndMax).times(100)
+    const sliderMax = liquidationRatio.minus(aaveOffsets.manage.max).times(100)
 
     const initialSlRatioWhenTriggerDoesntExist = getStartingSlRatio({
       stopLossLevel: stopLossLevel,

--- a/features/automation/protection/stopLoss/openFlow/openVaultStopLossAave.ts
+++ b/features/automation/protection/stopLoss/openFlow/openVaultStopLossAave.ts
@@ -5,7 +5,7 @@ import { collateralPriceAtRatio } from 'blockchain/vault.maths'
 import { AutomationPositionData } from 'components/AutomationContextProvider'
 import { OpenAaveContext, OpenAaveEvent } from 'features/aave/open/state'
 import { AutomationAddTriggerData } from 'features/automation/common/txDefinitions'
-import { aaveOffsetFromMinAndMax } from 'features/automation/metadata/aave/stopLossMetadata'
+import { aaveOffsets } from 'features/automation/metadata/aave/stopLossMetadata'
 import { StopLossMetadata } from 'features/automation/metadata/types'
 import {
   getCollateralDuringLiquidation,
@@ -74,9 +74,9 @@ export function getAaveStopLossData(context: OpenAaveContext, send: Sender<OpenA
   })
 
   const sliderMin = new BigNumber(
-    positionRatio.plus(aaveOffsetFromMinAndMax).times(100).toFixed(0, BigNumber.ROUND_UP),
+    positionRatio.plus(aaveOffsets.open.min).times(100).toFixed(0, BigNumber.ROUND_UP),
   )
-  const sliderMax = liquidationRatio.minus(aaveOffsetFromMinAndMax).times(100)
+  const sliderMax = liquidationRatio.minus(aaveOffsets.open.max).times(100)
 
   const afterNewLiquidationPrice = getDynamicStopLossPrice({
     liquidationPrice,


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/10646