### PR TITLE
fix: [sc-10652] [Aave multiply] Order information state is not reset when switching between options

### DIFF
--- a/features/aave/manage/containers/AaveManageTabBar.tsx
+++ b/features/aave/manage/containers/AaveManageTabBar.tsx
@@ -7,6 +7,8 @@ import { supportsAaveStopLoss } from 'features/aave/helpers/supportsAaveStopLoss
 import { useManageAaveStateMachineContext } from 'features/aave/manage/containers/AaveManageStateMachineContext'
 import { SidebarManageAaveVault } from 'features/aave/manage/sidebars/SidebarManageAaveVault'
 import { isSupportedAutomationTokenPair } from 'features/automation/common/helpers'
+import { STOP_LOSS_FORM_CHANGE } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
+import { uiChanges } from 'helpers/uiChanges'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { ReserveConfigurationData, ReserveData } from 'lendingProtocols/aaveCommon'
 import { useTranslation } from 'next-i18next'
@@ -28,6 +30,11 @@ export function AaveManageTabBar({
   const aaveProtection = useFeatureToggle('AaveV3Protection')
   const {
     triggerData: { stopLossTriggerData },
+    metadata: {
+      stopLossMetadata: {
+        values: { resetData },
+      },
+    },
   } = useAutomationContext()
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state] = useActor(stateMachine)
@@ -95,6 +102,12 @@ export function AaveManageTabBar({
                 value: 'protection',
                 tag: { include: true, active: protectionEnabled },
                 content: <ProtectionControl />,
+                callback: () => {
+                  uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
+                    type: 'reset',
+                    resetData,
+                  })
+                },
               },
             ]
           : []),

--- a/features/aave/manage/containers/AaveManageTabBar.tsx
+++ b/features/aave/manage/containers/AaveManageTabBar.tsx
@@ -7,8 +7,6 @@ import { supportsAaveStopLoss } from 'features/aave/helpers/supportsAaveStopLoss
 import { useManageAaveStateMachineContext } from 'features/aave/manage/containers/AaveManageStateMachineContext'
 import { SidebarManageAaveVault } from 'features/aave/manage/sidebars/SidebarManageAaveVault'
 import { isSupportedAutomationTokenPair } from 'features/automation/common/helpers'
-import { STOP_LOSS_FORM_CHANGE } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
-import { uiChanges } from 'helpers/uiChanges'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { ReserveConfigurationData, ReserveData } from 'lendingProtocols/aaveCommon'
 import { useTranslation } from 'next-i18next'
@@ -30,11 +28,6 @@ export function AaveManageTabBar({
   const aaveProtection = useFeatureToggle('AaveV3Protection')
   const {
     triggerData: { stopLossTriggerData },
-    metadata: {
-      stopLossMetadata: {
-        values: { resetData },
-      },
-    },
   } = useAutomationContext()
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state] = useActor(stateMachine)
@@ -102,12 +95,6 @@ export function AaveManageTabBar({
                 value: 'protection',
                 tag: { include: true, active: protectionEnabled },
                 content: <ProtectionControl />,
-                callback: () => {
-                  uiChanges.publish(STOP_LOSS_FORM_CHANGE, {
-                    type: 'reset',
-                    resetData,
-                  })
-                },
               },
             ]
           : []),

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -592,18 +592,22 @@ export function createManageAaveStateMachine(
           transition: undefined,
         })),
         riskRatioEvent: (context) => {
-          trackingEvents.earn.aaveAdjustRiskSliderAction(
-            'MoveSlider',
-            context.userInput.riskRatio!.loanToValue,
-            context.strategyConfig.type as AnalyticsProductType,
-          )
+          context.userInput.riskRatio?.loanToValue &&
+            context.strategyConfig.type &&
+            trackingEvents.earn.aaveAdjustRiskSliderAction(
+              'MoveSlider',
+              context.userInput.riskRatio.loanToValue,
+              context.strategyConfig.type as AnalyticsProductType,
+            )
         },
         riskRatioConfirmEvent: (context) => {
-          trackingEvents.earn.aaveAdjustRiskSliderAction(
-            'ConfirmRisk',
-            context.userInput.riskRatio!.loanToValue,
-            context.strategyConfig.type as AnalyticsProductType,
-          )
+          context.userInput.riskRatio?.loanToValue &&
+            context.strategyConfig.type &&
+            trackingEvents.earn.aaveAdjustRiskSliderAction(
+              'ConfirmRisk',
+              context.userInput.riskRatio.loanToValue,
+              context.strategyConfig.type as AnalyticsProductType,
+            )
         },
         // riskRatioConfirmTransactionEvent: (context) => {
         //   trackingEvents.earn.stETHAdjustRiskConfirmTransaction(

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -236,6 +236,7 @@ export function createManageAaveStateMachine(
               },
             },
             manageCollateral: {
+              entry: ['reset'],
               on: {
                 NEXT_STEP: [
                   {
@@ -255,6 +256,7 @@ export function createManageAaveStateMachine(
                 BACK_TO_EDITING: {
                   cond: 'canAdjustPosition',
                   target: 'editing',
+                  actions: ['reset'],
                 },
                 CLOSE_POSITION: {
                   cond: 'canChangePosition',
@@ -268,6 +270,7 @@ export function createManageAaveStateMachine(
               },
             },
             manageDebt: {
+              entry: ['reset'],
               on: {
                 NEXT_STEP: [
                   {
@@ -286,6 +289,7 @@ export function createManageAaveStateMachine(
                 BACK_TO_EDITING: {
                   cond: 'canAdjustPosition',
                   target: 'editing',
+                  actions: ['reset'],
                 },
                 CLOSE_POSITION: {
                   cond: 'canChangePosition',
@@ -336,6 +340,7 @@ export function createManageAaveStateMachine(
               on: {
                 BACK_TO_EDITING: {
                   target: 'editing',
+                  actions: ['reset', 'killCurrentParametersMachine'],
                 },
                 NEXT_STEP: [
                   {
@@ -425,7 +430,7 @@ export function createManageAaveStateMachine(
                 BACK_TO_EDITING: {
                   cond: 'canAdjustPosition',
                   target: 'editing',
-                  actions: ['reset'],
+                  actions: ['reset', 'killCurrentParametersMachine'],
                 },
               },
             },
@@ -473,7 +478,7 @@ export function createManageAaveStateMachine(
         BACK_TO_EDITING: {
           cond: 'canAdjustPosition',
           target: 'frontend.editing',
-          actions: ['reset'],
+          actions: ['reset', 'killCurrentParametersMachine'],
         },
         CLOSE_POSITION: {
           target: ['frontend.reviewingClosing'],


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/10652