### PR TITLE
fix: [sc-10656] [Aave multiply] App slow to recognize Stop Loss is active

### DIFF
--- a/components/AutomationContextProvider.tsx
+++ b/components/AutomationContextProvider.tsx
@@ -111,7 +111,11 @@ export interface AutomationContextProviderProps {
   overwriteTriggersDefaults?: OverwriteTriggersDefaults
 }
 
-const automationTriggersDataInitialState = { isAutomationEnabled: false, triggers: [] }
+const automationTriggersDataInitialState = {
+  isAutomationEnabled: false,
+  triggers: [],
+  isAutomationDataLoaded: false,
+}
 
 export const automationContext = React.createContext<AutomationContext | undefined>(undefined)
 

--- a/components/Tab.tsx
+++ b/components/Tab.tsx
@@ -14,6 +14,7 @@ interface TabProps {
   tag?: {
     include: boolean
     active: boolean
+    isLoading?: boolean
   }
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
@@ -33,7 +34,9 @@ export function Tab({ variant, value, label, selected, tag, onClick }: TabProps)
       }}
     >
       {label}
-      {variant === 'underline' && tag?.include && <VaultTabTag isEnabled={tag.active} />}
+      {variant === 'underline' && tag?.include && (
+        <VaultTabTag isEnabled={tag.active} isLoading={tag.isLoading} />
+      )}
     </Button>
   )
 }

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -14,6 +14,7 @@ export type TabSection = {
   tag?: {
     include: boolean
     active: boolean
+    isLoading?: boolean
   }
   topContent?: JSX.Element | string
   content: JSX.Element
@@ -81,7 +82,9 @@ export function TabBar({
                 return (
                   <Flex sx={{ alignItems: 'center' }}>
                     {data.label}
-                    {data.tag && <VaultTabTag isEnabled={data.tag.active} />}
+                    {data.tag && (
+                      <VaultTabTag isEnabled={data.tag.active} isLoading={data.tag.isLoading} />
+                    )}
                   </Flex>
                 )
               },
@@ -103,7 +106,9 @@ export function TabBar({
                       sx={{ fontWeight: isSelected ? 'semiBold' : 'body', alignItems: 'center' }}
                     >
                       {data.label}
-                      {data.tag && <VaultTabTag isEnabled={data.tag.active} />}
+                      {data.tag && (
+                        <VaultTabTag isEnabled={data.tag.active} isLoading={data.tag.isLoading} />
+                      )}
                     </Flex>
                   </Box>
                 )

--- a/components/vault/VaultTabTag.tsx
+++ b/components/vault/VaultTabTag.tsx
@@ -1,18 +1,20 @@
 import { Box } from '@theme-ui/components'
+import { AppSpinner } from 'helpers/AppSpinner'
 import React from 'react'
 
 interface VaultTabTagProps {
   isEnabled?: boolean
+  isLoading?: boolean
 }
 
-export function VaultTabTag({ isEnabled }: VaultTabTagProps) {
+export function VaultTabTag({ isEnabled, isLoading }: VaultTabTagProps) {
   return (
     <Box
       sx={{
         height: '19px',
         lineHeight: '19px',
         borderRadius: '5px',
-        backgroundColor: isEnabled ? 'success100' : 'warning100',
+        backgroundColor: !isLoading ? (isEnabled ? 'success100' : 'warning100') : 'neutral70',
         color: 'white',
         fontSize: 1,
         fontWeight: 'semiBold',
@@ -20,7 +22,15 @@ export function VaultTabTag({ isEnabled }: VaultTabTagProps) {
         ml: 2,
       }}
     >
-      {isEnabled ? 'ON' : 'OFF'}
+      {!isLoading ? (
+        isEnabled ? (
+          'ON'
+        ) : (
+          'OFF'
+        )
+      ) : (
+        <AppSpinner size={15} sx={{ color: 'white', pt: '3px' }} />
+      )}
     </Box>
   )
 }

--- a/features/aave/manage/containers/AaveManageTabBar.tsx
+++ b/features/aave/manage/containers/AaveManageTabBar.tsx
@@ -27,6 +27,7 @@ export function AaveManageTabBar({
   const { t } = useTranslation()
   const aaveProtection = useFeatureToggle('AaveV3Protection')
   const {
+    automationTriggersData: { isAutomationDataLoaded },
     triggerData: { stopLossTriggerData },
   } = useAutomationContext()
   const { stateMachine } = useManageAaveStateMachineContext()
@@ -93,7 +94,11 @@ export function AaveManageTabBar({
               {
                 label: t('system.protection'),
                 value: 'protection',
-                tag: { include: true, active: protectionEnabled },
+                tag: {
+                  include: true,
+                  active: protectionEnabled,
+                  isLoading: !isAutomationDataLoaded,
+                },
                 content: <ProtectionControl />,
               },
             ]

--- a/features/automation/api/automationTriggersData.ts
+++ b/features/automation/api/automationTriggersData.ts
@@ -44,6 +44,7 @@ async function loadTriggerDataFromCache({
   )
 
   return {
+    isAutomationDataLoaded: true,
     isAutomationEnabled: activeTriggersForVault.length > 0,
     triggers: activeTriggersForVault,
   }
@@ -57,6 +58,7 @@ export interface TriggerRecord {
 }
 
 export interface TriggersData {
+  isAutomationDataLoaded: boolean
   isAutomationEnabled: boolean
   triggers?: TriggerRecord[]
 }

--- a/features/vaultHistory/vaultHistory.ts
+++ b/features/vaultHistory/vaultHistory.ts
@@ -71,6 +71,7 @@ export function unpackTriggerDataForHistory(event: AutomationEvent) {
     case 'basic-sell': {
       const autoBSData = extractAutoBSData({
         triggersData: {
+          isAutomationDataLoaded: true,
           isAutomationEnabled: false,
           triggers: [
             {
@@ -92,6 +93,7 @@ export function unpackTriggerDataForHistory(event: AutomationEvent) {
     }
     case 'stop-loss':
       const stopLossData = extractStopLossData({
+        isAutomationDataLoaded: true,
         isAutomationEnabled: false,
         triggers: [
           {
@@ -108,6 +110,7 @@ export function unpackTriggerDataForHistory(event: AutomationEvent) {
       }
     case 'auto-take-profit':
       const autoTakeProfitData = extractAutoTakeProfitData({
+        isAutomationDataLoaded: true,
         isAutomationEnabled: false,
         triggers: [
           {

--- a/features/vaultHistory/vaultsHistory.ts
+++ b/features/vaultHistory/vaultsHistory.ts
@@ -133,11 +133,13 @@ function mapToVaultWithHistory(
 
     const history = flatEvents([vaultEvents, vaultAutomationEvents])
     const stopLossData = extractStopLossData({
+      isAutomationDataLoaded: true,
       isAutomationEnabled,
       triggers,
     })
     const autoSellData = extractAutoBSData({
       triggersData: {
+        isAutomationDataLoaded: true,
         isAutomationEnabled,
         triggers,
       },

--- a/helpers/mocks/stopLoss.mock.ts
+++ b/helpers/mocks/stopLoss.mock.ts
@@ -2,6 +2,7 @@ import { TriggersData } from 'features/automation/api/automationTriggersData'
 
 // mock with 300% stop loss level
 export const mockedStopLossTrigger: TriggersData = {
+  isAutomationDataLoaded: true,
   isAutomationEnabled: true,
   triggers: [
     {
@@ -14,6 +15,7 @@ export const mockedStopLossTrigger: TriggersData = {
 }
 
 export const mockedEmptyStopLossTrigger: TriggersData = {
+  isAutomationDataLoaded: true,
   isAutomationEnabled: false,
   triggers: [],
 }


### PR DESCRIPTION
Changes 🤺 
- added loading state to the Aave position Protection tab

Story details: https://app.shortcut.com/oazo-apps/story/10656