### PR TITLE
Add connection-cancelled handling and correct createConnector behaviour

### DIFF
--- a/features/web3OnBoard/use-bridge-connector.tsx
+++ b/features/web3OnBoard/use-bridge-connector.tsx
@@ -6,7 +6,7 @@ import { useCallback, useMemo } from 'react'
 import { BridgeConnector } from './bridge-connector'
 
 export interface BridgeConnectorState {
-  createConnector: () => Promise<void>
+  createConnector: () => Promise<boolean>
   connecting: boolean
   connector: BridgeConnector | undefined
   wallet: WalletState | null
@@ -30,9 +30,10 @@ export function useBridgeConnector(): BridgeConnectorState {
 
   const createConnector = useCallback(async () => {
     if (connector || connecting || wallet) {
-      return
+      return true
     }
-    await connect()
+    const currentWallet = await connect()
+    return !(!currentWallet || currentWallet.length === 0)
   }, [wallet, connect, connecting, connector])
 
   const disconnectProxy = useCallback(async () => {

--- a/features/web3OnBoard/use-bridge-connector.tsx
+++ b/features/web3OnBoard/use-bridge-connector.tsx
@@ -33,7 +33,8 @@ export function useBridgeConnector(): BridgeConnectorState {
       return true
     }
     const currentWallet = await connect()
-    return !(!currentWallet || currentWallet.length === 0)
+    const isWalletConnected = currentWallet && currentWallet.length > 0
+    return isWalletConnected
   }, [wallet, connect, connecting, connector])
 
   const disconnectProxy = useCallback(async () => {

--- a/features/web3OnBoard/wallet-state/connecting-wallet-state-reducer.ts
+++ b/features/web3OnBoard/wallet-state/connecting-wallet-state-reducer.ts
@@ -35,5 +35,11 @@ export const connectingWalletStateReducer: Reducer<WalletManagementState, Wallet
         walletNetworkHexId: event.connector.hexChainId,
       }
     })
+    .with({ type: 'connection-cancelled' }, () => {
+      return {
+        ...state,
+        status: 'disconnected',
+      }
+    })
     .otherwise(() => state)
 }

--- a/features/web3OnBoard/wallet-state/wallet-state-event.ts
+++ b/features/web3OnBoard/wallet-state/wallet-state-event.ts
@@ -11,6 +11,9 @@ export type WalletStateEvent = ReductoActions<
       desiredNetworkHexId?: NetworkConfigHexId
     }
   | {
+      type: 'connection-cancelled'
+    }
+  | {
       type: 'connected'
       connector: BridgeConnector
     }

--- a/features/web3OnBoard/web3-on-board-connector-provider.tsx
+++ b/features/web3OnBoard/web3-on-board-connector-provider.tsx
@@ -136,9 +136,14 @@ function InternalProvider({ children }: WithChildren) {
       if (bridgeConnector) dispatch({ type: 'connected', connector: bridgeConnector })
       else {
         if (!connecting) {
-          void createConnector().then((result) => {
-            if (!result) dispatch({ type: 'connection-cancelled' })
-          })
+          createConnector()
+            .then((result) => {
+              if (!result) dispatch({ type: 'connection-cancelled' })
+            })
+            .catch((error) => {
+              console.error(error)
+              dispatch({ type: 'connection-cancelled' })
+            })
         }
       }
     }

--- a/features/web3OnBoard/web3-on-board-connector-provider.tsx
+++ b/features/web3OnBoard/web3-on-board-connector-provider.tsx
@@ -93,7 +93,12 @@ function InternalProvider({ children }: WithChildren) {
     },
     reducer: walletStateReducer,
   })
-  const { createConnector, connector: bridgeConnector, disconnect } = useBridgeConnector()
+  const {
+    createConnector,
+    connector: bridgeConnector,
+    disconnect,
+    connecting,
+  } = useBridgeConnector()
 
   useDebugWalletState({ state })
 
@@ -129,9 +134,15 @@ function InternalProvider({ children }: WithChildren) {
   useEffect(() => {
     if (state.status === 'connecting') {
       if (bridgeConnector) dispatch({ type: 'connected', connector: bridgeConnector })
-      else void createConnector()
+      else {
+        if (!connecting) {
+          void createConnector().then((result) => {
+            if (!result) dispatch({ type: 'connection-cancelled' })
+          })
+        }
+      }
     }
-  }, [state.status, createConnector, bridgeConnector, dispatch])
+  }, [state.status, createConnector, bridgeConnector, dispatch, connecting])
 
   useEffect(() => {
     if (state.status === 'disconnected' && bridgeConnector) {


### PR DESCRIPTION
Added a new `connection-cancelled` event and modified the `createConnector` function to handle cases where the connection is canceled. In addition, the return type of createConnector was changed from `Promise<void>` to `Promise<Boolean>`, with the result indicating if the connection is successful.
