### PR TITLE
Aave Position overview Card - Add Stop Loss information

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -37,7 +37,7 @@ export function ModalCloseIcon({ close, sx, size = 3, color = 'neutral80' }: Mod
   const handleEscClose = useCallback((event) => {
     const { keyCode } = event
     if (keyCode === 27) {
-      close()
+      close && close()
     }
   }, [])
 

--- a/components/vault/VaultDetails.tsx
+++ b/components/vault/VaultDetails.tsx
@@ -165,7 +165,7 @@ export function VaultDetailsCardModal({
   close,
   children,
 }: {
-  close: () => void
+  close?: () => void
   children: ReactNode
 }) {
   return (

--- a/components/vault/detailsSection/ContentCardLtv.tsx
+++ b/components/vault/detailsSection/ContentCardLtv.tsx
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { ContentCardProps, DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
 import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
+import { AppSpinner } from 'helpers/AppSpinner'
 import { formatDecimalAsPercent, formatPercent } from 'helpers/formatters/format'
 import { useModal } from 'helpers/modalHook'
 import { useHash } from 'helpers/useHash'
@@ -31,6 +32,7 @@ interface ContentCardLtvModalProps {
   liquidationThreshold: BigNumber
   maxLoanToValue?: BigNumber
   stopLossLevel?: BigNumber
+  stopLossLevelLoading?: boolean
 }
 
 function ContentCardLtvModal({
@@ -38,6 +40,7 @@ function ContentCardLtvModal({
   liquidationThreshold,
   maxLoanToValue,
   stopLossLevel,
+  stopLossLevelLoading,
 }: ContentCardLtvModalProps) {
   const { close: closeModal } = useModal()
   const { t } = useTranslation()
@@ -94,7 +97,7 @@ function ContentCardLtvModal({
           formatDecimalAsPercent(stopLossLevel)
         ) : (
           <Text as="p" variant="paragraph3" onClick={goToProtection} sx={{ cursor: 'pointer' }}>
-            Not set - click to set up stop loss
+            {stopLossLevelLoading ? <AppSpinner /> : t('aave-position-modal.ltv.stop-loss-not-set')}
           </Text>
         )}
       </Card>
@@ -108,6 +111,7 @@ interface ContentCardLtvProps {
   maxLoanToValue?: BigNumber
   afterLoanToValue?: BigNumber
   stopLossLevel?: BigNumber
+  stopLossLevelLoading?: boolean
 }
 
 export function ContentCardLtv({
@@ -116,6 +120,7 @@ export function ContentCardLtv({
   afterLoanToValue,
   maxLoanToValue,
   stopLossLevel,
+  stopLossLevelLoading,
 }: ContentCardLtvProps) {
   const { t } = useTranslation()
 
@@ -131,6 +136,7 @@ export function ContentCardLtv({
     maxLoanToValue,
     liquidationThreshold,
     stopLossLevel,
+    stopLossLevelLoading,
   }
 
   const contentCardSettings: ContentCardProps = {

--- a/components/vault/detailsSection/ContentCardLtv.tsx
+++ b/components/vault/detailsSection/ContentCardLtv.tsx
@@ -1,8 +1,11 @@
 import BigNumber from 'bignumber.js'
 import { ContentCardProps, DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
+import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
 import { formatDecimalAsPercent, formatPercent } from 'helpers/formatters/format'
+import { useModal } from 'helpers/modalHook'
+import { useHash } from 'helpers/useHash'
 import { zero } from 'helpers/zero'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import React from 'react'
 import { theme } from 'theme'
 import { Card, Grid, Heading, Text } from 'theme-ui'
@@ -27,14 +30,23 @@ interface ContentCardLtvModalProps {
   loanToValue: BigNumber
   liquidationThreshold: BigNumber
   maxLoanToValue?: BigNumber
+  stopLossLevel?: BigNumber
 }
 
 function ContentCardLtvModal({
   loanToValue,
   liquidationThreshold,
   maxLoanToValue,
+  stopLossLevel,
 }: ContentCardLtvModalProps) {
+  const { close: closeModal } = useModal()
   const { t } = useTranslation()
+  const [, setHash] = useHash()
+
+  const goToProtection = () => {
+    closeModal!()
+    setHash(VaultViewMode.Protection)
+  }
 
   return (
     <Grid gap={2}>
@@ -63,6 +75,29 @@ function ContentCardLtvModal({
       <Card as="p" variant="vaultDetailsCardModal">
         {formatDecimalAsPercent(liquidationThreshold)}
       </Card>
+      <Heading variant="header4">{t('aave-position-modal.ltv.fourth-header')}</Heading>
+      <Text as="p" variant="paragraph3" sx={{ mb: 1 }}>
+        <Trans
+          i18nKey="aave-position-modal.ltv.fourth-description-line"
+          components={[
+            <Text
+              as="span"
+              variant="boldParagraph3"
+              onClick={goToProtection}
+              sx={{ cursor: 'pointer' }}
+            />,
+          ]}
+        />
+      </Text>
+      <Card as="p" variant="vaultDetailsCardModal">
+        {stopLossLevel ? (
+          formatDecimalAsPercent(stopLossLevel)
+        ) : (
+          <Text as="p" variant="paragraph3" onClick={goToProtection} sx={{ cursor: 'pointer' }}>
+            Not set - click to set up stop loss
+          </Text>
+        )}
+      </Card>
     </Grid>
   )
 }
@@ -72,6 +107,7 @@ interface ContentCardLtvProps {
   liquidationThreshold: BigNumber
   maxLoanToValue?: BigNumber
   afterLoanToValue?: BigNumber
+  stopLossLevel?: BigNumber
 }
 
 export function ContentCardLtv({
@@ -79,6 +115,7 @@ export function ContentCardLtv({
   liquidationThreshold,
   afterLoanToValue,
   maxLoanToValue,
+  stopLossLevel,
 }: ContentCardLtvProps) {
   const { t } = useTranslation()
 
@@ -86,20 +123,26 @@ export function ContentCardLtv({
     loanToValue: formatDecimalAsPercent(loanToValue),
     afterLoanToValue: afterLoanToValue && formatDecimalAsPercent(afterLoanToValue),
     liquidationThreshold: formatPercent(liquidationThreshold.times(100)),
+    stopLossLevel: stopLossLevel && formatPercent(stopLossLevel.times(100)),
   }
 
   const contentCardModalSettings: ContentCardLtvModalProps = {
     loanToValue,
     maxLoanToValue,
     liquidationThreshold,
+    stopLossLevel,
   }
 
   const contentCardSettings: ContentCardProps = {
     title: t('system.loan-to-value'),
     value: formatted.loanToValue,
-    footnote: `${t('manage-earn-vault.liquidation-threshold', {
-      percentage: formatted.liquidationThreshold,
-    })}`,
+    footnote: stopLossLevel
+      ? t('manage-earn-vault.stop-loss-ltv', {
+          percentage: formatted.stopLossLevel,
+        })
+      : t('manage-earn-vault.liquidation-threshold', {
+          percentage: formatted.liquidationThreshold,
+        }),
     customBackground:
       afterLoanToValue && !liquidationThreshold.eq(zero)
         ? getLTVRatioColor(liquidationThreshold.minus(loanToValue).times(100))

--- a/features/multiply/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/multiply/aave/components/AaveMultiplyPositionData.tsx
@@ -1,6 +1,7 @@
 import { IPosition } from '@oasisdex/dma-library'
 import { amountFromWei } from '@oasisdex/utils'
 import BigNumber from 'bignumber.js'
+import { useAutomationContext } from 'components/AutomationContextProvider'
 import { DetailsSection } from 'components/DetailsSection'
 import {
   DetailsSectionContentCard,
@@ -88,6 +89,11 @@ export function AaveMultiplyPositionData({
   aaveHistory,
 }: AaveMultiplyPositionDataProps) {
   const { t } = useTranslation()
+  const {
+    triggerData: {
+      stopLossTriggerData: { isStopLossEnabled, stopLossLevel },
+    },
+  } = useAutomationContext()
 
   const currentPositionThings = calcViewValuesForPosition(
     currentPosition,
@@ -197,6 +203,7 @@ export function AaveMultiplyPositionData({
               liquidationThreshold={currentPosition.category.liquidationThreshold}
               afterLoanToValue={nextPosition?.riskRatio.loanToValue}
               maxLoanToValue={currentPosition.category.maxLoanToValue}
+              stopLossLevel={isStopLossEnabled ? stopLossLevel : undefined}
             />
             <DetailsSectionContentCard
               title={t('system.net-borrow-cost')}

--- a/features/multiply/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/multiply/aave/components/AaveMultiplyPositionData.tsx
@@ -204,6 +204,7 @@ export function AaveMultiplyPositionData({
               afterLoanToValue={nextPosition?.riskRatio.loanToValue}
               maxLoanToValue={currentPosition.category.maxLoanToValue}
               stopLossLevel={isStopLossEnabled ? stopLossLevel : undefined}
+              stopLossLevelLoading={true}
             />
             <DetailsSectionContentCard
               title={t('system.net-borrow-cost')}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -813,7 +813,8 @@
       "first-description-line": "Your Loan to Value ratio represents how much you have borrowed based on your collateral supplied",
       "second-description-line": "The Max Loan to Value (LTV) ratio defines the maximum amount that can be borrowed with your collateral",
       "third-description-line": "The liquidation threshold is the percentage at which a position is undercollateralised. If your LTV rises above the LT, the position is undercollateralised and could be liquidated.",
-      "fourth-description-line": "The Stop loss Loan to Value indicates the Loan to value at which your position will be stop lossed. You can adjust this in the <0>protection tab</0>."
+      "fourth-description-line": "The Stop loss Loan to Value indicates the Loan to value at which your position will be stop lossed. You can adjust this in the <0>protection tab</0>.",
+      "stop-loss-not-set": "Not set - click to set up stop loss."
     },
     "net-borrow-cost": {
       "first-header": "Net borrow Cost %",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -791,6 +791,7 @@
     "below-current-ratio": "({{percentage}} below current ratio)",
     "below-current-price": "{{percentage}} below current price",
     "liquidation-threshold": "Liq Threshold: {{percentage}}",
+    "stop-loss-ltv": "Stop Loss LTV: {{percentage}}",
     "has-asset-already": "There is an active Aave position open in this address. Therefore, you cannot open a stETH earn position. Close your Aave position first to continue.",
     "net-value-modal": "Net Value",
     "net-value-calculation": "The current net value is calculated based on the oracle price of {{oraclePrice}} {{collateralSymbol}}/{{debtSymbol}}. This net value doesn't include the cost of the closing fee or the difference that might happen due to slippage or price changes once you close your position. Net value of position if closed will likely be lower.",
@@ -808,9 +809,11 @@
       "first-header": "Current Loan to Value (LTV)",
       "second-header": "Max Loan to value",
       "third-header": "Liquidation Threshold (LT)",
+      "fourth-header": "Stop loss Loan to Value",
       "first-description-line": "Your Loan to Value ratio represents how much you have borrowed based on your collateral supplied",
       "second-description-line": "The Max Loan to Value (LTV) ratio defines the maximum amount that can be borrowed with your collateral",
-      "third-description-line": "The liquidation threshold is the percentage at which a position is undercollateralised. If your LTV rises above the LT, the position is undercollateralised and could be liquidated."
+      "third-description-line": "The liquidation threshold is the percentage at which a position is undercollateralised. If your LTV rises above the LT, the position is undercollateralised and could be liquidated.",
+      "fourth-description-line": "The Stop loss Loan to Value indicates the Loan to value at which your position will be stop lossed. You can adjust this in the <0>protection tab</0>."
     },
     "net-borrow-cost": {
       "first-header": "Net borrow Cost %",


### PR DESCRIPTION
Changes 🕺 
- added stop loss information on the LTV block of the overview (pic 1)
- added stop loss information in the LTV modal (pic 2)
- added a way to close the modal (hacky, cause `openModal` from `useModal` now has additional `openModal.close` function, but it works and the types are there)

Story details: https://app.shortcut.com/oazo-apps/story/6940

<details>
<summary>pic 1</summary>

![image](https://github.com/OasisDEX/oasis-borrow/assets/5095527/26a2ff08-d58d-4bc2-bb65-68c5bf6f28de)

</details>
<details>
<summary>pic 2</summary>

![image](https://github.com/OasisDEX/oasis-borrow/assets/5095527/ed15ab6d-f74b-4805-9709-d0533a20ce07)

</details>



