### PR TITLE
Ajna rewards banner adjustment

### DIFF
--- a/features/ajna/positions/common/controls/AjnaTokensBannerController.tsx
+++ b/features/ajna/positions/common/controls/AjnaTokensBannerController.tsx
@@ -1,25 +1,53 @@
 import { Banner } from 'components/Banner'
+import { AppLink } from 'components/Links'
 import { AjnaFlow } from 'features/ajna/common/types'
-import { INTERNAL_LINKS } from 'helpers/applicationLinks'
+import { EXTERNAL_LINKS, INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useRedirect } from 'helpers/useRedirect'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import React, { FC } from 'react'
 
 interface AjnaTokensBannerControllerProps {
   flow: AjnaFlow
+  isPriceBelowLup?: boolean // used only in earn product
 }
 
-export const AjnaTokensBannerController: FC<AjnaTokensBannerControllerProps> = ({ flow }) => {
+const PriceBelowLupDescription = () => (
+  <Trans
+    i18nKey="ajna.position-page.common.banners.tokens.description-manage-below-lup"
+    components={{
+      1: <strong />,
+      2: (
+        <AppLink
+          href={EXTERNAL_LINKS.DOCS.AJNA.HOW_TO_PICK_LENDING_PRICE}
+          sx={{ display: 'inline-block' }}
+        />
+      ),
+    }}
+  />
+)
+
+export const AjnaTokensBannerController: FC<AjnaTokensBannerControllerProps> = ({
+  flow,
+  isPriceBelowLup = false,
+}) => {
   const { t } = useTranslation()
   const { push } = useRedirect()
 
   return (
     <Banner
-      title={t('ajna.position-page.common.banners.tokens.title')}
+      title={
+        isPriceBelowLup
+          ? t('ajna.position-page.common.banners.tokens.title-below-lup')
+          : t('ajna.position-page.common.banners.tokens.title')
+      }
       description={
-        flow === 'open'
-          ? t('ajna.position-page.common.banners.tokens.description-open')
-          : t('ajna.position-page.common.banners.tokens.description-manage')
+        flow === 'open' ? (
+          t('ajna.position-page.common.banners.tokens.description-open')
+        ) : isPriceBelowLup ? (
+          <PriceBelowLupDescription />
+        ) : (
+          t('ajna.position-page.common.banners.tokens.description-manage')
+        )
       }
       image={{
         src: '/static/img/ajna-tokens-banner.svg',

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewController.tsx
@@ -1,4 +1,5 @@
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
+import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaTokensBannerController } from 'features/ajna/positions/common/controls/AjnaTokensBannerController'
 import { isPoolWithRewards } from 'features/ajna/positions/common/helpers/isPoolWithRewards'
 import { AjnaEarnOverviewManageController } from 'features/ajna/positions/earn/controls/AjnaEarnOverviewManageController'
@@ -10,13 +11,23 @@ export function AjnaEarnOverviewController() {
   const {
     environment: { collateralToken, flow, quoteToken },
   } = useAjnaGeneralContext()
+  const {
+    position: {
+      currentPosition: {
+        position: { pool, price },
+      },
+    },
+  } = useAjnaProductContext('earn')
+
+  const isPriceBelowLup =
+    price.lt(pool.lowestUtilizedPrice) && !pool.lowestUtilizedPriceIndex.isZero()
 
   return (
     <Grid gap={2}>
       {flow === 'open' && <AjnaEarnOverviewOpenController />}
       {flow === 'manage' && <AjnaEarnOverviewManageController />}
       {isPoolWithRewards({ collateralToken, quoteToken }) && (
-        <AjnaTokensBannerController flow={flow} />
+        <AjnaTokensBannerController flow={flow} isPriceBelowLup={isPriceBelowLup} />
       )}
     </Grid>
   )

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2561,7 +2561,9 @@
         "banners": {
           "tokens": {
             "title": "This position earns AJNA tokens",
+            "title-below-lup": "Adjust your position to earn AJNA tokens",
             "description-open": "Opening this Ajna position on Summer.fi makes you eligible for AJNA token rewards. You will earn automatically with weekly claim periods.",
+            "description-manage-below-lup": "By opening an Ajna position on Summer.fi you can earn exclusive AJNA tokens. Adjust your position lending price to the active liquidity range in order to start earning AJNA rewards. <1><2>Find out more here.</1></2>",
             "description-manage": "This Ajna position on Summer.fi makes you eligible for AJNA token rewards. You are earning automatically and tokens will be claimable weekly in the near future.",
             "button-open": "Read more about AJNA rewards",
             "button-manage": "Claim your AJNA tokens"


### PR DESCRIPTION
# [Ajna rewards banner adjustment](https://app.shortcut.com/oazo-apps/story/10720/ajna-token-reward-banner-changes)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted rewards banner copies in earn positions when lenders price is below lup
  
## How to test 🧪
  <Please explain how to test your changes>

- when lenders price is below lup a different copies should be displayed in rewards banner
