### PR TITLE
Aave Stop loss fixes

### DIFF
--- a/components/vault/detailsSection/ContentCardLtv.tsx
+++ b/components/vault/detailsSection/ContentCardLtv.tsx
@@ -169,7 +169,7 @@ export function ContentCardLtv({
     title: t('system.loan-to-value'),
     value: formatted.loanToValue,
     footnote:
-      isAutomationAvailable && stopLossLevel
+      isAutomationAvailable && isStopLossEnabled && stopLossLevel
         ? t('manage-earn-vault.stop-loss-ltv', {
             percentage: formatted.stopLossLevel,
           })

--- a/components/vault/detailsSection/ContentCardLtv.tsx
+++ b/components/vault/detailsSection/ContentCardLtv.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { useAutomationContext } from 'components/AutomationContextProvider'
 import { ContentCardProps, DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
 import { VaultViewMode } from 'components/vault/GeneralManageTabBar'
 import { AppSpinner } from 'helpers/AppSpinner'
@@ -31,20 +32,26 @@ interface ContentCardLtvModalProps {
   loanToValue: BigNumber
   liquidationThreshold: BigNumber
   maxLoanToValue?: BigNumber
+  isAutomationAvailable?: boolean
   stopLossLevel?: BigNumber
-  stopLossLevelLoading?: boolean
+  isStopLossEnabled?: boolean
+  isAutomationDataLoaded?: boolean
 }
 
 function ContentCardLtvModal({
   loanToValue,
   liquidationThreshold,
   maxLoanToValue,
+  isAutomationAvailable,
+  isStopLossEnabled,
+  isAutomationDataLoaded,
   stopLossLevel,
-  stopLossLevelLoading,
 }: ContentCardLtvModalProps) {
   const { close: closeModal } = useModal()
   const { t } = useTranslation()
   const [, setHash] = useHash()
+  const usableStopLossLevel = isStopLossEnabled ? stopLossLevel : undefined
+  const stopLossLevelLoading = !isAutomationDataLoaded
 
   const goToProtection = () => {
     closeModal!()
@@ -78,29 +85,42 @@ function ContentCardLtvModal({
       <Card as="p" variant="vaultDetailsCardModal">
         {formatDecimalAsPercent(liquidationThreshold)}
       </Card>
-      <Heading variant="header4">{t('aave-position-modal.ltv.fourth-header')}</Heading>
-      <Text as="p" variant="paragraph3" sx={{ mb: 1 }}>
-        <Trans
-          i18nKey="aave-position-modal.ltv.fourth-description-line"
-          components={[
-            <Text
-              as="span"
-              variant="boldParagraph3"
-              onClick={goToProtection}
-              sx={{ cursor: 'pointer' }}
-            />,
-          ]}
-        />
-      </Text>
-      <Card as="p" variant="vaultDetailsCardModal">
-        {stopLossLevel ? (
-          formatDecimalAsPercent(stopLossLevel)
-        ) : (
-          <Text as="p" variant="paragraph3" onClick={goToProtection} sx={{ cursor: 'pointer' }}>
-            {stopLossLevelLoading ? <AppSpinner /> : t('aave-position-modal.ltv.stop-loss-not-set')}
+      {isAutomationAvailable && (
+        <>
+          <Heading variant="header4">{t('aave-position-modal.ltv.fourth-header')}</Heading>
+          <Text as="p" variant="paragraph3" sx={{ mb: 1 }}>
+            <Trans
+              i18nKey="aave-position-modal.ltv.fourth-description-line"
+              components={[
+                <Text
+                  as="span"
+                  variant="boldParagraph3"
+                  onClick={goToProtection}
+                  sx={{ cursor: 'pointer' }}
+                />,
+              ]}
+            />
           </Text>
-        )}
-      </Card>
+          <Card as="p" variant="vaultDetailsCardModal">
+            {usableStopLossLevel ? (
+              formatDecimalAsPercent(usableStopLossLevel)
+            ) : (
+              <Text
+                as="p"
+                variant="paragraph3"
+                onClick={!stopLossLevelLoading ? goToProtection : undefined}
+                sx={!stopLossLevelLoading ? { cursor: 'pointer' } : {}}
+              >
+                {stopLossLevelLoading ? (
+                  <AppSpinner />
+                ) : (
+                  t('aave-position-modal.ltv.stop-loss-not-set')
+                )}
+              </Text>
+            )}
+          </Card>
+        </>
+      )}
     </Grid>
   )
 }
@@ -110,8 +130,7 @@ interface ContentCardLtvProps {
   liquidationThreshold: BigNumber
   maxLoanToValue?: BigNumber
   afterLoanToValue?: BigNumber
-  stopLossLevel?: BigNumber
-  stopLossLevelLoading?: boolean
+  isAutomationAvailable?: boolean
 }
 
 export function ContentCardLtv({
@@ -119,10 +138,15 @@ export function ContentCardLtv({
   liquidationThreshold,
   afterLoanToValue,
   maxLoanToValue,
-  stopLossLevel,
-  stopLossLevelLoading,
+  isAutomationAvailable,
 }: ContentCardLtvProps) {
   const { t } = useTranslation()
+  const {
+    triggerData: {
+      stopLossTriggerData: { stopLossLevel, isStopLossEnabled },
+    },
+    automationTriggersData: { isAutomationDataLoaded },
+  } = useAutomationContext()
 
   const formatted = {
     loanToValue: formatDecimalAsPercent(loanToValue),
@@ -135,20 +159,23 @@ export function ContentCardLtv({
     loanToValue,
     maxLoanToValue,
     liquidationThreshold,
+    isAutomationAvailable,
     stopLossLevel,
-    stopLossLevelLoading,
+    isStopLossEnabled,
+    isAutomationDataLoaded,
   }
 
   const contentCardSettings: ContentCardProps = {
     title: t('system.loan-to-value'),
     value: formatted.loanToValue,
-    footnote: stopLossLevel
-      ? t('manage-earn-vault.stop-loss-ltv', {
-          percentage: formatted.stopLossLevel,
-        })
-      : t('manage-earn-vault.liquidation-threshold', {
-          percentage: formatted.liquidationThreshold,
-        }),
+    footnote:
+      isAutomationAvailable && stopLossLevel
+        ? t('manage-earn-vault.stop-loss-ltv', {
+            percentage: formatted.stopLossLevel,
+          })
+        : t('manage-earn-vault.liquidation-threshold', {
+            percentage: formatted.liquidationThreshold,
+          }),
     customBackground:
       afterLoanToValue && !liquidationThreshold.eq(zero)
         ? getLTVRatioColor(liquidationThreshold.minus(loanToValue).times(100))

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -37,6 +37,7 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
 
   return (
     <SimulateSection
+      isOpenView
       strategyConfig={config}
       currentPosition={state.context.currentPosition}
       collateralPrice={state.context.collateralPrice}

--- a/features/multiply/aave/components/AaveMultiplyManageComponent.tsx
+++ b/features/multiply/aave/components/AaveMultiplyManageComponent.tsx
@@ -2,6 +2,8 @@ import { IPosition } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 import { useAaveContext } from 'features/aave'
 import { IStrategyConfig } from 'features/aave/common/StrategyConfigTypes'
+import { supportsAaveStopLoss } from 'features/aave/helpers/supportsAaveStopLoss'
+import { isSupportedAaveAutomationTokenPair } from 'features/automation/common/helpers'
 import { AppSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from 'helpers/observableHook'
@@ -10,6 +12,7 @@ import React from 'react'
 import { AaveMultiplyPositionData } from './AaveMultiplyPositionData'
 
 export type AaveMultiplyManageComponentProps = {
+  isOpenView?: boolean
   currentPosition?: IPosition
   nextPosition?: IPosition
   strategyConfig: IStrategyConfig
@@ -26,6 +29,7 @@ export function AaveMultiplyManageComponent({
   strategyConfig,
   nextPosition,
   dpmProxy,
+  isOpenView,
 }: AaveMultiplyManageComponentProps) {
   const { getAaveReserveData$, aaveReserveConfigurationData$, aaveHistory$ } = useAaveContext(
     strategyConfig.protocol,
@@ -45,6 +49,13 @@ export function AaveMultiplyManageComponent({
       debtToken: strategyConfig.tokens.collateral,
     }),
   )
+  const isAutomationAvailable =
+    !isOpenView &&
+    isSupportedAaveAutomationTokenPair(
+      strategyConfig.tokens.collateral,
+      strategyConfig.tokens.debt,
+    ) &&
+    supportsAaveStopLoss(strategyConfig.protocol, strategyConfig.networkId)
 
   return (
     <WithErrorHandler
@@ -86,6 +97,7 @@ export function AaveMultiplyManageComponent({
               debtTokenReserveConfigurationData={_debtTokenReserveConfigurationData}
               nextPosition={nextPosition}
               aaveHistory={_aaveHistory}
+              isAutomationAvailable={isAutomationAvailable}
             />
           )
         }}

--- a/features/multiply/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/multiply/aave/components/AaveMultiplyPositionData.tsx
@@ -1,7 +1,6 @@
 import { IPosition } from '@oasisdex/dma-library'
 import { amountFromWei } from '@oasisdex/utils'
 import BigNumber from 'bignumber.js'
-import { useAutomationContext } from 'components/AutomationContextProvider'
 import { DetailsSection } from 'components/DetailsSection'
 import {
   DetailsSectionContentCard,
@@ -32,6 +31,7 @@ type AaveMultiplyPositionDataProps = {
   debtTokenReserveData: ReserveData
   debtTokenReserveConfigurationData: ReserveConfigurationData
   aaveHistory: VaultHistoryEvent[]
+  isAutomationAvailable?: boolean
 }
 
 function calcViewValuesForPosition(
@@ -87,13 +87,9 @@ export function AaveMultiplyPositionData({
   debtTokenReserveData,
   debtTokenReserveConfigurationData,
   aaveHistory,
+  isAutomationAvailable,
 }: AaveMultiplyPositionDataProps) {
   const { t } = useTranslation()
-  const {
-    triggerData: {
-      stopLossTriggerData: { isStopLossEnabled, stopLossLevel },
-    },
-  } = useAutomationContext()
 
   const currentPositionThings = calcViewValuesForPosition(
     currentPosition,
@@ -203,8 +199,7 @@ export function AaveMultiplyPositionData({
               liquidationThreshold={currentPosition.category.liquidationThreshold}
               afterLoanToValue={nextPosition?.riskRatio.loanToValue}
               maxLoanToValue={currentPosition.category.maxLoanToValue}
-              stopLossLevel={isStopLossEnabled ? stopLossLevel : undefined}
-              stopLossLevelLoading={true}
+              isAutomationAvailable={isAutomationAvailable}
             />
             <DetailsSectionContentCard
               title={t('system.net-borrow-cost')}


### PR DESCRIPTION
Couple of fixes:
- on open: do not display stop loss values
- on manage: remove hardcoded `stopLossLevelLoading={true}` and use a real value