### PR TITLE
Fix `NaN` in available to withdraw after pill

### DIFF
--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -141,7 +141,9 @@ export function AjnaEarnOverviewManageController() {
             // TODO adjust once data available in subgraph
             projectedAnnualReward={zero}
             afterAvailableToWithdraw={
-              simulation ? negativeToZero(availableToWithdraw.minus(withdrawAmount)) : undefined
+              simulation
+                ? negativeToZero(availableToWithdraw.minus(withdrawAmount || zero))
+                : undefined
             }
           />
         </DetailsSectionFooterItemWrapper>


### PR DESCRIPTION
# [Fix `NaN` in available to withdraw after pill](https://app.shortcut.com/oazo-apps/story/10778/available-to-withdraw-after-pill-is-not-working)

Available to withdrawn was `NaN` because the calculation used `withdrawAmount` which is undefined by default.
  
## Changes 👷‍♀️

- Added `zero` as fallback for `withdrawAmount`.
  
## How to test 🧪

Check available to withdraw after pill on any Ajna Earn position.
