### PR TITLE
Secure token identifier

### DIFF
--- a/blockchain/contracts/index.ts
+++ b/blockchain/contracts/index.ts
@@ -70,11 +70,6 @@ export function extendTokensContracts(tokens: Tokens[]): void {
     }
   })
 }
-export function pruneTokensContracts(): void {
-  Object.keys(extendedTokensContracts).forEach((key) => {
-    delete extendedTokensContracts[key]
-  })
-}
 
 export function ensureContractsExist(
   chainId: NetworkIds,


### PR DESCRIPTION
# Secure token identifier

Do not prune previously identified tokens.
  
## Changes 👷‍♀️

- Removed pruning function,
- added additional check for identifying to see if token exists in our metadata.
  
## How to test 🧪

- Try loading couple different results in pool finder,
- open borrow UI for one of the pools,
- see if there is any error on the way.
