### PR TITLE
Ajna oracless earn order info

### DIFF
--- a/features/ajna/positions/earn/controls/AjnaEarnFormOrderInformation.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnFormOrderInformation.tsx
@@ -18,7 +18,7 @@ export const AjnaEarnFormOrderInformation: FC<AjnaIsCachedPosition> = ({ cached 
   const { t } = useTranslation()
 
   const {
-    environment: { quoteToken, collateralPrice, quotePrice, isShort, priceFormat },
+    environment: { quoteToken, collateralPrice, quotePrice, isShort, priceFormat, isOracless },
     steps: { isFlowStateReady },
     tx: { txDetails, isTxSuccess },
   } = useAjnaGeneralContext()
@@ -92,12 +92,16 @@ export const AjnaEarnFormOrderInformation: FC<AjnaIsCachedPosition> = ({ cached 
           change: formatted.afterLendingPrice,
           isLoading,
         },
-        {
-          label: t('max-ltv-to-lend-at'),
-          value: formatted.maxLtv,
-          change: formatted.afterMaxLtv,
-          isLoading,
-        },
+        ...(!isOracless
+          ? [
+              {
+                label: t('max-ltv-to-lend-at'),
+                value: formatted.maxLtv,
+                change: formatted.afterMaxLtv,
+                isLoading,
+              },
+            ]
+          : []),
         ...(withAjnaFee
           ? [
               {


### PR DESCRIPTION
# [Ajna oracless earn order info](https://app.shortcut.com/oazo-apps/story/10805/oracless-order-information?vc_group_by=day&ct_workflow=all&cf_workflow=500000053)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed max ltv and after max ltv from ajna oracless order information section
  
## How to test 🧪
  <Please explain how to test your changes>

- max ltv and after max ltv shouldn't be visible in earn order information in oracless mdoe
