### PR TITLE
Add new pools with rewards to config

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -38,6 +38,8 @@ export const AJNA_POOLS_WITH_REWARDS = [
   'ETH-USDC',
   'RETH-DAI',
   'RETH-ETH',
+  'SDAI-USDC',
+  'TBTC-USDC',
   'USDC-ETH',
   'USDC-WBTC',
   'WBTC-DAI',
@@ -45,6 +47,7 @@ export const AJNA_POOLS_WITH_REWARDS = [
   'WSTETH-DAI',
   'WSTETH-ETH',
   'WSTETH-USDC',
+  'YFI-DAI',
 ]
 export const AJNA_SHORT_POSITION_COLLATERALS = ['DAI', 'USDC']
 export const AJNA_TOKENS_WITH_MULTIPLY = [

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyOverviewController.tsx
@@ -9,6 +9,7 @@ import { ContentCardNetValue } from 'features/ajna/positions/common/components/c
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaTokensBannerController } from 'features/ajna/positions/common/controls/AjnaTokensBannerController'
+import { isPoolWithRewards } from 'features/ajna/positions/common/helpers/isPoolWithRewards'
 import { ContentFooterItemsMultiply } from 'features/ajna/positions/multiply/components/ContentFooterItemsMultiply'
 import { one, zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
@@ -136,7 +137,9 @@ export function AjnaMultiplyOverviewController() {
           </DetailsSectionFooterItemWrapper>
         }
       />
-      <AjnaTokensBannerController flow={flow} />
+      {isPoolWithRewards({ collateralToken, quoteToken }) && (
+        <AjnaTokensBannerController flow={flow} />
+      )}
     </Grid>
   )
 }

--- a/handlers/product-hub/promo-cards/collections/ajna.ts
+++ b/handlers/product-hub/promo-cards/collections/ajna.ts
@@ -66,6 +66,7 @@ export function getAjnaPromoCards(table: ProductHubItem[]) {
     debtToken: 'DAI',
     product: ETHDAIAjnaBorrowishProduct,
     ...commonBorrowPromoCardPayload,
+    pills: [],
   })
   const promoCardETHUSDCAjnaBorrow = parseBorrowPromoCard({
     collateralToken: 'ETH',
@@ -85,7 +86,6 @@ export function getAjnaPromoCards(table: ProductHubItem[]) {
     debtToken: 'USDC',
     product: SDAIUSDCAjnaBorrowishProduct,
     ...commonBorrowPromoCardPayload,
-    pills: [],
   })
   const promoCardTBTCWBTCAjnaBorrow = parseBorrowPromoCard({
     collateralToken: 'TBTC',


### PR DESCRIPTION
# [Add new pools with rewards to config](https://app.shortcut.com/oazo-apps/story/10854/update-ajna-reward-banner-and-stars-for-correct-pools)
  
## Changes 👷‍♀️

- Added `SDAI-USDC`, `TBTC-USDC` and `YFI-DAI` to array with rewards supporting pools,
- hidden rewards banner on multiply UI when pool is not supporting rewards,
- fix reward pill on promo cards.
  
## How to test 🧪

Patch Product Hub and compare with list of the changes.
