### PR TITLE
Implement network check in AjnaProductController and WalletManager

### DIFF
--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -1,4 +1,5 @@
 import { AjnaEarnPosition, AjnaPosition } from '@oasisdex/dma-library'
+import { NetworkHexIds } from 'blockchain/networks'
 import { WithConnection } from 'components/connectWallet'
 import { PageSEOTags } from 'components/HeadTags'
 import { PositionLoadingState } from 'components/vault/PositionLoadingState'
@@ -83,7 +84,7 @@ export function AjnaProductController({
   if (redirect) void push(redirect)
 
   return (
-    <WithConnection>
+    <WithConnection pageChainId={NetworkHexIds.MAINNET} includeTestNet={true}>
       <WithTermsOfService>
         <WithWalletAssociatedRisk>
           <AjnaWrapper>

--- a/features/web3OnBoard/web3-on-board-connector-provider.tsx
+++ b/features/web3OnBoard/web3-on-board-connector-provider.tsx
@@ -186,6 +186,19 @@ function InternalProvider({ children }: WithChildren) {
     }
   }, [state, disconnect, dispatch])
 
+  useEffect(() => {
+    if (
+      state.status === WalletManagementStateStatus.connected &&
+      state.pageNetworkHexIds &&
+      !state.pageNetworkHexIds.includes(state.walletNetworkHexId)
+    ) {
+      dispatch({
+        type: WalletStateEventType.changeChain,
+        desiredNetworkHexId: state.pageNetworkHexIds[0],
+      })
+    }
+  }, [state.pageNetworkHexIds, state.status])
+
   return (
     <web3OnBoardConnectorContext.Provider
       value={{


### PR DESCRIPTION
Introduced a network check in AjnaProductController.tsx and web3-on-board-connector-provider.tsx. Modified the WithConnection component in AjnaProductController to specify MAINNET explicitly and to include TestNet. In web3OnBoard, implemented a useEffect hook to handle change of network if the network of connected wallet does not match the required networks. These changes provide the ability for the Ajna page to switch to the required network when user's wallet is connected to a different network. A proper network check and possible switch increases the seamless user experience and mitigates any contract interaction errors caused due to the wrong network.

