### PR TITLE
Show price ratio in aave headers

### DIFF
--- a/features/aave/strategies/arbitrum-aave-v3-strategies.ts
+++ b/features/aave/strategies/arbitrum-aave-v3-strategies.ts
@@ -6,7 +6,7 @@ import {
   adjustRiskView,
 } from 'features/aave/components'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/aave/services'
-import { IStrategyConfig, ProxyType } from 'features/aave/types'
+import { IStrategyConfig, ProxyType, StrategyType } from 'features/aave/types'
 import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -41,6 +41,7 @@ export const arbitrumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3Arbitrum',
     availableActions: ['close'],
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.arbitrumMainnet,
@@ -72,6 +73,7 @@ export const arbitrumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3Arbitrum',
     availableActions: ['close'],
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.arbitrumMainnet,
@@ -103,5 +105,6 @@ export const arbitrumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3Arbitrum',
     availableActions: ['close'],
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
 ]

--- a/features/aave/strategies/ethereum-aave-v2-strategies.ts
+++ b/features/aave/strategies/ethereum-aave-v2-strategies.ts
@@ -1,12 +1,10 @@
 import { ethereumMainnetHexId, NetworkIds, NetworkNames } from 'blockchain/networks'
 import {
-  AaveBorrowManageComponent,
   AaveManageHeader,
   AaveMultiplyManageComponent,
   AaveOpenHeader,
   AavePositionHeaderNoDetails,
   adjustRiskView,
-  DebtInput,
   headerWithDetails,
   ManageSectionComponent,
   SimulateSectionComponent,
@@ -14,49 +12,13 @@ import {
 } from 'features/aave/components'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/aave/services'
 import { adjustRiskSliders } from 'features/aave/services/riskSliderConfig'
-import { IStrategyConfig, ProductType, ProxyType } from 'features/aave/types'
+import { IStrategyConfig, ProxyType, StrategyType } from 'features/aave/types'
 import { AaveEarnFaqV2 } from 'features/content/faqs/aave/earn'
 import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
-import { AaveLendingProtocol, LendingProtocol } from 'lendingProtocols'
+import { LendingProtocol } from 'lendingProtocols'
 
 import { allActionsAvailable } from './all-actions-available'
 
-const supportedAaveBorrowCollateralTokens = ['ETH', 'WBTC']
-export const ethereumAaveV2BorrowStrategies: Array<IStrategyConfig> = [
-  ...supportedAaveBorrowCollateralTokens.map((collateral) => {
-    return {
-      network: NetworkNames.ethereumMainnet,
-      networkId: NetworkIds.MAINNET,
-      networkHexId: ethereumMainnetHexId,
-      name: `borrow-against-${collateral}`,
-      urlSlug: collateral,
-      proxyType: ProxyType.DpmProxy,
-      viewComponents: {
-        headerOpen: AaveOpenHeader,
-        headerManage: AaveManageHeader,
-        headerView: AaveManageHeader,
-        simulateSection: AaveBorrowManageComponent,
-        vaultDetailsManage: AaveBorrowManageComponent,
-        vaultDetailsView: AaveBorrowManageComponent,
-        secondaryInput: DebtInput,
-        positionInfo: AaveMultiplyFaq,
-        sidebarTitle: 'open-borrow.sidebar.title',
-        sidebarButton: 'open-borrow.sidebar.open-btn',
-      },
-      tokens: {
-        collateral: collateral,
-        debt: 'USDC',
-        deposit: collateral,
-      },
-      riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
-      featureToggle: 'AaveBorrow' as const,
-      type: 'Borrow' as ProductType,
-      protocol: LendingProtocol.AaveV2 as AaveLendingProtocol,
-      availableActions: allActionsAvailable,
-      executeTransactionWith: 'web3' as const,
-    }
-  }),
-]
 export const ethereumAaveV2Strategies: Array<IStrategyConfig> = [
   {
     network: NetworkNames.ethereumMainnet,
@@ -88,6 +50,7 @@ export const ethereumAaveV2Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV2ProductCard',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'web3',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -119,6 +82,7 @@ export const ethereumAaveV2Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV2ProductCard',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'web3',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -150,6 +114,7 @@ export const ethereumAaveV2Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV2ProductCard',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'web3',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -181,6 +146,6 @@ export const ethereumAaveV2Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV2ProductCard',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'web3',
+    strategyType: StrategyType.Long,
   },
-  ...ethereumAaveV2BorrowStrategies,
 ]

--- a/features/aave/strategies/ethereum-aave-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-aave-v3-strategies.ts
@@ -15,31 +15,31 @@ import {
 } from 'features/aave/components'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/aave/services'
 import { adjustRiskSliders } from 'features/aave/services/riskSliderConfig'
-import { IStrategyConfig, ProductType, ProxyType } from 'features/aave/types'
+import { IStrategyConfig, ProductType, ProxyType, StrategyType } from 'features/aave/types'
 import { AaveEarnFaqV3 } from 'features/content/faqs/aave/earn'
 import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
 import { AaveLendingProtocol, LendingProtocol } from 'lendingProtocols'
 
 import { allActionsAvailable } from './all-actions-available'
 
-type tokenPair = { collateral: string; debt: string }
+type tokenPair = { collateral: string; debt: string; strategyType: StrategyType }
 
 const availableTokenPairs: tokenPair[] = [
-  { collateral: 'CBETH', debt: 'ETH' },
-  { collateral: 'DAI', debt: 'ETH' },
-  { collateral: 'DAI', debt: 'WBTC' },
-  { collateral: 'ETH', debt: 'DAI' },
-  { collateral: 'ETH', debt: 'USDC' },
-  { collateral: 'RETH', debt: 'DAI' },
-  { collateral: 'RETH', debt: 'ETH' },
-  { collateral: 'RETH', debt: 'USDC' },
-  { collateral: 'USDC', debt: 'ETH' },
-  { collateral: 'USDC', debt: 'WBTC' },
-  { collateral: 'WBTC', debt: 'DAI' },
-  { collateral: 'WBTC', debt: 'USDC' },
-  { collateral: 'WSTETH', debt: 'DAI' },
-  { collateral: 'WSTETH', debt: 'ETH' },
-  { collateral: 'WSTETH', debt: 'USDC' },
+  { collateral: 'CBETH', debt: 'ETH', strategyType: StrategyType.Long },
+  { collateral: 'DAI', debt: 'ETH', strategyType: StrategyType.Short },
+  { collateral: 'DAI', debt: 'WBTC', strategyType: StrategyType.Short },
+  { collateral: 'ETH', debt: 'DAI', strategyType: StrategyType.Long },
+  { collateral: 'ETH', debt: 'USDC', strategyType: StrategyType.Long },
+  { collateral: 'RETH', debt: 'DAI', strategyType: StrategyType.Long },
+  { collateral: 'RETH', debt: 'ETH', strategyType: StrategyType.Long },
+  { collateral: 'RETH', debt: 'USDC', strategyType: StrategyType.Long },
+  { collateral: 'USDC', debt: 'ETH', strategyType: StrategyType.Short },
+  { collateral: 'USDC', debt: 'WBTC', strategyType: StrategyType.Short },
+  { collateral: 'WBTC', debt: 'DAI', strategyType: StrategyType.Long },
+  { collateral: 'WBTC', debt: 'USDC', strategyType: StrategyType.Long },
+  { collateral: 'WSTETH', debt: 'DAI', strategyType: StrategyType.Long },
+  { collateral: 'WSTETH', debt: 'ETH', strategyType: StrategyType.Long },
+  { collateral: 'WSTETH', debt: 'USDC', strategyType: StrategyType.Long },
 ]
 
 const borrowStrategies = availableTokenPairs.map((pair) => {
@@ -73,6 +73,7 @@ const borrowStrategies = availableTokenPairs.map((pair) => {
     protocol: LendingProtocol.AaveV3 as AaveLendingProtocol,
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers' as const,
+    strategyType: pair.strategyType,
   }
 })
 
@@ -109,6 +110,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     availableActions: allActionsAvailable,
     defaultSlippage: new BigNumber(0.001),
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
 
   {
@@ -142,6 +144,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     availableActions: allActionsAvailable,
     defaultSlippage: new BigNumber(0.001),
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -174,6 +177,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     availableActions: allActionsAvailable,
     defaultSlippage: new BigNumber(0.001),
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
 
   {
@@ -206,6 +210,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3MultiplyETHusdc',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -237,6 +242,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3MultiplycbETHusdc',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -268,6 +274,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3MultiplywBTCusdc',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -299,6 +306,7 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3MultiplywstETHusdc',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.ethereumMainnet,
@@ -330,5 +338,6 @@ export const ethereumAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3MultiplyrETHusdc',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
 ]

--- a/features/aave/strategies/optimism-aave-v3-strategies.ts
+++ b/features/aave/strategies/optimism-aave-v3-strategies.ts
@@ -2,7 +2,7 @@ import { NetworkIds, NetworkNames, optimismMainnetHexId } from 'blockchain/netwo
 import { AaveManageHeader, AaveOpenHeader, adjustRiskView } from 'features/aave/components'
 import { AaveMultiplyManageComponent } from 'features/aave/components/AaveMultiplyManageComponent'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/aave/services'
-import { IStrategyConfig, ProxyType } from 'features/aave/types'
+import { IStrategyConfig, ProxyType, StrategyType } from 'features/aave/types'
 import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -39,6 +39,7 @@ export const optimismAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3Optimism',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.optimismMainnet,
@@ -70,6 +71,7 @@ export const optimismAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3Optimism',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
   {
     network: NetworkNames.optimismMainnet,
@@ -101,5 +103,6 @@ export const optimismAaveV3Strategies: Array<IStrategyConfig> = [
     featureToggle: 'AaveV3Optimism',
     availableActions: allActionsAvailable,
     executeTransactionWith: 'ethers',
+    strategyType: StrategyType.Long,
   },
 ]

--- a/features/aave/types/strategy-config.ts
+++ b/features/aave/types/strategy-config.ts
@@ -53,6 +53,11 @@ export enum ProxyType {
   DpmProxy = 'DpmProxy',
 }
 
+export enum StrategyType {
+  Short = 'short',
+  Long = 'long',
+}
+
 export interface IStrategyConfig {
   network: NetworkNames
   networkId: NetworkIds
@@ -87,4 +92,5 @@ export interface IStrategyConfig {
   featureToggle?: Feature
   defaultSlippage?: BigNumber
   executeTransactionWith: 'web3' | 'ethers'
+  strategyType: StrategyType
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1237,6 +1237,7 @@
     "header-aave-open": "Open {{collateral}}/{{debt}} Aave position",
     "header-aave-view": "Aave {{collateral}}/{{debt}}",
     "header-aave-view-id": "Aave {{collateral}}/{{debt}} Vault {{vaultId}}",
+    "header-current-market-price": "Current Market Price",
     "insti-header": "Institutional {{ilk}} Vault {{id}}",
     "next-price": "Next price in {{count}} minute",
     "open-vault": "Open {{ilk}} Vault",
@@ -2957,5 +2958,10 @@
   "navigation-network": {
     "l2beat-title": "Learn about L2s",
     "l2beat-description": "L2BEAT is an analytics and research website about Ethereum layer two (L2) scaling."
+  },
+  "aave": {
+    "header": {
+      "current-market-price": "Current Market Price"
+    }
   }
 }


### PR DESCRIPTION
# Show price ratio in aave header

## Changes
- On aave multiply, borrow and manage earn instead of collateral price and debt price we show ratio between those prices. In case of short position we show debt to collateral. 

## How to test
- Go to open aave postion
- Go to manage aave positon.