### PR TITLE
Handling duplicated token symbol in pool finder

### DIFF
--- a/features/poolFinder/helpers/getOraclessTokenAddress.ts
+++ b/features/poolFinder/helpers/getOraclessTokenAddress.ts
@@ -10,7 +10,7 @@ async function tokensSearch(query: string): Promise<string[]> {
     return [query]
   } else {
     if (query.length > 2) {
-      const response = Object.values(
+      const response = (
         (await (
           await fetch(`/api/tokens-search`, {
             method: 'POST',
@@ -21,8 +21,8 @@ async function tokensSearch(query: string): Promise<string[]> {
               query: [query],
             }),
           })
-        ).json()) as { [key: string]: string },
-      )
+        ).json()) as [string, string][]
+      ).map(([, address]) => address)
 
       return response.length ? response : [query]
     } else return query.length ? [query] : []

--- a/features/poolFinder/helpers/getOraclessTokenAddress.ts
+++ b/features/poolFinder/helpers/getOraclessTokenAddress.ts
@@ -1,4 +1,5 @@
 import { isAddress } from 'ethers/lib/utils'
+import { SearchTokensResponse } from 'features/poolFinder/types'
 
 interface GetOraclessTokenAddressParams {
   collateralToken: string
@@ -21,8 +22,8 @@ async function tokensSearch(query: string): Promise<string[]> {
               query: [query],
             }),
           })
-        ).json()) as [string, string][]
-      ).map(([, address]) => address)
+        ).json()) as SearchTokensResponse[]
+      ).map(({ address }) => address)
 
       return response.length ? response : [query]
     } else return query.length ? [query] : []

--- a/features/poolFinder/types.ts
+++ b/features/poolFinder/types.ts
@@ -1,5 +1,10 @@
 import { ProductHubItemTooltips, ProductHubManagementType } from 'features/productHub/types'
 
+export interface SearchTokensResponse {
+  symbol: string
+  address: string
+}
+
 export interface PoolFinderFormState {
   poolAddress: string
   collateralAddress: string

--- a/handlers/tokens-search/get.ts
+++ b/handlers/tokens-search/get.ts
@@ -21,7 +21,10 @@ export async function get(req: NextApiRequest, res: NextApiResponse) {
         (item) => name.toLowerCase().includes(item) || symbol.toLowerCase().includes(item),
       ),
     )
-    .map(({ symbol, address }) => [symbol, address])
+    .map(({ symbol, address }) => ({
+      symbol,
+      address,
+    }))
 
   return res.status(200).json(response)
 }

--- a/handlers/tokens-search/get.ts
+++ b/handlers/tokens-search/get.ts
@@ -21,13 +21,7 @@ export async function get(req: NextApiRequest, res: NextApiResponse) {
         (item) => name.toLowerCase().includes(item) || symbol.toLowerCase().includes(item),
       ),
     )
-    .reduce<{ [key: string]: string }>(
-      (total, { address, symbol }) => ({
-        ...total,
-        [symbol]: address,
-      }),
-      {},
-    )
+    .map(({ symbol, address }) => [symbol, address])
 
   return res.status(200).json(response)
 }


### PR DESCRIPTION
# Handling duplicated token symbol in pool finder

Tokens list we are using had two tokens with `RETH` symbol. Response from our API endpoint was using token symbol as key in object, so whenever duplication was found, old data was overwritten by new data. I've updated response, so it's no longer:
```
{ tokenSymbol: tokenAddress }
```
but now it's
```
{symbol: string, address: string}[]
```
  
## Changes 👷‍♀️

- Updated API response structure, so it can handle multiply tokens with same symbol.
  
## How to test 🧪

Try finding any `RETH` pool on pool finder.
