### PR TITLE
Fixing grammar mistake in oracle-less tooltip

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2874,7 +2874,7 @@
       "no-max-ltv": "There are currently no borrow or multiply positions for this pool. Max LTV will be calculated following the creation of the first position.",
       "no-max-multiple": "There are currently no borrow or multiply positions for this pool. Max multiple will be calculated following the creation of the first position.",
       "no-weekly-apy": "There are currently no borrow or multiply positions for this pool. 7 day net APY will be calculated following the creation of the first position.",
-      "oracless-ltv": "Max LTV is not available for this pool as Summer.fi does not currently support USD price feeds for these assets. You can still open a position and in this pool. The maximum risk will be determined by lenders in the pool.",
+      "oracless-ltv": "Max LTV is not available for this pool as Summer.fi does not currently support USD price feeds for these assets. You can still open a position in this pool. The maximum risk will be determined by lenders in the pool.",
       "rewards-available-soon": "Rewards are earned automatically and will be claimable weekly in the near future.",
       "this-pool-is-earning-ajna-tokens": "This pool is earning Summer.fi × Ajna token Rewards"
     },


### PR DESCRIPTION
# Fixing grammar mistake in oracle-less tooltip
  
## Changes 👷‍♀️
- From:
" ... You can still open a position **and in** this pool. ..."
- To:
" ... You can still open a position **in** this pool. ..."

  
