### PR TITLE
Extended pool finder error message

### DIFF
--- a/features/poolFinder/controls/PoolFinderContentController.tsx
+++ b/features/poolFinder/controls/PoolFinderContentController.tsx
@@ -2,6 +2,7 @@ import { NetworkIds } from 'blockchain/networks'
 import { AssetsResponsiveTable } from 'components/assetsTable/AssetsResponsiveTable'
 import { AssetsTableContainer } from 'components/assetsTable/AssetsTableContainer'
 import { AssetsTableNoResults } from 'components/assetsTable/AssetsTableNoResults'
+import { isAddress } from 'ethers/lib/utils'
 import { parseRows } from 'features/poolFinder/helpers'
 import { OraclessPoolResult, PoolFinderFormState } from 'features/poolFinder/types'
 import { ProductHubProductType } from 'features/productHub/types'
@@ -16,6 +17,7 @@ interface PoolFinderContentControllerProps {
 }
 
 export const PoolFinderContentController: FC<PoolFinderContentControllerProps> = ({
+  addresses: { collateralAddress, quoteAddress },
   chainId,
   selectedProduct,
   tableData,
@@ -34,7 +36,12 @@ export const PoolFinderContentController: FC<PoolFinderContentControllerProps> =
       ) : (
         <AssetsTableNoResults
           header={t('ajna.oracless.pool-finder.no-results')}
-          content={t('ajna.oracless.pool-finder.no-results-description')}
+          content={t(
+            (collateralAddress && !isAddress(collateralAddress)) ||
+              (quoteAddress && !isAddress(quoteAddress))
+              ? 'ajna.oracless.pool-finder.no-results-suggest-address'
+              : 'ajna.oracless.pool-finder.no-results-description',
+          )}
         />
       )}
     </AssetsTableContainer>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2888,7 +2888,8 @@
       },
       "pool-finder": {
         "no-results": "There are no items matching your criteria.",
-        "no-results-description": "Find other pools by updating your criteria. If you are missing a pool you would like to see, you can create one by yourself."
+        "no-results-description": "Find other pools by updating your criteria. If you are missing a pool you would like to see, you can create one by yourself.",
+        "no-results-suggest-address": "Try searching for a pool by providing token address instead of it's name or symbol. If you are missing a pool you would like to see, you can create one by yourself."
       }
     }
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2889,7 +2889,7 @@
       "pool-finder": {
         "no-results": "There are no items matching your criteria.",
         "no-results-description": "Find other pools by updating your criteria. If you are missing a pool you would like to see, you can create one by yourself.",
-        "no-results-suggest-address": "Try searching for a pool by providing token address instead of it's name or symbol. If you are missing a pool you would like to see, you can create one by yourself."
+        "no-results-suggest-address": "Try searching for a pool by providing token address instead of its name or symbol. If you are missing a pool you would like to see, you can create one by yourself."
       }
     }
   },


### PR DESCRIPTION
# Extended pool finder error message

There is YieldETH/ETH pool on mainnet (`0x25d63c91a85d0a21dc84021df01a800cd3cda797`). If you try to search for it by providing collateral address (`0xb5b29320d2dde5ba5bafa1ebcd270052070483ec`) it works as intended. Unfortunately, tokens list that we are using for identifying by name or symbol does not contain YieldETH, so by putting `yield` in search, there a no results.

I've updated error message whenever user put as a token something else than direct address, to encourage they to try again, using address, instead of giving up search.
  
## Changes 👷‍♀️

- Added additional error message depending on what kind of input user provided.
  