### PR TITLE
Ajna unblock second inputs in borrow

### DIFF
--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentDeposit.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentDeposit.tsx
@@ -49,14 +49,9 @@ export function AjnaBorrowFormContentDeposit() {
         tokenPrice={collateralPrice}
         tokenPrecision={collateralPrecision}
       />
-      <AjnaFormFieldGenerate
-        dispatchAmount={dispatch}
-        isDisabled={!depositAmount || depositAmount?.lte(0)}
-        maxAmount={debtMax}
-        minAmount={debtMin}
-      />
+      <AjnaFormFieldGenerate dispatchAmount={dispatch} maxAmount={debtMax} minAmount={debtMin} />
       {generateAmount && <AjnaBorrowOriginationFee />}
-      {depositAmount && (
+      {(depositAmount || generateAmount) && (
         <AjnaFormContentSummary>
           <AjnaBorrowFormOrder />
         </AjnaFormContentSummary>

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentGenerate.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentGenerate.tsx
@@ -25,7 +25,7 @@ export function AjnaBorrowFormContentGenerate() {
   const {
     form: {
       dispatch,
-      state: { generateAmount },
+      state: { generateAmount, depositAmount },
     },
     position: {
       currentPosition: { position, simulation },
@@ -49,15 +49,14 @@ export function AjnaBorrowFormContentGenerate() {
       />
       <AjnaFormFieldDeposit
         dispatchAmount={dispatch}
-        isDisabled={!generateAmount || generateAmount?.lte(0)}
         maxAmount={collateralBalance}
         token={collateralToken}
         tokenPrice={collateralPrice}
         tokenPrecision={collateralPrecision}
       />
-      {generateAmount && (
+      {generateAmount && <AjnaBorrowOriginationFee />}
+      {(generateAmount || depositAmount) && (
         <>
-          <AjnaBorrowOriginationFee />
           <AjnaFormContentSummary>
             <AjnaBorrowFormOrder />
           </AjnaFormContentSummary>

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
@@ -24,7 +24,7 @@ export function AjnaBorrowFormContentPayback() {
   const {
     form: {
       dispatch,
-      state: { paybackAmount },
+      state: { paybackAmount, withdrawAmount },
     },
     position: {
       currentPosition: { position, simulation },
@@ -53,13 +53,12 @@ export function AjnaBorrowFormContentPayback() {
       />
       <AjnaFormFieldWithdraw
         dispatchAmount={dispatch}
-        isDisabled={!paybackAmount || paybackAmount?.lte(0)}
         maxAmount={collateralMax}
         token={collateralToken}
         tokenPrice={collateralPrice}
         tokenPrecision={collateralPrecision}
       />
-      {paybackAmount && (
+      {(paybackAmount || withdrawAmount) && (
         <AjnaFormContentSummary>
           <AjnaBorrowFormOrder />
         </AjnaFormContentSummary>

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
@@ -24,7 +24,7 @@ export function AjnaBorrowFormContentWithdraw() {
   const {
     form: {
       dispatch,
-      state: { withdrawAmount },
+      state: { withdrawAmount, paybackAmount },
     },
     position: {
       currentPosition: { position, simulation },
@@ -55,11 +55,10 @@ export function AjnaBorrowFormContentWithdraw() {
       />
       <AjnaFormFieldPayback
         dispatchAmount={dispatch}
-        isDisabled={!withdrawAmount || withdrawAmount?.lte(0)}
         maxAmount={paybackMax}
         maxAmountLabel={quoteBalance.lt(debtAmount) ? 'balance' : 'max'}
       />
-      {withdrawAmount && (
+      {(withdrawAmount || paybackAmount) && (
         <AjnaFormContentSummary>
           <AjnaBorrowFormOrder />
         </AjnaFormContentSummary>

--- a/features/ajna/positions/common/validation.tsx
+++ b/features/ajna/positions/common/validation.tsx
@@ -138,13 +138,13 @@ function isFormValid({
           switch (action) {
             case 'open-borrow':
             case 'deposit-borrow':
-              return !!depositAmount?.gt(0)
+              return !!depositAmount?.gt(0) || !!generateAmount?.gt(0)
             case 'withdraw-borrow':
-              return !!withdrawAmount?.gt(0)
+              return !!withdrawAmount?.gt(0) || !!paybackAmount?.gt(0)
             case 'generate-borrow':
-              return !!generateAmount?.gt(0)
+              return !!generateAmount?.gt(0) || !!depositAmount?.gt(0)
             case 'payback-borrow':
-              return !!paybackAmount?.gt(0)
+              return !!paybackAmount?.gt(0) || !!withdrawAmount?.gt(0)
             case 'switch-borrow':
               return true
             default:


### PR DESCRIPTION
# [Ajna unblock second inputs in borrow](https://app.shortcut.com/oazo-apps/story/10556/unblock-the-second-input-on-borrow-actions)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed isDisabled condition for second inputs in ajna borrow actions, so it's possible to generate without depositing while being on deposit & generate form step etc.
  
## How to test 🧪
  <Please explain how to test your changes>

- go through all ajna borrow actions, verify whether user is able to use only second inputs to send tx
- order information should be displayed correctly
