### PR TITLE
Add conditional rendering for MultiplyInformation component

### DIFF
--- a/features/aave/components/order-information/StrategyInformationContainer.tsx
+++ b/features/aave/components/order-information/StrategyInformationContainer.tsx
@@ -6,7 +6,7 @@ import {
   PositionTransition,
 } from '@oasisdex/dma-library'
 import { VaultChangesInformationContainer } from 'components/vault/VaultChangesInformation'
-import { getSlippage, StrategyTokenBalance } from 'features/aave/types'
+import { getSlippage, ProductType, StrategyTokenBalance } from 'features/aave/types'
 import { IStrategyConfig } from 'features/aave/types/strategy-config'
 import { UserSettingsState } from 'features/userSettings/userSettings'
 import { HasGasEstimation } from 'helpers/form'
@@ -57,10 +57,12 @@ export function StrategyInformationContainer({
 }: OpenAaveInformationContainerProps) {
   const { t } = useTranslation()
 
-  const { transition, currentPosition, balance } = state.context
+  const { transition, currentPosition, balance, strategyConfig } = state.context
 
   const simulationHasSwap =
     transitionHasSwap(transition) && transition?.simulation.swap?.toTokenAmount.gt(zero)
+
+  const shouldShowMultiplyInformation = strategyConfig.type !== ProductType.Borrow
 
   return transition && currentPosition ? (
     <VaultChangesInformationContainer title={t('vault-changes.order-information')}>
@@ -86,11 +88,13 @@ export function StrategyInformationContainer({
           changeSlippage={changeSlippageSource}
         />
       )}
-      <MultiplyInformation
-        {...state.context}
-        transactionParameters={transition}
-        currentPosition={currentPosition}
-      />
+      {shouldShowMultiplyInformation && (
+        <MultiplyInformation
+          {...state.context}
+          transactionParameters={transition}
+          currentPosition={currentPosition}
+        />
+      )}
       <OutstandingDebtInformation
         currentPosition={currentPosition}
         newPosition={transition.simulation.position}


### PR DESCRIPTION
Modified `StrategyInformationContainer` to conditionally render the `MultiplyInformation` component based on the strategy configuration. This change was made to avoid rendering `MultiplyInformation` when the product type is set to 'Borrow'.