### PR TITLE
Tokens source

### DIFF
--- a/blockchain/identifyTokens.ts
+++ b/blockchain/identifyTokens.ts
@@ -12,7 +12,7 @@ export interface IdentifiedTokens {
 
 function reduceIdentifiedTokens(
   total: IdentifiedTokens,
-  { address, name, precision, symbol }: Tokens,
+  { address, name, precision, symbol, source }: Tokens,
 ) {
   return {
     ...total,
@@ -20,6 +20,7 @@ function reduceIdentifiedTokens(
       precision,
       name,
       symbol,
+      source,
     },
   }
 }
@@ -58,6 +59,7 @@ export const identifyTokens$ = (
           precision: getToken(token).precision,
           address: tokensContracts[token].address,
           chain_id: context.chainId,
+          source: 'local',
         }))
 
         if (tokensAddresses.length === localTokensAddresses.length)

--- a/blockchain/tokensMetadata.ts
+++ b/blockchain/tokensMetadata.ts
@@ -36,9 +36,10 @@ export interface TokenConfig {
   protocol: LendingProtocol
   chain: MainNetworkNames
   oracleTicker?: string
+  source?: string
 }
 
-export type SimplifiedTokenConfig = Pick<TokenConfig, 'name' | 'precision' | 'symbol'>
+export type SimplifiedTokenConfig = Pick<TokenConfig, 'name' | 'precision' | 'symbol' | 'source'>
 
 export const COIN_TAGS = ['stablecoin', 'lp-token'] as const
 export type CoinTag = ElementOf<typeof COIN_TAGS>

--- a/components/SimulateTitle.tsx
+++ b/components/SimulateTitle.tsx
@@ -9,10 +9,11 @@ import { Box, Flex, Heading, Text } from 'theme-ui'
 
 interface SimulateTitleProps {
   token: string
+  tokenSymbol?: string
   depositAmount?: BigNumber
 }
 
-export function SimulateTitle({ token, depositAmount }: SimulateTitleProps) {
+export function SimulateTitle({ token, tokenSymbol, depositAmount }: SimulateTitleProps) {
   const tokenConfig = getTokenGuarded(token)
 
   return (
@@ -47,7 +48,7 @@ export function SimulateTitle({ token, depositAmount }: SimulateTitleProps) {
             color: 'primary100',
           }}
         >
-          {`${formatCryptoBalance(depositAmount || zero)} ${token}`}
+          {`${formatCryptoBalance(depositAmount || zero)} ${tokenSymbol || token}`}
         </Heading>
         <Text
           variant="paragraph3"

--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -73,6 +73,8 @@ export function VaultHeadline({
             flexShrink: 0,
             alignItems: 'center',
             columnGap: 2,
+            flexWrap: 'wrap',
+            maxWidth: '100%',
           }}
         >
           {tokens.length > 0 && (

--- a/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
@@ -15,7 +15,7 @@ import React from 'react'
 export function AjnaBorrowFormController() {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, flow, quoteToken, collateralTokenIcon, quoteTokenIcon },
+    environment: { collateralToken, flow, quoteToken, collateralIcon, quoteIcon },
     steps: { currentStep },
   } = useAjnaGeneralContext()
   const {
@@ -42,7 +42,7 @@ export function AjnaBorrowFormController() {
               }),
               panel: 'collateral',
               shortLabel: collateralToken,
-              tokenIcon: collateralTokenIcon,
+              tokenIcon: collateralIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'collateral')
@@ -56,7 +56,7 @@ export function AjnaBorrowFormController() {
               }),
               panel: 'quote',
               shortLabel: quoteToken,
-              tokenIcon: quoteTokenIcon,
+              tokenIcon: quoteIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'quote')

--- a/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowFormController.tsx
@@ -15,7 +15,7 @@ import React from 'react'
 export function AjnaBorrowFormController() {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, flow, quoteToken },
+    environment: { collateralToken, flow, quoteToken, collateralTokenIcon, quoteTokenIcon },
     steps: { currentStep },
   } = useAjnaGeneralContext()
   const {
@@ -42,7 +42,7 @@ export function AjnaBorrowFormController() {
               }),
               panel: 'collateral',
               shortLabel: collateralToken,
-              tokenIcon: collateralToken,
+              tokenIcon: collateralTokenIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'collateral')
@@ -56,7 +56,7 @@ export function AjnaBorrowFormController() {
               }),
               panel: 'quote',
               shortLabel: quoteToken,
-              tokenIcon: quoteToken,
+              tokenIcon: quoteTokenIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'quote')

--- a/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
@@ -33,6 +33,7 @@ interface AjnaGeneralContextProviderProps {
   collateralPrecision: number
   collateralPrice: BigNumber
   collateralToken: string
+  collateralTokenSource: string
   dpmProxy?: string
   ethBalance: BigNumber
   ethPrice: BigNumber
@@ -47,6 +48,7 @@ interface AjnaGeneralContextProviderProps {
   quotePrecision: number
   quotePrice: BigNumber
   quoteToken: string
+  quoteTokenSource: string
   steps: AjnaSidebarStep[]
   gasPrice: GasPriceParams
   slippage: BigNumber

--- a/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
@@ -33,7 +33,7 @@ interface AjnaGeneralContextProviderProps {
   collateralPrecision: number
   collateralPrice: BigNumber
   collateralToken: string
-  collateralTokenSource: string
+  collateralTokenIcon: string
   dpmProxy?: string
   ethBalance: BigNumber
   ethPrice: BigNumber
@@ -48,7 +48,7 @@ interface AjnaGeneralContextProviderProps {
   quotePrecision: number
   quotePrice: BigNumber
   quoteToken: string
-  quoteTokenSource: string
+  quoteTokenIcon: string
   steps: AjnaSidebarStep[]
   gasPrice: GasPriceParams
   slippage: BigNumber

--- a/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaGeneralContext.tsx
@@ -33,7 +33,7 @@ interface AjnaGeneralContextProviderProps {
   collateralPrecision: number
   collateralPrice: BigNumber
   collateralToken: string
-  collateralTokenIcon: string
+  collateralIcon: string
   dpmProxy?: string
   ethBalance: BigNumber
   ethPrice: BigNumber
@@ -48,7 +48,7 @@ interface AjnaGeneralContextProviderProps {
   quotePrecision: number
   quotePrice: BigNumber
   quoteToken: string
-  quoteTokenIcon: string
+  quoteIcon: string
   steps: AjnaSidebarStep[]
   gasPrice: GasPriceParams
   slippage: BigNumber

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -110,8 +110,8 @@ export function AjnaProductController({
                       flow,
                       product: dpmPositionData?.product as AjnaProduct,
                       quoteToken: dpmPositionData?.quoteToken,
-                      collateralTokenIcon: tokensIconsData?.collateralToken,
-                      quoteTokenIcon: tokensIconsData?.quoteToken,
+                      collateralIcon: tokensIconsData?.collateralToken,
+                      quoteIcon: tokensIconsData?.quoteToken,
                       id,
                     })}
                   />
@@ -152,7 +152,7 @@ export function AjnaProductController({
                         isOracless ? one : tokenPriceUSD[dpmPosition.collateralToken]
                       }
                       collateralToken={dpmPosition.collateralToken}
-                      collateralTokenIcon={tokensIconsData.collateralToken}
+                      collateralIcon={tokensIconsData.collateralToken}
                       {...(flow === 'manage' && { dpmProxy: dpmPosition.proxy })}
                       ethBalance={ethBalance}
                       ethPrice={tokenPriceUSD.ETH}
@@ -167,7 +167,7 @@ export function AjnaProductController({
                       quotePrecision={quotePrecision}
                       quotePrice={isOracless ? one : tokenPriceUSD[dpmPosition.quoteToken]}
                       quoteToken={dpmPosition.quoteToken}
-                      quoteTokenIcon={tokensIconsData.quoteToken}
+                      quoteIcon={tokensIconsData.quoteToken}
                       steps={steps[dpmPosition.product as AjnaProduct][flow]}
                       gasPrice={gasPrice}
                       slippage={slippage}

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -62,11 +62,11 @@ export function AjnaProductController({
       gasPriceData,
       tokenPriceUSDData,
       userSettingsData,
+      tokensIconsData,
     },
     errors,
     isOracless,
     tokensPrecision,
-    tokensSource,
   } = useAjnaData({
     collateralToken,
     id,
@@ -101,6 +101,7 @@ export function AjnaProductController({
                   ajnaPositionAggregatedData,
                   userSettingsData,
                   tokensPrecision,
+                  tokensIconsData,
                 ]}
                 customLoader={
                   <PositionLoadingState
@@ -109,6 +110,8 @@ export function AjnaProductController({
                       flow,
                       product: dpmPositionData?.product as AjnaProduct,
                       quoteToken: dpmPositionData?.quoteToken,
+                      collateralTokenIcon: tokensIconsData?.collateralToken,
+                      quoteTokenIcon: tokensIconsData?.quoteToken,
                       id,
                     })}
                   />
@@ -124,6 +127,7 @@ export function AjnaProductController({
                   { auction, history, cumulatives },
                   { slippage },
                   { collateralDigits, collateralPrecision, quoteDigits, quotePrecision },
+                  tokensIconsData,
                 ]) => (
                   <>
                     <PageSEOTags
@@ -148,7 +152,7 @@ export function AjnaProductController({
                         isOracless ? one : tokenPriceUSD[dpmPosition.collateralToken]
                       }
                       collateralToken={dpmPosition.collateralToken}
-                      collateralTokenSource={tokensSource.collateralToken}
+                      collateralTokenIcon={tokensIconsData.collateralToken}
                       {...(flow === 'manage' && { dpmProxy: dpmPosition.proxy })}
                       ethBalance={ethBalance}
                       ethPrice={tokenPriceUSD.ETH}
@@ -163,7 +167,7 @@ export function AjnaProductController({
                       quotePrecision={quotePrecision}
                       quotePrice={isOracless ? one : tokenPriceUSD[dpmPosition.quoteToken]}
                       quoteToken={dpmPosition.quoteToken}
-                      quoteTokenSource={tokensSource.quoteToken}
+                      quoteTokenIcon={tokensIconsData.quoteToken}
                       steps={steps[dpmPosition.product as AjnaProduct][flow]}
                       gasPrice={gasPrice}
                       slippage={slippage}

--- a/features/ajna/positions/common/controls/AjnaProductController.tsx
+++ b/features/ajna/positions/common/controls/AjnaProductController.tsx
@@ -66,6 +66,7 @@ export function AjnaProductController({
     errors,
     isOracless,
     tokensPrecision,
+    tokensSource,
   } = useAjnaData({
     collateralToken,
     id,
@@ -147,6 +148,7 @@ export function AjnaProductController({
                         isOracless ? one : tokenPriceUSD[dpmPosition.collateralToken]
                       }
                       collateralToken={dpmPosition.collateralToken}
+                      collateralTokenSource={tokensSource.collateralToken}
                       {...(flow === 'manage' && { dpmProxy: dpmPosition.proxy })}
                       ethBalance={ethBalance}
                       ethPrice={tokenPriceUSD.ETH}
@@ -161,6 +163,7 @@ export function AjnaProductController({
                       quotePrecision={quotePrecision}
                       quotePrice={isOracless ? one : tokenPriceUSD[dpmPosition.quoteToken]}
                       quoteToken={dpmPosition.quoteToken}
+                      quoteTokenSource={tokensSource.quoteToken}
                       steps={steps[dpmPosition.product as AjnaProduct][flow]}
                       gasPrice={gasPrice}
                       slippage={slippage}

--- a/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
+++ b/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
@@ -12,8 +12,8 @@ interface AjnaBorrowHeadlinePropsParams {
   quoteToken?: string
   collateralAddress?: string
   quoteAddress?: string
-  collateralTokenIcon?: string
-  quoteTokenIcon?: string
+  collateralIcon?: string
+  quoteIcon?: string
 }
 
 export function getAjnaHeadlineProps({
@@ -22,23 +22,23 @@ export function getAjnaHeadlineProps({
   id,
   product,
   quoteToken,
-  collateralTokenIcon,
-  quoteTokenIcon,
+  collateralIcon,
+  quoteIcon,
 }: AjnaBorrowHeadlinePropsParams) {
   const { t } = useTranslation()
 
   return {
     ...(collateralToken &&
       quoteToken &&
-      collateralTokenIcon &&
-      quoteTokenIcon && {
+      collateralIcon &&
+      quoteIcon && {
         header: t(`ajna.position-page.common.headline.${flow}`, {
           collateralToken,
           id,
           product: upperFirst(product),
           quoteToken,
         }),
-        tokens: [collateralTokenIcon, quoteTokenIcon],
+        tokens: [collateralIcon, quoteIcon],
         protocol: {
           network: NetworkNames.ethereumMainnet,
           protocol: LendingProtocol.Ajna,

--- a/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
+++ b/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
@@ -1,8 +1,11 @@
+import { Icon } from '@makerdao/dai-ui-icons'
 import { NetworkNames } from 'blockchain/networks'
 import { AjnaFlow, AjnaProduct } from 'features/ajna/common/types'
 import { LendingProtocol } from 'lendingProtocols'
 import { upperFirst } from 'lodash'
 import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Flex } from 'theme-ui'
 
 interface AjnaBorrowHeadlinePropsParams {
   collateralToken?: string
@@ -10,6 +13,8 @@ interface AjnaBorrowHeadlinePropsParams {
   id?: string
   product?: AjnaProduct
   quoteToken?: string
+  collateralTokenSource?: string
+  quoteTokenSource?: string
 }
 
 export function getAjnaHeadlineProps({
@@ -18,18 +23,48 @@ export function getAjnaHeadlineProps({
   id,
   product,
   quoteToken,
+  collateralTokenSource,
+  quoteTokenSource,
 }: AjnaBorrowHeadlinePropsParams) {
   const { t } = useTranslation()
 
   return {
     ...(collateralToken &&
       quoteToken && {
-        header: t(`ajna.position-page.common.headline.${flow}`, {
-          collateralToken,
-          id,
-          product: upperFirst(product),
-          quoteToken,
-        }),
+        header: (
+          <>
+            <Flex sx={{ alignItems: 'center' }}>
+              {collateralToken}
+              {collateralTokenSource === 'blockchain' && (
+                <Icon
+                  name="warning"
+                  size="32px"
+                  sx={{
+                    verticalAlign: 'bottom',
+                    color: 'red',
+                  }}
+                />
+              )}
+              /{quoteToken}
+              {quoteTokenSource === 'blockchain' && (
+                <Icon
+                  name="warning"
+                  size="32px"
+                  sx={{
+                    verticalAlign: 'bottom',
+                    color: 'red',
+                  }}
+                />
+              )}
+            </Flex>
+            {flow === 'open' && (
+              <>
+                {upperFirst(product)} {t('position')}
+              </>
+            )}
+            {flow === 'manage' && <>#{id}</>}
+          </>
+        ),
         tokens: [collateralToken, quoteToken],
         protocol: {
           network: NetworkNames.ethereumMainnet,

--- a/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
+++ b/features/ajna/positions/common/helpers/getAjnaHeadlineProps.tsx
@@ -1,11 +1,8 @@
-import { Icon } from '@makerdao/dai-ui-icons'
 import { NetworkNames } from 'blockchain/networks'
 import { AjnaFlow, AjnaProduct } from 'features/ajna/common/types'
 import { LendingProtocol } from 'lendingProtocols'
 import { upperFirst } from 'lodash'
 import { useTranslation } from 'next-i18next'
-import React from 'react'
-import { Flex } from 'theme-ui'
 
 interface AjnaBorrowHeadlinePropsParams {
   collateralToken?: string
@@ -13,8 +10,10 @@ interface AjnaBorrowHeadlinePropsParams {
   id?: string
   product?: AjnaProduct
   quoteToken?: string
-  collateralTokenSource?: string
-  quoteTokenSource?: string
+  collateralAddress?: string
+  quoteAddress?: string
+  collateralTokenIcon?: string
+  quoteTokenIcon?: string
 }
 
 export function getAjnaHeadlineProps({
@@ -23,49 +22,23 @@ export function getAjnaHeadlineProps({
   id,
   product,
   quoteToken,
-  collateralTokenSource,
-  quoteTokenSource,
+  collateralTokenIcon,
+  quoteTokenIcon,
 }: AjnaBorrowHeadlinePropsParams) {
   const { t } = useTranslation()
 
   return {
     ...(collateralToken &&
-      quoteToken && {
-        header: (
-          <>
-            <Flex sx={{ alignItems: 'center' }}>
-              {collateralToken}
-              {collateralTokenSource === 'blockchain' && (
-                <Icon
-                  name="warning"
-                  size="32px"
-                  sx={{
-                    verticalAlign: 'bottom',
-                    color: 'red',
-                  }}
-                />
-              )}
-              /{quoteToken}
-              {quoteTokenSource === 'blockchain' && (
-                <Icon
-                  name="warning"
-                  size="32px"
-                  sx={{
-                    verticalAlign: 'bottom',
-                    color: 'red',
-                  }}
-                />
-              )}
-            </Flex>
-            {flow === 'open' && (
-              <>
-                {upperFirst(product)} {t('position')}
-              </>
-            )}
-            {flow === 'manage' && <>#{id}</>}
-          </>
-        ),
-        tokens: [collateralToken, quoteToken],
+      quoteToken &&
+      collateralTokenIcon &&
+      quoteTokenIcon && {
+        header: t(`ajna.position-page.common.headline.${flow}`, {
+          collateralToken,
+          id,
+          product: upperFirst(product),
+          quoteToken,
+        }),
+        tokens: [collateralTokenIcon, quoteTokenIcon],
         protocol: {
           network: NetworkNames.ethereumMainnet,
           protocol: LendingProtocol.Ajna,

--- a/features/ajna/positions/common/hooks/useAjnaData.ts
+++ b/features/ajna/positions/common/hooks/useAjnaData.ts
@@ -182,17 +182,30 @@ export function useAjnaData({ collateralToken, id, product, quoteToken }: AjnaDa
       : undefined
   }, [isOracless, dpmPositionData, identifiedTokensData, collateralToken, quoteToken])
 
-  const tokensSource = useMemo(() => {
-    return identifiedTokensData && isOracless
+  const tokensIconsData = useMemo(() => {
+    return collateralToken && quoteToken
       ? {
-          collateralToken: identifiedTokensData[collateralToken].source || 'blockchain',
-          quoteToken: identifiedTokensData[quoteToken].source || 'blockchain',
+          collateralToken,
+          quoteToken,
         }
-      : {
-          collateralToken: 'local',
-          quoteToken: 'local',
+      : dpmPositionData && isOracless && identifiedTokensData
+      ? {
+          collateralToken:
+            identifiedTokensData[dpmPositionData.collateralToken].source === 'blockchain'
+              ? dpmPositionData.collateralTokenAddress
+              : dpmPositionData.collateralToken,
+          quoteToken:
+            identifiedTokensData[dpmPositionData.quoteToken].source === 'blockchain'
+              ? dpmPositionData.quoteTokenAddress
+              : dpmPositionData.quoteToken,
         }
-  }, [identifiedTokensData, collateralToken, quoteToken, isOracless])
+      : dpmPositionData
+      ? {
+          collateralToken: dpmPositionData.collateralToken,
+          quoteToken: dpmPositionData.quoteToken,
+        }
+      : undefined
+  }, [identifiedTokensData, collateralToken, quoteToken, isOracless, dpmPositionData])
 
   return {
     data: {
@@ -204,6 +217,7 @@ export function useAjnaData({ collateralToken, id, product, quoteToken }: AjnaDa
       gasPriceData,
       tokenPriceUSDData,
       userSettingsData,
+      tokensIconsData,
     },
     errors: [
       ajnaPositionAggregatedError,
@@ -218,6 +232,5 @@ export function useAjnaData({ collateralToken, id, product, quoteToken }: AjnaDa
     ],
     isOracless,
     tokensPrecision,
-    tokensSource,
   }
 }

--- a/features/ajna/positions/common/hooks/useAjnaData.ts
+++ b/features/ajna/positions/common/hooks/useAjnaData.ts
@@ -182,6 +182,18 @@ export function useAjnaData({ collateralToken, id, product, quoteToken }: AjnaDa
       : undefined
   }, [isOracless, dpmPositionData, identifiedTokensData, collateralToken, quoteToken])
 
+  const tokensSource = useMemo(() => {
+    return identifiedTokensData && isOracless
+      ? {
+          collateralToken: identifiedTokensData[collateralToken].source || 'blockchain',
+          quoteToken: identifiedTokensData[quoteToken].source || 'blockchain',
+        }
+      : {
+          collateralToken: 'local',
+          quoteToken: 'local',
+        }
+  }, [identifiedTokensData, collateralToken, quoteToken, isOracless])
+
   return {
     data: {
       ajnaPositionAggregatedData,
@@ -206,5 +218,6 @@ export function useAjnaData({ collateralToken, id, product, quoteToken }: AjnaDa
     ],
     isOracless,
     tokensPrecision,
+    tokensSource,
   }
 }

--- a/features/ajna/positions/common/views/AjnaPositionView.tsx
+++ b/features/ajna/positions/common/views/AjnaPositionView.tsx
@@ -41,6 +41,8 @@ export function AjnaPositionView({
       quotePrice,
       quoteToken,
       dpmProxy,
+      collateralTokenSource,
+      quoteTokenSource,
     },
   } = useAjnaGeneralContext()
 
@@ -59,6 +61,8 @@ export function AjnaPositionView({
           id,
           product,
           quoteToken,
+          collateralTokenSource,
+          quoteTokenSource,
         })}
         {...(flow === 'manage' && { shareButton: true })}
         details={[
@@ -77,7 +81,9 @@ export function AjnaPositionView({
             : []),
         ]}
         handleClick={
-          proxyReveal ? () => console.log(`DPM proxy: ${dpmProxy?.toLowerCase()}`) : undefined
+          proxyReveal
+            ? () => console.log(`DPM proxy: ${dpmProxy?.toLowerCase()}, DPM owner: ${owner}`)
+            : undefined
         }
       />
       <TabBar

--- a/features/ajna/positions/common/views/AjnaPositionView.tsx
+++ b/features/ajna/positions/common/views/AjnaPositionView.tsx
@@ -41,8 +41,8 @@ export function AjnaPositionView({
       quotePrice,
       quoteToken,
       dpmProxy,
-      collateralTokenIcon,
-      quoteTokenIcon,
+      collateralIcon,
+      quoteIcon,
     },
   } = useAjnaGeneralContext()
 
@@ -61,8 +61,8 @@ export function AjnaPositionView({
           id,
           product,
           quoteToken,
-          collateralTokenIcon,
-          quoteTokenIcon,
+          collateralIcon,
+          quoteIcon,
         })}
         {...(flow === 'manage' && { shareButton: true })}
         details={[

--- a/features/ajna/positions/common/views/AjnaPositionView.tsx
+++ b/features/ajna/positions/common/views/AjnaPositionView.tsx
@@ -41,8 +41,8 @@ export function AjnaPositionView({
       quotePrice,
       quoteToken,
       dpmProxy,
-      collateralTokenSource,
-      quoteTokenSource,
+      collateralTokenIcon,
+      quoteTokenIcon,
     },
   } = useAjnaGeneralContext()
 
@@ -61,8 +61,8 @@ export function AjnaPositionView({
           id,
           product,
           quoteToken,
-          collateralTokenSource,
-          quoteTokenSource,
+          collateralTokenIcon,
+          quoteTokenIcon,
         })}
         {...(flow === 'manage' && { shareButton: true })}
         details={[

--- a/features/ajna/positions/earn/controls/AjnaEarnFormController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnFormController.tsx
@@ -14,7 +14,7 @@ import React from 'react'
 export function AjnaEarnFormController() {
   const { t } = useTranslation()
   const {
-    environment: { flow, quoteToken, collateralToken },
+    environment: { flow, quoteToken, collateralToken, quoteTokenIcon, collateralTokenIcon },
     steps: { currentStep },
   } = useAjnaGeneralContext()
   const {
@@ -58,7 +58,7 @@ export function AjnaEarnFormController() {
                 }),
                 panel: 'liquidity',
                 shortLabel: quoteToken,
-                tokenIcon: quoteToken,
+                tokenIcon: quoteTokenIcon,
                 action: () => {
                   dispatch({ type: 'reset' })
                   updateState('uiDropdown', 'liquidity')
@@ -72,7 +72,7 @@ export function AjnaEarnFormController() {
                       label: t('system.claim-collateral'),
                       panel: 'claim-collateral',
                       shortLabel: collateralToken,
-                      tokenIcon: collateralToken,
+                      tokenIcon: collateralTokenIcon,
                       iconShrink: 2,
                       action: () => {
                         dispatch({ type: 'reset' })

--- a/features/ajna/positions/earn/controls/AjnaEarnFormController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnFormController.tsx
@@ -14,7 +14,7 @@ import React from 'react'
 export function AjnaEarnFormController() {
   const { t } = useTranslation()
   const {
-    environment: { flow, quoteToken, collateralToken, quoteTokenIcon, collateralTokenIcon },
+    environment: { flow, quoteToken, collateralToken, quoteIcon, collateralIcon },
     steps: { currentStep },
   } = useAjnaGeneralContext()
   const {
@@ -58,7 +58,7 @@ export function AjnaEarnFormController() {
                 }),
                 panel: 'liquidity',
                 shortLabel: quoteToken,
-                tokenIcon: quoteTokenIcon,
+                tokenIcon: quoteIcon,
                 action: () => {
                   dispatch({ type: 'reset' })
                   updateState('uiDropdown', 'liquidity')
@@ -72,7 +72,7 @@ export function AjnaEarnFormController() {
                       label: t('system.claim-collateral'),
                       panel: 'claim-collateral',
                       shortLabel: collateralToken,
-                      tokenIcon: collateralTokenIcon,
+                      tokenIcon: collateralIcon,
                       iconShrink: 2,
                       action: () => {
                         dispatch({ type: 'reset' })

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 export function AjnaEarnOverviewOpenController() {
   const { t } = useTranslation()
   const {
-    environment: { quoteToken, quotePrice, isOracless },
+    environment: { quoteToken, quotePrice, isOracless, quoteTokenIcon },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -41,7 +41,13 @@ export function AjnaEarnOverviewOpenController() {
 
   return (
     <DetailsSection
-      title={<SimulateTitle token={quoteToken} depositAmount={depositAmount} />}
+      title={
+        <SimulateTitle
+          token={quoteTokenIcon}
+          tokenSymbol={quoteToken}
+          depositAmount={depositAmount}
+        />
+      }
       notifications={notifications}
       content={
         <>

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewOpenController.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 export function AjnaEarnOverviewOpenController() {
   const { t } = useTranslation()
   const {
-    environment: { quoteToken, quotePrice, isOracless, quoteTokenIcon },
+    environment: { quoteToken, quotePrice, isOracless, quoteIcon },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -42,11 +42,7 @@ export function AjnaEarnOverviewOpenController() {
   return (
     <DetailsSection
       title={
-        <SimulateTitle
-          token={quoteTokenIcon}
-          tokenSymbol={quoteToken}
-          depositAmount={depositAmount}
-        />
+        <SimulateTitle token={quoteIcon} tokenSymbol={quoteToken} depositAmount={depositAmount} />
       }
       notifications={notifications}
       content={

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next'
 export function AjnaMultiplyFormController() {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, flow, quoteToken, collateralTokenIcon, quoteTokenIcon },
+    environment: { collateralToken, flow, quoteToken, collateralIcon, quoteIcon },
     steps: { currentStep },
   } = useAjnaGeneralContext()
   const {
@@ -49,7 +49,7 @@ export function AjnaMultiplyFormController() {
               }),
               panel: 'collateral',
               shortLabel: collateralToken,
-              tokenIcon: collateralTokenIcon,
+              tokenIcon: collateralIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'collateral')
@@ -63,7 +63,7 @@ export function AjnaMultiplyFormController() {
               }),
               panel: 'quote',
               shortLabel: quoteToken,
-              tokenIcon: quoteTokenIcon,
+              tokenIcon: quoteIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'quote')

--- a/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
+++ b/features/ajna/positions/multiply/controls/AjnaMultiplyFormController.tsx
@@ -1,4 +1,3 @@
-import { getToken } from 'blockchain/tokensMetadata'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { AjnaFormContentRisk } from 'features/ajna/positions/common/sidebars/AjnaFormContentRisk'
@@ -14,7 +13,7 @@ import { useTranslation } from 'react-i18next'
 export function AjnaMultiplyFormController() {
   const { t } = useTranslation()
   const {
-    environment: { collateralToken, flow, quoteToken },
+    environment: { collateralToken, flow, quoteToken, collateralTokenIcon, quoteTokenIcon },
     steps: { currentStep },
   } = useAjnaGeneralContext()
   const {
@@ -50,7 +49,7 @@ export function AjnaMultiplyFormController() {
               }),
               panel: 'collateral',
               shortLabel: collateralToken,
-              icon: getToken(collateralToken).iconCircle,
+              tokenIcon: collateralTokenIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'collateral')
@@ -64,7 +63,7 @@ export function AjnaMultiplyFormController() {
               }),
               panel: 'quote',
               shortLabel: quoteToken,
-              icon: getToken(quoteToken).iconCircle,
+              tokenIcon: quoteTokenIcon,
               action: () => {
                 dispatch({ type: 'reset' })
                 updateState('uiDropdown', 'quote')

--- a/features/poolFinder/helpers/parsePoolResponse.ts
+++ b/features/poolFinder/helpers/parsePoolResponse.ts
@@ -75,13 +75,13 @@ export function parsePoolResponse(
           managementType: 'active',
           collateralAddress: collateralAddress,
           collateralToken: identifiedTokens[collateralAddress].symbol,
-          collateralTokenIcon:
+          collateralIcon:
             identifiedTokens[collateralAddress].source === 'blockchain'
               ? collateralAddress
               : collateralToken,
           quoteAddress: quoteTokenAddress,
           quoteToken: identifiedTokens[quoteTokenAddress].symbol,
-          quoteTokenIcon:
+          quoteIcon:
             identifiedTokens[quoteTokenAddress].source === 'blockchain'
               ? quoteTokenAddress
               : quoteToken,

--- a/features/poolFinder/helpers/parsePoolResponse.ts
+++ b/features/poolFinder/helpers/parsePoolResponse.ts
@@ -75,8 +75,16 @@ export function parsePoolResponse(
           managementType: 'active',
           collateralAddress: collateralAddress,
           collateralToken: identifiedTokens[collateralAddress].symbol,
+          collateralTokenIcon:
+            identifiedTokens[collateralAddress].source === 'blockchain'
+              ? collateralAddress
+              : collateralToken,
           quoteAddress: quoteTokenAddress,
           quoteToken: identifiedTokens[quoteTokenAddress].symbol,
+          quoteTokenIcon:
+            identifiedTokens[quoteTokenAddress].source === 'blockchain'
+              ? quoteTokenAddress
+              : quoteToken,
           tooltips: {
             ...(isPoolWithRewards({ collateralToken, quoteToken }) && {
               fee: productHubAjnaRewardsTooltip,

--- a/features/poolFinder/helpers/parseRows.tsx
+++ b/features/poolFinder/helpers/parseRows.tsx
@@ -29,6 +29,8 @@ export function parseRows(
       quoteToken,
       tooltips,
       weeklyNetApy,
+      collateralTokenIcon,
+      quoteTokenIcon,
     } = row
 
     const label = `${collateralToken}/${quoteToken}`
@@ -43,7 +45,7 @@ export function parseRows(
 
     return {
       collateralQuote: (
-        <AssetsTableDataCellAsset asset={label} icons={[collateralToken, quoteToken]} />
+        <AssetsTableDataCellAsset asset={label} icons={[collateralTokenIcon, quoteTokenIcon]} />
       ),
       ...parseProduct(
         {

--- a/features/poolFinder/helpers/parseRows.tsx
+++ b/features/poolFinder/helpers/parseRows.tsx
@@ -29,8 +29,8 @@ export function parseRows(
       quoteToken,
       tooltips,
       weeklyNetApy,
-      collateralTokenIcon,
-      quoteTokenIcon,
+      collateralIcon,
+      quoteIcon,
     } = row
 
     const label = `${collateralToken}/${quoteToken}`
@@ -45,7 +45,7 @@ export function parseRows(
 
     return {
       collateralQuote: (
-        <AssetsTableDataCellAsset asset={label} icons={[collateralTokenIcon, quoteTokenIcon]} />
+        <AssetsTableDataCellAsset asset={label} icons={[collateralIcon, quoteIcon]} />
       ),
       ...parseProduct(
         {

--- a/features/poolFinder/types.ts
+++ b/features/poolFinder/types.ts
@@ -22,4 +22,6 @@ export interface OraclessPoolResult extends ProductHubItemTooltips {
   quoteAddress: string
   quoteToken: string
   weeklyNetApy?: string
+  collateralTokenIcon: string
+  quoteTokenIcon: string
 }

--- a/features/poolFinder/types.ts
+++ b/features/poolFinder/types.ts
@@ -22,6 +22,6 @@ export interface OraclessPoolResult extends ProductHubItemTooltips {
   quoteAddress: string
   quoteToken: string
   weeklyNetApy?: string
-  collateralTokenIcon: string
-  quoteTokenIcon: string
+  collateralIcon: string
+  quoteIcon: string
 }

--- a/handlers/tokens-info/tokens.ts
+++ b/handlers/tokens-info/tokens.ts
@@ -46,6 +46,7 @@ export const readTokensFromBlockchain = async ({
         symbol,
         precision,
         chain_id: chainId,
+        source: 'blockchain',
       }))
     }),
   )
@@ -63,6 +64,7 @@ export const readTokensFromApi = async (tokens: string[]): Promise<Tokens[]> => 
         symbol,
         precision: decimals,
         name,
+        source: 'api',
       })) || []
   )
 }

--- a/server/database/migrations/027-tokens-source.sql
+++ b/server/database/migrations/027-tokens-source.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tokens
+  ADD COLUMN source VARCHAR

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -363,6 +363,7 @@ model Tokens {
   symbol    String
   precision Int
   chain_id  Int
+  source    String
 
   @@unique([address, chain_id], name: "address_chain_id_unique_id")
   @@map("tokens")


### PR DESCRIPTION
# Tokens source

https://app.shortcut.com/oazo-apps/story/11038/right-icon-is-shown-for-any-token-called-usdt-icon-should-only-display-based-on-tokenlist
https://app.shortcut.com/oazo-apps/story/10878/secure-token-identifier-against-scam-tokens

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added additional field in db and in tokens interface to support token `source`
- adjusted idenftifyTokens observable to handle `source` prop
- added new props to ajna environment context which are `collateralTokenIcon` and `quoteTokenIcon`
  
## How to test 🧪
  <Please explain how to test your changes>

- try to use oracless pools which tokens for sure are not within our config or api token list to see if generic icons will be used
- pool finder shouldn't show token icon if token source is blockchain
- verify whether standard position UI remain unchanged
