### PR TITLE
"Handle undefined vaultType in getStrategyConfig"

### DIFF
--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -120,11 +120,16 @@ export async function getAaveV3StrategyConfig(
   if (!lastCreatedPosition) {
     throw new Error(`Can't load strategy config for position without dmpProxy. VaultId: ${vaultId}`)
   }
+  const _vaultType =
+    vaultType === undefined || vaultType === VaultType.Unknown
+      ? productToVaultType(lastCreatedPosition.positionType)
+      : vaultType
+
   return loadStrategyFromTokens(
     lastCreatedPosition.collateralTokenSymbol,
     lastCreatedPosition.debtTokenSymbol,
     networkName,
     lastCreatedPosition.protocol,
-    vaultType,
+    _vaultType,
   )
 }


### PR DESCRIPTION
This commit introduces a fallback mechanism for undefined or unknown `vaultType` in `getStrategyConfig.ts`. Now, if `vaultType` is undefined or unknown, it defaults to the `positionType` of the last created position.
