### PR TITLE
feat: add `tx_processed` to MerkleTree table

### DIFF
--- a/server/database/migrations/027-alter-referrals.sql
+++ b/server/database/migrations/027-alter-referrals.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "merkle_tree" ADD COLUMN     "tx_processed" BOOLEAN NOT NULL DEFAULT false;

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -73,12 +73,13 @@ model WeeklyClaim {
 }
 
 model MerkleTree {
-  week_number Int       @unique
-  start_block Int?
-  end_block   Int?
-  timestamp   DateTime? @default(now())
-  tree_root   String
-  snapshot    String?
+  week_number  Int       @unique
+  start_block  Int?
+  end_block    Int?
+  timestamp    DateTime? @default(now())
+  tree_root    String
+  snapshot     String?
+  tx_processed Boolean   @default(false)
 
   @@map("merkle_tree")
 }


### PR DESCRIPTION
# [sc-11142]


  
## Changes 👷‍♀️
add tx_processed column to borrow db - is used if redeemer transaction to add weekly root fails but snapshots are added to the database.

## How to test 🧪
migrate locally
