### PR TITLE
Ajna withdraw on repay only action

### DIFF
--- a/actions/ajna/borrow.ts
+++ b/actions/ajna/borrow.ts
@@ -6,7 +6,7 @@ import {
 } from '@oasisdex/dma-library'
 import { AjnaGenericPosition } from 'features/ajna/common/types'
 import { AjnaBorrowFormState } from 'features/ajna/positions/borrow/state/ajnaBorrowFormReducto'
-import { zero } from 'helpers/zero'
+import { one, zero } from 'helpers/zero'
 
 export const ajnaOpenBorrow = ({
   state,
@@ -66,10 +66,17 @@ export const ajnaPaybackWithdrawBorrow = ({
 }) => {
   const { withdrawAmount, paybackAmount } = state
 
+  // TODO temporary fix in order to force refresh of neutral price
+  //  and therefore liquidation price on repay-only action
+  const resolvedWithdrawFallback =
+    !withdrawAmount?.gt(zero) && paybackAmount?.gt(zero)
+      ? one.shiftedBy(-commonPayload.collateralTokenPrecision)
+      : zero
+
   return strategies.ajna.borrow.paybackWithdraw(
     {
       ...commonPayload,
-      collateralAmount: withdrawAmount || zero,
+      collateralAmount: withdrawAmount || resolvedWithdrawFallback,
       position: position as AjnaPosition,
       quoteAmount: paybackAmount || zero,
     },


### PR DESCRIPTION
# Ajna withdraw on repay only action
<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- on repay only action, a withdraw of smallest possible amount of collateral based on precision is added to ensure refresh of netural price and therefore liquidation price
  
## How to test 🧪
  <Please explain how to test your changes>

- do repay only action on ajna borrow / multiply position, after sending tx verify whether a small amount of collateral has been withdrawn (potentially you could also check for repay withdraw event in history)
