### PR TITLE
fix: Wrong values displayed in Owner page for 'Risk ratio' and 'Variable %'

### DIFF
--- a/features/vaultsOverview/parsers.tsx
+++ b/features/vaultsOverview/parsers.tsx
@@ -198,7 +198,7 @@ export function parseAaveBorrowPositionRows(positions: AavePosition[]): Position
     network: networksById[position.chainId].name,
     protocol: position.protocol,
     riskRatio: {
-      level: position.riskRatio.loanToValue,
+      level: position.riskRatio.loanToValue.times(100),
       isAtRiskDanger: position.isAtRiskDanger,
       isAtRiskWarning: position.isAtRiskWarning,
       type: 'LTV',
@@ -207,7 +207,7 @@ export function parseAaveBorrowPositionRows(positions: AavePosition[]): Position
     autoSellData: position.autoSellData,
     isOwner: position.isOwner,
     url: position.url,
-    variable: position.variableBorrowRate,
+    variable: position.variableBorrowRate.times(100),
   }))
 }
 

--- a/features/vaultsOverview/pipes/positions.ts
+++ b/features/vaultsOverview/pipes/positions.ts
@@ -210,11 +210,10 @@ function buildAaveViewModel(
         }`
 
         const { loanToValue } = position.riskRatio
-        const { liquidationThreshold } = position.category
         const { maxLoanToValue } = position.category
-        const warnignThreshold = maxLoanToValue.minus(maxLoanToValue.times(3))
+        const warnignThreshold = maxLoanToValue.minus(maxLoanToValue.times(0.03))
 
-        const isDanger = loanToValue.gte(liquidationThreshold)
+        const isDanger = loanToValue.gte(maxLoanToValue)
         const isWarning = loanToValue.gte(warnignThreshold)
 
         return {


### PR DESCRIPTION
This commit modifies the risk ratio representation by multiplying loanToValue by 100 in parsers.tsx to express the ratio as a percentage for better user comprehension. Similarly, the variable borrow rate is also converted to a percentage. Additionally, the warning threshold calculation in positions.ts was adjusted by subtracting 3% of maxLoanToValue instead of 3 times maxLoanToValue. The notion of danger is also updated to compare loanToValue with maxLoanToValue instead of liquidation threshold. 

Story details: https://app.shortcut.com/oazo-apps/story/11152