### PR TITLE
Pool creator redirect not updating

### DIFF
--- a/pages/ajna/pool-creator.tsx
+++ b/pages/ajna/pool-creator.tsx
@@ -1,3 +1,4 @@
+import { WithConnection } from 'components/connectWallet'
 import { WithFeatureToggleRedirect } from 'components/FeatureToggleRedirect'
 import { AjnaPoolCreatorController } from 'features/ajna/common/controls/AjnaPoolCreatorController'
 import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
@@ -8,13 +9,15 @@ import React from 'react'
 
 function AjnaPoolCreatorPage() {
   return (
-    <WithTermsOfService>
-      <WithWalletAssociatedRisk>
-        <WithFeatureToggleRedirect feature="AjnaPoolFinder">
-          <AjnaPoolCreatorController />
-        </WithFeatureToggleRedirect>
-      </WithWalletAssociatedRisk>
-    </WithTermsOfService>
+    <WithConnection>
+      <WithTermsOfService>
+        <WithWalletAssociatedRisk>
+          <WithFeatureToggleRedirect feature="AjnaPoolFinder">
+            <AjnaPoolCreatorController />
+          </WithFeatureToggleRedirect>
+        </WithWalletAssociatedRisk>
+      </WithTermsOfService>
+    </WithConnection>
   )
 }
 

--- a/pages/ajna/pool-creator.tsx
+++ b/pages/ajna/pool-creator.tsx
@@ -1,5 +1,3 @@
-import { NetworkHexIds } from 'blockchain/networks'
-import { WithConnection } from 'components/connectWallet'
 import { WithFeatureToggleRedirect } from 'components/FeatureToggleRedirect'
 import { AjnaPoolCreatorController } from 'features/ajna/common/controls/AjnaPoolCreatorController'
 import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
@@ -10,15 +8,13 @@ import React from 'react'
 
 function AjnaPoolCreatorPage() {
   return (
-    <WithConnection pageChainId={NetworkHexIds.MAINNET} includeTestNet={true}>
-      <WithTermsOfService>
-        <WithWalletAssociatedRisk>
-          <WithFeatureToggleRedirect feature="AjnaPoolFinder">
-            <AjnaPoolCreatorController />
-          </WithFeatureToggleRedirect>
-        </WithWalletAssociatedRisk>
-      </WithTermsOfService>
-    </WithConnection>
+    <WithTermsOfService>
+      <WithWalletAssociatedRisk>
+        <WithFeatureToggleRedirect feature="AjnaPoolFinder">
+          <AjnaPoolCreatorController />
+        </WithFeatureToggleRedirect>
+      </WithWalletAssociatedRisk>
+    </WithTermsOfService>
   )
 }
 


### PR DESCRIPTION
# [Pool creator redirect not updating](https://discord.com/channels/837076147694207067/1138393690331680768/1142044720265166929)

`WithConnection` component is causing page to not update. When user clicks on the link somewhere in the UI, the URL in the browser bar is updated, but page is not refreshed. After manual reload new page is loaded. 

There is something wrong with `WithConnection` component that has to be investigated.
  
## Changes 👷‍♀️

- Removed additional props from `WithConnection` component.
  
## How to test 🧪

Go to pool creator and either try to create pool that already exists or create new one. In both cases there are links to borrow and earn rendered. Click on one of the urls and check if you're getting redirected.
