### PR TITLE
Liquidation Price & Net Value - Aave Positions

### DIFF
--- a/features/aave/components/AaveBorrowManageComponent.tsx
+++ b/features/aave/components/AaveBorrowManageComponent.tsx
@@ -75,6 +75,7 @@ export function AaveBorrowManageComponent({
         ]) => {
           return (
             <AaveBorrowPositionData
+              strategyType={strategyConfig.strategyType}
               currentPosition={_currentPosition}
               collateralTokenPrice={_collateralTokenPrice}
               collateralTokenReserveData={_collateralTokenReserveData}

--- a/features/aave/components/AaveMultiplyManageComponent.tsx
+++ b/features/aave/components/AaveMultiplyManageComponent.tsx
@@ -89,6 +89,7 @@ export function AaveMultiplyManageComponent({
         ]) => {
           return (
             <AaveMultiplyPositionData
+              strategyType={strategyConfig.strategyType}
               currentPosition={_currentPosition}
               collateralTokenPrice={_collateralTokenPrice}
               collateralTokenReserveData={_collateralTokenReserveData}

--- a/features/aave/components/LiquidationPriceCard.tsx
+++ b/features/aave/components/LiquidationPriceCard.tsx
@@ -1,0 +1,94 @@
+import { IPosition } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
+import { DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
+import { calculateViewValuesForPosition } from 'features/aave/services'
+import { StrategyType } from 'features/aave/types'
+import { formatDecimalAsPercent, formatPrecision } from 'helpers/formatters/format'
+import { zero } from 'helpers/zero'
+import { ReserveConfigurationData, ReserveData } from 'lendingProtocols/aaveCommon'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import { Card, Grid, Heading, Text } from 'theme-ui'
+
+export function LiquidationPriceCard(props: {
+  position: IPosition
+  strategyType: StrategyType
+  collateralTokenPrice: BigNumber
+  debtTokenPrice: BigNumber
+  currentPositionThings: ReturnType<typeof calculateViewValuesForPosition>
+  nextPositionThings: ReturnType<typeof calculateViewValuesForPosition> | undefined
+  collateralTokenReserveData: ReserveData
+  debtTokenReserveData: ReserveData
+  debtTokenReserveConfigurationData: ReserveConfigurationData
+}) {
+  const belowCurrentPricePercentage = formatDecimalAsPercent(
+    props.currentPositionThings.liquidationPriceInDebt
+      .minus(props.collateralTokenPrice)
+      .dividedBy(props.collateralTokenPrice)
+      .absoluteValue(),
+  )
+
+  const liquidationPriceSymbol =
+    props.strategyType === StrategyType.Long
+      ? props.position.debt.symbol
+      : props.position.collateral.symbol
+  const currentLiquidationPrice =
+    props.strategyType === StrategyType.Long
+      ? props.currentPositionThings.liquidationPriceInDebt
+      : props.currentPositionThings.liquidationPriceInCollateral
+  const nextLiquidationPrice = props.nextPositionThings
+    ? props.strategyType === StrategyType.Long
+      ? props.nextPositionThings.liquidationPriceInDebt
+      : props.nextPositionThings.liquidationPriceInCollateral
+    : undefined
+
+  const { t } = useTranslation()
+  return (
+    <DetailsSectionContentCard
+      title={t('system.liquidation-price')}
+      value={`${formatPrecision(currentLiquidationPrice, 2)} ${liquidationPriceSymbol}`}
+      change={
+        nextLiquidationPrice && {
+          variant: nextLiquidationPrice.gte(currentLiquidationPrice) ? 'positive' : 'negative',
+          value: `${formatPrecision(nextLiquidationPrice, 2)} ${t('after')}`,
+        }
+      }
+      footnote={
+        !currentLiquidationPrice.eq(zero)
+          ? t('manage-earn-vault.below-current-price', { percentage: belowCurrentPricePercentage })
+          : undefined
+      }
+      modal={
+        <Grid gap={2}>
+          <Heading variant="header4">
+            {t('aave-position-modal.liquidation-price.first-header')}
+          </Heading>
+          <Text as="p" variant="paragraph3" sx={{ mb: 1 }}>
+            {props.strategyType === StrategyType.Long
+              ? t('aave-position-modal.liquidation-price.first-description-line-long')
+              : t('aave-position-modal.liquidation-price.first-description-line-short')}
+          </Text>
+          <Card as="p" variant="vaultDetailsCardModal">
+            {`${formatPrecision(currentLiquidationPrice, 2)} ${liquidationPriceSymbol}`}
+          </Card>
+          {!props.currentPositionThings.liquidationPriceInDebt.isNaN() && (
+            <Text as="p" variant="paragraph3" sx={{ mt: 1 }}>
+              {t('aave-position-modal.liquidation-price.second-description-line', {
+                percent: belowCurrentPricePercentage,
+              })}
+            </Text>
+          )}
+          <Heading variant="header4">
+            {t('aave-position-modal.liquidation-price.second-header')}
+          </Heading>
+          <Text as="p" variant="paragraph3" sx={{ mb: 1 }}>
+            {t('aave-position-modal.liquidation-price.third-description-line')}
+          </Text>
+          <Card as="p" variant="vaultDetailsCardModal">
+            {formatDecimalAsPercent(props.debtTokenReserveConfigurationData.liquidationBonus)}
+          </Card>
+        </Grid>
+      }
+    />
+  )
+}

--- a/features/aave/components/NetValueCard.tsx
+++ b/features/aave/components/NetValueCard.tsx
@@ -1,0 +1,48 @@
+import { IPosition } from '@oasisdex/dma-library'
+import { DetailsSectionContentCard } from 'components/DetailsSectionContentCard'
+import { calculateViewValuesForPosition } from 'features/aave/services'
+import { StrategyType } from 'features/aave/types'
+import { formatPrecision } from 'helpers/formatters/format'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+
+export function NetValueCard({
+  strategyType,
+  currentPosition,
+  nextPositionThings,
+  currentPositionThings,
+}: {
+  strategyType: StrategyType
+  currentPositionThings: ReturnType<typeof calculateViewValuesForPosition>
+  currentPosition: IPosition
+  nextPositionThings: ReturnType<typeof calculateViewValuesForPosition> | undefined
+}) {
+  const { t } = useTranslation()
+
+  const currentNetValue =
+    strategyType === StrategyType.Long
+      ? currentPositionThings.netValueInDebtToken
+      : currentPositionThings.netValueInCollateralToken
+  const nextNetValue =
+    nextPositionThings &&
+    (strategyType === StrategyType.Long
+      ? nextPositionThings.netValueInDebtToken
+      : nextPositionThings.netValueInCollateralToken)
+  const netValueSymbol =
+    strategyType === StrategyType.Long
+      ? currentPosition.debt.symbol
+      : currentPosition.collateral.symbol
+
+  return (
+    <DetailsSectionContentCard
+      title={t('system.net-value')}
+      value={`${formatPrecision(currentNetValue, 2)} ${netValueSymbol}`}
+      change={
+        nextNetValue && {
+          variant: nextNetValue.gt(currentNetValue) ? 'positive' : 'negative',
+          value: `${formatPrecision(nextNetValue, 2)} ${t('after')}`,
+        }
+      }
+    />
+  )
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -802,7 +802,8 @@
     "liquidation-price": {
       "first-header": "Liquidation Price",
       "second-header": "Liquidation Penalty",
-      "first-description-line": "The Liquidation Price is the collateral price at which a position will be liquidated. This number is denominated in debt",
+      "first-description-line-long": "The Liquidation Price is the collateral price at which a position will be liquidated. This number is denominated in debt",
+      "first-description-line-short": "The Liquidation Price is the debt price at which a position will be liquidated. This number is denominated in collateral",
       "second-description-line": "This is {{percent}} below current price",
       "third-description-line": "The liquidation penalty is the % that will be added to the debt as a penalty in case of liquidation."
     },


### PR DESCRIPTION
# Changes
- Refactor way of displaying Liquidation Price and Net Value of the position in Aave
- New components only for `NetValue` & `LiquidationPrice` 
- In case of short position tyle we are displaying Debt/Collateral instead of Collateral/Debt
- It's a just view change without changing any significant calculations. 