### PR TITLE
Lowercase tokens for pool creator form

### DIFF
--- a/features/poolCreator/hooks/usePoolCreatorData.tsx
+++ b/features/poolCreator/hooks/usePoolCreatorData.tsx
@@ -192,19 +192,19 @@ export function usePoolCreatorData({
             } else if (tokensKeys.length < 2) {
               const identifyingErrors: AjnaValidationItem[] = []
 
-              if (!tokensKeys.includes(collateralAddress))
+              if (!tokensKeys.includes(collateralAddress.toLowerCase()))
                 identifyingErrors.push({
                   message: { translationKey: 'collateral-is-not-erc20' },
                 })
-              if (!tokensKeys.includes(quoteAddress))
+              if (!tokensKeys.includes(quoteAddress.toLowerCase()))
                 identifyingErrors.push({
                   message: { translationKey: 'quote-is-not-erc20' },
                 })
 
               setErrors(identifyingErrors)
             } else {
-              setCollateralToken(identifiedTokens[collateralAddress].symbol)
-              setQuoteToken(identifiedTokens[quoteAddress].symbol)
+              setCollateralToken(identifiedTokens[collateralAddress.toLowerCase()].symbol)
+              setQuoteToken(identifiedTokens[quoteAddress.toLowerCase()].symbol)
               setIsFormValid(true)
             }
           })


### PR DESCRIPTION
# Lowercase tokens for pool creator form

Context: https://discord.com/channels/837076147694207067/1138393690331680768/1142106474852646912
  
## Changes 👷‍♀️

- Transformed token addresses provided by user in inputs into lowercase.
  
## How to test 🧪

Use not lowercased addresses that weren't working before, but should work now:
`0x0B1ba0af832d7C05fD64161E0Db78E85978E8082` and `0xea100Bec80418680e55D28b655da6CbEF427275f`.
