### PR TITLE
Oracless borrow after pills always green

### DIFF
--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -54,7 +54,7 @@ export function AjnaBorrowOverviewController() {
   const afterLiquidationPrice =
     simulation?.liquidationPrice &&
     (isShort ? normalizeValue(one.div(simulation.liquidationPrice)) : simulation.liquidationPrice)
-  const changeVariant = getBorrowishChangeVariant(simulation)
+  const changeVariant = getBorrowishChangeVariant({ simulation, isOracless })
 
   const originationFee = getOriginationFee(position, simulation)
 

--- a/features/ajna/positions/common/helpers/getBorrowishChangeVariant.ts
+++ b/features/ajna/positions/common/helpers/getBorrowishChangeVariant.ts
@@ -1,11 +1,19 @@
 import { AjnaPosition } from '@oasisdex/dma-library'
 import { LTVWarningThreshold } from 'features/ajna/common/consts'
 
-export const getBorrowishChangeVariant = (simulation?: AjnaPosition) =>
+export const getBorrowishChangeVariant = ({
+  isOracless,
+  simulation,
+}: {
+  isOracless: boolean
+  simulation?: AjnaPosition
+}) =>
   simulation
-    ? simulation.maxRiskRatio.loanToValue
-        .minus(simulation.riskRatio.loanToValue)
-        .gt(LTVWarningThreshold)
+    ? isOracless
+      ? 'positive'
+      : simulation.maxRiskRatio.loanToValue
+          .minus(simulation.riskRatio.loanToValue)
+          .gt(LTVWarningThreshold)
       ? 'positive'
       : 'negative'
     : 'positive'

--- a/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
+++ b/features/ajna/positions/multiply/components/AjnaMultiplySlider.tsx
@@ -58,7 +58,7 @@ export function AjnaMultiplySlider({ disabled = false }: AjnaMultiplySliderProps
   const ltv = position.riskRatio.loanToValue
   const liquidationPrice = simulation?.liquidationPrice || position.liquidationPriceT0Np
 
-  const changeVariant = getBorrowishChangeVariant(simulation)
+  const changeVariant = getBorrowishChangeVariant({ simulation, isOracless: false })
 
   useEffect(() => {
     if (!loanToValue && currentStep === 'setup' && depositAmount) {


### PR DESCRIPTION
# [Oracless borrow after pills always green](https://app.shortcut.com/oazo-apps/story/11165/bug-ajna-oracless-borrow-after-pills-are-always-red-orange-when-creating-updating-a-position-from-a-pool-just-created-with)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated method responsible for calculating change variant
  
## How to test 🧪
  <Please explain how to test your changes>

- when using oracless borrow, after pills should always be green
