### PR TITLE
Ajna current step update adjustment

### DIFF
--- a/features/ajna/positions/common/views/AjnaFormView.tsx
+++ b/features/ajna/positions/common/views/AjnaFormView.tsx
@@ -60,7 +60,6 @@ export function AjnaFormView({
       setIsFlowStateReady,
       setNextStep,
       setStep,
-      steps,
     },
     tx: {
       isTxError,
@@ -219,10 +218,6 @@ export function AjnaFormView({
     })
   }, [flowState.availableProxies])
   useEffect(() => setIsFlowStateReady(flowState.isEverythingReady), [flowState.isEverythingReady])
-  useEffect(() => {
-    if (!walletAddress && steps.indexOf(currentStep) > steps.indexOf(editingStep))
-      setStep(editingStep)
-  }, [walletAddress])
 
   return (
     <>


### PR DESCRIPTION
# [Ajna current step update adjustment](https://app.shortcut.com/oazo-apps/story/11039/bug-after-depositing-there-is-infinite-loader-until-navigation-somewhere-else-or-refresh?vc_group_by=day&ct_workflow=all&cf_workflow=500000053)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed useEffect which was causing unexpected update of `currentStep`
  
## How to test 🧪
  <Please explain how to test your changes>

- either borrow, earn or multiply - during transaction switch between tabs (overview -> faq or history -> overview), transaction state should be persisted
