### PR TITLE
Oracless borrow notifications

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -26,6 +26,7 @@ export const ajnaFormExternalSteps: AjnaSidebarStep[] = ['dpm']
 export const ajnaFormStepsWithTransaction: AjnaSidebarStep[] = ['transaction']
 
 export const LTVWarningThreshold = new BigNumber(0.05)
+export const LUPPercentageOffset = new BigNumber(0.05)
 
 export const ajnaLastIndexBucketPrice = new BigNumber(99836282890)
 

--- a/features/ajna/positions/common/contexts/AjnaProductContext.tsx
+++ b/features/ajna/positions/common/contexts/AjnaProductContext.tsx
@@ -185,6 +185,7 @@ export function AjnaProductContextProvider({
       quoteBalance,
       quotePrecision,
       quoteToken,
+      isOracless,
     },
     steps: { currentStep },
     tx: { txDetails },
@@ -261,6 +262,7 @@ export function AjnaProductContextProvider({
         collateralToken,
         dispatch: form.dispatch,
         updateState: form.updateState,
+        isOracless,
       }),
     [quoteToken, collateralToken, position],
   )

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2678,6 +2678,14 @@
             "title": "Opening Ajna positions temporary disabled",
             "message": "Due to a technical issue we have currently disabled opening new Ajna positions, as they might not result in the expected outcome for our users. We are working on a resolution. Further announcements will be made via <0>our discord →</0>"
           },
+          "near-lup": {
+            "title": "Your position's threshold price is approaching the LUP",
+            "message": "Adjust your position to ensure it stays below the LUP in order to avoid being eligible for liquidation"
+          },
+          "above-lup": {
+            "title": "Your position is eligible for liquidation",
+            "message": "Adjust your position to ensure the Threshold price stays below the LUP in order to avoid being eligible for liquidation"
+          },
           "read-more": "Read more about Ajna Liquidations"
         }
       },


### PR DESCRIPTION
# [Oracless borrow notifications](https://app.shortcut.com/oazo-apps/story/11079/warning-message-when-tp-lup)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added two notifications for ajna oracless borrow positions
  
## How to test 🧪
  <Please explain how to test your changes>

- adjust ajna borrow position so threshold price will be within 5% range to LUP, orange notification should be visible in this case
- adjust ajna borrow position so threshold price will be above LUP, red notification should be visible in this case
