### PR TITLE
Add values to TP content card

### DIFF
--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -79,6 +79,8 @@ export function AjnaBorrowOverviewController() {
               <ContentCardThresholdPrice
                 isLoading={isSimulationLoading}
                 thresholdPrice={position.thresholdPrice}
+                debtAmount={position.debtAmount}
+                collateralAmount={position.collateralAmount}
                 afterThresholdPrice={simulation?.thresholdPrice}
                 priceFormat={priceFormat}
                 changeVariant={changeVariant}

--- a/features/ajna/positions/common/components/contentCards/ContentCardThresholdPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardThresholdPrice.tsx
@@ -12,18 +12,28 @@ import { Card, Text } from 'theme-ui'
 
 interface ContentCardThresholdPriceModalProps {
   thresholdPrice: string
+  debtAmount: string
+  collateralAmount: string
+  lup?: string
 }
 
 interface ContentCardThresholdPriceProps {
   isLoading?: boolean
   priceFormat: string
   thresholdPrice: BigNumber
+  debtAmount: BigNumber
+  collateralAmount: BigNumber
   afterThresholdPrice?: BigNumber
   lup?: BigNumber
   changeVariant?: ChangeVariantType
 }
 
-function ContentCardThresholdPriceModal({ thresholdPrice }: ContentCardThresholdPriceModalProps) {
+function ContentCardThresholdPriceModal({
+  thresholdPrice,
+  collateralAmount,
+  debtAmount,
+  lup,
+}: ContentCardThresholdPriceModalProps) {
   const { t } = useTranslation()
 
   return (
@@ -36,12 +46,10 @@ function ContentCardThresholdPriceModal({ thresholdPrice }: ContentCardThreshold
         sx={{ my: 2, fontSize: 2, fontWeight: 'regular', lineHeight: 'body' }}
       >
         <code>
-          TP ={' '}
-          {t('ajna.position-page.borrow.common.overview.threshold-price-modal-desc-formula-part-1')}
+          TP = {t('ajna.position-page.borrow.common.overview.threshold-price-modal-desc-formula')}
           <br />
           {'\u00A0'}
-          {'\u00A0'} ={' '}
-          {t('ajna.position-page.borrow.common.overview.threshold-price-modal-desc-formula-part-2')}
+          {'\u00A0'} = {debtAmount} / {collateralAmount}
           <br />
           {'\u00A0'}
           {'\u00A0'} = {thresholdPrice}
@@ -54,12 +62,16 @@ function ContentCardThresholdPriceModal({ thresholdPrice }: ContentCardThreshold
         {t('ajna.position-page.borrow.common.overview.threshold-price-modal-desc-part-3')}
       </Text>
       <Card variant="vaultDetailsCardModal" sx={{ mt: 2 }}>
-        {t(
-          'ajna.position-page.borrow.common.overview.threshold-price-modal-desc-explanation-part-1',
-        )}
-        <br />
-        {t(
-          'ajna.position-page.borrow.common.overview.threshold-price-modal-desc-explanation-part-2',
+        {t('ajna.position-page.borrow.common.overview.threshold-price-modal-desc-explanation-tp')}{' '}
+        {thresholdPrice}
+        {lup && (
+          <>
+            <br />
+            {t(
+              'ajna.position-page.borrow.common.overview.threshold-price-modal-desc-explanation-lup',
+            )}{' '}
+            {lup}
+          </>
         )}
       </Card>
     </>
@@ -70,6 +82,8 @@ export function ContentCardThresholdPrice({
   isLoading,
   priceFormat,
   thresholdPrice,
+  collateralAmount,
+  debtAmount,
   afterThresholdPrice,
   lup,
   changeVariant = 'positive',
@@ -78,6 +92,8 @@ export function ContentCardThresholdPrice({
 
   const formatted = {
     thresholdPrice: formatCryptoBalance(thresholdPrice),
+    collateralAmount: formatCryptoBalance(collateralAmount),
+    debtAmount: formatCryptoBalance(debtAmount),
     afterThresholdPrice: afterThresholdPrice && formatCryptoBalance(afterThresholdPrice),
     lup: lup && formatCryptoBalance(lup),
   }
@@ -95,7 +111,12 @@ export function ContentCardThresholdPrice({
       <AjnaDetailsSectionContentSimpleModal
         title={t('ajna.position-page.borrow.common.overview.threshold-price')}
       >
-        <ContentCardThresholdPriceModal thresholdPrice={formatted.thresholdPrice} />
+        <ContentCardThresholdPriceModal
+          thresholdPrice={formatted.thresholdPrice}
+          collateralAmount={formatted.collateralAmount}
+          debtAmount={formatted.debtAmount}
+          lup={formatted.lup}
+        />
       </AjnaDetailsSectionContentSimpleModal>
     ),
   }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2698,10 +2698,9 @@
             "threshold-price-modal-desc-part-1": "By taking the debt token amount and dividing it by the collateral token amount, the loan’s threshold price, TP, can be calculated.",
             "threshold-price-modal-desc-part-2": "Your loan will be eligible to be kicked into the liquidation queue if the pool's Lowest Utilization Price (LUP) is less than your Threshold price.",
             "threshold-price-modal-desc-part-3": "To avoid liquidation, always ensure your TP < LUP",
-            "threshold-price-modal-desc-formula-part-1": "debt amount / collateral amount",
-            "threshold-price-modal-desc-formula-part-2": "[loan debt] / [loan collateral]",
-            "threshold-price-modal-desc-explanation-part-1": "Threshold Price = [Position TP]",
-            "threshold-price-modal-desc-explanation-part-2": "Lowest Utilization Price = [Pool LUP]",
+            "threshold-price-modal-desc-formula": "debt amount / collateral amount",
+            "threshold-price-modal-desc-explanation-tp": "Threshold Price =",
+            "threshold-price-modal-desc-explanation-lup": "Lowest Utilization Price =",
             "position-debt": "Position debt",
             "position-debt-modal-desc": "This is the total number of tokens you have borrowed plus any accrued interests."
           },


### PR DESCRIPTION
# [Add values to TP content card](https://app.shortcut.com/oazo-apps/story/11205/variables-in-tp-modal-window-are-missing)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/c3f97984-cc82-4f1f-953a-d5149eb854b1)
  
## Changes 👷‍♀️

- Added missing values in place of brackets.
  
## How to test 🧪

Go to any oracless borrow position and click on "Threshold Price" content card.