### PR TITLE
fix: [sc-11269] [Bug][staging] aave v3 mainnet positions aren't loading on the portfolio page

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -913,7 +913,7 @@ export function setupAppContext() {
         tokenPriceUSDStatic$,
         mainnetAaveV3PositionCreatedEvents$,
         getApiVaults,
-        aaveV3Optimism,
+        aaveV3,
         NetworkIds.MAINNET,
       ),
       (wallet) => wallet,


### PR DESCRIPTION
In the context of resolving merge issues, the variable 'aaveV3Optimism' has been renamed to 'aaveV3'. This change ensures consistency and correctness in the usage of aaveV3 across the component."