### PR TITLE
Ajna earn max withdraw negative to zero

### DIFF
--- a/features/ajna/positions/earn/components/ContentFooterItemsEarnManage.tsx
+++ b/features/ajna/positions/earn/components/ContentFooterItemsEarnManage.tsx
@@ -1,3 +1,4 @@
+import { negativeToZero } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 import { ChangeVariantType } from 'components/DetailsSectionContentCard'
 import { DetailsSectionFooterItem } from 'components/DetailsSectionFooterItem'
@@ -35,9 +36,12 @@ export function ContentFooterItemsEarnManage({
   const userAjnaRewards = useAjnaRewards(owner)
 
   const formatted = {
-    availableToWithdraw: `${formatCryptoBalance(availableToWithdraw)} ${quoteToken}`,
+    availableToWithdraw: `${formatCryptoBalance(
+      negativeToZero(availableToWithdraw),
+    )} ${quoteToken}`,
     afterAvailableToWithdraw:
-      afterAvailableToWithdraw && `${formatCryptoBalance(afterAvailableToWithdraw)} ${quoteToken}`,
+      afterAvailableToWithdraw &&
+      `${formatCryptoBalance(negativeToZero(afterAvailableToWithdraw))} ${quoteToken}`,
     // projectedAnnualReward: `${formatDecimalAsPercent(projectedAnnualReward)}`,
     // TODO: replace with value when available
     projectedAnnualReward: 'n/a',


### PR DESCRIPTION
# [Ajna earn max withdraw negative to zero](https://app.shortcut.com/oazo-apps/story/11277/when-a-pool-is-near-to-or-100-utilised-the-earn-users-are-seeing-negative-available-withdrawal-amounts)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- when max ajna earn withdraw is below 0, convert it to 0
  
## How to test 🧪
  <Please explain how to test your changes>

- negative values of max withdraw amount should be converted to 0 on UI, position WBTC-USDC, 1250 on mainnet
