### PR TITLE
fix: [sc-11271] [Bug][staging] Aave v3 position 1015 not loading

### DIFF
--- a/features/aave/strategies/index.ts
+++ b/features/aave/strategies/index.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js'
 import { isSupportedNetwork, NetworkNames } from 'blockchain/networks'
 import { isSupportedProductType, IStrategyConfig, ProductType } from 'features/aave/types'
 import { VaultType } from 'features/generalManageVault/vaultType'
+import { productToVaultType } from 'helpers/productToVaultType'
 import { getFeatureToggle } from 'helpers/useFeatureToggle'
 import { zero } from 'helpers/zero'
 import { isLendingProtocol, LendingProtocol } from 'lendingProtocols'
@@ -67,7 +68,7 @@ export function loadStrategyFromTokens(
     const matchesVaultType =
       vaultType === undefined ||
       vaultType === VaultType.Unknown ||
-      vaultType.toLowerCase() === s.type.toLowerCase()
+      vaultType === productToVaultType(s.type)
     return (
       s.tokens.collateral === actualCollateralToken &&
       s.tokens.debt === actualDebtToken &&

--- a/pages/[networkOrProduct]/aave/[version]/[vault].tsx
+++ b/pages/[networkOrProduct]/aave/[version]/[vault].tsx
@@ -8,19 +8,18 @@ import { ManageAaveStateMachineContextProvider } from 'features/aave/manage/cont
 import { AaveManagePositionView } from 'features/aave/manage/containers/AaveManageView'
 import { PositionId } from 'features/aave/types/position-id'
 import { VaultType } from 'features/generalManageVault/vaultType'
-import { getVaultFromApi$ } from 'features/shared/vaultApi'
+import { useApiVaults } from 'features/shared/vaultApi'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { VaultContainerSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
-import { hexToDecimal } from 'helpers/hex-to-decimal'
 import { useObservable } from 'helpers/observableHook'
 import { AaveLendingProtocol, checkIfAave } from 'lendingProtocols'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useRouter } from 'next/router'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { Grid } from 'theme-ui'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
@@ -59,13 +58,10 @@ function WithStrategy({
 }) {
   const { push } = useRouter()
   const { t } = useTranslation()
-  const chainId = hexToDecimal(networksByName[network].hexId)
+  const chainId = networksByName[network].id
 
-  const vaultFromApi$ = useMemo(
-    () => getVaultFromApi$(positionId.vaultId || 0, chainId || 0, protocol),
-    [positionId.vaultId, chainId, protocol],
-  )
-  const [vaultFromApi] = useObservable(vaultFromApi$)
+  const apiVaults = useApiVaults({ vaultIds: [positionId.vaultId ?? -1], protocol, chainId })
+
   const {
     strategyConfig$,
     updateStrategyConfig,
@@ -74,7 +70,7 @@ function WithStrategy({
   } = useAaveContext(protocol, network)
   const [strategyConfig, strategyConfigError] = useObservable(
     /* If VaultType.Unknown specified then when loading config it'll try to respect position created type */
-    strategyConfig$(positionId, network, vaultFromApi?.type || VaultType.Unknown),
+    strategyConfig$(positionId, network, apiVaults[0]?.type || VaultType.Unknown),
   )
   const [proxiesRelatedWithPosition, proxiesRelatedWithPositionError] = useObservable(
     proxiesRelatedWithPosition$(positionId),


### PR DESCRIPTION
Implemented the useApiVaults hook to consolidate and handle vault information in an optimized way. This simplifies the logic, reducing the need for useMemo and useObservable in several places. Adjusted retrieval of chainId to directly access the id property, removing the need for hexToDecimal helper function. The vault type check in the strategies/index.ts file was also revised to leverage the productToVaultType helper function, ensuring consistent vault type validation across the application.
