### PR TITLE
Add Pool Creation button to Ajna landing page

### DIFF
--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -49,6 +49,8 @@ export const benefitCardsAnja = [
 
 export function AjnaHomepageView() {
   const ajnaSafetySwitchOn = useFeatureToggle('AjnaSafetySwitch')
+  const ajnaPoolFinderEnabled = useFeatureToggle('AjnaPoolFinder')
+
   const { t } = useTranslation()
   const { context$ } = useAppContext()
   const [context] = useObservable(context$)
@@ -77,10 +79,14 @@ export function AjnaHomepageView() {
           isVisible: true,
           translationKey: 'landing.hero.ajna.primary-cta',
         }}
-        secondaryButton={{
-          link: INTERNAL_LINKS.ajnaPoolCreator,
-          translationKey: 'landing.hero.ajna.secondary-cta',
-        }}
+        secondaryButton={
+          ajnaPoolFinderEnabled
+            ? {
+                link: INTERNAL_LINKS.ajnaPoolCreator,
+                translationKey: 'landing.hero.ajna.secondary-cta',
+              }
+            : undefined
+        }
       />
       <Box sx={{ mt: '180px', borderTop: '1px solid', borderColor: 'neutral20' }}>
         <ProductHubView

--- a/features/homepage/AjnaHomepageView.tsx
+++ b/features/homepage/AjnaHomepageView.tsx
@@ -73,6 +73,14 @@ export function AjnaHomepageView() {
           />
         }
         subheadingWidth="740px"
+        primaryButton={{
+          isVisible: true,
+          translationKey: 'landing.hero.ajna.primary-cta',
+        }}
+        secondaryButton={{
+          link: INTERNAL_LINKS.ajnaPoolCreator,
+          translationKey: 'landing.hero.ajna.secondary-cta',
+        }}
       />
       <Box sx={{ mt: '180px', borderTop: '1px solid', borderColor: 'neutral20' }}>
         <ProductHubView

--- a/features/homepage/common/Hero.tsx
+++ b/features/homepage/common/Hero.tsx
@@ -1,10 +1,11 @@
 import { Icon } from '@makerdao/dai-ui-icons'
+import { AppLink } from 'components/Links'
 import { useConnection } from 'features/web3OnBoard'
 import { scrollTo } from 'helpers/scrollTo'
 import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode } from 'react'
-import { Button, Flex, Heading, SxStyleProp, Text } from 'theme-ui'
+import { Button, Flex, Grid, Heading, SxStyleProp, Text } from 'theme-ui'
 
 export function Hero({
   sx,
@@ -13,7 +14,11 @@ export function Hero({
   headingWidth = '700px',
   subheading,
   subheadingWidth = '450px',
-  showButton = true,
+  primaryButton = {
+    isVisible: true,
+    translationKey: 'find-your-defi-product',
+  },
+  secondaryButton,
 }: {
   sx?: SxStyleProp
   isConnected: boolean
@@ -21,7 +26,14 @@ export function Hero({
   headingWidth?: string
   subheading: ReactNode
   subheadingWidth?: string
-  showButton?: boolean
+  primaryButton?: {
+    isVisible: boolean
+    translationKey: string
+  }
+  secondaryButton?: {
+    link: string
+    translationKey: string
+  }
 }) {
   const { t } = useTranslation()
   const referralsEnabled = useFeatureToggle('Referrals')
@@ -54,33 +66,51 @@ export function Hero({
       >
         {subheading}
       </Text>
-      {showButton && (
-        <Button
-          variant="primary"
-          sx={{
-            display: 'flex',
-            margin: '0 auto',
-            px: '40px',
-            py: 2,
-            alignItems: 'center',
-            '&:hover svg': {
-              transform: 'translateX(10px)',
-            },
-          }}
-          onClick={isConnected ? scrollTo('product-hub') : () => connecting || connect()}
-        >
-          {isConnected ? t('find-your-defi-product') : t('connect-wallet')}
-          <Icon
-            name="arrow_right"
+      <Grid gap="12px">
+        {primaryButton.isVisible && (
+          <Button
+            variant="primary"
             sx={{
-              ml: 2,
-              position: 'relative',
-              left: 2,
-              transition: '0.2s',
+              display: 'flex',
+              margin: '0 auto',
+              px: '40px',
+              py: 2,
+              alignItems: 'center',
+              '&:hover svg': {
+                transform: 'translateX(10px)',
+              },
             }}
-          />
-        </Button>
-      )}
+            onClick={isConnected ? scrollTo('product-hub') : () => connecting || connect()}
+          >
+            {isConnected ? t(primaryButton.translationKey) : t('connect-wallet')}
+            <Icon
+              name="arrow_right"
+              sx={{
+                ml: 2,
+                position: 'relative',
+                left: 2,
+                transition: '0.2s',
+              }}
+            />
+          </Button>
+        )}
+        {secondaryButton && (
+          <AppLink href={secondaryButton.link}>
+            <Button
+              variant="action"
+              sx={{
+                width: '100%',
+                height: '52px',
+                fontSize: '18px',
+                borderColor: 'primary100',
+                borderRadius: 'round',
+              }}
+            >
+              {t(secondaryButton.translationKey)}
+            </Button>
+          </AppLink>
+        )}
+      </Grid>
     </Flex>
   )
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -513,7 +513,9 @@
       },
       "ajna": {
         "headline": "Use the only market-driven lending protocol",
-        "subheader": "On Ajna you can borrow crypto and earn yield. Benefiting from more competitive, market-driven parameters. <0>Learn more about Ajna on Summer.fi →</0>"
+        "subheader": "On Ajna you can borrow crypto and earn yield. Benefiting from more competitive, market-driven parameters. <0>Learn more about Ajna on Summer.fi →</0>",
+        "primary-cta": "Discover Ajna Pools",
+        "secondary-cta": "Create an Ajna Pool"
       }
     },
     "stats": {


### PR DESCRIPTION
# [Add Pool Creation button to Ajna landing page](https://app.shortcut.com/oazo-apps/story/11210/add-pool-creation-button-to-ajna-landing-page)
  
## Changes 👷‍♀️

- Modified `Hero` component props to allow using two cta buttons.
  
## How to test 🧪

Check Ajna landing page and see if there is additional button leading to pool creator.
