### PR TITLE
Add AJNA WSTETH/ETH to multiply product finder

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -61,5 +61,6 @@ export const AJNA_TOKENS_WITH_MULTIPLY = [
   'SDAI',
   'USDC',
   'WBTC',
+  'WSTETH',
   'YFI',
 ]


### PR DESCRIPTION
# [Add AJNA WSTETH/ETH to multiply product finder](https://app.shortcut.com/oazo-apps/story/11294/add-ajna-wsteth-eth-to-multiply-product-finder)
  
## Changes 👷‍♀️

- Added `WSTETH` to `AJNA_TOKENS_WITH_MULTIPLY` array.
  
## How to test 🧪

Patch Product Finder and check if multiply/earn contains WSTETH/ETH Ajna pool.
