### PR TITLE
Bump dma lib 0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.42",
     "@oasisdex/automation": "^1.5.2",
-    "@oasisdex/dma-library": "0.4.10",
+    "@oasisdex/dma-library": "0.4.11",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3914,10 +3914,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.4.10":
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.4.10.tgz#a15f887df59be8c8489bd3175f22265ee765f3b7"
-  integrity sha512-6iUlMwGtp1WgtlVNHVHLGUsfj0Hr3ZHyC0o1CnFcNuT3elQda+td2ZbWFvOmFfrA7KvXB9zvxgDtYSRmg9Rtig==
+"@oasisdex/dma-library@0.4.11":
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.4.11.tgz#864614154516db8cb2c9e0e9c7e5e851cd3a6ee1"
+  integrity sha512-BI84FbJ82ImSY2RT6grItb0OB+qt3yrfSNs+AaAXrIfwqRlGoM+fHp+QgdbpA8dNspcdS2h0SdcoO1ZNAw01cA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# Bump dma lib 0.4.11

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- Bumped dma lib to 0.4.11
  
## How to test 🧪
  <Please explain how to test your changes>

- claim collateral UI should be triggered on following position: `ethereum/ajna/earn/YFI-DAI/1097#overview`
