### PR TITLE
Bump dma lib 0.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@next/mdx": "12.0.4",
     "@oasisdex/addresses": "0.0.42",
     "@oasisdex/automation": "^1.5.2",
-    "@oasisdex/dma-library": "0.4.11",
+    "@oasisdex/dma-library": "0.4.12",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3914,10 +3914,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.4.11":
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.4.11.tgz#864614154516db8cb2c9e0e9c7e5e851cd3a6ee1"
-  integrity sha512-BI84FbJ82ImSY2RT6grItb0OB+qt3yrfSNs+AaAXrIfwqRlGoM+fHp+QgdbpA8dNspcdS2h0SdcoO1ZNAw01cA==
+"@oasisdex/dma-library@0.4.12":
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.4.12.tgz#4d011741e3eb4750199c7f0bd0d8b702f6b34118"
+  integrity sha512-NA1/wBA0yUOuI/mxl7VL/ZIoACKm5onNgQ0BqoBfGgoryUMxLbceTJyjiAHD0ExKh5wyiy4Cnq728PvAKg/ZMA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# Bump dma lib 0.4.12

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- Bumped dma lib 0.4.12
  
## How to test 🧪
  <Please explain how to test your changes>

- position ethereum/ajna/1223#overview max generate should be way above 0. At this moment, base on the pool state it should be ~31k
