### PR TITLE
Ajna oracless full token prices

### DIFF
--- a/components/DetailsSectionContentCard.tsx
+++ b/components/DetailsSectionContentCard.tsx
@@ -1,9 +1,10 @@
 import { Icon } from '@makerdao/dai-ui-icons'
 import { SystemStyleObject } from '@styled-system/css'
 import { Skeleton } from 'components/Skeleton'
+import { StatefulTooltip } from 'components/Tooltip'
 import { ModalProps, useModal } from 'helpers/modalHook'
 import { TranslateStringType } from 'helpers/translateStringType'
-import React, { ReactElement, ReactNode, useState } from 'react'
+import React, { PropsWithChildren, ReactNode, useState } from 'react'
 import { Box, Flex, Grid, Text } from 'theme-ui'
 
 import { AppLink } from './Links'
@@ -12,9 +13,14 @@ import { WithArrow } from './WithArrow'
 
 export type ChangeVariantType = 'positive' | 'negative'
 
+interface DetailsSectionContentCardTooltipProps {
+  value: ReactNode
+}
+
 export interface DetailsSectionContentCardChangePillProps {
   isLoading?: boolean
-  value?: string
+  tooltip?: string
+  value?: string | [string, string, string]
   variant: ChangeVariantType
 }
 
@@ -26,16 +32,19 @@ interface DetailsSectionContentCardLinkProps {
 
 export interface ContentCardProps {
   change?: DetailsSectionContentCardChangePillProps
+  changeTooltip?: ReactNode
   customBackground?: string
   customUnitStyle?: SystemStyleObject
   customValueColor?: string
   extra?: ReactNode
-  footnote?: TranslateStringType
+  footnote?: string | [string, string, string]
+  footnoteTooltip?: string
   link?: DetailsSectionContentCardLinkProps
   modal?: TranslateStringType | JSX.Element
   title: string
   unit?: TranslateStringType
-  value?: ReactElement | string
+  value?: ReactNode
+  valueTooltip?: ReactNode
 }
 
 export function getChangeVariant(collRatioColor: CollRatioColor): ChangeVariantType {
@@ -44,11 +53,39 @@ export function getChangeVariant(collRatioColor: CollRatioColor): ChangeVariantT
     : 'negative'
 }
 
+function DetailsSectionContentCardTooltip({
+  children,
+  value,
+}: PropsWithChildren<DetailsSectionContentCardTooltipProps>) {
+  return (
+    <StatefulTooltip
+      inline
+      tooltip={value}
+      containerSx={{ display: 'inline', borderBottom: '1px dotted', borderColor: 'inherit' }}
+      tooltipSx={{
+        fontSize: 1,
+        fontWeight: 'regular',
+        fontFamily: 'body',
+        lineHeight: 'body',
+        whiteSpace: 'pre',
+        border: 'none',
+        borderRadius: 'medium',
+        boxShadow: 'buttonMenu',
+      }}
+    >
+      {children}
+    </StatefulTooltip>
+  )
+}
+
 export function DetailsSectionContentCardChangePill({
   isLoading,
+  tooltip,
   value,
   variant,
 }: DetailsSectionContentCardChangePillProps) {
+  const isValueArray = Array.isArray(value)
+
   return (
     <>
       {(value || isLoading) && (
@@ -78,14 +115,23 @@ export function DetailsSectionContentCardChangePill({
               opacity: isLoading ? 0 : 1,
             }}
           >
-            {value}
+            {tooltip ? (
+              <>
+                {isValueArray && `${value[0]} `}
+                <DetailsSectionContentCardTooltip value={tooltip}>
+                  {isValueArray ? value[1] : value}
+                </DetailsSectionContentCardTooltip>
+                {isValueArray && ` ${value[2]}`}
+              </>
+            ) : (
+              <>{isValueArray ? value.join(' ') : value}</>
+            )}
           </Text>
         </>
       )}
     </>
   )
 }
-
 function DetailsSectionContentCardLink({ label, url, action }: DetailsSectionContentCardLinkProps) {
   return (
     <>
@@ -106,7 +152,6 @@ function DetailsSectionContentCardLink({ label, url, action }: DetailsSectionCon
     </>
   )
 }
-
 function DetailsSectionContentCardModal({
   close,
   children,
@@ -133,11 +178,13 @@ export function DetailsSectionContentCard({
   customValueColor,
   extra,
   footnote,
+  footnoteTooltip,
   link,
   modal,
   title,
   unit,
   value,
+  valueTooltip,
 }: ContentCardProps) {
   const openModal = useModal()
   const [isHighlighted, setIsHighlighted] = useState(false)
@@ -154,6 +201,7 @@ export function DetailsSectionContentCard({
     cardBackgroundColor = customBackground
   }
   const cursorStyle = { cursor: modal ? 'pointer' : 'auto' }
+  const isFootnoteArray = Array.isArray(footnote)
 
   return (
     <Flex
@@ -199,7 +247,13 @@ export function DetailsSectionContentCard({
         }}
         {...hightlightableItemEvents}
       >
-        {value || '-'}
+        {valueTooltip ? (
+          <DetailsSectionContentCardTooltip value={valueTooltip}>
+            {value || '-'}
+          </DetailsSectionContentCardTooltip>
+        ) : (
+          value || '-'
+        )}
         {unit && (
           <Text as="small" sx={{ ml: 1, fontSize: 5, ...customUnitStyle }}>
             {unit}
@@ -223,7 +277,17 @@ export function DetailsSectionContentCard({
           sx={{ maxWidth: '100%', pt: 2, fontSize: '12px', ...cursorStyle }}
           {...hightlightableItemEvents}
         >
-          {footnote}
+          {footnoteTooltip ? (
+            <>
+              {isFootnoteArray && `${footnote[0]} `}
+              <DetailsSectionContentCardTooltip value={footnoteTooltip}>
+                {isFootnoteArray ? footnote[1] : footnote}
+              </DetailsSectionContentCardTooltip>
+              {isFootnoteArray && ` ${footnote[2]}`}
+            </>
+          ) : (
+            <>{isFootnoteArray ? footnote.join(' ') : footnote}</>
+          )}
         </Text>
       )}
       {link?.label && (link?.url || link?.action) && <DetailsSectionContentCardLink {...link} />}

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -37,6 +37,7 @@ export function Tooltip({ children, sx }: { children: ReactNode; sx?: SxStylePro
 }
 
 interface StatefulTooltipProps {
+  inline?: boolean
   tooltip: ReactNode
   children: ReactNode
   tooltipSx?: SxStyleProp
@@ -44,6 +45,7 @@ interface StatefulTooltipProps {
 }
 
 export function StatefulTooltip({
+  inline,
   tooltip,
   tooltipSx,
   containerSx,
@@ -69,6 +71,7 @@ export function StatefulTooltip({
       onMouseLeave={handleMouseLeave}
       onClick={handleClick}
       sx={{ display: 'flex', ...containerSx }}
+      {...(inline && { as: 'span' })}
     >
       {children}
       <Tooltip

--- a/components/constants.ts
+++ b/components/constants.ts
@@ -22,4 +22,4 @@ export const SECONDS_PER_YEAR_BI = new BigNumber(SECONDS_PER_YEAR)
 
 export const FLASH_MINT_LIMIT_PER_TX = new BigNumber('500000000')
 
-export const DEFAULT_TOKEN_DIGITS = 5
+export const DEFAULT_TOKEN_DIGITS = 18

--- a/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
+++ b/features/ajna/positions/borrow/controls/AjnaBorrowOverviewController.tsx
@@ -70,6 +70,7 @@ export function AjnaBorrowOverviewController() {
               priceFormat={priceFormat}
               liquidationPrice={liquidationPrice}
               afterLiquidationPrice={afterLiquidationPrice}
+              withTooltips={isOracless}
               changeVariant={changeVariant}
               {...(!isOracless && {
                 belowCurrentPrice,
@@ -83,6 +84,7 @@ export function AjnaBorrowOverviewController() {
                 collateralAmount={position.collateralAmount}
                 afterThresholdPrice={simulation?.thresholdPrice}
                 priceFormat={priceFormat}
+                withTooltips
                 changeVariant={changeVariant}
                 {...(position.pool.lowestUtilizedPriceIndex.gt(zero) && {
                   lup: position.pool.lup,

--- a/features/ajna/positions/borrow/helpers/getAjnaBorrowDebtMax.ts
+++ b/features/ajna/positions/borrow/helpers/getAjnaBorrowDebtMax.ts
@@ -2,13 +2,13 @@ import { AjnaPosition } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 
 interface AjnaBorrowDebtMaxParams {
-  precision: number
+  digits: number
   position: AjnaPosition
   simulation?: AjnaPosition
 }
 
-export function getAjnaBorrowDebtMax({ precision, position, simulation }: AjnaBorrowDebtMaxParams) {
+export function getAjnaBorrowDebtMax({ digits, position, simulation }: AjnaBorrowDebtMaxParams) {
   const maxDebt = position.debtAvailable(simulation?.collateralAmount || position.collateralAmount)
 
-  return maxDebt.decimalPlaces(precision, BigNumber.ROUND_DOWN)
+  return maxDebt.decimalPlaces(digits, BigNumber.ROUND_DOWN)
 }

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentDeposit.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentDeposit.tsx
@@ -15,11 +15,10 @@ export function AjnaBorrowFormContentDeposit() {
   const {
     environment: {
       collateralBalance,
-      collateralPrecision,
+      collateralDigits,
       collateralPrice,
       collateralToken,
       quoteDigits,
-      quotePrecision,
     },
   } = useAjnaGeneralContext()
   const {
@@ -34,7 +33,7 @@ export function AjnaBorrowFormContentDeposit() {
 
   const debtMin = getAjnaBorrowDebtMin({ digits: quoteDigits, position })
   const debtMax = getAjnaBorrowDebtMax({
-    precision: quotePrecision,
+    digits: quoteDigits,
     position,
     simulation,
   })
@@ -47,7 +46,7 @@ export function AjnaBorrowFormContentDeposit() {
         resetOnClear
         token={collateralToken}
         tokenPrice={collateralPrice}
-        tokenPrecision={collateralPrecision}
+        tokenDigits={collateralDigits}
       />
       <AjnaFormFieldGenerate dispatchAmount={dispatch} maxAmount={debtMax} minAmount={debtMin} />
       {generateAmount && <AjnaBorrowOriginationFee />}

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentGenerate.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentGenerate.tsx
@@ -14,9 +14,8 @@ import React from 'react'
 export function AjnaBorrowFormContentGenerate() {
   const {
     environment: {
-      collateralDigits,
       collateralBalance,
-      collateralPrecision,
+      collateralDigits,
       collateralPrice,
       collateralToken,
       quoteDigits,
@@ -34,7 +33,7 @@ export function AjnaBorrowFormContentGenerate() {
 
   const debtMin = getAjnaBorrowDebtMin({ digits: collateralDigits, position })
   const debtMax = getAjnaBorrowDebtMax({
-    precision: quoteDigits,
+    digits: quoteDigits,
     position,
     simulation,
   })
@@ -52,7 +51,7 @@ export function AjnaBorrowFormContentGenerate() {
         maxAmount={collateralBalance}
         token={collateralToken}
         tokenPrice={collateralPrice}
-        tokenPrecision={collateralPrecision}
+        tokenDigits={collateralDigits}
       />
       {generateAmount && <AjnaBorrowOriginationFee />}
       {(generateAmount || depositAmount) && (

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
@@ -14,7 +14,6 @@ export function AjnaBorrowFormContentPayback() {
   const {
     environment: {
       collateralDigits,
-      collateralPrecision,
       collateralPrice,
       quoteDigits,
       collateralToken,
@@ -56,7 +55,7 @@ export function AjnaBorrowFormContentPayback() {
         maxAmount={collateralMax}
         token={collateralToken}
         tokenPrice={collateralPrice}
-        tokenPrecision={collateralPrecision}
+        tokenDigits={collateralDigits}
       />
       {(paybackAmount || withdrawAmount) && (
         <AjnaFormContentSummary>

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentPayback.tsx
@@ -12,13 +12,7 @@ import React from 'react'
 
 export function AjnaBorrowFormContentPayback() {
   const {
-    environment: {
-      collateralDigits,
-      collateralPrice,
-      quoteDigits,
-      collateralToken,
-      quoteBalance,
-    },
+    environment: { collateralDigits, collateralPrice, quoteDigits, collateralToken, quoteBalance },
   } = useAjnaGeneralContext()
   const {
     form: {

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
@@ -12,13 +12,7 @@ import React from 'react'
 
 export function AjnaBorrowFormContentWithdraw() {
   const {
-    environment: {
-      collateralDigits,
-      quoteDigits,
-      collateralPrice,
-      collateralToken,
-      quoteBalance,
-    },
+    environment: { collateralDigits, quoteDigits, collateralPrice, collateralToken, quoteBalance },
   } = useAjnaGeneralContext()
   const {
     form: {

--- a/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
+++ b/features/ajna/positions/borrow/sidebars/AjnaBorrowFormContentWithdraw.tsx
@@ -14,7 +14,6 @@ export function AjnaBorrowFormContentWithdraw() {
   const {
     environment: {
       collateralDigits,
-      collateralPrecision,
       quoteDigits,
       collateralPrice,
       collateralToken,
@@ -51,7 +50,7 @@ export function AjnaBorrowFormContentWithdraw() {
         resetOnClear
         token={collateralToken}
         tokenPrice={collateralPrice}
-        tokenPrecision={collateralPrecision}
+        tokenDigits={collateralDigits}
       />
       <AjnaFormFieldPayback
         dispatchAmount={dispatch}

--- a/features/ajna/positions/common/components/contentCards/ContentCardLiquidationPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardLiquidationPrice.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { DEFAULT_TOKEN_DIGITS } from 'components/constants'
 import {
   ChangeVariantType,
   ContentCardProps,
@@ -16,6 +17,7 @@ interface ContentCardLiquidationPriceProps {
   liquidationPrice: BigNumber
   afterLiquidationPrice?: BigNumber
   belowCurrentPrice?: BigNumber
+  withTooltips?: boolean
   changeVariant?: ChangeVariantType
 }
 
@@ -25,6 +27,7 @@ export function ContentCardLiquidationPrice({
   liquidationPrice,
   afterLiquidationPrice,
   belowCurrentPrice,
+  withTooltips,
   changeVariant = 'positive',
 }: ContentCardLiquidationPriceProps) {
   const { t } = useTranslation()
@@ -41,9 +44,13 @@ export function ContentCardLiquidationPrice({
     unit: `${priceFormat}`,
     change: {
       isLoading,
-      value:
-        afterLiquidationPrice &&
-        `${formatted.afterLiquidationPrice} ${priceFormat} ${t('system.cards.common.after')}`,
+      value: afterLiquidationPrice && [
+        '',
+        `${formatted.afterLiquidationPrice}`,
+        `${priceFormat} ${t('system.cards.common.after')}`,
+      ],
+      tooltip:
+        afterLiquidationPrice && `${afterLiquidationPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
       variant: changeVariant,
     },
     modal: (
@@ -53,6 +60,10 @@ export function ContentCardLiquidationPrice({
         value={`${formatted.liquidationPrice} ${priceFormat}`}
       />
     ),
+  }
+
+  if (withTooltips && !liquidationPrice.isZero()) {
+    contentCardSettings.valueTooltip = `${liquidationPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`
   }
 
   if (belowCurrentPrice && !liquidationPrice.isZero()) {

--- a/features/ajna/positions/common/components/contentCards/ContentCardThresholdPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardThresholdPrice.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { DEFAULT_TOKEN_DIGITS } from 'components/constants'
 import {
   ChangeVariantType,
   ContentCardProps,
@@ -25,6 +26,7 @@ interface ContentCardThresholdPriceProps {
   collateralAmount: BigNumber
   afterThresholdPrice?: BigNumber
   lup?: BigNumber
+  withTooltips?: boolean
   changeVariant?: ChangeVariantType
 }
 
@@ -86,6 +88,7 @@ export function ContentCardThresholdPrice({
   debtAmount,
   afterThresholdPrice,
   lup,
+  withTooltips,
   changeVariant = 'positive',
 }: ContentCardThresholdPriceProps) {
   const { t } = useTranslation()
@@ -104,7 +107,9 @@ export function ContentCardThresholdPrice({
     unit: priceFormat,
     change: {
       isLoading,
-      value: afterThresholdPrice && `${formatted.afterThresholdPrice} ${priceFormat}`,
+      value: afterThresholdPrice && ['', `${formatted.afterThresholdPrice}`, `${priceFormat}`],
+      tooltip:
+        afterThresholdPrice && `${afterThresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
       variant: changeVariant,
     },
     modal: (
@@ -121,8 +126,13 @@ export function ContentCardThresholdPrice({
     ),
   }
 
+  if (withTooltips && !thresholdPrice.isZero()) {
+    contentCardSettings.valueTooltip = `${thresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`
+  }
+
   if (lup) {
-    contentCardSettings.footnote = `LUP: ${formatted.lup} ${priceFormat}`
+    contentCardSettings.footnote = ['LUP:', `${formatted.lup}`, `${priceFormat}`]
+    contentCardSettings.footnoteTooltip = `${lup.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`
   }
 
   return <DetailsSectionContentCard {...contentCardSettings} />

--- a/features/ajna/positions/common/sidebars/AjnaFormFields.tsx
+++ b/features/ajna/positions/common/sidebars/AjnaFormFields.tsx
@@ -21,7 +21,7 @@ interface AjnaFormField<D> {
 
 interface AjnaFormFieldWithDefinedToken {
   token: string
-  tokenPrecision?: number
+  tokenDigits?: number
   tokenPrice: BigNumber
 }
 
@@ -42,7 +42,7 @@ export function AjnaFormFieldDeposit({
   maxAmountLabel = 'balance',
   resetOnClear,
   token,
-  tokenPrecision,
+  tokenDigits,
   tokenPrice,
 }: AjnaFormField<AjnaFormActionsUpdateDeposit> &
   AjnaFormFieldWithDefinedToken &
@@ -60,7 +60,7 @@ export function AjnaFormFieldDeposit({
     <VaultActionInput
       action="Deposit"
       currencyCode={token}
-      currencyDigits={tokenPrecision}
+      currencyDigits={tokenDigits}
       tokenUsdPrice={tokenPrice}
       amount={state.depositAmount}
       auxiliaryAmount={state.depositAmountUSD}
@@ -111,7 +111,7 @@ export function AjnaFormFieldGenerate({
   AjnaFormFieldWithMaxAmount) {
   const { t } = useTranslation()
   const {
-    environment: { isOracless, product, quotePrecision, quotePrice, quoteToken },
+    environment: { isOracless, product, quoteDigits, quotePrice, quoteToken },
   } = useAjnaGeneralContext()
   const {
     form: { dispatch, state },
@@ -122,7 +122,7 @@ export function AjnaFormFieldGenerate({
     <VaultActionInput
       action="Borrow"
       currencyCode={quoteToken}
-      currencyDigits={quotePrecision}
+      currencyDigits={quoteDigits}
       tokenUsdPrice={quotePrice}
       amount={state.generateAmount}
       auxiliaryAmount={state.generateAmountUSD}
@@ -180,7 +180,7 @@ export function AjnaFormFieldPayback({
 }: AjnaFormField<AjnaFormActionsUpdatePayback> & AjnaFormFieldWithMaxAmount) {
   const { t } = useTranslation()
   const {
-    environment: { isOracless, quotePrecision, quotePrice, quoteToken, product },
+    environment: { isOracless, quoteDigits, quotePrice, quoteToken, product },
   } = useAjnaGeneralContext()
   const {
     form: { dispatch, state },
@@ -191,7 +191,7 @@ export function AjnaFormFieldPayback({
     <VaultActionInput
       action="Payback"
       currencyCode={quoteToken}
-      currencyDigits={quotePrecision}
+      currencyDigits={quoteDigits}
       tokenUsdPrice={quotePrice}
       amount={state.paybackAmount}
       auxiliaryAmount={state.paybackAmountUSD}
@@ -237,7 +237,7 @@ export function AjnaFormFieldWithdraw({
   maxAmountLabel = 'max',
   resetOnClear,
   token,
-  tokenPrecision,
+  tokenDigits,
   tokenPrice,
 }: AjnaFormField<AjnaFormActionsUpdateWithdraw> &
   AjnaFormFieldWithDefinedToken &
@@ -256,7 +256,7 @@ export function AjnaFormFieldWithdraw({
     <VaultActionInput
       action="Withdraw"
       currencyCode={token}
-      currencyDigits={tokenPrecision}
+      currencyDigits={tokenDigits}
       tokenUsdPrice={tokenPrice}
       amount={state.withdrawAmount}
       auxiliaryAmount={state.withdrawAmountUSD}

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormContentDeposit.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormContentDeposit.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 export function AjnaEarnFormContentDeposit() {
   const { t } = useTranslation()
   const {
-    environment: { quotePrice, quoteToken, quoteBalance, quotePrecision, isOracless },
+    environment: { quotePrice, quoteToken, quoteBalance, quoteDigits, isOracless },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -34,7 +34,7 @@ export function AjnaEarnFormContentDeposit() {
         token={quoteToken}
         tokenPrice={quotePrice}
         maxAmount={quoteBalance}
-        tokenPrecision={quotePrecision}
+        tokenDigits={quoteDigits}
       />
       <PillAccordion title={t('ajna.position-page.earn.common.form.adjust-lending-price-bucket')}>
         <AjnaEarnSlider

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormContentOpen.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormContentOpen.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 
 export function AjnaEarnFormContentOpen() {
   const {
-    environment: { quotePrice, quoteToken, quoteBalance, quotePrecision, isOracless },
+    environment: { quotePrice, quoteToken, quoteBalance, quoteDigits, isOracless },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -30,7 +30,7 @@ export function AjnaEarnFormContentOpen() {
         token={quoteToken}
         tokenPrice={quotePrice}
         maxAmount={quoteBalance}
-        tokenPrecision={quotePrecision}
+        tokenDigits={quoteDigits}
         resetOnClear
       />
       <AjnaEarnSlider

--- a/features/ajna/positions/earn/sidebars/AjnaEarnFormContentWithdraw.tsx
+++ b/features/ajna/positions/earn/sidebars/AjnaEarnFormContentWithdraw.tsx
@@ -13,7 +13,7 @@ import React from 'react'
 export function AjnaEarnFormContentWithdraw() {
   const { t } = useTranslation()
   const {
-    environment: { quotePrice, quoteToken, isOracless, quotePrecision },
+    environment: { quotePrice, quoteToken, isOracless, quoteDigits },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -33,7 +33,7 @@ export function AjnaEarnFormContentWithdraw() {
       position,
       simulation,
     }),
-    digits: quotePrecision,
+    digits: quoteDigits,
   })
 
   return (
@@ -44,7 +44,7 @@ export function AjnaEarnFormContentWithdraw() {
         token={quoteToken}
         tokenPrice={quotePrice}
         maxAmount={withdrawMax}
-        tokenPrecision={quotePrecision}
+        tokenDigits={quoteDigits}
       />
       <PillAccordion title={t('ajna.position-page.earn.common.form.adjust-lending-price-bucket')}>
         <AjnaEarnSlider

--- a/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentGenerate.tsx
+++ b/features/ajna/positions/multiply/sidebars/AjnaMultiplyFormContentGenerate.tsx
@@ -24,7 +24,7 @@ export function AjnaMultiplyFormContentGenerate() {
 
   const debtMin = getAjnaBorrowDebtMin({ digits: getToken(quoteToken).digits, position })
   const debtMax = getAjnaBorrowDebtMax({
-    precision: getToken(quoteToken).precision,
+    digits: getToken(quoteToken).precision,
     position,
     simulation,
   })


### PR DESCRIPTION
# [Ajna oracless full token prices](https://app.shortcut.com/oazo-apps/story/11324/decimal-precision-in-input-boxed-for-oracleless-is-limited)

This is probably temporary measure to solve some issues that users are having on oracless mode UI.

[Tab-1692792734724.webm](https://github.com/OasisDEX/oasis-borrow/assets/16230404/ad17f1b4-964a-4046-94f9-cd0f271f3b0c)
  
## Changes 👷‍♀️

- Updated overview section components to allow adding tooltips to content card value, afterpill and footer,
- updated all Ajna form inputs on oracless UI so they accepts 18 decimal places.
  
## How to test 🧪

Try on both borro oracless and earn oracless position
- check if you can input up to 18 decimal places,
- check if tooltips are available (for main values only if they are different, than zero).