### PR TITLE
Adjust loading ETH balance via address

### DIFF
--- a/components/AppContext.ts
+++ b/components/AppContext.ts
@@ -527,7 +527,7 @@ export function setupAppContext() {
   )
 
   const balanceFromAddress$ = memoize(
-    curry(createBalanceFromAddress$)(tokenBalanceFromAddress$),
+    curry(createBalanceFromAddress$)(onEveryBlock$, chainContext$, tokenBalanceFromAddress$),
     (token, address) => `${token.address}_${token.precision}_${address}`,
   )
 


### PR DESCRIPTION
# [Adjust loading ETH balance via address](https://app.shortcut.com/oazo-apps/story/11329/eth-weth-earn-deposit-bug)

There was specific condition to load ETH balance in `createBalance$` which allowed to combine (?) both ETH and WETH (?) into one, which was missing in `createBalanceFromAddress$` observable.
  
## Changes 👷‍♀️

- Copied ETH specific condition from old function creating balanceof by token symbol.
  
## How to test 🧪

- Follow steps from attached story, also more info here: https://discord.com/channels/837076147694207067/1143665588468711435/1143891740328214618
