### PR TITLE
Additional decimal adjustments for Ajna oracless Earn

### DIFF
--- a/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
@@ -1,5 +1,6 @@
 import { normalizeValue } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
+import { DEFAULT_TOKEN_DIGITS } from 'components/constants'
 import {
   ChangeVariantType,
   ContentCardProps,
@@ -74,6 +75,7 @@ interface ContentCardPositionLendingPriceProps {
   afterPositionLendingPrice?: BigNumber
   priceColor: string
   priceColorIndex: number
+  withTooltips?: boolean
   changeVariant?: ChangeVariantType
 }
 
@@ -87,6 +89,7 @@ export function ContentCardPositionLendingPrice({
   afterPositionLendingPrice,
   priceColor,
   priceColorIndex,
+  withTooltips,
   changeVariant = 'positive',
 }: ContentCardPositionLendingPriceProps) {
   const { t } = useTranslation()
@@ -113,9 +116,14 @@ export function ContentCardPositionLendingPrice({
     ),
     change: {
       isLoading,
-      value:
+      value: afterPositionLendingPrice && [
+        '',
+        `${formatted.afterPositionLendingPrice}`,
+        `${priceFormat} ${t('system.cards.common.after')}`,
+      ],
+      tooltip:
         afterPositionLendingPrice &&
-        `${formatted.afterPositionLendingPrice} ${t('system.cards.common.after')}`,
+        `${afterPositionLendingPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
       variant: changeVariant,
     },
     modal: (
@@ -132,5 +140,12 @@ export function ContentCardPositionLendingPrice({
       </AjnaDetailsSectionContentSimpleModal>
     ),
   }
+
+  if (withTooltips && !positionLendingPrice.isZero()) {
+    contentCardSettings.valueTooltip = `${positionLendingPrice.dp(
+      DEFAULT_TOKEN_DIGITS,
+    )} ${priceFormat}`
+  }
+
   return <DetailsSectionContentCard {...contentCardSettings} />
 }

--- a/features/ajna/positions/earn/components/AjnaEarnInput.tsx
+++ b/features/ajna/positions/earn/components/AjnaEarnInput.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { DEFAULT_TOKEN_DIGITS } from 'components/constants'
 import { useAjnaGeneralContext } from 'features/ajna/positions/common/contexts/AjnaGeneralContext'
 import { useAjnaProductContext } from 'features/ajna/positions/common/contexts/AjnaProductContext'
 import { resolveLendingPriceIfOutsideRange } from 'features/ajna/positions/earn/helpers/resolveLendingPriceIfOutsideRange'
@@ -92,7 +93,7 @@ const AjnaEarnInputButton: FC<AjnaEarnInputButtonProps> = ({ disabled, variant, 
 export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled }) => {
   const { t } = useTranslation()
   const {
-    environment: { priceFormat, quoteToken, isShort },
+    environment: { isOracless, isShort, priceFormat, quoteToken },
   } = useAjnaGeneralContext()
   const {
     form: {
@@ -166,7 +167,9 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled }) => {
           type="text"
           mask={createNumberMask({
             allowDecimal: true,
-            decimalLimit: formatCryptoBalance(manualAmount).split('.')[1]?.length || 0,
+            decimalLimit: isOracless
+              ? DEFAULT_TOKEN_DIGITS
+              : formatCryptoBalance(manualAmount).split('.')[1]?.length || 0,
             prefix: '',
           })}
           onFocus={() => {
@@ -180,7 +183,13 @@ export const AjnaEarnInput: FC<AjnaEarnInputProps> = ({ disabled }) => {
           })}
           onKeyPress={enterPressedHandler}
           value={
-            manualAmount ? formatCryptoBalance(isShort ? one.div(manualAmount) : manualAmount) : ''
+            manualAmount
+              ? isOracless
+                ? (isShort ? one.div(manualAmount) : manualAmount)
+                    .dp(DEFAULT_TOKEN_DIGITS)
+                    .toString()
+                : formatCryptoBalance(isShort ? one.div(manualAmount) : manualAmount)
+              : ''
           }
           sx={{
             px: 5,

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -23,21 +23,21 @@ export function AjnaEarnOverviewManageController() {
   const {
     environment: {
       collateralToken,
+      isOracless,
       isShort,
       owner,
       priceFormat,
-      quoteToken,
       quotePrice,
-      isOracless,
+      quoteToken,
     },
   } = useAjnaGeneralContext()
   const {
-    position: {
-      isSimulationLoading,
-      currentPosition: { position, simulation },
-    },
     form: {
-      state: { withdrawAmount, depositAmount },
+      state: { depositAmount, withdrawAmount },
+    },
+    position: {
+      currentPosition: { position, simulation },
+      isSimulationLoading,
     },
     notifications,
   } = useAjnaProductContext('earn')
@@ -97,6 +97,7 @@ export function AjnaEarnOverviewManageController() {
             afterPositionLendingPrice={simulation?.price}
             priceColor={lendingPriceColor.color}
             priceColorIndex={lendingPriceColor.index}
+            withTooltips={isOracless}
           />
         </DetailsSectionContentCardWrapper>
       }


### PR DESCRIPTION
# [Additional decimal adjustments for Ajna oracless Earn](https://app.shortcut.com/oazo-apps/story/11324/decimal-precision-in-input-boxed-for-oracleless-is-limited)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/d4256598-3d17-4a40-8691-d88c3167e737)

  
## Changes 👷‍♀️

- Added tooltip with full value for lending price content card in oracless mode,
- adjusted manual price input to accept 18 decimal places in oracless mode.
  
## How to test 🧪

You can check both here: `/ethereum/ajna/earn/0x6982508145454Ce325dDbE47a25d4ec3d2311933-0x6B175474E89094C44Da98b954EedeAC495271d0F/1253`.
