### PR TITLE
Display afterpill only on oracless mode

### DIFF
--- a/features/ajna/positions/common/components/contentCards/ContentCardLiquidationPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardLiquidationPrice.tsx
@@ -49,8 +49,11 @@ export function ContentCardLiquidationPrice({
         `${formatted.afterLiquidationPrice}`,
         `${priceFormat} ${t('system.cards.common.after')}`,
       ],
-      tooltip:
-        afterLiquidationPrice && `${afterLiquidationPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
+      ...(withTooltips &&
+        afterLiquidationPrice &&
+        !afterLiquidationPrice.isZero() && {
+          tooltip: `${afterLiquidationPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
+        }),
       variant: changeVariant,
     },
     modal: (

--- a/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardPositionLendingPrice.tsx
@@ -121,9 +121,11 @@ export function ContentCardPositionLendingPrice({
         `${formatted.afterPositionLendingPrice}`,
         `${priceFormat} ${t('system.cards.common.after')}`,
       ],
-      tooltip:
+      ...(withTooltips &&
         afterPositionLendingPrice &&
-        `${afterPositionLendingPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
+        !afterPositionLendingPrice.isZero() && {
+          tooltip: `${afterPositionLendingPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
+        }),
       variant: changeVariant,
     },
     modal: (

--- a/features/ajna/positions/common/components/contentCards/ContentCardThresholdPrice.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardThresholdPrice.tsx
@@ -108,8 +108,11 @@ export function ContentCardThresholdPrice({
     change: {
       isLoading,
       value: afterThresholdPrice && ['', `${formatted.afterThresholdPrice}`, `${priceFormat}`],
-      tooltip:
-        afterThresholdPrice && `${afterThresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
+      ...(withTooltips &&
+        afterThresholdPrice &&
+        !afterThresholdPrice.isZero() && {
+          tooltip: `${afterThresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${priceFormat}`,
+        }),
       variant: changeVariant,
     },
     modal: (


### PR DESCRIPTION
# Display afterpill only on oracless mode

Tooltip on afterpill condition was not strict enough and was displayed on curated pool borrow products.
  
## Changes 👷‍♀️

- Updated content card afterpills tooltip conditions.
  
## How to test 🧪

Go to curated and oracless positions and check if afterpill tooltips are visible. They should be visible ONLY in oracless mode.
