### PR TITLE
Remove `getMaxIncreasedValue` usage from Ajna lib wrapper

### DIFF
--- a/actions/ajna/oasisActionsLibWrapper.ts
+++ b/actions/ajna/oasisActionsLibWrapper.ts
@@ -19,7 +19,6 @@ import { ethers } from 'ethers'
 import { AjnaFormState, AjnaGenericPosition } from 'features/ajna/common/types'
 import { getAjnaPoolAddress } from 'features/ajna/positions/common/helpers/getAjnaPoolAddress'
 import { getAjnaPoolData } from 'features/ajna/positions/common/helpers/getAjnaPoolData'
-import { getMaxIncreasedValue } from 'features/ajna/positions/common/helpers/getMaxIncreasedValue'
 
 interface AjnaTxHandlerInput {
   collateralAddress: string
@@ -97,13 +96,7 @@ export async function getAjnaParameters({
     case 'payback-borrow':
     case 'withdraw-borrow': {
       return ajnaPaybackWithdrawBorrow({
-        state: {
-          ...state,
-          paybackAmount:
-            state.paybackAmount && state.paybackAmountMax
-              ? getMaxIncreasedValue(state.paybackAmount, position.pool.interestRate)
-              : state.paybackAmount,
-        },
+        state,
         commonPayload,
         dependencies,
         position,
@@ -173,17 +166,10 @@ export async function getAjnaParameters({
     case 'payback-multiply':
     case 'withdraw-multiply': {
       const { loanToValue } = state
-      const resolvedState = {
-        ...state,
-        paybackAmount:
-          state.paybackAmount && state.paybackAmountMax
-            ? getMaxIncreasedValue(state.paybackAmount, position.pool.interestRate)
-            : state.paybackAmount,
-      }
 
       if (loanToValue) {
         return ajnaAdjustMultiply({
-          state: resolvedState,
+          state,
           commonPayload,
           dependencies,
           position,
@@ -194,7 +180,7 @@ export async function getAjnaParameters({
       }
 
       return ajnaPaybackWithdrawBorrow({
-        state: resolvedState,
+        state,
         commonPayload,
         dependencies,
         position,


### PR DESCRIPTION
# Remove `getMaxIncreasedValue` usage from Ajna lib wrapper

Partial revert of https://github.com/OasisDEX/oasis-borrow/pull/2788.
  
## Changes 👷‍♀️

- Removed increased max debt amount from `getAjnaParameters`.
