### PR TITLE
Middleware to handle CORS

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || []
+  const response = NextResponse.next()
+
+  if (allowedOrigins.includes(request.headers.get('origin') || '')) {
+    response.headers.set('Access-Control-Allow-Origin', request.headers.get('origin') || '')
+  }
+  return response
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,9 +3,12 @@ import { NextRequest, NextResponse } from 'next/server'
 export function middleware(request: NextRequest) {
   const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || []
   const response = NextResponse.next()
+  const origin = request.headers.get('origin') || ''
 
-  if (allowedOrigins.includes(request.headers.get('origin') || '')) {
-    response.headers.set('Access-Control-Allow-Origin', request.headers.get('origin') || '')
+  // If the origin is in the ALLOWED_ORIGINS env, add it to the Access-Control-Allow-Origin header
+  if (allowedOrigins.includes(origin)) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
   }
+
   return response
 }

--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,7 @@ const baseConfig = {
     ignoreBuildErrors: isProduction,
   },
   productionBrowserSourceMaps: true,
-  pageExtensions: ['mdx', 'tsx'],
+  pageExtensions: ['mdx', 'tsx', 'ts'],
   publicRuntimeConfig: publicRuntimeConfig,
   webpack: function (config, { isServer }) {
     config.module.rules.push({
@@ -169,7 +169,6 @@ const baseConfig = {
           { key: 'X-Frame-Options', value: 'ALLOW' },
           { key: 'X-XSS-Protection', value: '1; mode=block' },
           { key: 'Referrer-Policy', value: 'same-origin' },
-          { key: 'Access-Control-Allow-Origin', value: 'https://app.safe.global' },
         ],
       },
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "runtimeConfig.js", "next-i18next.config.js"],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "runtimeConfig.js", "next-i18next.config.js", "middleware.ts"],
   "exclude": ["node_modules", "types", "coverage"]
 }


### PR DESCRIPTION
# Changes
-  Middleware to handle `Access-Control-Allow-Origin`. If the current origin exists in the header and in the `ALLOWED_ORIGINS` environment variable, there will be an `Access-Control-Allow-Origin` header in the response.

@cristidas please add `ALLOWED_ORIGINS` to AWS. 