### PR TITLE
Remove rewards sparks and banner from TBTC Pools

### DIFF
--- a/features/ajna/common/consts.ts
+++ b/features/ajna/common/consts.ts
@@ -40,7 +40,6 @@ export const AJNA_POOLS_WITH_REWARDS = [
   'RETH-DAI',
   'RETH-ETH',
   'SDAI-USDC',
-  'TBTC-USDC',
   'USDC-ETH',
   'USDC-WBTC',
   'WBTC-DAI',


### PR DESCRIPTION
# [Remove rewards sparks and banner from TBTC Pools](https://app.shortcut.com/oazo-apps/story/11635/remove-rewards-stars-and-banner-from-tbtc-pools)
  
## Changes 👷‍♀️
  <Please add short list of changes>
- Removed TBTC-USDC from `AJNA_POOLS_WITH_REWARDS` config.
  
## How to test 🧪

1. Patch Product Finder data.
2. Check if sparks are gone in Product Finder TBTC-USDC row.
3. Check if rewards banner is gone on TBTC-USDC open and manage flow pages.
