### PR TITLE
fix: [sc-11664] User cannot access AAVE v2 Earn position (P2)

### DIFF
--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -55,16 +55,15 @@ export function getStrategyConfig$(
         throw new Error(`There is no PositionCreatedEvent and AaveUserConfiguration`)
       }
 
-      const _vaultType = vaultTypeIsUnknown ? VaultType.Borrow : vaultType
       switch (true) {
-        // For aave v3 we should have the event.
+        // For aave v3 we should have the event. and we don't support changing vault type in aave v2
         case aaveUserConfigurations.hasAssets(['STETH'], ['ETH', 'WETH']):
           return loadStrategyFromTokens(
             'STETH',
             'ETH',
             networkName,
             LendingProtocol.AaveV2,
-            _vaultType,
+            VaultType.Earn,
           )
         case aaveUserConfigurations.hasAssets(['ETH', 'WETH'], ['USDC']):
           return loadStrategyFromTokens(
@@ -72,7 +71,7 @@ export function getStrategyConfig$(
             'USDC',
             networkName,
             LendingProtocol.AaveV2,
-            _vaultType,
+            VaultType.Multiply,
           )
         case aaveUserConfigurations.hasAssets(['WBTC'], ['USDC']):
           return loadStrategyFromTokens(
@@ -80,7 +79,7 @@ export function getStrategyConfig$(
             'USDC',
             networkName,
             LendingProtocol.AaveV2,
-            _vaultType,
+            VaultType.Multiply,
           )
         case aaveUserConfigurations.hasAssets(['STETH'], ['USDC']):
           return loadStrategyFromTokens(
@@ -88,7 +87,7 @@ export function getStrategyConfig$(
             'USDC',
             networkName,
             LendingProtocol.AaveV2,
-            _vaultType,
+            VaultType.Multiply,
           )
         default:
           throw new Error(`User doesn't have assets supported in the app`)


### PR DESCRIPTION
Refactored the handling of the vault type in Aave V2 strategy configuration. Removed the dynamic vaultType variable and replaced it with fixed values per each case of asset configurations. This was necessary as changing vault type in Aave v2 is not supported.