### PR TITLE
feat: [sc-11192] ✨ [Frontend] Spark V3 Earn strats using multiply UI

### DIFF
--- a/features/aave/components/AavePositionHeader.tsx
+++ b/features/aave/components/AavePositionHeader.tsx
@@ -65,12 +65,16 @@ function AavePositionHeader({
   minimumRiskRatio: IRiskRatio
 }) {
   const { t } = useTranslation()
+  const isSparkProtocol = strategy.protocol === LendingProtocol.SparkV3
 
-  const minYields = useAaveEarnYields(minimumRiskRatio, strategy.protocol, strategy.network, [
-    '7Days',
-  ])
+  const minYields = useAaveEarnYields(
+    !isSparkProtocol ? minimumRiskRatio : undefined,
+    strategy.protocol,
+    strategy.network,
+    ['7Days'],
+  )
   const maxYields = useAaveEarnYields(
-    maxRisk || minimumRiskRatio,
+    !isSparkProtocol ? maxRisk || minimumRiskRatio : undefined,
     strategy.protocol,
     strategy.network,
     ['7Days', '7DaysOffset', '90Days', '90DaysOffset'],
@@ -101,7 +105,7 @@ function AavePositionHeader({
       }),
     })
   }
-  if (maxYields?.annualisedYield90days) {
+  if (maxYields && maxYields?.annualisedYield90days) {
     const yield90DaysDiff = maxYields.annualisedYield90daysOffset!.minus(
       maxYields.annualisedYield90days,
     )

--- a/features/aave/strategies/ethereum-spark-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-spark-v3-strategies.ts
@@ -4,19 +4,12 @@ import {
   AaveManageHeader,
   AaveMultiplyManageComponent,
   AaveOpenHeader,
-  AavePositionHeaderNoDetails,
   adjustRiskView,
   DebtInput,
-  headerWithDetails,
-  ManageSectionComponent,
-  SimulateSectionComponent,
-  ViewPositionSectionComponent,
 } from 'features/aave/components'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/aave/services'
-import { adjustRiskSliders } from 'features/aave/services/riskSliderConfig'
 import { IStrategyConfig, ProductType, ProxyType, StrategyType } from 'features/aave/types'
 import { AaveBorrowFaq } from 'features/content/faqs/aave/borrow'
-import { AaveEarnFaqV3 } from 'features/content/faqs/aave/earn'
 import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
 import { getFeatureToggle } from 'helpers/useFeatureToggle'
 import { LendingProtocol } from 'lendingProtocols'
@@ -262,24 +255,24 @@ const earnStrategies: IStrategyConfig[] = availableTokenPairs
       urlSlug: `${config.collateral.toLowerCase()}${config.debt.toLowerCase()}`,
       proxyType: ProxyType.DpmProxy,
       viewComponents: {
-        headerOpen: headerWithDetails(adjustRiskSliders.wstethEth.riskRatios.minimum),
-        headerManage: AavePositionHeaderNoDetails,
-        headerView: AavePositionHeaderNoDetails,
-        simulateSection: SimulateSectionComponent,
-        vaultDetailsManage: ManageSectionComponent,
-        vaultDetailsView: ViewPositionSectionComponent,
-        secondaryInput: adjustRiskView(adjustRiskSliders.wstethEth),
-        adjustRiskInput: adjustRiskView(adjustRiskSliders.wstethEth),
-        positionInfo: AaveEarnFaqV3,
-        sidebarTitle: 'open-earn.aave.vault-form.title',
-        sidebarButton: 'open-earn.aave.vault-form.open-btn',
+        headerOpen: AaveOpenHeader,
+        headerManage: AaveManageHeader,
+        headerView: AaveManageHeader,
+        simulateSection: AaveMultiplyManageComponent,
+        vaultDetailsManage: AaveMultiplyManageComponent,
+        vaultDetailsView: AaveMultiplyManageComponent,
+        secondaryInput: adjustRiskView(multiplyAdjustRiskSliderConfig),
+        adjustRiskInput: adjustRiskView(multiplyAdjustRiskSliderConfig),
+        positionInfo: AaveMultiplyFaq,
+        sidebarTitle: 'open-multiply.sidebar.title',
+        sidebarButton: 'open-multiply.sidebar.open-btn',
       },
       tokens: {
         collateral: config.collateral,
         debt: config.debt,
         deposit: config.collateral,
       },
-      riskRatios: adjustRiskSliders.wstethEth.riskRatios,
+      riskRatios: multiplyAdjustRiskSliderConfig.riskRatios,
       type: ProductType.Earn,
       protocol: LendingProtocol.SparkV3,
       availableActions: () => {


### PR DESCRIPTION
 - disabled the yield calcs on aave-like earn header
 - changed the UI on Spark V3 Earn strats to multiply UI (because theres no yield calcs)