### PR TITLE
fix: [sc-11795] Replace deb token symbol in buying power with USD for Aave and Spark

### DIFF
--- a/features/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/aave/components/AaveMultiplyPositionData.tsx
@@ -230,15 +230,13 @@ export function AaveMultiplyPositionData({
             <DetailsSectionFooterItem
               sx={{ pr: 3 }}
               title={t('system.buying-power')}
-              value={`${formatPrecision(currentPositionThings.buyingPower, 2)} ${debtToken.symbol}`}
+              value={`${formatPrecision(currentPositionThings.buyingPower, 2)} USD`}
               change={
                 nextPositionThings && {
                   variant: nextPositionThings.buyingPower.gt(currentPositionThings.buyingPower)
                     ? 'positive'
                     : 'negative',
-                  value: `${formatPrecision(nextPositionThings.buyingPower, 2)} ${
-                    nextPosition.debt.symbol
-                  } ${t('after')}`,
+                  value: `${formatPrecision(nextPositionThings.buyingPower, 2)} USD ${t('after')}`,
                 }
               }
             />

--- a/features/productHub/controls/ProductHubContentController.tsx
+++ b/features/productHub/controls/ProductHubContentController.tsx
@@ -45,6 +45,7 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
     sparkBorrowEnabled,
     sparkEarnEnabled,
     sparkMultiplyEnabled,
+    sparkSDAIETHEnabled,
   ] = useFeatureToggles([
     'AjnaSafetySwitch',
     'AjnaPoolFinder',
@@ -52,6 +53,7 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
     'SparkProtocolBorrow',
     'SparkProtocolEarn',
     'SparkProtocolMultiply',
+    'SparkProtocolSDAIETH',
   ])
 
   const { chainId } = useWalletManagement()
@@ -66,13 +68,15 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
 
   const dataMatchedToFeatureFlags = useMemo(
     () =>
-      tableData.filter(({ label, protocol, product }) => {
+      tableData.filter(({ label, protocol, product, primaryToken, secondaryToken }) => {
         const isAjna = protocol === LendingProtocol.Ajna
         const isSpark = protocol === LendingProtocol.SparkV3
 
         const isBorrow = product.includes(ProductHubProductType.Borrow)
         const isEarn = product.includes(ProductHubProductType.Earn)
         const isMultiply = product.includes(ProductHubProductType.Multiply)
+
+        const isSDAIETH = primaryToken === 'SDAI' && secondaryToken === 'ETH'
 
         const unalailableChecksList = [
           // these checks predicate that the pool/strategy is UNAVAILABLE
@@ -83,6 +87,10 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
           isSpark && isBorrow && !(sparkEnabled && sparkBorrowEnabled),
           isSpark && isEarn && !(sparkEnabled && sparkEarnEnabled),
           isSpark && isMultiply && !(sparkEnabled && sparkMultiplyEnabled),
+          isSpark &&
+            isSDAIETH &&
+            (isMultiply || isBorrow) &&
+            !(sparkEnabled && sparkSDAIETHEnabled),
         ]
         if (unalailableChecksList.some((check) => !!check)) {
           return false
@@ -95,6 +103,7 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
       sparkBorrowEnabled,
       sparkEarnEnabled,
       sparkMultiplyEnabled,
+      sparkSDAIETHEnabled,
       ajnaSafetySwitchOn,
       ajnaPoolFinderEnabled,
       ajnaOraclessPoolPairsKeys,

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -41,6 +41,7 @@ export type Feature =
   | 'SparkProtocolEarn'
   | 'SparkProtocolBorrow'
   | 'SparkProtocolMultiply'
+  | 'SparkProtocolSDAIETH'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
@@ -80,6 +81,7 @@ const configuredFeatures: Record<Feature, boolean> = {
   SparkProtocolEarn: false,
   SparkProtocolBorrow: false,
   SparkProtocolMultiply: false,
+  SparkProtocolSDAIETH: false,
 }
 
 export function configureLocalStorageForTests(data: { [feature in Feature]?: boolean }) {


### PR DESCRIPTION
Also added `SparkProtocolSDAIETH` feature toggle

Story details: https://app.shortcut.com/oazo-apps/story/11795