### PR TITLE
chore: [sc-11890] Release chores for Arbitrum Multiply   Shorting

### DIFF
--- a/blockchain/networks/networks-config.ts
+++ b/blockchain/networks/networks-config.ts
@@ -14,7 +14,6 @@ import { ethers } from 'ethers'
 import { ContractDesc } from 'features/web3Context'
 import { GraphQLClient } from 'graphql-request'
 import { Abi } from 'helpers/types'
-import { getFeatureToggle } from 'helpers/useFeatureToggle'
 import { keyBy, memoize } from 'lodash'
 import { env } from 'process'
 import arbitrumMainnetBadge from 'public/static/img/network_icons/arbitrum_badge_mainnet.svg'
@@ -146,7 +145,7 @@ const arbitrumMainnetConfig: NetworkConfig = {
   icon: arbitrumMainnetIcon as string,
   badge: arbitrumMainnetBadge as string,
   testnet: false,
-  isEnabled: () => getFeatureToggle('UseNetworkSwitcherArbitrum'),
+  isEnabled: () => true,
   token: 'ETH',
   rpcUrl: arbitrumMainnetRpc,
   getReadProvider: memoize(
@@ -179,7 +178,7 @@ const arbitrumGoerliConfig: NetworkConfig = {
   icon: arbitrumMainnetIcon as string,
   badge: arbitrumMainnetBadge as string,
   testnet: true,
-  isEnabled: () => getFeatureToggle('UseNetworkSwitcherArbitrum'),
+  isEnabled: () => true,
   token: 'AGOR',
   rpcUrl: arbitrumGoerliRpc,
   getReadProvider: memoize(
@@ -251,7 +250,7 @@ const optimismMainnetConfig: NetworkConfig = {
   icon: optimismMainnetIcon as string,
   badge: optimismMainnetBadge as string,
   testnet: false,
-  isEnabled: () => getFeatureToggle('UseNetworkSwitcherOptimism'),
+  isEnabled: () => true,
   token: 'ETH',
   rpcUrl: optimismMainnetRpc,
   getReadProvider: memoize(
@@ -284,7 +283,7 @@ const optimismGoerliConfig: NetworkConfig = {
   icon: optimismMainnetIcon as string,
   badge: optimismMainnetBadge as string,
   testnet: true,
-  isEnabled: () => getFeatureToggle('UseNetworkSwitcherOptimism'),
+  isEnabled: () => true,
   token: 'ETH',
   rpcUrl: optimismGoerliRpc,
   getReadProvider: () => undefined,

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -521,6 +521,10 @@ export function createOpenAaveStateMachine(
           useFeatureToggle('AaveV3ProtectionWrite') &&
           supportsAaveStopLoss(strategyConfig.protocol, strategyConfig.networkId) &&
           strategyConfig.type === ProductType.Multiply &&
+          isSupportedAaveAutomationTokenPair(
+            strategyConfig.tokens.collateral,
+            strategyConfig.tokens.debt,
+          ) &&
           canOpenPosition({
             userInput,
             hasOpenedPosition,

--- a/features/aave/strategies/arbitrum-aave-v3-strategies.ts
+++ b/features/aave/strategies/arbitrum-aave-v3-strategies.ts
@@ -30,20 +30,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -55,20 +55,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -80,20 +80,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -105,20 +105,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -130,20 +130,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -155,20 +155,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -180,20 +180,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -205,20 +205,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -234,12 +234,12 @@ const availableTokenPairs: TokenPairConfig[] = [
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-earn',
@@ -259,12 +259,12 @@ const availableTokenPairs: TokenPairConfig[] = [
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-earn',
@@ -280,20 +280,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -305,20 +305,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -330,20 +330,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -355,20 +355,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3ArbitrumBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3ArbitrumMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3ArbitrumMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3ArbitrumBorrow',
+            featureToggle: undefined,
           },
         ],
       },

--- a/features/aave/strategies/ethereum-aave-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-aave-v3-strategies.ts
@@ -15,13 +15,7 @@ import {
 } from 'features/aave/components'
 import { adjustRiskSliderConfig as multiplyAdjustRiskSliderConfig } from 'features/aave/services'
 import { adjustRiskSliders } from 'features/aave/services/riskSliderConfig'
-import {
-  IStrategyConfig,
-  ManagePositionAvailableActions,
-  ProductType,
-  ProxyType,
-  StrategyType,
-} from 'features/aave/types'
+import { IStrategyConfig, ProductType, ProxyType, StrategyType } from 'features/aave/types'
 import { AaveBorrowFaq } from 'features/content/faqs/aave/borrow'
 import { AaveEarnFaqV3 } from 'features/content/faqs/aave/earn'
 import { AaveMultiplyFaq } from 'features/content/faqs/aave/multiply'
@@ -119,20 +113,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3Multiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3Borrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3Borrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3Multiply',
+            featureToggle: undefined,
           },
         ],
       },
@@ -144,20 +138,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3Multiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3Borrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3Borrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3Multiply',
+            featureToggle: undefined,
           },
         ],
       },
@@ -248,7 +242,7 @@ const availableTokenPairs: TokenPairConfig[] = [
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3Borrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -294,20 +288,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3Multiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3Borrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3Borrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3Multiply',
+            featureToggle: undefined,
           },
         ],
       },
@@ -319,20 +313,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3Multiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3Borrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3Borrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3Multiply',
+            featureToggle: undefined,
           },
         ],
       },
@@ -403,7 +397,7 @@ const availableTokenPairs: TokenPairConfig[] = [
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3Borrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
@@ -718,11 +712,7 @@ export const ethereumAaveV3Strategies: IStrategyConfig[] = [
     type: ProductType.Earn,
     protocol: LendingProtocol.AaveV3,
     availableActions: () => {
-      const isBorrowEnabled = getFeatureToggle('AaveV3Borrow')
-      const additionalActions: ManagePositionAvailableActions[] = isBorrowEnabled
-        ? ['switch-to-borrow']
-        : []
-      return [...allActionsAvailableInMultiply, ...additionalActions]
+      return [...allActionsAvailableInMultiply, 'switch-to-borrow']
     },
     defaultSlippage: new BigNumber(0.001),
     executeTransactionWith: 'ethers',
@@ -758,11 +748,7 @@ export const ethereumAaveV3Strategies: IStrategyConfig[] = [
     protocol: LendingProtocol.AaveV3,
     featureToggle: 'AaveV3EarnrETHeth',
     availableActions: () => {
-      const isBorrowEnabled = getFeatureToggle('AaveV3Borrow')
-      const additionalActions: ManagePositionAvailableActions[] = isBorrowEnabled
-        ? ['switch-to-borrow']
-        : []
-      return [...allActionsAvailableInMultiply, ...additionalActions]
+      return [...allActionsAvailableInMultiply, 'switch-to-borrow']
     },
     defaultSlippage: new BigNumber(0.001),
     executeTransactionWith: 'ethers',
@@ -798,11 +784,7 @@ export const ethereumAaveV3Strategies: IStrategyConfig[] = [
     protocol: LendingProtocol.AaveV3,
     featureToggle: 'AaveV3EarncbETHeth',
     availableActions: () => {
-      const isBorrowEnabled = getFeatureToggle('AaveV3Borrow')
-      const additionalActions: ManagePositionAvailableActions[] = isBorrowEnabled
-        ? ['switch-to-borrow']
-        : []
-      return [...allActionsAvailableInMultiply, ...additionalActions]
+      return [...allActionsAvailableInMultiply, 'switch-to-borrow']
     },
     defaultSlippage: new BigNumber(0.001),
     executeTransactionWith: 'ethers',

--- a/features/aave/strategies/ethereum-spark-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-spark-v3-strategies.ts
@@ -31,20 +31,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'SparkProtocolMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'SparkProtocolMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'SparkProtocolBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'SparkProtocolBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -56,20 +56,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'SparkProtocolMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'SparkProtocolMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'SparkProtocolBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'SparkProtocolBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -81,20 +81,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'SparkProtocolMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'SparkProtocolMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'SparkProtocolBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'SparkProtocolBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -103,23 +103,23 @@ const availableTokenPairs: TokenPairConfig[] = [
   {
     collateral: 'SDAI',
     debt: 'ETH',
-    strategyType: StrategyType.Long,
+    strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Multiply]: {
-        featureToggle: 'SparkProtocolMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'SparkProtocolMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'SparkProtocolBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'SparkProtocolBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -131,7 +131,7 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Earn]: {
-        featureToggle: 'SparkProtocolEarn',
+        featureToggle: undefined,
         additionalManageActions: [],
       },
     },
@@ -142,7 +142,7 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Earn]: {
-        featureToggle: 'SparkProtocolEarn',
+        featureToggle: undefined,
         additionalManageActions: [],
       },
     },

--- a/features/aave/strategies/optimism-aave-v3-strategies.ts
+++ b/features/aave/strategies/optimism-aave-v3-strategies.ts
@@ -30,20 +30,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -55,20 +55,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -80,20 +80,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -105,20 +105,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -130,20 +130,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -155,20 +155,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Long,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -184,12 +184,12 @@ const availableTokenPairs: TokenPairConfig[] = [
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-earn',
@@ -205,20 +205,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -230,20 +230,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -255,20 +255,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },
@@ -280,20 +280,20 @@ const availableTokenPairs: TokenPairConfig[] = [
     strategyType: StrategyType.Short,
     productTypes: {
       [ProductType.Borrow]: {
-        featureToggle: 'AaveV3OptimismBorrow',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-multiply',
-            featureToggle: 'AaveV3OptimismMultiply',
+            featureToggle: undefined,
           },
         ],
       },
       [ProductType.Multiply]: {
-        featureToggle: 'AaveV3OptimismMultiply',
+        featureToggle: undefined,
         additionalManageActions: [
           {
             action: 'switch-to-borrow',
-            featureToggle: 'AaveV3OptimismBorrow',
+            featureToggle: undefined,
           },
         ],
       },

--- a/features/navigation/controls/NavigationActionsController.tsx
+++ b/features/navigation/controls/NavigationActionsController.tsx
@@ -6,7 +6,6 @@ import { WalletPanelMobile } from 'components/navigation/content/WalletPanelMobi
 import { navigationBreakpoints } from 'components/navigation/Navigation'
 import { NavigationNetworkSwitcherOrb } from 'components/navigation/NavigationNetworkSwitcher'
 import { ConnectButton } from 'features/web3OnBoard'
-import { useFeatureToggle } from 'helpers/useFeatureToggle'
 import React from 'react'
 import { useMediaQuery } from 'usehooks-ts'
 
@@ -19,8 +18,6 @@ export function NavigationActionsController({ isConnected }: NavigationActionsCo
   const isViewBelowL = useMediaQuery(`(max-width: ${navigationBreakpoints[2] - 1}px)`)
   const isViewBelowM = useMediaQuery(`(max-width: ${navigationBreakpoints[1] - 1}px)`)
 
-  const useNetworkSwitcher = useFeatureToggle('UseNetworkSwitcher')
-
   return (
     <>
       {isConnected ? (
@@ -28,12 +25,12 @@ export function NavigationActionsController({ isConnected }: NavigationActionsCo
           {isViewBelowXl && <SwapWidgetOrb />}
           {isViewBelowXl && <MyPositionsOrb />}
           <NotificationsOrb />
-          {useNetworkSwitcher && <NavigationNetworkSwitcherOrb />}
+          {<NavigationNetworkSwitcherOrb />}
           {isViewBelowM ? <WalletPanelMobile /> : <WalletOrb />}
         </>
       ) : (
         <>
-          {useNetworkSwitcher && <NavigationNetworkSwitcherOrb />}
+          {<NavigationNetworkSwitcherOrb />}
           {!isViewBelowL && <ConnectButton />}
         </>
       )}

--- a/features/productHub/controls/ProductHubContentController.tsx
+++ b/features/productHub/controls/ProductHubContentController.tsx
@@ -38,22 +38,9 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
   onChange,
   limitRows,
 }) => {
-  const [
-    ajnaSafetySwitchOn,
-    ajnaPoolFinderEnabled,
-    sparkEnabled,
-    sparkBorrowEnabled,
-    sparkEarnEnabled,
-    sparkMultiplyEnabled,
-    sparkSDAIETHEnabled,
-  ] = useFeatureToggles([
+  const [ajnaSafetySwitchOn, ajnaPoolFinderEnabled] = useFeatureToggles([
     'AjnaSafetySwitch',
     'AjnaPoolFinder',
-    'SparkProtocol',
-    'SparkProtocolBorrow',
-    'SparkProtocolEarn',
-    'SparkProtocolMultiply',
-    'SparkProtocolSDAIETH',
   ])
 
   const { chainId } = useWalletManagement()
@@ -68,15 +55,8 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
 
   const dataMatchedToFeatureFlags = useMemo(
     () =>
-      tableData.filter(({ label, protocol, product, primaryToken, secondaryToken }) => {
+      tableData.filter(({ label, protocol }) => {
         const isAjna = protocol === LendingProtocol.Ajna
-        const isSpark = protocol === LendingProtocol.SparkV3
-
-        const isBorrow = product.includes(ProductHubProductType.Borrow)
-        const isEarn = product.includes(ProductHubProductType.Earn)
-        const isMultiply = product.includes(ProductHubProductType.Multiply)
-
-        const isSDAIETH = primaryToken === 'SDAI' && secondaryToken === 'ETH'
 
         const unalailableChecksList = [
           // these checks predicate that the pool/strategy is UNAVAILABLE
@@ -84,30 +64,13 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
           isAjna &&
             !ajnaPoolFinderEnabled &&
             ajnaOraclessPoolPairsKeys.includes(label.replace('/', '-')),
-          isSpark && isBorrow && !(sparkEnabled && sparkBorrowEnabled),
-          isSpark && isEarn && !(sparkEnabled && sparkEarnEnabled),
-          isSpark && isMultiply && !(sparkEnabled && sparkMultiplyEnabled),
-          isSpark &&
-            isSDAIETH &&
-            (isMultiply || isBorrow) &&
-            !(sparkEnabled && sparkSDAIETHEnabled),
         ]
         if (unalailableChecksList.some((check) => !!check)) {
           return false
         }
         return true
       }),
-    [
-      tableData,
-      sparkEnabled,
-      sparkBorrowEnabled,
-      sparkEarnEnabled,
-      sparkMultiplyEnabled,
-      sparkSDAIETHEnabled,
-      ajnaSafetySwitchOn,
-      ajnaPoolFinderEnabled,
-      ajnaOraclessPoolPairsKeys,
-    ],
+    [tableData, ajnaSafetySwitchOn, ajnaPoolFinderEnabled, ajnaOraclessPoolPairsKeys],
   )
   const dataMatchedByNL = useMemo(
     () => matchRowsByNL(dataMatchedToFeatureFlags, selectedProduct, selectedToken),

--- a/features/productHub/meta.ts
+++ b/features/productHub/meta.ts
@@ -232,6 +232,5 @@ export const productHubProtocolFilter: GenericMultiselectOption[] = [
     label: lendingProtocolsByName[LendingProtocol.SparkV3].label,
     value: lendingProtocolsByName[LendingProtocol.SparkV3].name,
     image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
-    featureFlag: 'SparkProtocol',
   },
 ]

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
@@ -48,8 +48,8 @@ export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.SparkV3,
     label: 'SDAI/ETH',
-    multiplyStrategyType: 'long',
-    multiplyStrategy: 'Long SDAI',
+    multiplyStrategyType: 'short',
+    multiplyStrategy: 'Short ETH',
   },
   {
     product: [ProductHubProductType.Borrow],

--- a/helpers/useFeatureToggle.ts
+++ b/helpers/useFeatureToggle.ts
@@ -8,15 +8,11 @@ export type Feature =
   | 'AnotherTestFeature'
   | '🌞'
   | 'AaveV3ArbitrumBorrow'
-  | 'AaveV3ArbitrumMultiply'
   | 'AaveV3ArbitrumEarn'
   | 'AaveV3OptimismBorrow'
-  | 'AaveV3OptimismMultiply'
   | 'AaveV3OptimismEarn'
-  | 'AaveV3Borrow'
   | 'AaveV3EarncbETHeth'
   | 'AaveV3EarnrETHeth'
-  | 'AaveV3Multiply'
   | 'AaveV3History'
   | 'AaveV3Protection'
   | 'AaveV3ProtectionWrite'
@@ -37,31 +33,19 @@ export type Feature =
   | 'StopLossOpenFlow'
   | 'StopLossRead'
   | 'StopLossWrite'
-  | 'UseNetworkSwitcher'
-  | 'UseNetworkSwitcherArbitrum'
   | 'UseNetworkSwitcherForks'
-  | 'UseNetworkSwitcherOptimism'
   | 'UseNetworkSwitcherTestnets'
-  | 'SparkProtocol'
-  | 'SparkProtocolEarn'
-  | 'SparkProtocolBorrow'
-  | 'SparkProtocolMultiply'
-  | 'SparkProtocolSDAIETH'
 
 const configuredFeatures: Record<Feature, boolean> = {
   TestFeature: false, // used in unit tests
   AnotherTestFeature: true, // used in unit tests
   '🌞': false, // or https://summer.fi/harheeharheeharhee to enable.  https://summer.fi/<any vault ID> to disable.
   AaveV3ArbitrumBorrow: false,
-  AaveV3ArbitrumMultiply: false,
   AaveV3ArbitrumEarn: false,
   AaveV3OptimismBorrow: false,
-  AaveV3OptimismMultiply: false,
   AaveV3OptimismEarn: false,
-  AaveV3Borrow: false,
   AaveV3EarncbETHeth: false,
   AaveV3EarnrETHeth: false,
-  AaveV3Multiply: false,
   AaveV3History: false,
   AaveV3Protection: true,
   AaveV3ProtectionWrite: true,
@@ -82,16 +66,8 @@ const configuredFeatures: Record<Feature, boolean> = {
   StopLossOpenFlow: false,
   StopLossRead: true,
   StopLossWrite: true,
-  UseNetworkSwitcher: true,
-  UseNetworkSwitcherArbitrum: false,
   UseNetworkSwitcherForks: false,
-  UseNetworkSwitcherOptimism: true,
   UseNetworkSwitcherTestnets: false,
-  SparkProtocol: true,
-  SparkProtocolEarn: true,
-  SparkProtocolBorrow: true,
-  SparkProtocolMultiply: true,
-  SparkProtocolSDAIETH: false,
 }
 
 export function configureLocalStorageForTests(data: { [feature in Feature]?: boolean }) {


### PR DESCRIPTION
# Changes
- Ready for release.
- Enabling all shorts for aave v3 & spark
- Enabling arbitrum (all multiply) and optimism (missing multiply pairs)
- sDAI/ETH on Spark -> it's Short ETH
- Remove some unused flags