### PR TITLE
Ajna history origination fee in quote token

### DIFF
--- a/components/history/PositionHistoryItemDetails.tsx
+++ b/components/history/PositionHistoryItemDetails.tsx
@@ -132,7 +132,7 @@ export const PositionHistoryItemDetails: FC<PositionHistoryItemDetailsProps> = (
       )}
       {!isOracless && 'originationFee' in event && event.originationFee?.gt(zero) && (
         <PositionHistoryRow label={t('position-history.origination-fee')}>
-          {formatFiatBalance(event.originationFee)} USD
+          {formatFiatBalance(event.originationFee)} {quoteToken}
         </PositionHistoryRow>
       )}
       {isOracless &&


### PR DESCRIPTION
# [Ajna history origination fee in quote token](https://app.shortcut.com/oazo-apps/story/11640/origination-fee-is-displayed-in-usd-not-in-token)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- changed origination fee symbol from USD to quote token
  
## How to test 🧪
  <Please explain how to test your changes>

- for example position 1311, origination fee in history should be in ETH
