### PR TITLE
Remove footnote from max lending ltv card

### DIFF
--- a/features/ajna/positions/common/components/contentCards/ContentCardMaxLendingLTV.tsx
+++ b/features/ajna/positions/common/components/contentCards/ContentCardMaxLendingLTV.tsx
@@ -5,13 +5,12 @@ import {
   DetailsSectionContentCard,
 } from 'components/DetailsSectionContentCard'
 import { AjnaDetailsSectionContentSimpleModal } from 'features/ajna/common/components/AjnaDetailsSectionContentSimpleModal'
-import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
+import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
 interface ContentCardMaxLendingLTVProps {
   maxLendingPercentage: BigNumber
-  price: BigNumber
   quoteToken: string
   collateralToken: string
   afterMaxLendingPercentage?: BigNumber
@@ -21,7 +20,6 @@ interface ContentCardMaxLendingLTVProps {
 
 export function ContentCardMaxLendingLTV({
   maxLendingPercentage,
-  price,
   quoteToken,
   collateralToken,
   isLoading,
@@ -46,7 +44,6 @@ export function ContentCardMaxLendingLTV({
         `${formatted.afterMaxLendingPercentage} ${t('system.cards.common.after')}`,
       variant: changeVariant,
     },
-    footnote: `${formatCryptoBalance(price)} ${quoteToken}`,
     modal: (
       <AjnaDetailsSectionContentSimpleModal
         title={t('ajna.position-page.earn.manage.overview.max-lending-ltv')}

--- a/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
+++ b/features/ajna/positions/earn/controls/AjnaEarnOverviewManageController.tsx
@@ -80,7 +80,6 @@ export function AjnaEarnOverviewManageController() {
           {!isOracless && (
             <ContentCardMaxLendingLTV
               isLoading={isSimulationLoading}
-              price={position.price}
               quoteToken={quoteToken}
               collateralToken={collateralToken}
               maxLendingPercentage={position.maxRiskRatio.loanToValue}


### PR DESCRIPTION
# [Remove footnote from max lending ltv card](https://app.shortcut.com/oazo-apps/story/10354/earn-remove-lending-price-from-below-max-ltv)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed lending price from max lending ltv card footnote
  
## How to test 🧪
  <Please explain how to test your changes>

- visit ajna earn position, max lending ltv card shouldn't have footnote
