### PR TITLE
feat: enable optimism history

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -50,6 +50,7 @@ AJNA_SUBGRAPH_URL=""
 AJNA_SUBGRAPH_URL_GOERLI=""
 REFERRAL_SUBGRAPH_URL=""
 AAVE_SUBGRAPH_URL=""
+AAVE_OPTIMISM_SUBGRAPH_URL=""
 MAINNET_CACHE_URL="https://cache-mainnet-staging.staging.summer.fi/api/v1"
 
 # Notifications

--- a/features/aave/aave-history-support.ts
+++ b/features/aave/aave-history-support.ts
@@ -3,7 +3,7 @@ import { NetworkIds } from 'blockchain/networks'
 export const aaveHistorySupport: Record<number, boolean> = {
   // Mainnets
   [NetworkIds.MAINNET]: true,
-  [NetworkIds.OPTIMISMMAINNET]: false,
+  [NetworkIds.OPTIMISMMAINNET]: true,
   [NetworkIds.ARBITRUMMAINNET]: false,
   [NetworkIds.POLYGONMAINNET]: false,
 

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -24,7 +24,7 @@ export const subgraphsRecord: SubgraphsRecord = {
     [NetworkIds.ARBITRUMGOERLI]: '',
     [NetworkIds.POLYGONMAINNET]: '',
     [NetworkIds.POLYGONMUMBAI]: '',
-    [NetworkIds.OPTIMISMMAINNET]: '',
+    [NetworkIds.OPTIMISMMAINNET]: getConfig()?.publicRuntimeConfig?.aaveSubgraphUrlOptimism,
     [NetworkIds.OPTIMISMGOERLI]: '',
     [NetworkIds.EMPTYNET]: '',
   },

--- a/runtime.config.js
+++ b/runtime.config.js
@@ -22,6 +22,7 @@ const publicRuntimeConfig = {
   ajnaSubgraphUrl: process.env.AJNA_SUBGRAPH_URL,
   ajnaSubgraphUrlGoerli: process.env.AJNA_SUBGRAPH_URL_GOERLI,
   aaveSubgraphUrl: process.env.AAVE_SUBGRAPH_URL,
+  aaveSubgraphUrlOptimism: process.env.AAVE_OPTIMISM_SUBGRAPH_URL,
   rebrandingUrl: process.env.REBRANDING_POST_URL,
   referralSubgraphUrl: process.env.REFERRAL_SUBGRAPH_URL,
 }


### PR DESCRIPTION
# Add optimism Aave history
  
## Changes 👷‍♀️
- Adds config for aave history
- Add new env variable `AAVE_OPTIMISM_SUBGRAPH_URL` 
  
## How to test 🧪
- You can preview example position `/optimism/aave/v3/108#overview` 
