### PR TITLE
Ajna partially liquidated fix

### DIFF
--- a/features/ajna/positions/common/observables/getAjnaPositionAggregatedData.ts
+++ b/features/ajna/positions/common/observables/getAjnaPositionAggregatedData.ts
@@ -64,17 +64,19 @@ function parseAggregatedDataAuction({
 
       const auction = auctions[0]
       const borrowishEvents = mapAjnaBorrowishEvents(history)
+
       const mostRecentHistoryEvent = borrowishEvents[0]
+      const isEventAfterAuction = !['AuctionSettle', 'Kick'].includes(
+        mostRecentHistoryEvent.kind as string,
+      )
 
       const graceTimeRemaining = timeAgo({
         to: new Date(auction.endOfGracePeriod),
       })
 
-      const isDuringGraceTime = auction.endOfGracePeriod - new Date().getTime() > 0
+      const isDuringGraceTime =
+        auction.endOfGracePeriod - new Date().getTime() > 0 && !isEventAfterAuction
       const isBeingLiquidated = !isDuringGraceTime && auction.inLiquidation
-      const isEventAfterAuction = !['AuctionSettle', 'Kick'].includes(
-        mostRecentHistoryEvent.kind as string,
-      )
       const isPartiallyLiquidated =
         mostRecentHistoryEvent.kind === 'AuctionSettle' &&
         ajnaBorrowishPosition.debtAmount.gt(zero) &&

--- a/features/ajna/positions/common/observables/getAjnaPositionAggregatedData.ts
+++ b/features/ajna/positions/common/observables/getAjnaPositionAggregatedData.ts
@@ -1,5 +1,6 @@
 import { AjnaEarnPosition, AjnaPosition } from '@oasisdex/dma-library'
 import { NetworkIds } from 'blockchain/networks'
+import dayjs from 'dayjs'
 import { AjnaGenericPosition, AjnaProduct } from 'features/ajna/common/types'
 import { AjnaUnifiedHistoryEvent } from 'features/ajna/history/ajnaUnifiedHistoryEvent'
 import {
@@ -75,7 +76,7 @@ function parseAggregatedDataAuction({
       })
 
       const isDuringGraceTime =
-        auction.endOfGracePeriod - new Date().getTime() > 0 && !isEventAfterAuction
+        auction.endOfGracePeriod - dayjs().valueOf() > 0 && !isEventAfterAuction
       const isBeingLiquidated = !isDuringGraceTime && auction.inLiquidation
       const isPartiallyLiquidated =
         mostRecentHistoryEvent.kind === 'AuctionSettle' &&


### PR DESCRIPTION
## [Ajna partially liquidated fix](https://app.shortcut.com/oazo-apps/story/10341/partial-liquidation-mesage-is-not-being-shown)

## [Ajna liquidation dodge UI fix](https://app.shortcut.com/oazo-apps/story/10322/borrow-position-is-showing-liquidated-when-it-is-not)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted conditions regarding auctions so the last event is used to determine whether position was partially or completely liquidated
- adjusted condition regarding grace period
  
## How to test 🧪
  <Please explain how to test your changes>

- search for partially / completely liquidated position to check if correct notifications are displayed or do manual testing by mocking values locally
- when user save position during grace period, warning message about grace period should no longer be visible
