### PR TITLE
Config overrides defaults to null instead of actual value

### DIFF
--- a/helpers/clean-object.ts
+++ b/helpers/clean-object.ts
@@ -1,0 +1,55 @@
+import { clone } from 'lodash'
+
+export const cleanObjectToNull = (object: Record<string, any | any[]> | any) => {
+  // this is used to replace everything in config to null, so its easy to change the values in localStorage
+  let newObject = clone(object)
+  if (object !== null) {
+    switch (typeof newObject) {
+      case 'object':
+        if (newObject instanceof Array) {
+          const length = newObject.length
+          for (let i = 0; i < length; i++) {
+            newObject[i] = cleanObjectToNull(newObject[i])
+          }
+        } else {
+          Object.keys(newObject).forEach((key) => {
+            newObject[key] = cleanObjectToNull(newObject[key])
+          })
+        }
+        break
+      default:
+        newObject = null
+        break
+    }
+  }
+  return newObject
+}
+
+export const cleanObjectFromNull = (object: Record<string, any | any[]> | any) => {
+  // this is used to replace everything null in config to undefined
+  // so it doesnt overwrite the actual config (unless its not null, so changed)
+  let newObject = clone(object)
+  if (object !== null) {
+    switch (typeof newObject) {
+      case 'object':
+        if (newObject === null) {
+          newObject = undefined
+        }
+        if (newObject instanceof Array) {
+          const length = newObject.length
+          for (let i = 0; i < length; i++) {
+            newObject[i] = cleanObjectFromNull(newObject[i])
+          }
+        } else {
+          Object.keys(newObject).forEach((key) => {
+            newObject[key] = cleanObjectFromNull(newObject[key])
+          })
+        }
+        break
+      default:
+        newObject = undefined
+        break
+    }
+  }
+  return newObject
+}

--- a/helpers/config/access-config-context.ts
+++ b/helpers/config/access-config-context.ts
@@ -1,5 +1,6 @@
 'use client'
 import { configContext, emptyConfig } from 'components/context/ConfigContextProvider'
+import { cleanObjectFromNull, cleanObjectToNull } from 'helpers/clean-object'
 import {
   ConfigContext,
   configLSKey,
@@ -50,7 +51,7 @@ export function updateConfigOverrides(config: ConfigResponseType): void {
   }
   try {
     const overrideConfig = JSON.parse(overrideConfigRaw)
-    const newOverrideConfig = { ...config, ...overrideConfig }
+    const newOverrideConfig = { ...cleanObjectToNull(config), ...overrideConfig }
     localStorage.setItem(configLSOverridesKey, JSON.stringify(newOverrideConfig))
   } catch (error) {
     console.error('updateConfigOverrides: Error parsing override config from localStorage', error)
@@ -85,7 +86,7 @@ export function loadConfigFromLocalStorage() {
   try {
     const config = {
       ...JSON.parse(configRaw),
-      ...JSON.parse(localStorage.getItem(configLSOverridesKey) ?? '{}'),
+      ...cleanObjectFromNull(JSON.parse(localStorage.getItem(configLSOverridesKey) ?? '{}')),
     }
     return config as ConfigResponseType
   } catch (error) {


### PR DESCRIPTION
# Config overrides defaults to null instead of actual value

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- `ob-config` still has the current config
- `ob-config-overrides` has the current config but the new values are set to null (and then the null values are cleared when overrides are loaded, boolean values stay)
  
## How to test 🧪
- clear you cache
- use `ob-config-overrides` to test feature toggle overriding
