### PR TITLE
Fixes errors on automation context

### DIFF
--- a/features/automation/metadata/aave/stopLossMetadata.ts
+++ b/features/automation/metadata/aave/stopLossMetadata.ts
@@ -33,7 +33,7 @@ import {
 } from 'features/automation/protection/stopLoss/helpers'
 import { StopLossResetData } from 'features/automation/protection/stopLoss/state/StopLossFormChange'
 import { prepareStopLossTriggerDataV2 } from 'features/automation/protection/stopLoss/state/stopLossTriggerData'
-import { getAppConfig } from 'helpers/config'
+import { getLocalAppConfig } from 'helpers/config'
 import { formatPercent } from 'helpers/formatters/format'
 import { one, zero } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
@@ -54,7 +54,7 @@ export function createGetAaveStopLossMetadata(
   networkId: NetworkIds,
 ) {
   return function (context: ContextWithoutMetadata): StopLossMetadata {
-    const { AaveV3ProtectionWrite } = getAppConfig('features')
+    const { AaveV3ProtectionWrite } = getLocalAppConfig('features')
     const {
       automationTriggersData,
       triggerData: {


### PR DESCRIPTION
# Fixes errors on automation context

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- `createGetAaveStopLossMetadata` uses `getLocalAppConfig` instead of `getAppConfig`
  
## How to test 🧪
- go to any aave v3 position, it should not throw errors in the console
