### PR TITLE
Update net borrow cost to cost to borrow

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -833,11 +833,11 @@
       "stop-loss-not-set": "Not set - click to set up stop loss."
     },
     "net-borrow-cost": {
-      "first-header": "Net borrow Cost %",
-      "second-header": "Net borrow cost {{debtToken}}",
-      "first-description-line": "The net borrow cost is the debt APY minus the APY for the collateral supplied.",
+      "first-header": "Cost to borrow %",
+      "second-header": "Cost to borrow {{debtToken}}",
+      "first-description-line": "The cost to borrow is the percentage this position is paying on its net value, using the debt APY minus the APY for the collateral supplied.",
       "second-description-line": "Debt APY * Total Debt * Debt Price/Collateral Price - Lending APY * Total Collateral * Collateral Price",
-      "third-description-line": "The borrow cost expressed in {{debtToken}} amount over one year. This amount is an estimate that changes with the net borrow cost. Your effective real cost will be determined by your PNL.",
+      "third-description-line": "The borrow cost expressed in {{debtToken}} amount over one year. This amount is an estimate that changes with the changes in the rates. Your effective real cost will be determined by your PNL.",
       "positive-negative-line": " If the values are positive you are paying to borrow, if negative you are paid to borrow."
     }
   },
@@ -1224,7 +1224,7 @@
     "remove-trigger": "Remove trigger",
     "add-trigger": "Add trigger",
     "loan-to-value": "Loan to Value",
-    "net-borrow-cost": "Net Borrow Cost",
+    "net-borrow-cost": "Cost to Borrow",
     "position-debt": "Position Debt",
     "current-token-price": "Current {{token}} Price",
     "next-token-price": "Next {{token}} Price"
@@ -2838,8 +2838,8 @@
       "multiply": {
         "common": {
           "overview": {
-            "net-borrow-cost": "Net Borrow Cost",
-            "net-borrow-cost-modal-desc": "The net borrow cost rate represents how much your debt will increase in one year at the current market utilization. This rate is variable, changing every 12 hours with utilization in the pool.",
+            "net-borrow-cost": "Borrow rate",
+            "net-borrow-cost-modal-desc": "The borrow rate represents how much your debt will increase in one year at the current market utilization. This rate is variable, changing every 12 hours with utilization in the pool.",
             "net-value": "Net Value",
             "pnl": "P&L"
           },


### PR DESCRIPTION
#  Update net borrow cost to cost to borrow

We are using a calculation that calculates the cost to borrow based on your net value. The current wording is confusing, as it seems it is just using the borrow rate.