### PR TITLE
Extend product finder database

### DIFF
--- a/features/poolFinder/helpers/parsePoolResponse.ts
+++ b/features/poolFinder/helpers/parsePoolResponse.ts
@@ -1,4 +1,5 @@
 import { getPoolLiquidity } from '@oasisdex/dma-library'
+import { EarnStrategies } from '@prisma/client'
 import BigNumber from 'bignumber.js'
 import type { IdentifiedTokens } from 'blockchain/identifyTokens.types'
 import type { NetworkIds } from 'blockchain/networks'
@@ -16,8 +17,6 @@ import {
 } from 'features/productHub/content'
 import { formatCryptoBalance } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
-
-import { EarnStrategies } from '.prisma/client'
 
 export function parsePoolResponse(
   chainId: NetworkIds,

--- a/features/poolFinder/helpers/parsePoolResponse.ts
+++ b/features/poolFinder/helpers/parsePoolResponse.ts
@@ -17,6 +17,8 @@ import {
 import { formatCryptoBalance } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
 
+import { EarnStrategies } from '.prisma/client'
+
 export function parsePoolResponse(
   chainId: NetworkIds,
   identifiedTokens: IdentifiedTokens,
@@ -70,7 +72,8 @@ export function parsePoolResponse(
             weeklyNetApy,
           }),
           liquidity,
-          earnStrategy: `${collateralToken}/${quoteToken} LP`,
+          earnStrategy: EarnStrategies.liquidity_provision,
+          earnStrategyDescription: `${collateralToken}/${quoteToken} LP`,
           fee,
           managementType: 'active',
           collateralAddress: collateralAddress,

--- a/features/poolFinder/helpers/parseRows.tsx
+++ b/features/poolFinder/helpers/parseRows.tsx
@@ -22,6 +22,7 @@ export function parseRows(
       collateralAddress,
       collateralToken,
       earnStrategy,
+      earnStrategyDescription,
       fee,
       liquidity,
       managementType,
@@ -51,6 +52,7 @@ export function parseRows(
       ...parseProduct(
         {
           earnStrategy,
+          earnStrategyDescription,
           fee,
           label,
           liquidity,

--- a/features/poolFinder/types.ts
+++ b/features/poolFinder/types.ts
@@ -1,5 +1,7 @@
 import type { ProductHubItemTooltips, ProductHubManagementType } from 'features/productHub/types'
 
+import type { EarnStrategies } from '.prisma/client'
+
 export interface SearchTokensResponse {
   symbol: string
   address: string
@@ -14,7 +16,8 @@ export interface PoolFinderFormState {
 export interface OraclessPoolResult extends ProductHubItemTooltips {
   collateralAddress: string
   collateralToken: string
-  earnStrategy?: string
+  earnStrategy?: EarnStrategies
+  earnStrategyDescription?: string
   fee?: string
   liquidity?: string
   managementType?: ProductHubManagementType

--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -6,6 +6,8 @@ import { ProductHubProductType } from 'features/productHub/types'
 import { getLocalAppConfig } from 'helpers/config'
 import { LendingProtocol } from 'lendingProtocols'
 
+import { EarnStrategies } from '.prisma/client'
+
 export const getAaveLikeViewStrategyUrl = ({
   aaveLikeProduct,
   bypassFeatureFlag,
@@ -67,7 +69,7 @@ export function getActionUrl({
         chainId,
       })
       const productInUrl =
-        isEarnProduct && earnStrategy?.includes('Yield Loop')
+        isEarnProduct && earnStrategy?.includes(EarnStrategies.yield_loop)
           ? ProductHubProductType.Multiply
           : product
       const tokensInUrl = isOracless

--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -1,3 +1,4 @@
+import { EarnStrategies } from '@prisma/client'
 import type { NetworkIds } from 'blockchain/networks'
 import { strategies as aaveStrategyList } from 'features/aave'
 import { isPoolOracless } from 'features/ajna/common/helpers/isOracless'
@@ -5,8 +6,6 @@ import type { ProductHubItem } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { getLocalAppConfig } from 'helpers/config'
 import { LendingProtocol } from 'lendingProtocols'
-
-import { EarnStrategies } from '.prisma/client'
 
 export const getAaveLikeViewStrategyUrl = ({
   aaveLikeProduct,

--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -68,7 +68,7 @@ export function getActionUrl({
         chainId,
       })
       const productInUrl =
-        isEarnProduct && earnStrategy?.includes(EarnStrategies.yield_loop)
+        isEarnProduct && earnStrategy === EarnStrategies.yield_loop
           ? ProductHubProductType.Multiply
           : product
       const tokensInUrl = isOracless

--- a/features/productHub/helpers/parseProduct.tsx
+++ b/features/productHub/helpers/parseProduct.tsx
@@ -123,7 +123,9 @@ export function parseProduct(
         strategy: (
           <>
             {earnStrategyDescription || <AssetsTableDataCellInactive />}
-            {tooltips?.earnStrategy && <AssetsTableTooltip {...tooltips.earnStrategy} />}
+            {tooltips?.earnStrategyDescription && (
+              <AssetsTableTooltip {...tooltips.earnStrategyDescription} />
+            )}
           </>
         ),
         management: (

--- a/features/productHub/helpers/parseProduct.tsx
+++ b/features/productHub/helpers/parseProduct.tsx
@@ -20,7 +20,7 @@ const yieldLoopStables = [
 
 export function parseProduct(
   {
-    earnStrategy,
+    earnStrategyDescription,
     fee: feeString,
     liquidity: liquidityString,
     managementType,
@@ -122,7 +122,7 @@ export function parseProduct(
       return {
         strategy: (
           <>
-            {earnStrategy || <AssetsTableDataCellInactive />}
+            {earnStrategyDescription || <AssetsTableDataCellInactive />}
             {tooltips?.earnStrategy && <AssetsTableTooltip {...tooltips.earnStrategy} />}
           </>
         ),
@@ -140,7 +140,7 @@ export function parseProduct(
           sortable: weeklyNetApy?.toNumber() || 0,
           value: (
             <>
-              {earnStrategy && yieldLoopStables.includes(earnStrategy) ? (
+              {earnStrategyDescription && yieldLoopStables.includes(earnStrategyDescription) ? (
                 <AppLink href="https://dune.com/Lucianken/aave-v3-sdai-yield-multiple">
                   <WithArrow>APY</WithArrow>
                 </AppLink>

--- a/features/productHub/types.ts
+++ b/features/productHub/types.ts
@@ -3,6 +3,8 @@ import type { AssetsTableTooltipProps } from 'components/assetsTable/cellCompone
 import type { PromoCardProps } from 'components/PromoCard.types'
 import type { LendingProtocol } from 'lendingProtocols'
 
+import type { EarnStrategies } from '.prisma/client'
+
 export type ProductHubMultiplyStrategyType = 'long' | 'short'
 export type ProductHubManagementType = 'active' | 'passive'
 
@@ -36,7 +38,8 @@ export interface ProductHubItemBasics {
 export interface ProductHubItemDetails {
   weeklyNetApy?: string
   depositToken?: string
-  earnStrategy?: string
+  earnStrategy?: EarnStrategies
+  earnStrategyDescription?: string
   fee?: string
   liquidity?: string
   managementType?: ProductHubManagementType
@@ -45,6 +48,7 @@ export interface ProductHubItemDetails {
   multiplyStrategy?: string
   multiplyStrategyType?: ProductHubMultiplyStrategyType
   reverseTokens?: boolean
+  hasRewards?: boolean
 }
 
 export interface ProductHubItemTooltips {

--- a/handlers/product-hub/update-handlers/aaveV2/aaveV2Products.ts
+++ b/handlers/product-hub/update-handlers/aaveV2/aaveV2Products.ts
@@ -1,9 +1,8 @@
+import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
 import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import { EarnStrategies } from '.prisma/client'
 
 export const aaveV2ProductHubProducts: ProductHubItemWithoutAddress[] = [
   {

--- a/handlers/product-hub/update-handlers/aaveV2/aaveV2Products.ts
+++ b/handlers/product-hub/update-handlers/aaveV2/aaveV2Products.ts
@@ -3,6 +3,8 @@ import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
+import { EarnStrategies } from '.prisma/client'
+
 export const aaveV2ProductHubProducts: ProductHubItemWithoutAddress[] = [
   {
     product: [ProductHubProductType.Multiply],
@@ -45,7 +47,8 @@ export const aaveV2ProductHubProducts: ProductHubItemWithoutAddress[] = [
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV2,
     label: 'STETH/ETH',
-    earnStrategy: 'STETH/ETH Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'STETH/ETH Yield Loop',
     managementType: 'active',
   },
 ]

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/arbitrum-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/arbitrum-mainnet.ts
@@ -1,10 +1,10 @@
+import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
 import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
 import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
-import { EarnStrategies } from '.prisma/client'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/arbitrum-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/arbitrum-mainnet.ts
@@ -4,6 +4,7 @@ import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
 import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
+import { EarnStrategies } from '.prisma/client'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {
@@ -132,7 +133,8 @@ const earnProducts = aaveSeed
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.arbitrumMainnet,
       protocol: LendingProtocol.AaveV3,
-      earnStrategy: `${strategy.collateral}/${strategy.debt} Yield Loop`,
+      earnStrategyDescription: `${strategy.collateral}/${strategy.debt} Yield Loop`,
+      earnStrategy: EarnStrategies.yield_loop,
       managementType: 'active',
     }
   })

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/ethereum-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/ethereum-mainnet.ts
@@ -3,6 +3,8 @@ import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
+import { EarnStrategies } from '.prisma/client'
+
 export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddress[] = [
   // ethereum products
   {
@@ -14,7 +16,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'WSTETH/ETH',
-    earnStrategy: 'WSTETH/ETH Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'WSTETH/ETH Yield Loop',
     managementType: 'active',
   },
   {
@@ -35,7 +38,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'RETH/ETH',
-    earnStrategy: 'RETH/ETH Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'RETH/ETH Yield Loop',
     managementType: 'active',
   },
   {
@@ -56,7 +60,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'CBETH/ETH',
-    earnStrategy: 'CBETH/ETH Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'CBETH/ETH Yield Loop',
     managementType: 'active',
   },
   {
@@ -365,7 +370,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'SDAI/USDC',
-    earnStrategy: 'SDAI/USDC Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'SDAI/USDC Yield Loop',
     managementType: 'active',
   },
   {
@@ -386,7 +392,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'SDAI/LUSD',
-    earnStrategy: 'SDAI/LUSD Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'SDAI/LUSD Yield Loop',
     managementType: 'active',
   },
   {
@@ -408,7 +415,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'SDAI/FRAX',
-    earnStrategy: 'SDAI/FRAX Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'SDAI/FRAX Yield Loop',
     managementType: 'active',
   },
   {
@@ -429,7 +437,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'SDAI/DAI',
-    earnStrategy: 'SDAI/DAI Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'SDAI/DAI Yield Loop',
     managementType: 'active',
   },
 ]

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/ethereum-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/ethereum-mainnet.ts
@@ -1,9 +1,8 @@
+import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
 import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import { EarnStrategies } from '.prisma/client'
 
 export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddress[] = [
   // ethereum products

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/optimims-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/optimims-mainnet.ts
@@ -1,10 +1,10 @@
+import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
 import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
 import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
-import { EarnStrategies } from '.prisma/client'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/optimims-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/optimims-mainnet.ts
@@ -4,6 +4,7 @@ import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
 import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
+import { EarnStrategies } from '.prisma/client'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {
@@ -111,7 +112,8 @@ const earnProducts = aaveSeed
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.optimismMainnet,
       protocol: LendingProtocol.AaveV3,
-      earnStrategy: `${strategy.collateral}/${strategy.debt} Yield Loop`,
+      earnStrategyDescription: `${strategy.collateral}/${strategy.debt} Yield Loop`,
+      earnStrategy: EarnStrategies.yield_loop,
       managementType: 'active',
     }
   })

--- a/handlers/product-hub/update-handlers/aaveV3/aaveV3Handler.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aaveV3Handler.ts
@@ -171,6 +171,7 @@ export default async function (tickers: Tickers): ProductHubHandlerResponse {
           liquidity: liquidity.toString(),
           fee: fee.toString(),
           weeklyNetApy: flattenYields[`${label}-${network}`]?.toString(),
+          hasRewards: false,
         }
       }),
       warnings: [],

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -29,6 +29,8 @@ import { one, zero } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
 import { uniq } from 'lodash'
 
+import { EarnStrategies } from '.prisma/client'
+
 async function getAjnaPoolData(
   networkId: NetworkIds.MAINNET | NetworkIds.GOERLI,
   tickers: Tickers,
@@ -156,6 +158,7 @@ async function getAjnaPoolData(
                 // }),
                 primaryTokenAddress: collateralTokenAddress.toLowerCase(),
                 secondaryTokenAddress: quoteTokenAddress.toLowerCase(),
+                hasRewards: isPoolWithRewards({ collateralToken, quoteToken }),
                 tooltips: {
                   ...(isPoolWithRewards({ collateralToken, quoteToken }) && {
                     fee: productHubAjnaRewardsTooltip,
@@ -185,7 +188,8 @@ async function getAjnaPoolData(
                 protocol,
                 secondaryToken: collateralToken,
                 ...getTokenGroup(collateralToken, 'secondary'),
-                earnStrategy: earnLPStrategy,
+                earnStrategy: EarnStrategies.liquidity_provision,
+                earnStrategyDescription: earnLPStrategy,
                 liquidity,
                 managementType,
                 ...(isPoolNotEmpty && {
@@ -194,6 +198,7 @@ async function getAjnaPoolData(
                 reverseTokens: true,
                 primaryTokenAddress: quoteTokenAddress.toLowerCase(),
                 secondaryTokenAddress: collateralTokenAddress.toLowerCase(),
+                hasRewards: isPoolWithRewards({ collateralToken, quoteToken }),
                 tooltips: {
                   ...(isPoolNotEmpty &&
                     isPoolWithRewards({ collateralToken, quoteToken }) && {

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -1,4 +1,5 @@
 import { getPoolLiquidity } from '@oasisdex/dma-library'
+import { EarnStrategies } from '@prisma/client'
 import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { NetworkIds, networksById } from 'blockchain/networks'
@@ -28,8 +29,6 @@ import type {
 import { one, zero } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
 import { uniq } from 'lodash'
-
-import { EarnStrategies } from '.prisma/client'
 
 async function getAjnaPoolData(
   networkId: NetworkIds.MAINNET | NetworkIds.GOERLI,

--- a/handlers/product-hub/update-handlers/maker/makerHandler.ts
+++ b/handlers/product-hub/update-handlers/maker/makerHandler.ts
@@ -132,6 +132,7 @@ async function getMakerData(
                 .decimalPlaces(5, BigNumber.ROUND_UP)
                 .minus(1)
                 .toString(),
+              hasRewards: false,
             }
           }
           const ilk = getIlk(label)
@@ -149,6 +150,7 @@ async function getMakerData(
             fee: fee.toString(),
             maxMultiply: maxMultiple.toString(),
             maxLtv: maxLtv.toString(),
+            hasRewards: false,
           }
         })
         .filter(Boolean) as ProductHubItem[],

--- a/handlers/product-hub/update-handlers/maker/makerProducts.ts
+++ b/handlers/product-hub/update-handlers/maker/makerProducts.ts
@@ -1,8 +1,7 @@
+import { EarnStrategies } from '@prisma/client'
 import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import { EarnStrategies } from '.prisma/client'
 
 // network is added in the handler
 export const makerProductHubProducts: Omit<ProductHubItemWithoutAddress, 'network'>[] = [

--- a/handlers/product-hub/update-handlers/maker/makerProducts.ts
+++ b/handlers/product-hub/update-handlers/maker/makerProducts.ts
@@ -2,6 +2,8 @@ import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
+import { EarnStrategies } from '.prisma/client'
+
 // network is added in the handler
 export const makerProductHubProducts: Omit<ProductHubItemWithoutAddress, 'network'>[] = [
   {
@@ -107,6 +109,7 @@ export const makerProductHubProducts: Omit<ProductHubItemWithoutAddress, 'networ
     protocol: LendingProtocol.Maker,
     label: 'DSR',
     managementType: 'passive',
-    earnStrategy: 'DAI Savings Rate',
+    earnStrategy: EarnStrategies.other,
+    earnStrategyDescription: 'DAI Savings Rate',
   },
 ]

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Handler.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Handler.ts
@@ -156,6 +156,8 @@ export default async function (tickers: Tickers): ProductHubHandlerResponse {
           tokensReserveConfigurationData.find((data) => data[primaryToken]),
         )[primaryToken]
         const tokensAddresses = getNetworkContracts(NetworkIds.MAINNET).tokens
+        // rewards are available for the ETH-like/DAI pairs
+        const hasRewards = primaryTokenGroup === 'ETH' && secondaryToken === 'DAI'
 
         return {
           ...product,
@@ -169,13 +171,10 @@ export default async function (tickers: Tickers): ProductHubHandlerResponse {
           liquidity: liquidity.toString(),
           fee: fee.toString(),
           tooltips: {
-            fee:
-              // rewards are available for the ETHlike/DAI pairs
-              primaryTokenGroup === 'ETH' && secondaryToken === 'DAI'
-                ? productHubSparkRewardsTooltip
-                : undefined,
+            fee: hasRewards ? productHubSparkRewardsTooltip : undefined,
           },
           weeklyNetApy: weeklyNetApy?.[label] ? weeklyNetApy[label]?.toString() : undefined,
+          hasRewards,
         }
       }),
       warnings: [],

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
@@ -1,9 +1,8 @@
+import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
 import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import { EarnStrategies } from '.prisma/client'
 
 export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
   {

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
@@ -3,6 +3,8 @@ import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
+import { EarnStrategies } from '.prisma/client'
+
 export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
   {
     product: [ProductHubProductType.Multiply],
@@ -101,7 +103,8 @@ export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.SparkV3,
     label: 'WSTETH/ETH',
-    earnStrategy: 'WSTETH/ETH Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'WSTETH/ETH Yield Loop',
     managementType: 'active',
   },
   {
@@ -113,7 +116,8 @@ export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.SparkV3,
     label: 'RETH/ETH',
-    earnStrategy: 'RETH/ETH Yield Loop',
+    earnStrategy: EarnStrategies.yield_loop,
+    earnStrategyDescription: 'RETH/ETH Yield Loop',
     managementType: 'active',
   },
 ]

--- a/server/database/migrations/032-product-hub-rewards.sql
+++ b/server/database/migrations/032-product-hub-rewards.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "earnStrategies" AS ENUM ('liquidity_provision', 'yield_loop', 'other');
+
+ALTER TABLE "product_hub_items"
+  ADD COLUMN "hasRewards" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "earnStrategyDescription" TEXT;
+
+UPDATE "product_hub_items"
+  SET "earnStrategyDescription"="earnStrategy";
+
+ALTER TABLE "product_hub_items"
+  DROP COLUMN "earnStrategy",
+  ADD COLUMN "earnStrategy" "earnStrategies";
+

--- a/server/database/schema.prisma
+++ b/server/database/schema.prisma
@@ -228,30 +228,32 @@ model UsersWhoFollowVaults {
 }
 
 model ProductHubItems {
-  id                    String                      @id @default(uuid())
-  label                 String
-  network               NetworkNamesWithTestnets
-  primaryToken          String
-  primaryTokenGroup     String?
-  product               Product[]
-  protocol              Protocol
-  secondaryToken        String
-  secondaryTokenGroup   String?
-  weeklyNetApy          String?
-  depositToken          String?
-  earnStrategy          String?
-  fee                   String?
-  liquidity             String?
-  managementType        ProductHubManagementSimple?
-  maxLtv                String?
-  maxMultiply           String?
-  multiplyStrategy      String?
-  multiplyStrategyType  ProductHubStrategy?
-  reverseTokens         Boolean?
-  updatedAt             DateTime                    @updatedAt
-  tooltips              Json?
-  primaryTokenAddress   String                      @default("0x0000000000000000000000000000000000000000")
-  secondaryTokenAddress String                      @default("0x0000000000000000000000000000000000000000")
+  id                      String                      @id @default(uuid())
+  label                   String
+  network                 NetworkNamesWithTestnets
+  primaryToken            String
+  primaryTokenGroup       String?
+  product                 Product[]
+  protocol                Protocol
+  secondaryToken          String
+  secondaryTokenGroup     String?
+  weeklyNetApy            String?
+  depositToken            String?
+  earnStrategy            EarnStrategies?
+  earnStrategyDescription String?
+  fee                     String?
+  liquidity               String?
+  managementType          ProductHubManagementSimple?
+  maxLtv                  String?
+  maxMultiply             String?
+  multiplyStrategy        String?
+  multiplyStrategyType    ProductHubStrategy?
+  reverseTokens           Boolean?
+  updatedAt               DateTime                    @updatedAt
+  tooltips                Json?
+  primaryTokenAddress     String                      @default("0x0000000000000000000000000000000000000000")
+  secondaryTokenAddress   String                      @default("0x0000000000000000000000000000000000000000")
+  hasRewards              Boolean                     @default(false)
 
   @@unique([label, network, product, protocol, primaryToken, secondaryToken], name: "product_hub_item_id")
   @@map("product_hub_items")
@@ -310,6 +312,14 @@ enum ProductHubManagementSimple {
   passive
 
   @@map("managementTypeSimple")
+}
+
+enum EarnStrategies {
+  liquidity_provision
+  yield_loop
+  other
+
+  @@map("earnStrategies")
 }
 
 enum ProductHubStrategy {


### PR DESCRIPTION
# [Extend product finder database](https://app.shortcut.com/oazo-apps/story/12064/extend-product-finder-database)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- `earnStrategy` in db is now enum, values from this column copied to new column `earnStrategyDescription`
- handled change described above in all product-hub related handlers
- added `hasRewards` column
  
## How to test 🧪
  <Please explain how to test your changes>

- response from db regarding product-hub should contain additional property `earnStrategyDescription` and `earnStrategy` should be an enum value
- everything should work as before, no functional changes
