### PR TITLE
Bring back link in navigation

### DIFF
--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -3,8 +3,13 @@ import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
 import { Navigation, navigationBreakpoints } from 'components/navigation/Navigation'
 import { SwapWidgetShowHide } from 'components/swapWidget/SwapWidgetShowHide'
 import { NavigationActionsController } from 'features/navigation/controls/NavigationActionsController'
+import {
+  SWAP_WIDGET_CHANGE_SUBJECT,
+  SwapWidgetChangeAction,
+} from 'features/swapWidget/SwapWidgetChange'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAppConfig } from 'helpers/config'
+import { uiChanges } from 'helpers/uiChanges'
 import { useAccount } from 'helpers/useAccount'
 import { LendingProtocol } from 'lendingProtocols'
 import { lendingProtocolsByName } from 'lendingProtocols/lendingProtocolsConfigs'
@@ -68,6 +73,34 @@ export function NavigationController() {
     <>
       <Navigation
         links={[
+          ...(!isNewNavigationEnabled
+            ? [
+                {
+                  label: 'Borrow',
+                  link: INTERNAL_LINKS.borrow,
+                },
+                {
+                  label: 'Multiply',
+                  link: INTERNAL_LINKS.multiply,
+                },
+                {
+                  label: 'Earn',
+                  link: INTERNAL_LINKS.earn,
+                },
+              ]
+            : []),
+          ...(!isNewNavigationEnabled && isConnected && !isViewBelowXl
+            ? [
+                {
+                  label: 'Swap',
+                  onClick: () => {
+                    uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+                      type: 'open',
+                    })
+                  },
+                },
+              ]
+            : []),
           ...(isConnected && !isViewBelowXl
             ? [
                 {

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -4,8 +4,8 @@ import { Navigation, navigationBreakpoints } from 'components/navigation/Navigat
 import { SwapWidgetShowHide } from 'components/swapWidget/SwapWidgetShowHide'
 import { NavigationActionsController } from 'features/navigation/controls/NavigationActionsController'
 import {
-  SWAP_WIDGET_CHANGE_SUBJECT,
   type SwapWidgetChangeAction,
+  SWAP_WIDGET_CHANGE_SUBJECT,
 } from 'features/swapWidget/SwapWidgetChange'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAppConfig } from 'helpers/config'

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -5,7 +5,7 @@ import { SwapWidgetShowHide } from 'components/swapWidget/SwapWidgetShowHide'
 import { NavigationActionsController } from 'features/navigation/controls/NavigationActionsController'
 import {
   SWAP_WIDGET_CHANGE_SUBJECT,
-  SwapWidgetChangeAction,
+  type SwapWidgetChangeAction,
 } from 'features/swapWidget/SwapWidgetChange'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAppConfig } from 'helpers/config'


### PR DESCRIPTION
# Bring back link in navigation

Brought back links that were mistakenly removed from navigation when `NewNavigation` feature flag is off.
