### PR TITLE
Add missing getTokenGroup mapper

### DIFF
--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -88,7 +88,7 @@ export const getNavProductsPanel = ({
                     [capitalize(item.protocol), lendingProtocolsByName[item.protocol].gradient],
                     [capitalize(item.network), networksByName[item.network].gradient],
                   ] as NavigationMenuPanelListTags,
-                  url: `${INTERNAL_LINKS.earn}/${item.primaryToken}`,
+                  url: `${INTERNAL_LINKS.earn}/${getTokenGroup(item.primaryToken)}`,
                 })),
               ],
               link: {
@@ -117,7 +117,7 @@ export const getNavProductsPanel = ({
                     [capitalize(item.protocol), lendingProtocolsByName[item.protocol].gradient],
                     [capitalize(item.network), networksByName[item.network].gradient],
                   ] as NavigationMenuPanelListTags,
-                  url: `${INTERNAL_LINKS.multiply}/${item.collateralToken}`,
+                  url: `${INTERNAL_LINKS.multiply}/${getTokenGroup(item.collateralToken)}`,
                 })),
               ],
               link: {


### PR DESCRIPTION
# [Add missing getTokenGroup mapper](https://app.shortcut.com/oazo-apps/story/12115/aave-v3-products-render-page-not-found)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added `getTokenGroup` in places that were missed
  
## How to test 🧪
  <Please explain how to test your changes>

- in nav Product -> Earn -> Yield Loop WSTETH should redirect to `earn/ETH`
