### PR TITLE
Fix issue with lps on owner page

### DIFF
--- a/features/ajna/positions/earn/helpers/getAjnaEarnData.ts
+++ b/features/ajna/positions/earn/helpers/getAjnaEarnData.ts
@@ -38,7 +38,7 @@ export const getAjnaEarnData: (networkId: NetworkIds) => GetEarnData =
         ),
       }
 
-      if (!earnPosition) {
+      if (!earnPosition || !earnPosition.bucketPositions.length) {
         return {
           ...defaultResponse,
           ...cumulativeValues,

--- a/helpers/context/ProductContext.ts
+++ b/helpers/context/ProductContext.ts
@@ -981,6 +981,7 @@ export function setupProductContext(
 
   const ownersPositionsList$ = memoize(
     curry(createPositionsList$)(positionsList$, aaveLikePositions$, ajnaPositions$, dsr$),
+    (walletAddress: string) => walletAddress,
   )
 
   const followedList$ = memoize(


### PR DESCRIPTION
# [Fix issue with lps on owner page](https://app.shortcut.com/oazo-apps/story/12119/reading-lps-on-undefined-on-owner-page)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added additional condition to verify whether buckets length is > 0
  
## How to test 🧪
  <Please explain how to test your changes>

- visiting owner page with following address `0x10649c79428d718621821cf6299e91920284743f` shouldn't throw error regarding reading data `lps` of undefined

![image](https://github.com/OasisDEX/oasis-borrow/assets/39706811/b86b64c3-6b94-4e14-b5cd-8df26335b5d7)

