### PR TITLE
Add strategies specific direct links to nav

### DIFF
--- a/features/navigation/helpers/getProductBorrowNavItems.ts
+++ b/features/navigation/helpers/getProductBorrowNavItems.ts
@@ -1,3 +1,4 @@
+import { getActionUrl } from 'features/productHub/helpers'
 import type { ProductHubItem, ProductHubSupportedNetworks } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import type { LendingProtocol } from 'lendingProtocols'
@@ -8,6 +9,7 @@ type ProductBorrowNavItem = {
   primaryToken: string
   secondaryToken: string
   network: ProductHubSupportedNetworks
+  url: string
 }
 
 type ProductBorrowNavItems = {
@@ -22,6 +24,7 @@ const getProductBorrowInitNavItem = (startingValue: number): ProductBorrowNavIte
   secondaryToken: '',
   protocol: '' as LendingProtocol,
   network: '' as ProductHubSupportedNetworks,
+  url: '',
 })
 
 export const getProductBorrowNavItems = (
@@ -47,13 +50,19 @@ export const getProductBorrowNavItems = (
               ? acc.maxLtv.secondaryToken
               : curr.secondaryToken,
             network: accMaxLtvHigherThanCurr ? acc.maxLtv.network : curr.network,
+            url: accMaxLtvHigherThanCurr
+              ? acc.maxLtv.url
+              : getActionUrl({ ...curr, product: [ProductHubProductType.Borrow] }),
           },
           fee: {
             value: accFeeLowerThanCurr ? acc.fee.value : Number(curr.fee),
             protocol: accFeeLowerThanCurr ? acc.fee.protocol : curr.protocol,
             primaryToken: accFeeLowerThanCurr ? acc.fee.primaryToken : curr.primaryToken,
             secondaryToken: accFeeLowerThanCurr ? acc.fee.secondaryToken : curr.secondaryToken,
-            network: accFeeLowerThanCurr ? acc.maxLtv.network : curr.network,
+            network: accFeeLowerThanCurr ? acc.fee.network : curr.network,
+            url: accFeeLowerThanCurr
+              ? acc.fee.url
+              : getActionUrl({ ...curr, product: [ProductHubProductType.Borrow] }),
           },
           liquidity: {
             value: accLiquidityHigherThanCurr ? acc.liquidity.value : Number(curr.liquidity),
@@ -64,7 +73,10 @@ export const getProductBorrowNavItems = (
             secondaryToken: accLiquidityHigherThanCurr
               ? acc.liquidity.secondaryToken
               : curr.secondaryToken,
-            network: accLiquidityHigherThanCurr ? acc.maxLtv.network : curr.network,
+            network: accLiquidityHigherThanCurr ? acc.liquidity.network : curr.network,
+            url: accLiquidityHigherThanCurr
+              ? acc.liquidity.url
+              : getActionUrl({ ...curr, product: [ProductHubProductType.Borrow] }),
           },
         }
       },

--- a/features/navigation/helpers/getProductEarnNavItems.ts
+++ b/features/navigation/helpers/getProductEarnNavItems.ts
@@ -6,7 +6,7 @@ export const getProductEarnNavItems = (
   promoCards: ProductHubPromoCards,
   productHub: ProductHubItem[],
 ) => {
-  const data: ProductHubItem[] = []
+  const data: (ProductHubItem & { url?: string })[] = []
 
   promoCards.earn.default.forEach((promoCard) => {
     const foundItem = productHub.find(
@@ -20,7 +20,7 @@ export const getProductEarnNavItems = (
         item.protocol === promoCard.protocol.protocol &&
         item.product.includes(ProductHubProductType.Earn),
     )
-    if (foundItem) data.push(foundItem)
+    if (foundItem) data.push({ ...foundItem, url: promoCard.link?.href })
   })
 
   return data.map((item) => ({
@@ -32,5 +32,6 @@ export const getProductEarnNavItems = (
     earnStrategy: item.earnStrategy,
     earnStrategyDescription: item.earnStrategyDescription,
     reverseTokens: item.reverseTokens,
+    url: item.url,
   }))
 }

--- a/features/navigation/helpers/getProductMultiplyNavItems.ts
+++ b/features/navigation/helpers/getProductMultiplyNavItems.ts
@@ -5,7 +5,7 @@ export const getProductMultiplyNavItems = (
   promoCards: ProductHubPromoCards,
   productHub: ProductHubItem[],
 ) => {
-  const data: ProductHubItem[] = []
+  const data: (ProductHubItem & { url?: string })[] = []
 
   promoCards.multiply.default.forEach((promoCard) => {
     const foundItem = productHub.find(
@@ -17,7 +17,7 @@ export const getProductMultiplyNavItems = (
         item.product.includes(ProductHubProductType.Multiply),
     )
 
-    if (foundItem) data.push(foundItem)
+    if (foundItem) data.push({ ...foundItem, url: promoCard.link?.href })
   })
 
   return data.map((item) => ({
@@ -26,5 +26,6 @@ export const getProductMultiplyNavItems = (
     debtToken: item.secondaryToken,
     protocol: item.protocol,
     network: item.network,
+    url: item.url,
   }))
 }

--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -15,7 +15,6 @@ import {
 import type { ProductHubItem, ProductHubPromoCards } from 'features/productHub/types'
 import type { SwapWidgetChangeAction } from 'features/swapWidget/SwapWidgetChange'
 import { SWAP_WIDGET_CHANGE_SUBJECT } from 'features/swapWidget/SwapWidgetChange'
-import { getTokenGroup } from 'handlers/product-hub/helpers'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import { uiChanges } from 'helpers/uiChanges'
@@ -88,7 +87,7 @@ export const getNavProductsPanel = ({
                     [capitalize(item.protocol), lendingProtocolsByName[item.protocol].gradient],
                     [capitalize(item.network), networksByName[item.network].gradient],
                   ] as NavigationMenuPanelListTags,
-                  url: `${INTERNAL_LINKS.earn}/${getTokenGroup(item.primaryToken)}`,
+                  url: item.url,
                 })),
               ],
               link: {
@@ -117,7 +116,7 @@ export const getNavProductsPanel = ({
                     [capitalize(item.protocol), lendingProtocolsByName[item.protocol].gradient],
                     [capitalize(item.network), networksByName[item.network].gradient],
                   ] as NavigationMenuPanelListTags,
-                  url: `${INTERNAL_LINKS.multiply}/${getTokenGroup(item.collateralToken)}`,
+                  url: item.url,
                 })),
               ],
               link: {
@@ -155,9 +154,7 @@ export const getNavProductsPanel = ({
                       networksByName[productBorrowNavItems.maxLtv.network].gradient,
                     ],
                   ],
-                  url: `${INTERNAL_LINKS.borrow}/${getTokenGroup(
-                    productBorrowNavItems.maxLtv.primaryToken,
-                  )}`,
+                  url: productBorrowNavItems.maxLtv.url,
                 },
                 {
                   title: t('nav.borrow-lowest-fee', {
@@ -182,9 +179,7 @@ export const getNavProductsPanel = ({
                       networksByName[productBorrowNavItems.fee.network].gradient,
                     ],
                   ],
-                  url: `${INTERNAL_LINKS.borrow}/${getTokenGroup(
-                    productBorrowNavItems.fee.primaryToken,
-                  )}`,
+                  url: productBorrowNavItems.fee.url,
                 },
                 {
                   title: t('nav.earn-rewards-while-borrowing'),
@@ -206,9 +201,7 @@ export const getNavProductsPanel = ({
                       networksByName[productBorrowNavItems.liquidity.network].gradient,
                     ],
                   ],
-                  url: `${INTERNAL_LINKS.borrow}/${getTokenGroup(
-                    productBorrowNavItems.liquidity.primaryToken,
-                  )}`,
+                  url: productBorrowNavItems.liquidity.url,
                 },
               ],
               link: {


### PR DESCRIPTION
# [Add strategies specific direct links to nav](https://app.shortcut.com/oazo-apps/story/12114/specific-strategies-that-are-singular-should-link-to-the-open-flow-of-that-strategy)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- links in nav Products items should redirect to open flows of specific strategy
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
