### PR TITLE
Subgraph calls absolute url

### DIFF
--- a/features/subgraphLoader/useSubgraphLoader.ts
+++ b/features/subgraphLoader/useSubgraphLoader.ts
@@ -22,7 +22,9 @@ export async function loadSubgraph<
   networkId: NetworkIds,
   params: P = {} as P,
 ): Promise<SubgraphsResponses[S][keyof SubgraphsResponses[S]]> {
-  const response = await fetch(`/api/subgraph`, {
+  const resolvedUrl = global.window?.location.origin || 'http://localhost:3000'
+
+  const response = await fetch(`${resolvedUrl}/api/subgraph`, {
     method: 'POST',
     body: JSON.stringify({
       subgraph,


### PR DESCRIPTION
# Subgraph calls absolute url

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added condition to use absolute paths when calling subgraph endpoint
  
## How to test 🧪
  <Please explain how to test your changes>

- updating product hub locally should work
- calling staging / prod endpoint manually should update ajna stuff