### PR TITLE
Add steth to token group

### DIFF
--- a/handlers/product-hub/helpers/get-token-group.ts
+++ b/handlers/product-hub/helpers/get-token-group.ts
@@ -6,6 +6,7 @@ export function getTokenGroup(token: string): string {
     case 'CBETH':
     case 'RETH':
     case 'WSTETH':
+    case 'STETH':
     case 'YIELDETH':
       return 'ETH'
     case 'TBTC':


### PR DESCRIPTION
# [Add steth to token group](https://app.shortcut.com/oazo-apps/story/12130/token-selection-calls-to-action-render-inconsistent-pages-some-work-some-do-not)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added STETH to token group so it maps to ETH
  
## How to test 🧪
  <Please explain how to test your changes>

- when using new navigation and selections STETH token on token list, all links (borrow/earn/multiply) should base on ETH
