### PR TITLE
Remove CRVV1ETHSTETH from product hub

### DIFF
--- a/handlers/product-hub/update-handlers/maker/makerHandler.ts
+++ b/handlers/product-hub/update-handlers/maker/makerHandler.ts
@@ -35,8 +35,7 @@ const PotFactory = McdPot__factory
 // types/ethers-contracts uses ethers.BigNumber, but we need bignumber.js
 const bigNumberify = (val: BigNumberish) => new BigNumber(val.toString())
 
-const getIlk = (label: string) =>
-  ['CRVV1ETHSTETH-A', 'DSR'].includes(label) ? label : label.split('/')[0]
+const getIlk = (label: string) => (['DSR'].includes(label) ? label : label.split('/')[0])
 
 async function getMakerData(
   networkId: NetworkIds.MAINNET | NetworkIds.GOERLI,
@@ -118,10 +117,6 @@ async function getMakerData(
           const primaryTokenAddress = tokensAddresses[primaryToken].address
           const secondaryTokenAddress = tokensAddresses[secondaryToken].address
 
-          if (label === 'CRVV1ETHSTETH-A' && networkId === NetworkIds.GOERLI) {
-            // CRVV1ETHSTETH-A on goerli has some wonky numbers, skipping that
-            return
-          }
           if (label === 'DSR') {
             return {
               ...product,

--- a/handlers/product-hub/update-handlers/maker/makerProducts.ts
+++ b/handlers/product-hub/update-handlers/maker/makerProducts.ts
@@ -93,15 +93,6 @@ export const makerProductHubProducts: Omit<ProductHubItemWithoutAddress, 'networ
     multiplyStrategy: 'Long WBTC',
   },
   {
-    product: [ProductHubProductType.Borrow],
-    primaryToken: 'CRVV1ETHSTETH',
-    secondaryToken: 'DAI',
-    protocol: LendingProtocol.Maker,
-    label: 'CRVV1ETHSTETH-A',
-    multiplyStrategyType: 'long',
-    multiplyStrategy: 'Long CRVV1ETHSTETH',
-  },
-  {
     product: [ProductHubProductType.Earn],
     primaryToken: 'DAI',
     secondaryToken: 'DAI',

--- a/helpers/productCards.ts
+++ b/helpers/productCards.ts
@@ -49,7 +49,6 @@ export const supportedBorrowIlks = [
   'MATIC-A',
   'UNIV2USDCETH-A',
   'UNIV2DAIUSDC-A',
-  'CRVV1ETHSTETH-A',
   'WSTETH-B',
   'RETH-A',
   'GNO-A',

--- a/public/mocks/discover/highest-risk-positions.json
+++ b/public/mocks/discover/highest-risk-positions.json
@@ -74,19 +74,6 @@
         }
       },
       "cdpId": 54122
-    },
-    {
-      "asset": "CRVV1ETHSTETH",
-      "liquidationPrice": 0.92,
-      "nextOsmPrice": 1.03,
-      "maxLiquidationAmount": 3495.64,
-      "status": {
-        "kind": 3,
-        "additionalData": {
-          "tillLiquidation": 52.63
-        }
-      },
-      "cdpId": 3198
     }
   ]
 }


### PR DESCRIPTION
# [Remove CRVV1ETHSTETH from product hub](https://app.shortcut.com/oazo-apps/story/12126/products-borrow-earn-while-staking-product-is-incorrect)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed CRVV1ETHSTETH from product hub as this pair (CRVV1ETHSTETH-A/DAI) was offboarded from Maker
  
## How to test 🧪
  <Please explain how to test your changes>

- no data about CRVV1ETHSTETH within product hub
