### PR TITLE
Swap/Bridge add wallet connection

### DIFF
--- a/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/components/navigation/NavigationMenuDropdownContent.tsx
@@ -97,7 +97,7 @@ export function NavigationMenuDropdownContent({
           .map(({ items }, i) => (
             <Fragment key={i}>
               {items.map(({ list }, j) => (
-                <>
+                <Fragment key={j}>
                   {list && (
                     <Flex
                       key={`${i}-${j}`}
@@ -126,7 +126,7 @@ export function NavigationMenuDropdownContent({
                       <NavigationMenuDropdownContentList {...list} />
                     </Flex>
                   )}
-                </>
+                </Fragment>
               ))}
             </Fragment>
           ))}

--- a/components/navigation/NavigationMenuDropdownContentListItem.tsx
+++ b/components/navigation/NavigationMenuDropdownContentListItem.tsx
@@ -23,7 +23,7 @@ export function NavigationMenuDropdownContentListItem({
     left: 0,
     opacity: 0,
     transition: 'opacity 200ms',
-    '-webkit-background-clip': 'text',
+    WebkitBackgroundClip: 'text',
   }
 
   return (
@@ -63,7 +63,6 @@ export function NavigationMenuDropdownContentListItem({
         </Flex>
         {description && (
           <Text
-            as="p"
             variant="paragraph4"
             sx={{ mt: 1, color: 'neutral80', em: { color: 'primary100', fontStyle: 'normal' } }}
           >

--- a/features/navigation/components/NavigationBridgeDescription.tsx
+++ b/features/navigation/components/NavigationBridgeDescription.tsx
@@ -21,7 +21,7 @@ export const NavigationBridgeDescription = () => {
       >
         {[BaseNetworkNames.Ethereum, BaseNetworkNames.Optimism, BaseNetworkNames.Arbitrum].map(
           (network) => (
-            <Box as="li">
+            <Box as="li" key={network}>
               <Image
                 src={networksByName[network].icon}
                 width={20}

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -11,6 +11,7 @@ import {
   type SwapWidgetChangeAction,
   SWAP_WIDGET_CHANGE_SUBJECT,
 } from 'features/swapWidget/SwapWidgetChange'
+import { useConnection } from 'features/web3OnBoard'
 import { PROMO_CARD_COLLECTIONS_PARSERS } from 'handlers/product-hub/promo-cards'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAppConfig } from 'helpers/config'
@@ -28,6 +29,7 @@ export function NavigationController() {
     config: { navigation },
   } = usePreloadAppDataContext()
   const { isConnected, walletAddress } = useAccount()
+  const { connect } = useConnection()
   const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3] - 1}px)`)
 
   const { AjnaSafetySwitch } = useAppConfig('features')
@@ -38,8 +40,8 @@ export function NavigationController() {
     PROMO_CARD_COLLECTIONS_PARSERS[AjnaSafetySwitch ? 'Home' : 'HomeWithAjna'](productHubItems)
 
   const navProductsPanel = useMemo(
-    () => getNavProductsPanel({ t, productHubItems, promoCardsData }),
-    [t, productHubItems, promoCardsData],
+    () => getNavProductsPanel({ t, productHubItems, promoCardsData, isConnected, connect }),
+    [t, productHubItems, promoCardsData, isConnected, connect],
   )
   const navProtocolsPanel = useMemo(() => getNavProtocolsPanel({ t, navigation }), [t, navigation])
   const navTokensPanel = useMemo(

--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -28,21 +28,27 @@ export const getNavProductsPanel = ({
   t,
   productHubItems,
   promoCardsData,
+  isConnected,
+  connect,
 }: {
   t: TranslationType
   promoCardsData: ProductHubPromoCards
   productHubItems: ProductHubItem[]
+  isConnected: boolean
+  connect: () => void
 }): NavigationMenuPanelType => {
   const productMultiplyNavItems = getProductMultiplyNavItems(promoCardsData, productHubItems)
 
   const productEarnNavItems = getProductEarnNavItems(promoCardsData, productHubItems)
   const productBorrowNavItems = getProductBorrowNavItems(productHubItems)
 
-  const widgetCallback = (variant: 'swap' | 'bridge') =>
+  const widgetCallback = (variant: 'swap' | 'bridge') => {
+    !isConnected && connect()
     uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
       type: 'open',
       variant,
     })
+  }
 
   return {
     label: t('nav.products'),


### PR DESCRIPTION
# [Swap/Bridge add wallet connection](https://app.shortcut.com/oazo-apps/story/12127/swap-and-bridge-is-frozen-upon-selection-from-navigation)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added connection popup when user tries to use swap/bridge without connected wallet
- fixed issues with missing keys when mapping and other errors from console.
  
## How to test 🧪
  <Please explain how to test your changes>

- on disconnected wallet try to use swap/bridge from new navigation
