### PR TITLE
Turn off force connect while redirected to maker open positions flow

### DIFF
--- a/pages/earn/open/[ilk].tsx
+++ b/pages/earn/open/[ilk].tsx
@@ -1,5 +1,3 @@
-import { ethereumMainnetHexId } from 'blockchain/networks'
-import { WithWalletConnection } from 'components/connectWallet'
 import { AppLayout } from 'components/layouts/AppLayout'
 import { GuniOpenVaultView } from 'features/earn/guni/open/containers/GuniOpenVaultView'
 import { Survey } from 'features/survey'
@@ -29,12 +27,10 @@ export async function getStaticProps(ctx: GetServerSidePropsContext & { params: 
 function OpenVault({ ilk }: { ilk: string }) {
   return (
     <AppLayout>
-      <WithWalletConnection chainId={ethereumMainnetHexId}>
-        <WithTermsOfService>
-          <GuniOpenVaultView ilk={ilk} />
-          <Survey for="earn" />
-        </WithTermsOfService>
-      </WithWalletConnection>
+      <WithTermsOfService>
+        <GuniOpenVaultView ilk={ilk} />
+        <Survey for="earn" />
+      </WithTermsOfService>
     </AppLayout>
   )
 }

--- a/pages/vaults/open-multiply/[ilk].tsx
+++ b/pages/vaults/open-multiply/[ilk].tsx
@@ -1,5 +1,3 @@
-import { ethereumMainnetHexId } from 'blockchain/networks'
-import { WithWalletConnection } from 'components/connectWallet'
 import { ProductContextHandler } from 'components/context/ProductContextHandler'
 import { PageSEOTags } from 'components/HeadTags'
 import { AppLayout } from 'components/layouts/AppLayout'
@@ -36,25 +34,23 @@ function OpenVault({ ilk }: { ilk: string }) {
   return (
     <AppLayout>
       <ProductContextHandler>
-        <WithWalletConnection chainId={ethereumMainnetHexId} includeTestNet={true}>
-          <WithTermsOfService>
-            <WithWalletAssociatedRisk>
-              <PageSEOTags
-                title="seo.title-product-w-tokens"
-                titleParams={{
-                  product: t('seo.multiply.title'),
-                  protocol: LendingProtocolLabel.maker,
-                  token1: ilk,
-                  token2: 'DAI',
-                }}
-                description="seo.multiply.description"
-                url="/multiply"
-              />
-              <OpenMultiplyVaultView ilk={ilk} />
-              <Survey for="multiply" />
-            </WithWalletAssociatedRisk>
-          </WithTermsOfService>
-        </WithWalletConnection>
+        <WithTermsOfService>
+          <WithWalletAssociatedRisk>
+            <PageSEOTags
+              title="seo.title-product-w-tokens"
+              titleParams={{
+                product: t('seo.multiply.title'),
+                protocol: LendingProtocolLabel.maker,
+                token1: ilk,
+                token2: 'DAI',
+              }}
+              description="seo.multiply.description"
+              url="/multiply"
+            />
+            <OpenMultiplyVaultView ilk={ilk} />
+            <Survey for="multiply" />
+          </WithWalletAssociatedRisk>
+        </WithTermsOfService>
       </ProductContextHandler>
     </AppLayout>
   )

--- a/pages/vaults/open/[ilk].tsx
+++ b/pages/vaults/open/[ilk].tsx
@@ -1,5 +1,3 @@
-import { ethereumMainnetHexId } from 'blockchain/networks'
-import { WithWalletConnection } from 'components/connectWallet'
 import { ProductContextHandler } from 'components/context/ProductContextHandler'
 import { PageSEOTags } from 'components/HeadTags'
 import { AppLayout } from 'components/layouts/AppLayout'
@@ -35,24 +33,22 @@ function OpenVault({ ilk }: { ilk: string }) {
   return (
     <AppLayout>
       <ProductContextHandler>
-        <WithWalletConnection chainId={ethereumMainnetHexId} includeTestNet={true}>
-          <WithTermsOfService>
-            <WithWalletAssociatedRisk>
-              <PageSEOTags
-                title="seo.title-product-w-tokens"
-                titleParams={{
-                  product: t('seo.borrow.title'),
-                  protocol: LendingProtocolLabel.maker,
-                  token1: ilk,
-                  token2: 'DAI',
-                }}
-                description="seo.borrow.description"
-                url="/borrow"
-              />
-              <OpenVaultView ilk={ilk} />
-            </WithWalletAssociatedRisk>
-          </WithTermsOfService>
-        </WithWalletConnection>
+        <WithTermsOfService>
+          <WithWalletAssociatedRisk>
+            <PageSEOTags
+              title="seo.title-product-w-tokens"
+              titleParams={{
+                product: t('seo.borrow.title'),
+                protocol: LendingProtocolLabel.maker,
+                token1: ilk,
+                token2: 'DAI',
+              }}
+              description="seo.borrow.description"
+              url="/borrow"
+            />
+            <OpenVaultView ilk={ilk} />
+          </WithWalletAssociatedRisk>
+        </WithTermsOfService>
       </ProductContextHandler>
     </AppLayout>
   )


### PR DESCRIPTION
# [Turn off force connect while redirected to maker open positions flow](https://app.shortcut.com/oazo-apps/story/12128/all-maker-positions-that-link-directly-to-open-flow-are-blocked-by-wallet-connection-pop-up)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed necessity to connect wallet while being redirected to maker open borrow / multiply / earn open flows
- changes doesn't impact DSR as wallet connection is required there
  
## How to test 🧪
  <Please explain how to test your changes>

- disconnect your wallet, while using new navigation, click on maker product, you should be redirected to open flow without the need for wallet connection
