### PR TITLE
Default selection of protocol in Product Finder

### DIFF
--- a/components/InternalLink.tsx
+++ b/components/InternalLink.tsx
@@ -5,20 +5,21 @@ import { Link as ThemeLink } from 'theme-ui'
 import type { AppLinkProps } from './Links.types'
 
 export function InternalLink({
-  href,
-  sx,
-  children,
-  internalInNewTab,
   as,
-  variant,
-  onClick,
+  children,
   hash,
+  href,
+  internalInNewTab,
+  onClick,
+  sx,
+  query,
+  variant,
   ...rest
 }: AppLinkProps) {
   const readOnlyHref = href
   const readOnlyAs = as
 
-  const actualHref = { pathname: readOnlyHref as string, hash }
+  const actualHref = { pathname: readOnlyHref as string, hash, query }
 
   const actualAs = readOnlyAs ? { pathname: readOnlyAs as string } : readOnlyAs
 

--- a/components/Links.tsx
+++ b/components/Links.tsx
@@ -9,13 +9,13 @@ export function getIsInternalLink(href: string) {
 }
 
 export function AppLink({
-  href,
   children,
   disabled,
-  sx,
-  variant = 'styles.a',
+  href,
   onClick,
+  sx,
   target,
+  variant = 'styles.a',
   ...rest
 }: AppLinkProps) {
   const isInternalLink = href && getIsInternalLink(href)

--- a/components/Links.types.tsx
+++ b/components/Links.types.tsx
@@ -5,12 +5,13 @@ import type { ThemeUIStyleObject } from 'theme-ui'
 
 export interface AppLinkProps extends WithChildren, LinkProps {
   disabled?: boolean
-  href: string
-  sx?: ThemeUIStyleObject
-  variant?: string
-  internalInNewTab?: boolean
-  withAccountPrefix?: boolean
-  onClick?: React.MouseEventHandler<HTMLAnchorElement>
-  target?: string
   hash?: string
+  href: string
+  internalInNewTab?: boolean
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>
+  query?: { [key: string]: string }
+  sx?: ThemeUIStyleObject
+  target?: string
+  variant?: string
+  withAccountPrefix?: boolean
 }

--- a/components/navigation/Navigation.types.ts
+++ b/components/navigation/Navigation.types.ts
@@ -87,19 +87,21 @@ export interface NavigationMenuPanelList {
   items: NavigationMenuPanelListItem[]
   link?: {
     label: string
+    query?: { [key: string]: string }
     url: string
   }
   tight?: boolean
 }
 export interface NavigationMenuPanelListItem {
   description?: ReactNode
-  icon?: NavigationMenuPanelIcon
-  url?: string
-  list?: NavigationMenuPanelList
   hoverColor?: string
+  icon?: NavigationMenuPanelIcon
+  list?: NavigationMenuPanelList
   promoted?: boolean
+  query?: { [key: string]: string }
   tags?: NavigationMenuPanelListTags
   title: ReactNode
+  url?: string
   callback?: () => void
 }
 export interface NavigationMenuPanelType {

--- a/components/navigation/NavigationMenuDropdownContentList.tsx
+++ b/components/navigation/NavigationMenuDropdownContentList.tsx
@@ -67,7 +67,7 @@ export function NavigationMenuDropdownContentList({
           p: 0,
         }}
       >
-        {items.map(({ hoverColor, url, callback, ...item }, i) => (
+        {items.map(({ callback, hoverColor, query, url, ...item }, i) => (
           <Box
             key={i}
             as="li"
@@ -92,7 +92,7 @@ export function NavigationMenuDropdownContentList({
             }}
           >
             {url ? (
-              <AppLink href={url} sx={{ display: 'block', ...itemInnerPadding }}>
+              <AppLink href={url} query={query} sx={{ display: 'block', ...itemInnerPadding }}>
                 <NavigationMenuDropdownContentListItem hoverColor={hoverColor} {...item} />
               </AppLink>
             ) : (
@@ -106,6 +106,7 @@ export function NavigationMenuDropdownContentList({
       {link && (
         <AppLink
           href={link.url}
+          query={link.query}
           sx={{
             ml: 3,
             mr: 'auto',

--- a/features/navigation/helpers/getNavTokensNestedListItem.tsx
+++ b/features/navigation/helpers/getNavTokensNestedListItem.tsx
@@ -82,9 +82,9 @@ export const getNavTokensNestedListItem = (
         url: `${INTERNAL_LINKS.earn}/${getTokenGroup(token)}`,
       },
     ],
-    link: {
-      label: t('nav.tokens-more', { token }),
-      url: `${INTERNAL_LINKS.earn}/${getTokenGroup(token)}`,
-    },
+    // link: {
+    //   label: t('nav.tokens-more', { token }),
+    //   url: `${INTERNAL_LINKS.earn}/${getTokenGroup(token)}`,
+    // },
   }
 }

--- a/features/navigation/panels/getNavProtocolsPanel.tsx
+++ b/features/navigation/panels/getNavProtocolsPanel.tsx
@@ -19,210 +19,194 @@ export const getNavProtocolsPanel = ({
 }: {
   t: TranslationType
   navigation: AppConfigType['navigation']
-}): NavigationMenuPanelType => ({
-  label: t('nav.protocols'),
-  lists: [
-    {
-      items: [
-        {
-          title: 'Aave',
-          icon: {
-            image: lendingProtocolsByName[LendingProtocol.AaveV3].icon,
-            position: 'title',
-          },
-          hoverColor: lendingProtocolsByName[LendingProtocol.AaveV3].gradient,
-          description: t('nav.protocols-aave'),
-          list: {
-            items: [
-              {
-                title: t('nav.borrow'),
-                description: navigation.protocols.aave.borrow.description,
-                url: `${INTERNAL_LINKS.borrow}`,
-                query: {
-                  protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
-                    lendingProtocolsByName[LendingProtocol.AaveV3].name
-                  }`,
-                },
-              },
-              {
-                title: t('nav.multiply'),
-                description: navigation.protocols.aave.multiply.description,
-                url: `${INTERNAL_LINKS.multiply}`,
-                query: {
-                  protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
-                    lendingProtocolsByName[LendingProtocol.AaveV3].name
-                  }`,
-                },
-              },
-              {
-                title: t('nav.earn'),
-                description: navigation.protocols.aave.earn.description,
-                url: `${INTERNAL_LINKS.earn}`,
-                query: {
-                  protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
-                    lendingProtocolsByName[LendingProtocol.AaveV3].name
-                  }`,
-                },
-              },
-              {
-                title: navigation.protocols.aave.extra.title,
-                promoted: true,
-                description: navigation.protocols.aave.extra.description,
-                url: navigation.protocols.aave.extra.url,
-              },
-            ],
-            // link: {
-            //   label: t('nav.protocols-more', { protocol: 'Aave' }),
-            //   url: `${INTERNAL_LINKS.borrow}`,
-            // },
-          },
-        },
-        ...(AjnaSafetySwitch
-          ? []
-          : ([
-              {
-                title: 'Ajna',
-                icon: {
-                  image: lendingProtocolsByName[LendingProtocol.Ajna].icon,
-                  position: 'title',
-                },
-                hoverColor: lendingProtocolsByName[LendingProtocol.Ajna].gradient,
-                description: <Trans i18nKey="nav.protocols-ajna" components={{ br: <br /> }} />,
-                list: {
-                  items: [
-                    {
-                      title: t('nav.borrow'),
-                      description: navigation.protocols.ajna.borrow.description,
-                      url: `${INTERNAL_LINKS.borrow}`,
-                      query: {
-                        protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
-                      },
-                    },
-                    {
-                      title: t('nav.multiply'),
-                      description: navigation.protocols.ajna.multiply.description,
-                      url: `${INTERNAL_LINKS.multiply}`,
-                      query: {
-                        protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
-                      },
-                    },
-                    {
-                      title: t('nav.earn'),
-                      description: navigation.protocols.ajna.earn.description,
-                      url: `${INTERNAL_LINKS.earn}`,
-                      query: {
-                        protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
-                      },
-                    },
-                    {
-                      title: navigation.protocols.ajna.extra.title,
-                      promoted: true,
-                      description: navigation.protocols.ajna.extra.description,
-                      url: navigation.protocols.ajna.extra.url,
-                    },
-                  ],
-                  // link: {
-                  //   label: t('nav.protocols-more', { protocol: 'Ajna' }),
-                  //   url: `${INTERNAL_LINKS.borrow}`,
-                  // },
-                },
-              },
-            ] as NavigationMenuPanelListItem[])),
-        {
-          title: 'Maker',
-          icon: {
-            image: lendingProtocolsByName[LendingProtocol.Maker].icon,
-            position: 'title',
-          },
-          hoverColor: lendingProtocolsByName[LendingProtocol.Maker].gradient,
-          description: <Trans i18nKey="nav.protocols-maker" components={{ br: <br /> }} />,
-          list: {
-            items: [
-              {
-                title: t('nav.borrow'),
-                description: navigation.protocols.maker.borrow.description,
-                url: `${INTERNAL_LINKS.borrow}`,
-                query: {
-                  protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
-                },
-              },
-              {
-                title: t('nav.multiply'),
-                description: navigation.protocols.maker.multiply.description,
-                url: `${INTERNAL_LINKS.multiply}`,
-                query: {
-                  protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
-                },
-              },
-              {
-                title: t('nav.earn'),
-                description: navigation.protocols.maker.earn.description,
-                url: `${INTERNAL_LINKS.earn}`,
-                query: {
-                  protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
-                },
-              },
-              {
-                title: navigation.protocols.maker.extra.title,
-                promoted: true,
-                description: navigation.protocols.maker.extra.description,
-                url: navigation.protocols.maker.extra.url,
-              },
-            ],
-            // link: {
-            //   label: t('nav.protocols-more', { protocol: 'Maker' }),
-            //   url: `${INTERNAL_LINKS.borrow}`,
-            // },
-          },
-        },
-        {
-          title: 'Spark',
-          icon: {
-            image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
-            position: 'title',
-          },
-          hoverColor: lendingProtocolsByName[LendingProtocol.SparkV3].gradient,
-          description: <Trans i18nKey="nav.protocols-spark" components={{ br: <br /> }} />,
-          list: {
-            items: [
-              {
-                title: t('nav.borrow'),
-                description: navigation.protocols.spark.borrow.description,
-                url: `${INTERNAL_LINKS.borrow}`,
-                query: {
-                  protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
-                },
-              },
-              {
-                title: t('nav.multiply'),
-                description: navigation.protocols.spark.multiply.description,
-                url: `${INTERNAL_LINKS.multiply}`,
-                query: {
-                  protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
-                },
-              },
-              {
-                title: t('nav.earn'),
-                description: navigation.protocols.spark.earn.description,
-                url: `${INTERNAL_LINKS.earn}`,
-                query: {
-                  protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
-                },
-              },
-              {
-                title: navigation.protocols.spark.extra.title,
-                promoted: true,
-                description: navigation.protocols.spark.extra.description,
-                url: navigation.protocols.spark.extra.url,
-              },
-            ],
-            // link: {
-            //   label: t('nav.protocols-more', { protocol: 'Spark' }),
-            //   url: `${INTERNAL_LINKS.borrow}`,
-            // },
-          },
-        },
-      ],
+}): NavigationMenuPanelType => {
+  const query = {
+    aave: {
+      protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
+        lendingProtocolsByName[LendingProtocol.AaveV3].name
+      }`,
     },
-  ],
-})
+    ajna: {
+      protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
+    },
+    maker: {
+      protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
+    },
+    spark: {
+      protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+    },
+  }
+  return {
+    label: t('nav.protocols'),
+    lists: [
+      {
+        items: [
+          {
+            title: 'Aave',
+            icon: {
+              image: lendingProtocolsByName[LendingProtocol.AaveV3].icon,
+              position: 'title',
+            },
+            hoverColor: lendingProtocolsByName[LendingProtocol.AaveV3].gradient,
+            description: t('nav.protocols-aave'),
+            list: {
+              items: [
+                {
+                  title: t('nav.borrow'),
+                  description: navigation.protocols.aave.borrow.description,
+                  url: `${INTERNAL_LINKS.borrow}`,
+                  query: query.aave,
+                },
+                {
+                  title: t('nav.multiply'),
+                  description: navigation.protocols.aave.multiply.description,
+                  url: `${INTERNAL_LINKS.multiply}`,
+                  query: query.aave,
+                },
+                {
+                  title: t('nav.earn'),
+                  description: navigation.protocols.aave.earn.description,
+                  url: `${INTERNAL_LINKS.earn}`,
+                  query: query.aave,
+                },
+                {
+                  title: navigation.protocols.aave.extra.title,
+                  promoted: true,
+                  description: navigation.protocols.aave.extra.description,
+                  url: navigation.protocols.aave.extra.url,
+                },
+              ],
+              // link: {
+              //   label: t('nav.protocols-more', { protocol: 'Aave' }),
+              // },
+            },
+          },
+          ...(AjnaSafetySwitch
+            ? []
+            : ([
+                {
+                  title: 'Ajna',
+                  icon: {
+                    image: lendingProtocolsByName[LendingProtocol.Ajna].icon,
+                    position: 'title',
+                  },
+                  hoverColor: lendingProtocolsByName[LendingProtocol.Ajna].gradient,
+                  description: <Trans i18nKey="nav.protocols-ajna" components={{ br: <br /> }} />,
+                  list: {
+                    items: [
+                      {
+                        title: t('nav.borrow'),
+                        description: navigation.protocols.ajna.borrow.description,
+                        url: `${INTERNAL_LINKS.borrow}`,
+                        query: query.ajna,
+                      },
+                      {
+                        title: t('nav.multiply'),
+                        description: navigation.protocols.ajna.multiply.description,
+                        url: `${INTERNAL_LINKS.multiply}`,
+                        query: query.ajna,
+                      },
+                      {
+                        title: t('nav.earn'),
+                        description: navigation.protocols.ajna.earn.description,
+                        url: `${INTERNAL_LINKS.earn}`,
+                        query: query.ajna,
+                      },
+                      {
+                        title: navigation.protocols.ajna.extra.title,
+                        promoted: true,
+                        description: navigation.protocols.ajna.extra.description,
+                        url: navigation.protocols.ajna.extra.url,
+                      },
+                    ],
+                    // link: {
+                    //   label: t('nav.protocols-more', { protocol: 'Ajna' }),
+                    // },
+                  },
+                },
+              ] as NavigationMenuPanelListItem[])),
+          {
+            title: 'Maker',
+            icon: {
+              image: lendingProtocolsByName[LendingProtocol.Maker].icon,
+              position: 'title',
+            },
+            hoverColor: lendingProtocolsByName[LendingProtocol.Maker].gradient,
+            description: <Trans i18nKey="nav.protocols-maker" components={{ br: <br /> }} />,
+            list: {
+              items: [
+                {
+                  title: t('nav.borrow'),
+                  description: navigation.protocols.maker.borrow.description,
+                  url: `${INTERNAL_LINKS.borrow}`,
+                  query: query.maker,
+                },
+                {
+                  title: t('nav.multiply'),
+                  description: navigation.protocols.maker.multiply.description,
+                  url: `${INTERNAL_LINKS.multiply}`,
+                  query: query.maker,
+                },
+                {
+                  title: t('nav.earn'),
+                  description: navigation.protocols.maker.earn.description,
+                  url: `${INTERNAL_LINKS.earn}`,
+                  query: query.maker,
+                },
+                {
+                  title: navigation.protocols.maker.extra.title,
+                  promoted: true,
+                  description: navigation.protocols.maker.extra.description,
+                  url: navigation.protocols.maker.extra.url,
+                },
+              ],
+              // link: {
+              //   label: t('nav.protocols-more', { protocol: 'Maker' }),
+              // },
+            },
+          },
+          {
+            title: 'Spark',
+            icon: {
+              image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
+              position: 'title',
+            },
+            hoverColor: lendingProtocolsByName[LendingProtocol.SparkV3].gradient,
+            description: <Trans i18nKey="nav.protocols-spark" components={{ br: <br /> }} />,
+            list: {
+              items: [
+                {
+                  title: t('nav.borrow'),
+                  description: navigation.protocols.spark.borrow.description,
+                  url: `${INTERNAL_LINKS.borrow}`,
+                  query: query.spark,
+                },
+                {
+                  title: t('nav.multiply'),
+                  description: navigation.protocols.spark.multiply.description,
+                  url: `${INTERNAL_LINKS.multiply}`,
+                  query: query.spark,
+                },
+                {
+                  title: t('nav.earn'),
+                  description: navigation.protocols.spark.earn.description,
+                  url: `${INTERNAL_LINKS.earn}`,
+                  query: query.spark,
+                },
+                {
+                  title: navigation.protocols.spark.extra.title,
+                  promoted: true,
+                  description: navigation.protocols.spark.extra.description,
+                  url: navigation.protocols.spark.extra.url,
+                },
+              ],
+              // link: {
+              //   label: t('nav.protocols-more', { protocol: 'Spark' }),
+              // },
+            },
+          },
+        ],
+      },
+    ],
+  }
+}

--- a/features/navigation/panels/getNavProtocolsPanel.tsx
+++ b/features/navigation/panels/getNavProtocolsPanel.tsx
@@ -38,16 +38,31 @@ export const getNavProtocolsPanel = ({
                 title: t('nav.borrow'),
                 description: navigation.protocols.aave.borrow.description,
                 url: `${INTERNAL_LINKS.borrow}`,
+                query: {
+                  protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
+                    lendingProtocolsByName[LendingProtocol.AaveV3].name
+                  }`,
+                },
               },
               {
                 title: t('nav.multiply'),
                 description: navigation.protocols.aave.multiply.description,
                 url: `${INTERNAL_LINKS.multiply}`,
+                query: {
+                  protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
+                    lendingProtocolsByName[LendingProtocol.AaveV3].name
+                  }`,
+                },
               },
               {
                 title: t('nav.earn'),
                 description: navigation.protocols.aave.earn.description,
                 url: `${INTERNAL_LINKS.earn}`,
+                query: {
+                  protocol: `${lendingProtocolsByName[LendingProtocol.AaveV2].name},${
+                    lendingProtocolsByName[LendingProtocol.AaveV3].name
+                  }`,
+                },
               },
               {
                 title: navigation.protocols.aave.extra.title,
@@ -56,11 +71,10 @@ export const getNavProtocolsPanel = ({
                 url: navigation.protocols.aave.extra.url,
               },
             ],
-            link: {
-              label: t('nav.protocols-more', { protocol: 'Aave' }),
-              // TODO filter by protocol
-              url: `${INTERNAL_LINKS.borrow}`,
-            },
+            // link: {
+            //   label: t('nav.protocols-more', { protocol: 'Aave' }),
+            //   url: `${INTERNAL_LINKS.borrow}`,
+            // },
           },
         },
         ...(AjnaSafetySwitch
@@ -80,16 +94,25 @@ export const getNavProtocolsPanel = ({
                       title: t('nav.borrow'),
                       description: navigation.protocols.ajna.borrow.description,
                       url: `${INTERNAL_LINKS.borrow}`,
+                      query: {
+                        protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
+                      },
                     },
                     {
                       title: t('nav.multiply'),
                       description: navigation.protocols.ajna.multiply.description,
                       url: `${INTERNAL_LINKS.multiply}`,
+                      query: {
+                        protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
+                      },
                     },
                     {
                       title: t('nav.earn'),
                       description: navigation.protocols.ajna.earn.description,
                       url: `${INTERNAL_LINKS.earn}`,
+                      query: {
+                        protocol: lendingProtocolsByName[LendingProtocol.Ajna].name,
+                      },
                     },
                     {
                       title: navigation.protocols.ajna.extra.title,
@@ -98,11 +121,10 @@ export const getNavProtocolsPanel = ({
                       url: navigation.protocols.ajna.extra.url,
                     },
                   ],
-                  link: {
-                    label: t('nav.protocols-more', { protocol: 'Ajna' }),
-                    // TODO filter by protocol
-                    url: `${INTERNAL_LINKS.borrow}`,
-                  },
+                  // link: {
+                  //   label: t('nav.protocols-more', { protocol: 'Ajna' }),
+                  //   url: `${INTERNAL_LINKS.borrow}`,
+                  // },
                 },
               },
             ] as NavigationMenuPanelListItem[])),
@@ -120,16 +142,25 @@ export const getNavProtocolsPanel = ({
                 title: t('nav.borrow'),
                 description: navigation.protocols.maker.borrow.description,
                 url: `${INTERNAL_LINKS.borrow}`,
+                query: {
+                  protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
+                },
               },
               {
                 title: t('nav.multiply'),
                 description: navigation.protocols.maker.multiply.description,
                 url: `${INTERNAL_LINKS.multiply}`,
+                query: {
+                  protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
+                },
               },
               {
                 title: t('nav.earn'),
                 description: navigation.protocols.maker.earn.description,
                 url: `${INTERNAL_LINKS.earn}`,
+                query: {
+                  protocol: lendingProtocolsByName[LendingProtocol.Maker].name,
+                },
               },
               {
                 title: navigation.protocols.maker.extra.title,
@@ -138,11 +169,10 @@ export const getNavProtocolsPanel = ({
                 url: navigation.protocols.maker.extra.url,
               },
             ],
-            link: {
-              label: t('nav.protocols-more', { protocol: 'Maker' }),
-              // TODO filter by protocol
-              url: `${INTERNAL_LINKS.borrow}`,
-            },
+            // link: {
+            //   label: t('nav.protocols-more', { protocol: 'Maker' }),
+            //   url: `${INTERNAL_LINKS.borrow}`,
+            // },
           },
         },
         {
@@ -159,16 +189,25 @@ export const getNavProtocolsPanel = ({
                 title: t('nav.borrow'),
                 description: navigation.protocols.spark.borrow.description,
                 url: `${INTERNAL_LINKS.borrow}`,
+                query: {
+                  protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+                },
               },
               {
                 title: t('nav.multiply'),
                 description: navigation.protocols.spark.multiply.description,
                 url: `${INTERNAL_LINKS.multiply}`,
+                query: {
+                  protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+                },
               },
               {
                 title: t('nav.earn'),
                 description: navigation.protocols.spark.earn.description,
                 url: `${INTERNAL_LINKS.earn}`,
+                query: {
+                  protocol: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+                },
               },
               {
                 title: navigation.protocols.spark.extra.title,
@@ -177,11 +216,10 @@ export const getNavProtocolsPanel = ({
                 url: navigation.protocols.spark.extra.url,
               },
             ],
-            link: {
-              label: t('nav.protocols-more', { protocol: 'Spark' }),
-              // TODO filter by protocol
-              url: `${INTERNAL_LINKS.borrow}`,
-            },
+            // link: {
+            //   label: t('nav.protocols-more', { protocol: 'Spark' }),
+            //   url: `${INTERNAL_LINKS.borrow}`,
+            // },
           },
         },
       ],


### PR DESCRIPTION
# Default selection of protocol in Product Finder

Covers:
https://app.shortcut.com/oazo-apps/story/12030/default-selection-of-protocol-in-product-finder
https://app.shortcut.com/oazo-apps/story/12129/when-you-select-a-specific-protocol-for-a-specific-product-other-protocols-populate-the-dropdown-eg-select-aave-but-spark
  
## Changes 👷‍♀️

- Added preselected protocols to protocol specific links,
- removed links to "see all" when there was no specific place that link could take an user.
  
## How to test 🧪

Try to select any of the links from Protocols panel and check if protocol was preselected in Product Finder.
