### PR TITLE
Fix application crash with dead end routes in navigation

### DIFF
--- a/features/navigation/helpers/getNavTokensNestedListItem.tsx
+++ b/features/navigation/helpers/getNavTokensNestedListItem.tsx
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js'
 import type { NavigationMenuPanelList } from 'components/navigation/Navigation.types'
+import { productHubOptionsMap } from 'features/productHub/meta'
 import { ProductHubProductType } from 'features/productHub/types'
 import { getTokenGroup } from 'handlers/product-hub/helpers'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
@@ -21,70 +22,75 @@ export const getNavTokensNestedListItem = (
   token: string,
   { fee, apyPassive, apyActive, maxMultiple }: NavTokensNestedListParams,
 ): NavigationMenuPanelList => {
+  const tokenGroup = getTokenGroup(token)
+
+  const borrow = {
+    title: t('nav.borrow'),
+    description: (
+      <Trans
+        i18nKey="nav.tokens-borrow"
+        values={{ token, fee: formatDecimalAsPercent(new BigNumber(fee)) }}
+        components={{ em: <em /> }}
+      />
+    ),
+    url: `${INTERNAL_LINKS.borrow}/${tokenGroup}`,
+  }
+  const multiply = {
+    title: t('nav.multiply'),
+    description: (
+      <Trans
+        i18nKey={maxMultiple === 0 ? 'nav.tokens-multiply-simple' : 'nav.tokens-multiply'}
+        values={{
+          token,
+          maxMultiple: maxMultiple.toFixed(2),
+          product: capitalize(ProductHubProductType.Multiply),
+        }}
+        components={{ em: <em /> }}
+      />
+    ),
+    url: `${INTERNAL_LINKS.multiply}/${tokenGroup}`,
+  }
+  const earn = {
+    title: t('nav.earn'),
+    description: (
+      <Trans
+        i18nKey={
+          apyPassive === 0 && apyActive === 0
+            ? 'nav.tokens-earn-on-actively'
+            : `nav.tokens-earn${
+                apyPassive === 0 && apyActive !== 0
+                  ? '-active'
+                  : apyPassive !== 0 && apyActive === 0
+                  ? '-passive'
+                  : ''
+              }`
+        }
+        values={{
+          token,
+          apyPassive: formatDecimalAsPercent(new BigNumber(apyPassive)),
+          apyActive: formatDecimalAsPercent(new BigNumber(apyActive)),
+          apy:
+            apyPassive === 0 && apyActive !== 0
+              ? formatDecimalAsPercent(new BigNumber(apyActive))
+              : apyPassive !== 0 && apyActive === 0
+              ? formatDecimalAsPercent(new BigNumber(apyPassive))
+              : undefined,
+          product: capitalize(ProductHubProductType.Earn),
+        }}
+        components={{ em: <em /> }}
+      />
+    ),
+    url: `${INTERNAL_LINKS.earn}/${tokenGroup}`,
+  }
+
   return {
     items: [
-      {
-        title: t('nav.borrow'),
-        description: (
-          <Trans
-            i18nKey="nav.tokens-borrow"
-            values={{ token, fee: formatDecimalAsPercent(new BigNumber(fee)) }}
-            components={{ em: <em /> }}
-          />
-        ),
-        url: `${INTERNAL_LINKS.borrow}/${getTokenGroup(token)}`,
-      },
-      {
-        title: t('nav.multiply'),
-        description: (
-          <Trans
-            i18nKey={maxMultiple === 0 ? 'nav.tokens-multiply-simple' : 'nav.tokens-multiply'}
-            values={{
-              token,
-              maxMultiple: maxMultiple.toFixed(2),
-              product: capitalize(ProductHubProductType.Multiply),
-            }}
-            components={{ em: <em /> }}
-          />
-        ),
-        url: `${INTERNAL_LINKS.multiply}/${getTokenGroup(token)}`,
-      },
-      {
-        title: t('nav.earn'),
-        description: (
-          <Trans
-            i18nKey={
-              apyPassive === 0 && apyActive === 0
-                ? 'nav.tokens-earn-on-actively'
-                : `nav.tokens-earn${
-                    apyPassive === 0 && apyActive !== 0
-                      ? '-active'
-                      : apyPassive !== 0 && apyActive === 0
-                      ? '-passive'
-                      : ''
-                  }`
-            }
-            values={{
-              token,
-              apyPassive: formatDecimalAsPercent(new BigNumber(apyPassive)),
-              apyActive: formatDecimalAsPercent(new BigNumber(apyActive)),
-              apy:
-                apyPassive === 0 && apyActive !== 0
-                  ? formatDecimalAsPercent(new BigNumber(apyActive))
-                  : apyPassive !== 0 && apyActive === 0
-                  ? formatDecimalAsPercent(new BigNumber(apyPassive))
-                  : undefined,
-              product: capitalize(ProductHubProductType.Earn),
-            }}
-            components={{ em: <em /> }}
-          />
-        ),
-        url: `${INTERNAL_LINKS.earn}/${getTokenGroup(token)}`,
-      },
+      ...(Object.keys(productHubOptionsMap.borrow.tokens).includes(tokenGroup) ? [borrow] : []),
+      ...(Object.keys(productHubOptionsMap.multiply.tokens).includes(tokenGroup) ? [multiply] : []),
+      ...(Object.keys(productHubOptionsMap.earn.tokens).includes(tokenGroup) ? [earn] : []),
     ],
     // link: {
     //   label: t('nav.tokens-more', { token }),
-    //   url: `${INTERNAL_LINKS.earn}/${getTokenGroup(token)}`,
     // },
   }
 }


### PR DESCRIPTION
# [Fix application crash with dead end routes in navigation](https://app.shortcut.com/oazo-apps/story/12201/application-crashes-when-selecting-tokens-btc-earn-in-navigation)
  
## Changes 👷‍♀️

- Fixed an issue, where application was crashing when user selected combination of token and product, that is not available in Product Finder.
  
## How to test 🧪

Check if Tokens -> BTC/USDX has hidden Earn link.
