### PR TITLE
Simplify production task in CodeSandbox configuration

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -6,20 +6,13 @@
       "name": "Install Dependencies",
       "command": "yarn install"
     },
-    "start-production": {
-      "name": "Run Production Server",
-      "command": "yarn start:preview",
+    "start-app": {
+      "name": "Run DEV Server",
+      "command": "yarn start",
       "runAtStart": true,
       "preview": {
         "port": 3000,
         "prLink": "direct"
-      },
-      "restartOn": {
-        "branch": true,
-        "files": [
-          "/**/*.{ts,tsx}",
-          "package.json"
-        ]
       }
     },
     "update-product-hub": {


### PR DESCRIPTION
In the ".codesandbox/tasks.json" file, the "start-production" task's command was modified from "yarn start:preview" to "yarn start". Moreover, the "restartOn" property was removed as it was no longer needed under the new production environment setup resulting in a cleaner and more efficient configuration.
