### PR TITLE
AaveLike: Update conversion of collateral and debt values

### DIFF
--- a/features/aave/components/ErrorMessageCannotBorrowDueToProtocolCap.tsx
+++ b/features/aave/components/ErrorMessageCannotBorrowDueToProtocolCap.tsx
@@ -1,3 +1,4 @@
+import { amountFromWei } from 'blockchain/utils'
 import { MessageCard } from 'components/MessageCard'
 import type { BaseAaveContext } from 'features/aave/types'
 import { formatCryptoBalance } from 'helpers/formatters/format'
@@ -17,7 +18,7 @@ export function ErrorMessageCannotBorrowDueToProtocolCap({
 
   const maxBorrow = reserveData.debt.availableToBorrow
   const debtToken = transition.simulation.position.debt.symbol
-  const targetPositionDebt = transition.simulation.delta.debt
+  const targetPositionDebt = amountFromWei(transition.simulation.delta.debt, debtToken)
 
   const messages: string[] = []
 

--- a/features/aave/components/ErrorMessageCannotDepositDueToProtocolCap.tsx
+++ b/features/aave/components/ErrorMessageCannotDepositDueToProtocolCap.tsx
@@ -1,3 +1,4 @@
+import { amountFromWei } from 'blockchain/utils'
 import { MessageCard } from 'components/MessageCard'
 import type { BaseAaveContext } from 'features/aave/types'
 import { formatCryptoBalance } from 'helpers/formatters/format'
@@ -22,7 +23,10 @@ export function ErrorMessageCannotDepositDueToProtocolCap({
 
   const maxSupply = reserveData.collateral.availableToSupply
   const collateralToken = transition.simulation.position.collateral.symbol
-  const targetPositionCollateral = transition.simulation.delta.collateral
+  const targetPositionCollateral = amountFromWei(
+    transition.simulation.delta.collateral,
+    collateralToken,
+  )
 
   const messages: string[] = []
 


### PR DESCRIPTION
Added utility 'amountFromWei' to convert collateral and debt values from Wei to readable format in Aave component error messages. This change provides a more user-friendly error message by displaying token amounts in their standard unit instead of Wei, which enhances user comprehension.
