### PR TITLE
Update price impacting token display

### DIFF
--- a/features/aave/components/order-information/PriceImpact.tsx
+++ b/features/aave/components/order-information/PriceImpact.tsx
@@ -157,7 +157,7 @@ export function PriceImpact({
       label={t('vault-changes.price-impact', { token: displayToken })}
       value={
         <Text>
-          {formatCryptoBalance(marketPrice)}{' '}
+          {formatCryptoBalance(swapPrice)}{' '}
           <Text as="span" sx={{ color: 'critical100' }}>
             ({formatPercent(priceImpact, { precision: 2 })})
           </Text>


### PR DESCRIPTION
Changed the captured token price from 'marketPrice' to 'swapPrice' in the PriceImpact component. This provides a more accurate representation of the actual trade cost, ensuring users get the correct price impact value during swaps.
