### PR TITLE
fix: display multiply confirmation for closing action

### DIFF
--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultEditingStage.tsx
@@ -283,7 +283,7 @@ export function SidebarManageMultiplyVaultEditingStage(props: ManageMultiplyVaul
 
       <VaultErrors {...props} errorMessages={extractCommonErrors(errorMessages)} />
       <VaultWarnings {...props} warningMessages={extractCommonWarnings(warningMessages)} />
-      {vaultType === VaultType.Multiply || stage === 'adjustPosition' ? (
+      {vaultType === VaultType.Multiply || stage === 'adjustPosition' || (stage === 'otherActions' && otherAction === 'closeVault') ? (
         <ManageMultiplyVaultChangesInformation {...props} />
       ) : (
         <ManageVaultChangesInformation {...props} />

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage.tsx
@@ -11,7 +11,7 @@ import { OpenVaultAnimation } from 'theme/animations'
 export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVaultState) {
   const { t } = useTranslation()
 
-  const { stage, vaultType } = props
+  const { stage, vaultType, otherAction } = props
 
   const [, setVaultChanges] = useState<ManageMultiplyVaultState>(props)
 
@@ -25,7 +25,7 @@ export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVault
     case 'manageSuccess':
       return (
         <>
-          {vaultType === VaultType.Multiply ? (
+          {vaultType === VaultType.Multiply || otherAction === 'closeVault' ? (
             <ManageMultiplyVaultChangesInformation {...props} />
           ) : (
             <ManageVaultChangesInformation {...props} />
@@ -39,7 +39,7 @@ export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVault
           <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
             {t('vault-form.subtext.review-manage')}
           </Text>
-          {vaultType === VaultType.Multiply ? (
+          {vaultType === VaultType.Multiply || stage === 'adjustPosition' || (stage === 'otherActions' && otherAction === 'closeVault') ? (
             <ManageMultiplyVaultChangesInformation {...props} />
           ) : (
             <ManageVaultChangesInformation {...props} />


### PR DESCRIPTION
# [Title](https://shortcutLink)
  
## Changes 👷‍♀️
- Displays multiply confirmation for closing operation
  
## How to test 🧪
- Close position and verify the confirmation component
