### PR TITLE
fix: display proper confiramtion for multiply

### DIFF
--- a/features/multiply/manage/pipes/manageMultiplyVaultInput.ts
+++ b/features/multiply/manage/pipes/manageMultiplyVaultInput.ts
@@ -186,8 +186,8 @@ export function applyManageVaultInput(
     return {
       ...state,
       ...manageMultiplyInputsDefaults,
-      withdrawAmount: state.vaultType === VaultType.Borrow ? state.withdrawAmount : undefined,
-      withdrawAmountUSD: state.vaultType === VaultType.Borrow ? state.withdrawAmount : undefined,
+      withdrawAmount: state.withdrawAmount,
+      withdrawAmountUSD: state.withdrawAmount,
       paybackAmount: change.paybackAmount,
     }
   }
@@ -198,8 +198,8 @@ export function applyManageVaultInput(
     return {
       ...state,
       ...manageMultiplyInputsDefaults,
-      withdrawAmount: state.vaultType === VaultType.Borrow ? state.withdrawAmount : undefined,
-      withdrawAmountUSD: state.vaultType === VaultType.Borrow ? state.withdrawAmount : undefined,
+      withdrawAmount: state.withdrawAmount,
+      withdrawAmountUSD: state.withdrawAmount,
       paybackAmount: maxPaybackAmount,
     }
   }
@@ -211,7 +211,7 @@ export function applyManageVaultInput(
       ...manageMultiplyInputsDefaults,
       withdrawAmount: change.withdrawAmount,
       withdrawAmountUSD: change.withdrawAmount?.times(priceInfo.currentCollateralPrice),
-      paybackAmount: state.vaultType === VaultType.Borrow ? state.paybackAmount : undefined,
+      paybackAmount: state.paybackAmount,
       showSliderController: false,
     }
   }
@@ -223,7 +223,7 @@ export function applyManageVaultInput(
       ...manageMultiplyInputsDefaults,
       withdrawAmountUSD: change.withdrawAmountUSD,
       withdrawAmount: change.withdrawAmountUSD?.div(priceInfo.currentCollateralPrice),
-      paybackAmount: state.vaultType === VaultType.Borrow ? state.paybackAmount : undefined,
+      paybackAmount: state.paybackAmount,
       showSliderController: false,
     }
   }
@@ -236,7 +236,7 @@ export function applyManageVaultInput(
       ...manageMultiplyInputsDefaults,
       withdrawAmount: maxWithdrawAmount,
       withdrawAmountUSD: maxWithdrawAmountUSD,
-      paybackAmount: state.vaultType === VaultType.Borrow ? state.paybackAmount : undefined,
+      paybackAmount: state.paybackAmount,
       showSliderController: false,
     }
   }

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage.tsx
@@ -25,7 +25,7 @@ export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVault
     case 'manageSuccess':
       return (
         <>
-          {vaultType === VaultType.Multiply || otherAction === 'closeVault' ? (
+          {vaultType === VaultType.Multiply || props.originalEditingStage === 'adjustPosition' || (props.originalEditingStage === 'otherActions' && otherAction === 'closeVault') ? (
             <ManageMultiplyVaultChangesInformation {...props} />
           ) : (
             <ManageVaultChangesInformation {...props} />
@@ -39,7 +39,7 @@ export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVault
           <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
             {t('vault-form.subtext.review-manage')}
           </Text>
-          {vaultType === VaultType.Multiply || stage === 'adjustPosition' || (stage === 'otherActions' && otherAction === 'closeVault') ? (
+          {vaultType === VaultType.Multiply || props.originalEditingStage === 'adjustPosition' || (props.originalEditingStage === 'otherActions' && 'closeVault') ? (
             <ManageMultiplyVaultChangesInformation {...props} />
           ) : (
             <ManageVaultChangesInformation {...props} />


### PR DESCRIPTION
# Fix
  
## Changes 👷‍♀️
- Fix order confirmation for close and adjust
- Fix clearing inputs 
  
## How to test 🧪
- Close vault check if the order confirmation confirm swap info
- Adjust vault check if the confirmation is correct
- Payback the debt, withdraw collateral. Form should work as expected
