### PR TITLE
Product Finder default network filter

### DIFF
--- a/features/productHub/components/ProductHubLoadingState.tsx
+++ b/features/productHub/components/ProductHubLoadingState.tsx
@@ -1,0 +1,32 @@
+import { AssetsFiltersContainer } from 'components/assetsTable/AssetsFiltersContainer'
+import { AssetsTableContainer } from 'components/assetsTable/AssetsTableContainer'
+import { PromoCardLoadingState } from 'components/PromoCard'
+import { Skeleton } from 'components/Skeleton'
+import type { FC } from 'react'
+import React from 'react'
+import { Box, Grid } from 'theme-ui'
+
+export const ProductHubLoadingState: FC = () => {
+  return (
+    <>
+      <Grid columns={[1, null, 2, 3]} gap={3} sx={{ mb: 4 }}>
+        <PromoCardLoadingState />
+        <PromoCardLoadingState />
+        <PromoCardLoadingState />
+      </Grid>
+      <AssetsTableContainer>
+        <AssetsFiltersContainer
+          gridTemplateColumns={['100%', null, 'repeat(3, 1fr)', '270px auto 220px 220px']}
+        >
+          <Skeleton height="56px" />
+          <Box />
+          <Skeleton height="56px" />
+          <Skeleton height="56px" />
+        </AssetsFiltersContainer>
+        <Box sx={{ m: 4 }}>
+          <Skeleton count={5} gap={4} />
+        </Box>
+      </AssetsTableContainer>
+    </>
+  )
+}


### PR DESCRIPTION
# [Product Finder default network filter](https://app.shortcut.com/oazo-apps/story/12326/default-product-hub-tables-to-have-network-filtered-by-connected-wallet-network-when-page-loads-or-to-mainnet-when-no-wallet)
  
## Changes 👷‍♀️

- Added `useEffect` that reacts to network changes and sets initial network filter,
- removed `useMemo` for `resolvedInitialNetwork` as it wasn't doing anything, this data was loaded only once and never refreshed - it's value is not set directly as `selectedFilters` default value,
- as determining user's network is async, brought back `WithLoadingIndicator` into Product Hub that is displayed while app is checking what chain is user connected to,
- also brought back `ProductHubLoadingState` - it's not new, it was removed some time age when Product Hub data was loaded along with global config and was no longer needed at that moment.
  
## How to test 🧪

Please test use cases below besides just checking code:
- When user opens Product Hub network filter should be preselected to the network they are connected,
- if wallet is disconnected, default network should be Ethereum,
- whenever user is changing chain, Product Hub should react and refresh itself,
- unless network was manually selected by user and is a part of querystring - in that case changing wallet's chain is not overwriting user's selection.