### PR TITLE
Show maker position instead of infinite load

### DIFF
--- a/components/vault/GeneralManageControl.tsx
+++ b/components/vault/GeneralManageControl.tsx
@@ -29,8 +29,8 @@ export function GeneralManageControl({ id }: GeneralManageControlProps) {
       generalManageVaultData?.state.clear()
     }
   }, [])
-
-  const vaultHistoryCheck = generalManageVaultData?.state.vaultHistory.length || undefined
+  
+  const vaultHistoryCheck = generalManageVaultData?.state.vaultHistory.length
 
   return (
     <WithErrorHandler error={[generalManageVaultError]}>


### PR DESCRIPTION
# [Fix maker positions on fork](https://app.shortcut.com/oazo-apps/story/12560/staging-depositing-in-borrow-shows-multiply-confirmation-screen-only-on-first-load)
  
## Changes 👷‍♀️
- Removes the check that blocked the view when there was zero events
  
## How to test 🧪
- Open maker position on fork
- Navigate to it
- It should be displayed
