### PR TITLE
Remove `WithChildren` from codebase

### DIFF
--- a/blockchain/web3Context.tsx
+++ b/blockchain/web3Context.tsx
@@ -1,16 +1,18 @@
 import { isMainContextAvailable, useMainContext } from 'components/context/MainContextProvider'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
-function SetupWeb3ContextInternal({ children }: WithChildren) {
+function SetupWeb3ContextInternal({ children }: PropsWithChildren<{}>) {
   const { setupWeb3Context$ } = useMainContext()
   setupWeb3Context$()
-  return children
+
+  return <>{children}</>
 }
 
-export function SetupWeb3Context({ children }: WithChildren) {
+export function SetupWeb3Context({ children }: PropsWithChildren<{}>) {
   if (isMainContextAvailable()) {
     return <SetupWeb3ContextInternal>{children}</SetupWeb3ContextInternal>
   }
-  return children
+
+  return <>{children}</>
 }

--- a/components/BenefitCard.tsx
+++ b/components/BenefitCard.tsx
@@ -1,11 +1,11 @@
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useTranslation } from 'next-i18next'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Box, Card, Flex, Grid, Image, Text } from 'theme-ui'
 import { slideInAnimation } from 'theme/animations'
 
-export function BenefitCardsWrapper({ children }: WithChildren) {
+export function BenefitCardsWrapper({ children }: PropsWithChildren<{}>) {
   return (
     <Grid
       columns={[1, 2, 3]}

--- a/components/DImmedList.tsx
+++ b/components/DImmedList.tsx
@@ -1,8 +1,8 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Grid } from 'theme-ui'
 
-export function DimmedList({ children }: WithChildren) {
+export function DimmedList({ children }: PropsWithChildren<{}>) {
   return (
     <Grid
       as="ul"

--- a/components/InfoCard.tsx
+++ b/components/InfoCard.tsx
@@ -1,5 +1,5 @@
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
 import { Box, Card, Heading, Text } from 'theme-ui'
@@ -12,10 +12,10 @@ function CardContent({
   title,
   subtitle,
   children,
-}: {
+}: PropsWithChildren<{
   title: string
   subtitle: string
-} & WithChildren) {
+}>) {
   return (
     <Box sx={{ position: 'relative', zIndex: 2, pb: 4 }}>
       <Heading sx={{ my: 2, fontWeight: 'bold', color: 'primary100' }}>{title}</Heading>
@@ -30,11 +30,11 @@ function CardWrapper({
   backgroundGradient,
   sx,
   children,
-}: {
+}: PropsWithChildren<{
   backgroundImage: string
   backgroundGradient: string
   sx?: ThemeUIStyleObject
-} & WithChildren) {
+}>) {
   return (
     <Card
       sx={{

--- a/components/InternalLink.tsx
+++ b/components/InternalLink.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Link as ThemeLink } from 'theme-ui'
 
@@ -15,7 +16,7 @@ export function InternalLink({
   query,
   variant,
   ...rest
-}: AppLinkProps) {
+}: PropsWithChildren<AppLinkProps>) {
   const readOnlyHref = href
   const readOnlyAs = as
 

--- a/components/Links.tsx
+++ b/components/Links.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Link as ThemeLink } from 'theme-ui'
 
@@ -17,10 +18,10 @@ export function AppLink({
   target,
   variant = 'styles.a',
   ...rest
-}: AppLinkProps) {
+}: PropsWithChildren<AppLinkProps>) {
   const isInternalLink = href && getIsInternalLink(href)
 
-  if (disabled) return children
+  if (disabled) return <>{children}</>
 
   if (isInternalLink) {
     return <InternalLink {...{ href, sx, variant, onClick, ...rest }}>{children}</InternalLink>

--- a/components/Links.types.tsx
+++ b/components/Links.types.tsx
@@ -1,9 +1,8 @@
-import type { WithChildren } from 'helpers/types/With.types'
 import type { LinkProps } from 'next/dist/client/link'
 import type React from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
 
-export interface AppLinkProps extends WithChildren, LinkProps {
+export interface AppLinkProps extends LinkProps {
   disabled?: boolean
   hash?: string
   href: string

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -3,9 +3,8 @@ import { useSharedUI } from 'components/SharedUIProvider'
 import { useWalletManagement } from 'features/web3OnBoard/useConnection'
 import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import type { ModalProps } from 'helpers/modalHook'
-import type { WithChildren } from 'helpers/types/With.types'
 import { Trans, useTranslation } from 'next-i18next'
-import type { ReactNode } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import React, { useCallback, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { TRANSITIONS } from 'theme'
@@ -29,7 +28,7 @@ import { Icon } from './Icon'
 import { AppLink } from './Links'
 import curry from 'ramda/src/curry'
 
-interface ModalCloseIconProps extends ModalProps<WithChildren> {
+interface ModalCloseIconProps extends PropsWithChildren<ModalProps> {
   sx?: ThemeUIStyleObject
   size?: number
   color?: string
@@ -137,12 +136,12 @@ function ModalWrapper({
   close,
   sxWrapper,
   omitHTMLOverflow,
-}: WithChildren & {
+}: PropsWithChildren<{
   close: () => void
   id?: string
   sxWrapper?: ThemeUIStyleObject
   omitHTMLOverflow?: boolean
-}) {
+}>) {
   useEffect(() => {
     const curriedOverflowClickHandler = curry(overflowClickHandler)(close)
 
@@ -233,16 +232,16 @@ export function ModalErrorMessage({ message }: { message: string }) {
   )
 }
 
-export function MobileSidePanelPortal({ children }: WithChildren) {
+export function MobileSidePanelPortal({ children }: PropsWithChildren<{}>) {
   const onMobile = useOnMobile()
 
-  return onMobile && document.body ? createPortal(children, document.body) : children
+  return onMobile && document.body ? createPortal(children, document.body) : <>{children}</>
 }
 
 export function MobileSidePanel({
   toggleTitle,
   children,
-}: WithChildren & { toggleTitle: ReactNode }) {
+}: PropsWithChildren<{ toggleTitle: ReactNode }>) {
   const { vaultFormOpened, setVaultFormOpened, setVaultFormToggleTitle } = useSharedUI()
 
   useEffect(() => {

--- a/components/Notice.tsx
+++ b/components/Notice.tsx
@@ -1,4 +1,4 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
 import { Box, IconButton } from 'theme-ui'
@@ -12,7 +12,7 @@ type Closable = {
   withClose?: boolean
 }
 
-type NoticeProps = WithChildren & Closable
+type NoticeProps = PropsWithChildren<Closable>
 
 export function Notice({ children, close, sx, withClose = true }: NoticeProps) {
   return (

--- a/components/SharedUIProvider.tsx
+++ b/components/SharedUIProvider.tsx
@@ -1,5 +1,4 @@
-import type { WithChildren } from 'helpers/types/With.types'
-import type { ReactNode } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import React, { createContext, useContext, useState } from 'react'
 
 interface SharedUIState {
@@ -13,7 +12,7 @@ export const SharedUIContext = createContext<SharedUIState | {}>({})
 
 export const useSharedUI = () => useContext(SharedUIContext) as SharedUIState
 
-export function SharedUIProvider({ children }: WithChildren) {
+export function SharedUIProvider({ children }: PropsWithChildren<{}>) {
   const [vaultFormToggleTitle, setVaultFormToggleTitle] = useState<ReactNode | undefined>(undefined)
   const [vaultFormOpened, setVaultFormOpened] = useState(false)
 

--- a/components/TextWithCheckmark.tsx
+++ b/components/TextWithCheckmark.tsx
@@ -1,11 +1,11 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Flex, Text } from 'theme-ui'
 import { checkmark } from 'theme/icons'
 
 import { Icon } from './Icon'
 
-export function TextWithCheckmark({ children }: WithChildren) {
+export function TextWithCheckmark({ children }: PropsWithChildren<{}>) {
   return (
     <Flex sx={{ alignItems: 'center' }}>
       <Flex

--- a/components/assetsTable/AssetsTableHeading.tsx
+++ b/components/assetsTable/AssetsTableHeading.tsx
@@ -1,8 +1,8 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Heading } from 'theme-ui'
 
-export function AssetsTableHeading({ children }: WithChildren) {
+export function AssetsTableHeading({ children }: PropsWithChildren<{}>) {
   return (
     <Heading
       as="h3"

--- a/components/assetsTable/cellComponents/AssetsTableDataCellInactive.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellInactive.tsx
@@ -1,8 +1,8 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Text } from 'theme-ui'
 
-export function AssetsTableDataCellInactive({ children = 'n/a' }: WithChildren) {
+export function AssetsTableDataCellInactive({ children = 'n/a' }: PropsWithChildren<{}>) {
   return (
     <Text as="span" sx={{ color: 'neutral80' }}>
       {children}

--- a/components/connectWallet/Connection.tsx
+++ b/components/connectWallet/Connection.tsx
@@ -1,7 +1,6 @@
 import type { NetworkConfigHexId } from 'blockchain/networks'
 import { useConnection } from 'features/web3OnBoard/useConnection'
-import type { WithChildren } from 'helpers/types/With.types'
-import { useEffect } from 'react'
+import React, { type PropsWithChildren, useEffect } from 'react'
 
 export function Connection({
   children,
@@ -9,12 +8,12 @@ export function Connection({
   chainId,
   pageChainId,
   includeTestNet,
-}: WithChildren & {
+}: PropsWithChildren<{
   walletConnect: boolean
   chainId?: NetworkConfigHexId
   pageChainId?: NetworkConfigHexId
   includeTestNet?: boolean
-}) {
+}>) {
   const { connect, setPageNetworks } = useConnection()
 
   useEffect(() => {}, [pageChainId, setPageNetworks])
@@ -23,5 +22,5 @@ export function Connection({
     if (walletConnect) connect(chainId, includeTestNet)
   }, [walletConnect, chainId, connect, setPageNetworks, pageChainId, includeTestNet])
 
-  return children
+  return <>{children}</>
 }

--- a/components/connectWallet/index.tsx
+++ b/components/connectWallet/index.tsx
@@ -1,5 +1,5 @@
 import type { NetworkConfigHexId } from 'blockchain/networks'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 import { Connection } from './Connection'
@@ -8,7 +8,7 @@ export const WithConnection = ({
   children,
   pageChainId,
   includeTestNet,
-}: WithChildren & { pageChainId?: NetworkConfigHexId; includeTestNet?: boolean }) => (
+}: PropsWithChildren<{ pageChainId?: NetworkConfigHexId; includeTestNet?: boolean }>) => (
   <Connection walletConnect={false} pageChainId={pageChainId} includeTestNet={includeTestNet}>
     {children}
   </Connection>
@@ -17,7 +17,7 @@ export const WithWalletConnection = ({
   children,
   chainId,
   includeTestNet,
-}: WithChildren & { chainId: NetworkConfigHexId; includeTestNet?: boolean }) => (
+}: PropsWithChildren<{ chainId: NetworkConfigHexId; includeTestNet?: boolean }>) => (
   <Connection
     walletConnect={true}
     chainId={chainId}

--- a/components/context/AccountContextProvider.tsx
+++ b/components/context/AccountContextProvider.tsx
@@ -51,8 +51,8 @@ import {
 import { bigNumberTostring } from 'helpers/bigNumberToString'
 import type { DepreciatedServices } from 'helpers/context/types'
 import { ilkUrnAddressToString } from 'helpers/ilkUrnAddressToString'
-import type { WithChildren } from 'helpers/types/With.types'
 import { memoize } from 'lodash'
+import type { PropsWithChildren } from 'react'
 import React, { useContext as checkContext, useContext, useEffect, useState } from 'react'
 import type { Observable } from 'rxjs'
 import { combineLatest, of } from 'rxjs'
@@ -75,7 +75,7 @@ export function useAccountContext(): AccountContext {
   return ac
 }
 
-export function AccountContextProvider({ children }: WithChildren) {
+export function AccountContextProvider({ children }: PropsWithChildren<{}>) {
   const [context, setContext] = useState<AccountContext | undefined>(undefined)
   const {
     context$,

--- a/components/context/DeferedContextProvider.tsx
+++ b/components/context/DeferedContextProvider.tsx
@@ -1,5 +1,5 @@
 import { AppSpinnerWholePage } from 'helpers/AppSpinner'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React, { useContext } from 'react'
 
 // usable in situations where ProductContext and other context is rendered simultanously:
@@ -11,6 +11,6 @@ import React, { useContext } from 'react'
 export function DeferedContextProvider({
   children,
   context,
-}: WithChildren & { context: React.Context<any> }) {
-  return useContext(context) ? children : <AppSpinnerWholePage />
+}: PropsWithChildren<{ context: React.Context<any> }>) {
+  return useContext(context) ? <>{children}</> : <AppSpinnerWholePage />
 }

--- a/components/context/FunctionalContextHandler.tsx
+++ b/components/context/FunctionalContextHandler.tsx
@@ -1,10 +1,10 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 import { DeferedContextProvider } from './DeferedContextProvider'
 import { tosContext, TOSContextProvider } from './TOSContextProvider'
 
-export const FunctionalContextHandler = ({ children }: WithChildren) => {
+export const FunctionalContextHandler = ({ children }: PropsWithChildren<{}>) => {
   // theese are needed on rewards/discover, which is sort of between open/manage and static pages
   return (
     <TOSContextProvider>

--- a/components/context/GasEstimationContextProvider.tsx
+++ b/components/context/GasEstimationContextProvider.tsx
@@ -6,9 +6,9 @@ import type { TxPayloadChange } from 'helpers/gasEstimate.types'
 import { useObservable } from 'helpers/observableHook'
 import type { HasGasEstimation } from 'helpers/types/HasGasEstimation.types'
 import { GasEstimationStatus } from 'helpers/types/HasGasEstimation.types'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { zero } from 'helpers/zero'
+import type { PropsWithChildren } from 'react'
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { of } from 'rxjs'
 
@@ -37,7 +37,7 @@ export const useGasEstimationContext = () => {
   This component is providing data regarding gas based on txData received from uiChanges.
 */
 
-export function GasEstimationContextProvider({ children }: WithChildren) {
+export function GasEstimationContextProvider({ children }: PropsWithChildren<{}>) {
   if (!isProductContextAvailable()) {
     return null
   }

--- a/components/context/MainContextProvider.tsx
+++ b/components/context/MainContextProvider.tsx
@@ -1,6 +1,6 @@
 import { setupMainContext } from 'helpers/context/MainContext'
 import type { MainContext } from 'helpers/context/MainContext.types'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React, { useContext as checkContext, useContext, useEffect, useState } from 'react'
 
 export const mainContext = React.createContext<MainContext | undefined>(undefined)
@@ -17,7 +17,7 @@ export function useMainContext(): MainContext {
   return ac
 }
 
-export function MainContextProvider({ children }: WithChildren) {
+export function MainContextProvider({ children }: PropsWithChildren<{}>) {
   const [context, setContext] = useState<MainContext | undefined>(undefined)
 
   useEffect(() => {

--- a/components/context/NotificationSocketProvider.tsx
+++ b/components/context/NotificationSocketProvider.tsx
@@ -12,9 +12,9 @@ import {
 import { jwtAuthGetToken } from 'features/shared/jwt'
 import { getBrowserName } from 'helpers/functions'
 import { useObservable } from 'helpers/observableHook'
-import type { WithChildren } from 'helpers/types/With.types'
 import { uiChanges } from 'helpers/uiChanges'
 import getConfig from 'next/config'
+import type { PropsWithChildren } from 'react'
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import type { Socket } from 'socket.io-client'
 import io from 'socket.io-client'
@@ -30,7 +30,7 @@ export const NotificationSocketContext = createContext<WebSocket | {}>({})
 
 export const useNotificationSocket = () => useContext(NotificationSocketContext) as WebSocket
 
-export function NotificationSocketProvider({ children }: WithChildren) {
+export function NotificationSocketProvider({ children }: PropsWithChildren<{}>) {
   if (!isMainContextAvailable()) {
     return null
   }

--- a/components/context/PreloadAppDataContextProvider.tsx
+++ b/components/context/PreloadAppDataContextProvider.tsx
@@ -1,8 +1,8 @@
 import { useProductHubData } from 'features/productHub/hooks/useProductHubData'
 import type { ConfigResponseType, PreloadAppDataContext } from 'helpers/config'
 import { configCacheTime, getLocalAppConfig, saveConfigToLocalStorage } from 'helpers/config'
-import type { WithChildren } from 'helpers/types/With.types'
 import { LendingProtocol } from 'lendingProtocols'
+import type { PropsWithChildren } from 'react'
 import React, { useContext, useEffect, useState } from 'react'
 import { FeaturesEnum } from 'types/config'
 
@@ -35,7 +35,7 @@ export function usePreloadAppDataContext(): PreloadAppDataContext {
   return ac
 }
 
-export function PreloadAppDataContextProvider({ children }: WithChildren) {
+export function PreloadAppDataContextProvider({ children }: PropsWithChildren<{}>) {
   const [context, setContext] = useState<PreloadAppDataContext | undefined>(undefined)
   const { AjnaSafetySwitch } = getLocalAppConfig('features')
 

--- a/components/context/ProductContextHandler.tsx
+++ b/components/context/ProductContextHandler.tsx
@@ -1,14 +1,14 @@
 // @ts-ignore
 
 import { WithFollowVaults } from 'features/follow/view/WithFollowVaults'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 import { DeferedContextProvider } from './DeferedContextProvider'
 import { FunctionalContextHandler } from './FunctionalContextHandler'
 import { productContext, ProductContextProvider } from './ProductContextProvider'
 
-export const ProductContextHandler = ({ children }: WithChildren) => {
+export const ProductContextHandler = ({ children }: PropsWithChildren<{}>) => {
   // theese are needed on the opening/managing positions page, but not on the static pages
   return (
     <FunctionalContextHandler>

--- a/components/context/ProductContextProvider.tsx
+++ b/components/context/ProductContextProvider.tsx
@@ -1,6 +1,6 @@
 import { setupProductContext } from 'helpers/context/ProductContext'
 import type { ProductContext } from 'helpers/context/ProductContext.types'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React, { useContext as checkContext, useContext, useEffect, useState } from 'react'
 
 import { useAccountContext } from './AccountContextProvider'
@@ -27,7 +27,7 @@ export function useProductContext(): ProductContext {
   on top of that page with isProductContextAvailable.
 */
 
-export function ProductContextProvider({ children }: WithChildren) {
+export function ProductContextProvider({ children }: PropsWithChildren<{}>) {
   const [context, setContext] = useState<ProductContext | undefined>(undefined)
   const mainContext = useMainContext()
   const accountContext = useAccountContext()

--- a/components/context/TOSContextProvider.tsx
+++ b/components/context/TOSContextProvider.tsx
@@ -9,7 +9,7 @@ import {
 import { createWalletAssociatedRisk$ } from 'features/walletAssociatedRisk/walletRisk'
 import type { WalletRiskResponse } from 'features/walletAssociatedRisk/walletRiskApi'
 import type { DepreciatedServices } from 'helpers/context/types'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React, { useContext as checkContext, useContext, useEffect, useState } from 'react'
 import type { Observable } from 'rxjs'
 
@@ -29,7 +29,7 @@ export function useTOSContext(): TOSContext {
   return ac
 }
 
-export function TOSContextProvider({ children }: WithChildren) {
+export function TOSContextProvider({ children }: PropsWithChildren<{}>) {
   const [context, setContext] = useState<TOSContext | undefined>(undefined)
   const { web3Context$, txHelpers$ } = useMainContext()
 

--- a/components/forms/Details.tsx
+++ b/components/forms/Details.tsx
@@ -1,4 +1,4 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
 import { Card, Grid, Text } from 'theme-ui'
@@ -27,7 +27,7 @@ export function DetailsItem({ label, value }: { label: React.ReactNode; value: R
   )
 }
 
-export function Details({ children }: WithChildren) {
+export function Details({ children }: PropsWithChildren<{}>) {
   return (
     <Card bg="neutral30" sx={{ border: 'none' }}>
       <Grid columns={'auto 1fr'} gap={2}>

--- a/components/layouts/AppLayout.tsx
+++ b/components/layouts/AppLayout.tsx
@@ -1,25 +1,23 @@
 import { Footer } from 'components/Footer'
 import { ModalTrezorMetamaskEIP1559 } from 'components/Modal'
 import { NavigationController } from 'features/navigation/controls/NavigationController'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
 import { WithAnnouncementLayout } from './WithAnnouncementLayout'
 
-export function AppLayout({ children }: WithChildren) {
+export function AppLayout({ children }: PropsWithChildren<{}>) {
   return (
-    <>
-      <WithAnnouncementLayout
-        sx={{ zIndex: 2, position: 'relative' }}
-        showAnnouncement={false}
-        footer={<Footer />}
-        header={<NavigationController />}
-        bg={<BackgroundLight />}
-      >
-        {children}
-        <ModalTrezorMetamaskEIP1559 />
-      </WithAnnouncementLayout>
-    </>
+    <WithAnnouncementLayout
+      sx={{ zIndex: 2, position: 'relative' }}
+      showAnnouncement={false}
+      footer={<Footer />}
+      header={<NavigationController />}
+      bg={<BackgroundLight />}
+    >
+      {children}
+      <ModalTrezorMetamaskEIP1559 />
+    </WithAnnouncementLayout>
   )
 }

--- a/components/layouts/BasicLayout.tsx
+++ b/components/layouts/BasicLayout.tsx
@@ -1,9 +1,9 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
 import { Container, Flex } from 'theme-ui'
 
-export interface BasicLayoutProps extends WithChildren {
+export interface BasicLayoutProps extends PropsWithChildren<{}> {
   header: JSX.Element
   footer?: JSX.Element
   sx?: ThemeUIStyleObject

--- a/components/layouts/LandingPageLayout.tsx
+++ b/components/layouts/LandingPageLayout.tsx
@@ -1,12 +1,12 @@
 import { Footer } from 'components/Footer'
 import { HomepageHero } from 'features/homepage/HomepageHero'
 import { NavigationController } from 'features/navigation/controls/NavigationController'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 import { WithAnnouncementLandingLayout } from './WithAnnouncementLayout'
 
-export function LandingPageLayout({ children }: WithChildren) {
+export function LandingPageLayout({ children }: PropsWithChildren<{}>) {
   return (
     <WithAnnouncementLandingLayout
       header={

--- a/components/layouts/MarketingLayout.types.tsx
+++ b/components/layouts/MarketingLayout.types.tsx
@@ -1,8 +1,8 @@
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 
 import type { marketingBackgrounds } from './backgrounds'
 
-export interface MarketingLayoutProps extends WithChildren {
+export interface MarketingLayoutProps extends PropsWithChildren<{}> {
   variant?: string
   topBackground?: keyof typeof marketingBackgrounds
 }

--- a/components/layouts/ProductPagesLayout.tsx
+++ b/components/layouts/ProductPagesLayout.tsx
@@ -1,12 +1,12 @@
 import { Footer } from 'components/Footer'
 import { NavigationController } from 'features/navigation/controls/NavigationController'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
 import { WithAnnouncementLayout } from './WithAnnouncementLayout'
 
-export function ProductPagesLayout({ children }: WithChildren) {
+export function ProductPagesLayout({ children }: PropsWithChildren<{}>) {
   return (
     <>
       <WithAnnouncementLayout

--- a/components/vault/DefaultVaultHeader.tsx
+++ b/components/vault/DefaultVaultHeader.tsx
@@ -2,8 +2,8 @@ import type BigNumber from 'bignumber.js'
 import type { IlkData } from 'blockchain/ilks.types'
 import type { PriceInfo } from 'features/shared/priceInfo.types'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useTranslation } from 'next-i18next'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 import { VaultHeader, VaultIlkDetailsItem } from './VaultHeader'
@@ -16,7 +16,7 @@ export interface DefaultVaultHeaderProps {
   priceInfo: PriceInfo
 }
 
-export function DefaultVaultHeader(props: DefaultVaultHeaderProps & WithChildren) {
+export function DefaultVaultHeader(props: PropsWithChildren<DefaultVaultHeaderProps>) {
   const {
     ilkData: { liquidationRatio, stabilityFee, liquidationPenalty, debtFloor },
     id,

--- a/components/vault/VaultChangesInformation.tsx
+++ b/components/vault/VaultChangesInformation.tsx
@@ -9,10 +9,9 @@ import { formatAmount } from 'helpers/formatters/format'
 import { isTouchDevice } from 'helpers/isTouchDevice'
 import type { HasGasEstimation } from 'helpers/types/HasGasEstimation.types'
 import { GasEstimationStatus } from 'helpers/types/HasGasEstimation.types'
-import type { WithChildren } from 'helpers/types/With.types'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
-import type { ReactNode } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import React, { useCallback, useMemo } from 'react'
 import { arrow_right_light, question_o } from 'theme/icons'
 
@@ -79,7 +78,7 @@ export function VaultChangesInformationItem({
 export function VaultChangesInformationContainer({
   title,
   children,
-}: { title: string } & WithChildren) {
+}: PropsWithChildren<{ title: string }>) {
   return (
     <DimmedList>
       <Box as="li" sx={{ listStyle: 'none' }}>

--- a/components/vault/VaultDetails.tsx
+++ b/components/vault/VaultDetails.tsx
@@ -3,9 +3,8 @@ import { Icon } from 'components/Icon'
 import { Modal, ModalCloseIcon } from 'components/Modal'
 import type { PriceInfo } from 'features/shared/priceInfo.types'
 import type { CommonVaultState } from 'helpers/types/CommonVaultState.types'
-import type { WithChildren } from 'helpers/types/With.types'
 import { zero } from 'helpers/zero'
-import type { ReactNode } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import React from 'react'
 import type { SxProp } from 'theme-ui'
 import { Box, Card, Flex, Grid, Heading, Text } from 'theme-ui'
@@ -74,7 +73,7 @@ export function VaultDetailsAfterPill({
   children,
   afterPillColors,
   sx = {},
-}: WithChildren & AfterPillProps & SxProp) {
+}: PropsWithChildren<AfterPillProps & SxProp>) {
   return (
     <Card
       sx={{
@@ -185,7 +184,7 @@ export function VaultDetailsCardModal({
 export function VaultDetailsSummaryContainer({
   children,
   relevant = true,
-}: WithChildren & { relevant?: boolean }) {
+}: PropsWithChildren<{ relevant?: boolean }>) {
   return (
     <Card sx={{ borderRadius: 'large', border: 'lightMuted', opacity: relevant ? 1 : 0.5 }}>
       <Grid

--- a/components/vault/VaultForm.tsx
+++ b/components/vault/VaultForm.tsx
@@ -1,15 +1,15 @@
 import { Box, Flex, Text } from '@theme-ui/components'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 export function WithVaultFormStepIndicator({
   currentStep,
   totalSteps,
   children,
-}: {
+}: PropsWithChildren<{
   currentStep: number
   totalSteps: number
-} & WithChildren) {
+}>) {
   return (
     <Flex sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
       <Box sx={{ flex: 1 }}>{children}</Box>

--- a/components/vault/VaultFormContainer.tsx
+++ b/components/vault/VaultFormContainer.tsx
@@ -1,12 +1,12 @@
 import { MobileSidePanel } from 'components/Modal'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Card, Grid } from 'theme-ui'
 
 export function VaultFormContainer({
   children,
   toggleTitle,
-}: WithChildren & { toggleTitle: string }) {
+}: PropsWithChildren<{ toggleTitle: string }>) {
   return (
     <MobileSidePanel toggleTitle={toggleTitle}>
       <Card variant="vaultFormContainer">

--- a/features/aave/aave-context-provider.test.tsx
+++ b/features/aave/aave-context-provider.test.tsx
@@ -5,8 +5,8 @@ import { DeferedContextProvider } from 'components/context/DeferedContextProvide
 import { mainContext, MainContextProvider } from 'components/context/MainContextProvider'
 import { productContext } from 'components/context/ProductContextProvider'
 import type { ProductContext } from 'helpers/context/ProductContext.types'
-import type { WithChildren } from 'helpers/types/With.types'
 import { LendingProtocol } from 'lendingProtocols'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 
 import type { AaveContext } from './aave-context'
@@ -33,7 +33,7 @@ jest.mock('./setup-spark-v3-context', () => {
 
 describe('AaveContextProvider', () => {
   const context = { protocols: {} } as ProductContext
-  const wrapper = ({ children }: WithChildren) => (
+  const wrapper = ({ children }: PropsWithChildren<{}>) => (
     <MainContextProvider>
       <DeferedContextProvider context={mainContext}>
         <AccountContextProvider>

--- a/features/aave/aave-context-provider.tsx
+++ b/features/aave/aave-context-provider.tsx
@@ -2,9 +2,9 @@ import { NetworkNames } from 'blockchain/networks'
 import { useAccountContext } from 'components/context/AccountContextProvider'
 import { useMainContext } from 'components/context/MainContextProvider'
 import { useProductContext } from 'components/context/ProductContextProvider'
-import type { WithChildren } from 'helpers/types/With.types'
 import type { AaveLendingProtocol, SparkLendingProtocol } from 'lendingProtocols'
 import { LendingProtocol } from 'lendingProtocols'
+import type { PropsWithChildren } from 'react'
 import React, { useContext, useEffect, useState } from 'react'
 
 import type { AaveContext } from './aave-context'
@@ -44,7 +44,7 @@ export function useAaveContext(
   return aaveContextsForNetwork[protocol]!
 }
 
-export function AaveContextProvider({ children }: WithChildren) {
+export function AaveContextProvider({ children }: PropsWithChildren<{}>) {
   const mainContext = useMainContext()
   const accountContext = useAccountContext()
   const productContext = useProductContext()

--- a/features/aave/components/order-information/OrderInformationTooltipAction.tsx
+++ b/features/aave/components/order-information/OrderInformationTooltipAction.tsx
@@ -1,11 +1,11 @@
 import { Icon } from 'components/Icon'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useOutsideElementClickHandler } from 'helpers/useOutsideElementClickHandler'
+import type { PropsWithChildren } from 'react'
 import React, { useState } from 'react'
 import { Box, Flex } from 'theme-ui'
 import { question_o } from 'theme/icons'
 
-export function OrderInformationTooltipAction({ children }: WithChildren) {
+export function OrderInformationTooltipAction({ children }: PropsWithChildren<{}>) {
   const [isOpen, setIsOpen] = useState(false)
 
   const componentRef = useOutsideElementClickHandler(() => setIsOpen(false))

--- a/features/ajna/common/layout.tsx
+++ b/features/ajna/common/layout.tsx
@@ -2,13 +2,13 @@ import { Footer } from 'components/Footer'
 import { PageSEOTags } from 'components/HeadTags'
 import { WithAnnouncementLayout } from 'components/layouts/WithAnnouncementLayout'
 import { AjnaNavigationController } from 'features/navigation/controls/AjnaNavigationController'
-import type { WithChildren } from 'helpers/types/With.types'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { ajnaExtensionTheme } from 'theme'
 import { ThemeUIProvider } from 'theme-ui'
 import { BackgroundLight } from 'theme/BackgroundLight'
 
-export function AjnaLayout({ children }: WithChildren) {
+export function AjnaLayout({ children }: PropsWithChildren<{}>) {
   return (
     <ThemeUIProvider theme={ajnaExtensionTheme}>
       <WithAnnouncementLayout

--- a/features/automation/protection/stopLoss/controls/StopLossBannerLayout.tsx
+++ b/features/automation/protection/stopLoss/controls/StopLossBannerLayout.tsx
@@ -4,9 +4,8 @@ import { VaultDetailsAfterPill } from 'components/vault/VaultDetails'
 import { WithArrow } from 'components/WithArrow'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useTranslation } from 'next-i18next'
-import type { ReactNode } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import React from 'react'
 import { Box, Button, Card, Flex, Grid, Image, Text } from 'theme-ui'
 
@@ -45,7 +44,7 @@ function StopLossBannerSection({
   )
 }
 
-function StopLossBannerSectionCompact({ children }: WithChildren) {
+function StopLossBannerSectionCompact({ children }: PropsWithChildren<{}>) {
   return (
     <Flex
       sx={{

--- a/features/discover/common/DiscoverWrapperWithIntro.tsx
+++ b/features/discover/common/DiscoverWrapperWithIntro.tsx
@@ -1,12 +1,12 @@
 import { AppLink } from 'components/Links'
 import { WithArrow } from 'components/WithArrow'
 import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useTranslation } from 'next-i18next'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Box, Heading, Text } from 'theme-ui'
 
-export function DiscoverWrapperWithIntro({ children }: WithChildren) {
+export function DiscoverWrapperWithIntro({ children }: PropsWithChildren<{}>) {
   const { t } = useTranslation()
 
   return (

--- a/features/follow/view/WithFollowVaults.tsx
+++ b/features/follow/view/WithFollowVaults.tsx
@@ -1,8 +1,8 @@
 import { useFollowInitialization } from 'features/follow/common/useFollowInitialization'
-import type { WithChildren } from 'helpers/types/With.types'
+import React, { type PropsWithChildren } from 'react'
 
-export function WithFollowVaults({ children }: WithChildren) {
+export function WithFollowVaults({ children }: PropsWithChildren<{}>) {
   useFollowInitialization({ isLimitReached: false })
 
-  return children
+  return <>{children}</>
 }

--- a/features/notices/VaultsNoticesView.tsx
+++ b/features/notices/VaultsNoticesView.tsx
@@ -19,10 +19,10 @@ import {
 } from 'helpers/formatters/format'
 import { useObservable } from 'helpers/observableHook'
 import type { TranslateStringType } from 'helpers/translateStringType'
-import type { WithChildren } from 'helpers/types/With.types'
 import { zero } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
+import type { PropsWithChildren } from 'react'
 import React, { useEffect, useMemo, useState } from 'react'
 import { CountdownCircleTimer } from 'react-countdown-circle-timer'
 import type { ThemeUIStyleObject } from 'theme-ui'
@@ -42,7 +42,7 @@ type VaultNoticeProps = {
   withClose?: boolean
 }
 
-function StatusFrame({ children, sx }: WithChildren & { sx?: ThemeUIStyleObject }) {
+function StatusFrame({ children, sx }: PropsWithChildren<{ sx?: ThemeUIStyleObject }>) {
   return (
     <Flex
       sx={{

--- a/features/referralOverview/ReferralLayout.tsx
+++ b/features/referralOverview/ReferralLayout.tsx
@@ -1,14 +1,14 @@
 import { Icon } from 'components/Icon'
 import { AppLink } from 'components/Links'
 import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useTranslation } from 'next-i18next'
+import type { PropsWithChildren } from 'react'
 import React from 'react'
 import { Flex, Grid, Heading, Text } from 'theme-ui'
 import { fadeInAnimation } from 'theme/animations'
 import { arrow_right } from 'theme/icons'
 
-export function ReferralLayout({ children }: WithChildren) {
+export function ReferralLayout({ children }: PropsWithChildren<{}>) {
   const { t } = useTranslation()
 
   return (

--- a/features/vaultHistory/VaultHistoryEntry.tsx
+++ b/features/vaultHistory/VaultHistoryEntry.tsx
@@ -17,9 +17,9 @@ import {
   formatPercent,
 } from 'helpers/formatters/format'
 import { interpolate } from 'helpers/interpolate'
-import type { WithChildren } from 'helpers/types/With.types'
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
+import type { PropsWithChildren } from 'react'
 import React, { useState } from 'react'
 import { Box, Flex, Text } from 'theme-ui'
 import { chevron_down, chevron_up } from 'theme/icons'
@@ -80,7 +80,7 @@ export function getHistoryEventTranslation(t: TranslationType, event: VaultHisto
   })
 }
 
-function VaultHistoryEntryDetailsItem({ label, children }: { label: string } & WithChildren) {
+function VaultHistoryEntryDetailsItem({ label, children }: PropsWithChildren<{ label: string }>) {
   return (
     <DefinitionListItem sx={{ display: 'flex', justifyContent: 'space-between', pl: 3, pr: 2 }}>
       <Text

--- a/features/web3OnBoard/web3-on-board-connector-provider.tsx
+++ b/features/web3OnBoard/web3-on-board-connector-provider.tsx
@@ -2,8 +2,8 @@ import { ConnectorEvent } from '@web3-react/types'
 import type { NetworkConfigHexId } from 'blockchain/networks'
 import { NetworkIds } from 'blockchain/networks'
 import { useModalContext } from 'helpers/modalHook'
-import type { WithChildren } from 'helpers/types/With.types'
 import { useReducto } from 'helpers/useReducto'
+import type { PropsWithChildren } from 'react'
 import React, { createContext, useCallback, useContext, useEffect } from 'react'
 
 import { getNetworksFromPageNetwork } from './get-networks-from-page-network'
@@ -58,7 +58,7 @@ const web3OnBoardConnectorContext = createContext<Web3OnBoardConnectorContext>({
 
 export const useWeb3OnBoardConnectorContext = () => useContext(web3OnBoardConnectorContext)
 
-function InternalProvider({ children }: WithChildren) {
+function InternalProvider({ children }: PropsWithChildren<{}>) {
   const { networkConnector } = useNetworkConnector()
   const { dispatch, state } = useReducto<WalletManagementState, WalletStateEvent>({
     defaults: {
@@ -248,6 +248,6 @@ function InternalProvider({ children }: WithChildren) {
   )
 }
 
-export function Web3OnBoardConnectorProvider({ children }: WithChildren) {
+export function Web3OnBoardConnectorProvider({ children }: PropsWithChildren<{}>) {
   return <InternalProvider>{children}</InternalProvider>
 }

--- a/helpers/types/With.types.ts
+++ b/helpers/types/With.types.ts
@@ -1,7 +1,6 @@
 import type { TFunction } from 'next-i18next'
 import type { ParsedUrlQuery } from 'querystring'
 
-export type WithChildren = { children?: any }
 export type WithTranslation = { t: TFunction }
 export type WithQuery = { query?: ParsedUrlQuery }
 export type WithReadonlyAccount = { readonlyAccount?: boolean }


### PR DESCRIPTION
# [Remove `WithChildren` from codebase](https://shortcutLink)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/f80b9e28-34b3-4e2b-8a92-774d9b2b1496)
  
## Changes 👷‍♀️

- Replaced all `WithChildren` with native to React `PropsWithChildren`.
  
## How to test 🧪

As this is only typescript change, no need to be tested - if build passes everything should work.
