### PR TITLE
Minor Portfolio layout fixes

### DIFF
--- a/components/portfolio/PortfolioHeader.tsx
+++ b/components/portfolio/PortfolioHeader.tsx
@@ -29,7 +29,7 @@ export const PortfolioHeader = ({ address }: { address: string }) => {
       </Flex>
       <Flex sx={{ justifyContent: ['flex-start', 'flex-end'] }}>
         <AppLink href={`${EXTERNAL_LINKS.ETHERSCAN}/address/${address}`}>
-          <Button variant="secondary">{tPortfolio('view-on-etherscan')}</Button>
+          <Button variant="action">{tPortfolio('view-on-etherscan')}</Button>
         </AppLink>
       </Flex>
     </Flex>

--- a/components/portfolio/PortfolioOverview.tsx
+++ b/components/portfolio/PortfolioOverview.tsx
@@ -34,7 +34,7 @@ export const PortfolioOverview = ({
     >
       <Flex sx={{ alignItems: 'flex-start' }}>
         <PortfolioOverviewItem
-          header={tPortfolio('wallet-balance')}
+          header={tPortfolio('total-value')}
           value={
             <Heading variant="header4">
               ${formatAmount(new BigNumber(overviewData.walletBalanceUsdValue), 'USD')}
@@ -45,7 +45,6 @@ export const PortfolioOverview = ({
               <WithArrow sx={{ color: 'interactive100' }}>{tPortfolio('view-assets')}</WithArrow>
             </AppLink>
           }
-          firstInColumn
         />
       </Flex>
       <Flex
@@ -53,6 +52,7 @@ export const PortfolioOverview = ({
           flexDirection: ['column', 'row'],
           alignItems: 'flex-start',
           justifyItems: 'flex-start',
+          columnGap: 4,
         }}
       >
         <PortfolioOverviewItem

--- a/components/portfolio/PortfolioOverviewItem.tsx
+++ b/components/portfolio/PortfolioOverviewItem.tsx
@@ -7,17 +7,14 @@ export const PortfolioOverviewItem = ({
   header,
   value,
   subValue,
-  firstInColumn,
 }: {
   header: TranslateStringType
   value: ReactNode
   subValue?: ReactNode
-  firstInColumn?: boolean
 }) => {
   return (
     <Flex
       sx={{
-        ml: firstInColumn ? 0 : [0, 4],
         mb: [4, 0],
         flexDirection: 'column',
         minWidth: ['auto', '150px'],

--- a/components/portfolio/PortfolioOverviewSkeleton.tsx
+++ b/components/portfolio/PortfolioOverviewSkeleton.tsx
@@ -20,14 +20,13 @@ export const PortfolioOverviewSkeleton = ({ address }: { address: string }) => {
     >
       <Flex sx={{ alignItems: 'flex-start' }}>
         <PortfolioOverviewItem
-          header={tPortfolio('wallet-balance')}
+          header={tPortfolio('total-value')}
           value={<Skeleton sx={{ height: 4, mt: 2 }} />}
           subValue={
             <AppLink href={`/portfolio/${address}`} hash="wallet">
               <WithArrow sx={{ color: 'interactive100' }}>{tPortfolio('view-assets')}</WithArrow>
             </AppLink>
           }
-          firstInColumn
         />
       </Flex>
       <Flex
@@ -35,6 +34,7 @@ export const PortfolioOverviewSkeleton = ({ address }: { address: string }) => {
           flexDirection: ['column', 'row'],
           alignItems: 'flex-start',
           justifyItems: 'flex-start',
+          columnGap: 4,
         }}
       >
         <PortfolioOverviewItem

--- a/components/portfolio/positions/PortfolioPositionBlock.tsx
+++ b/components/portfolio/positions/PortfolioPositionBlock.tsx
@@ -3,7 +3,6 @@ import { AppLink } from 'components/Links'
 import { PortfolioPositionAutomationIcons } from 'components/portfolio/positions/PortfolioPositionAutomationIcons'
 import { PortfolioPositionBlockDetail } from 'components/portfolio/positions/PortfolioPositionBlockDetail'
 import { ProtocolLabel } from 'components/ProtocolLabel'
-import { WithArrow } from 'components/WithArrow'
 import dayjs from 'dayjs'
 import { ProductType } from 'features/aave/types'
 import { LendingProtocolLabel } from 'lendingProtocols'
@@ -96,7 +95,7 @@ export const PortfolioPositionBlock = ({ position }: { position: PortfolioPositi
               sx={{ fontSize: 1 }}
               href={`/${position.network}/${position.protocol}/${position.positionId}`}
             >
-              <WithArrow>{tPortfolio('view-position')}</WithArrow>
+              {tPortfolio('view-position')}
             </AppLink>
           </Flex>
         </Flex>

--- a/components/portfolio/positions/PortfolioPositionsView.tsx
+++ b/components/portfolio/positions/PortfolioPositionsView.tsx
@@ -93,7 +93,7 @@ export const PortfolioPositionsView = ({
   }, [filterState, portfolioPositionsData])
 
   return (
-    <Grid variant="vaultContainer">
+    <Grid variant="portfolio">
       <Box>
         <Flex
           sx={{

--- a/components/portfolio/wallet/PortfolioWalletView.tsx
+++ b/components/portfolio/wallet/PortfolioWalletView.tsx
@@ -1,5 +1,6 @@
 import type { NetworkNames } from 'blockchain/networks'
 import { GenericMultiselect } from 'components/GenericMultiselect'
+import { BlogPosts } from 'components/portfolio/blog-posts/BlogPosts'
 import { PortfolioWalletAssets } from 'components/portfolio/wallet/PortfolioWalletAssets'
 import { PortfolioWalletBanner } from 'components/portfolio/wallet/PortfolioWalletBanner'
 import { PortfolioWalletSummary } from 'components/portfolio/wallet/PortfolioWalletSummary'
@@ -70,7 +71,9 @@ export const PortfolioWalletView = ({
           </Box>
         )}
       </Box>
-      <Box></Box>
+      <Box>
+        <BlogPosts />
+      </Box>
     </Grid>
   )
 }

--- a/public/locales/en/portfolio.json
+++ b/public/locales/en/portfolio.json
@@ -2,7 +2,7 @@
   "positions-tab": "Positions",
   "wallet-tab": "Wallet",
   "view-on-etherscan": "View on Etherscan",
-  "wallet-balance": "Wallet balance",
+  "total-value": "Total Value",
   "view-assets": "View Assets",
   "total-portfolio": "Summer.fi Portfolio",
   "total-supplied": "Total Supplied",


### PR DESCRIPTION
#  Minor Portfolio layout fixes
  
## Changes 👷‍♀️

- Updated translations,
- changed Etherscan button variant to match the one in design,
- updated layout of headline items,
- removed arrow from buttons in positions - we were removing them from all places in Product Finder some time ago and we should keep it consistent,
- added blog posts to wallet tab.