### PR TITLE
Added chainlink oracle price as price source on BASE

### DIFF
--- a/blockchain/contracts/arbitrum.ts
+++ b/blockchain/contracts/arbitrum.ts
@@ -133,6 +133,7 @@ export const arbitrumContracts: MainnetContractsWithOptional = {
   chainlinkPriceOracle: {
     USDCUSD: contractDesc(chainLinkPriceOracle, arbitrum.common.ChainlinkPriceOracle_USDCUSD),
     ETHUSD: contractDesc(chainLinkPriceOracle, arbitrum.common.ChainlinkPriceOracle_ETHUSD),
+    CBETHUSD: emptyContractDesc('chainLinkPriceOracle'),
   },
   aaveV2LendingPool: emptyContractDesc('aaveV2LendingPool'),
 

--- a/blockchain/contracts/base.ts
+++ b/blockchain/contracts/base.ts
@@ -15,6 +15,7 @@ import * as automationBotAggregator from 'blockchain/abi/automation-bot-aggregat
 import * as automationBotV2 from 'blockchain/abi/automation-bot-v2.json'
 import * as balancerVault from 'blockchain/abi/balancer-vault.json'
 import * as cdpRegistry from 'blockchain/abi/cdp-registry.json'
+import * as chainLinkPriceOracle from 'blockchain/abi/chainlink-price-oracle.json'
 import * as dsProxyFactory from 'blockchain/abi/ds-proxy-factory.json'
 import * as dsProxyRegistry from 'blockchain/abi/ds-proxy-registry.json'
 import * as dssCdpManager from 'blockchain/abi/dss-cdp-manager.json'
@@ -127,7 +128,8 @@ export const baseContracts: MainnetContractsWithOptional = {
   aaveV2PriceOracle: contractDesc(aaveV2PriceOracle, base.aave.v2.Oracle),
   chainlinkPriceOracle: {
     USDCUSD: emptyContractDesc('chainLinkPriceOracle'),
-    ETHUSD: emptyContractDesc('chainLinkPriceOracle'),
+    ETHUSD: contractDesc(chainLinkPriceOracle, '0x71041dddad3595f9ced3dccfbe3d1f4b0a16bb70'),
+    CBETHUSD: contractDesc(chainLinkPriceOracle, '0xd7818272b9e248357d13057aab0b417af31e817d'),
   },
   aaveV2LendingPool: emptyContractDesc('aaveV2LendingPool'),
 

--- a/blockchain/contracts/goerli.ts
+++ b/blockchain/contracts/goerli.ts
@@ -47,7 +47,7 @@ import {
   getCollaterals,
   getOsms,
 } from 'blockchain/addresses/addressesUtils'
-import { contractDesc } from 'blockchain/networks'
+import { contractDesc, emptyContractDesc } from 'blockchain/networks'
 import {
   AAVE_V2_LENDING_POOL_GENESIS_GOERLI,
   AAVE_V3_POOL_GENESIS_GOERLI,
@@ -138,6 +138,7 @@ export const goerliContracts: MainnetContractsWithOptional = {
   chainlinkPriceOracle: {
     USDCUSD: contractDesc(chainLinkPriceOracle, goerli.common.ChainlinkPriceOracle_USDCUSD),
     ETHUSD: contractDesc(chainLinkPriceOracle, goerli.common.ChainlinkPriceOracle_ETHUSD),
+    CBETHUSD: emptyContractDesc('chainLinkPriceOracle'),
   },
   aaveV2LendingPool: contractDesc(
     aaveV2LendingPool,

--- a/blockchain/contracts/mainnet.ts
+++ b/blockchain/contracts/mainnet.ts
@@ -50,7 +50,7 @@ import {
   getCollaterals,
   getOsms,
 } from 'blockchain/addresses/addressesUtils'
-import { contractDesc } from 'blockchain/networks'
+import { contractDesc, emptyContractDesc } from 'blockchain/networks'
 import {
   AAVE_V2_LENDING_POOL_GENESIS_MAINNET,
   AAVE_V3_POOL_GENESIS_MAINNET,
@@ -136,6 +136,7 @@ export const mainnetContracts = {
   chainlinkPriceOracle: {
     USDCUSD: contractDesc(chainLinkPriceOracle, mainnet.common.ChainlinkPriceOracle_USDCUSD),
     ETHUSD: contractDesc(chainLinkPriceOracle, mainnet.common.ChainlinkPriceOracle_ETHUSD),
+    CBETHUSD: emptyContractDesc('chainLinkPriceOracle'),
   },
   aaveV2LendingPool: contractDesc(
     aaveV2LendingPool,

--- a/blockchain/contracts/optimism.ts
+++ b/blockchain/contracts/optimism.ts
@@ -143,6 +143,7 @@ export const optimismContracts: OptimismContracts = {
   chainlinkPriceOracle: {
     USDCUSD: contractDesc(chainLinkPriceOracle, optimism.common.ChainlinkPriceOracle_USDCUSD),
     ETHUSD: contractDesc(chainLinkPriceOracle, optimism.common.ChainlinkPriceOracle_ETHUSD),
+    CBETHUSD: emptyContractDesc('chainLinkPriceOracle'),
   },
   aaveV2LendingPool: emptyContractDesc('aaveV2LendingPool'),
 

--- a/blockchain/prices.ts
+++ b/blockchain/prices.ts
@@ -106,11 +106,11 @@ export function getTokenPrice(token: string, tickers: Tickers) {
   } = getToken(token)
 
   return getPrice(tickers, [
+    oracleTicker,
     coinbaseTicker,
     coinpaprikaTicker,
     coinGeckoTicker,
     coinpaprikaFallbackTicker,
-    oracleTicker,
   ])
 }
 

--- a/blockchain/token-metadata-list/token-configs.ts
+++ b/blockchain/token-metadata-list/token-configs.ts
@@ -128,6 +128,7 @@ export const tokenConfigs: TokenConfig[] = [
     name: 'Ether',
     icon: ether,
     iconCircle: ether_circle_color,
+    oracleTicker: 'ethBaseChainlinkTicker',
     coinpaprikaTicker: 'eth-ethereum',
     coinbaseTicker: 'eth-usd',
     coinGeckoId: 'ethereum',
@@ -257,9 +258,7 @@ export const tokenConfigs: TokenConfig[] = [
     //TODO: replace with values provided by design team - so far content is duplicated from ETH
     color: '#667FE3',
     background: 'linear-gradient(160.47deg, #F0F3FD 0.35%, #FCF0FD 99.18%), #FFFFFF',
-    coinbaseTicker: 'cbeth-usd',
-    coinGeckoTicker: 'coinbase-wrapped-staked-eth',
-    coinpaprikaTicker: 'cbeth-coinbase-wrapped-staked-eth',
+    oracleTicker: 'cbethBaseChainlinkTicker',
     rootToken: 'ETH',
     tags: [],
   },

--- a/helpers/api/tokenTickers.ts
+++ b/helpers/api/tokenTickers.ts
@@ -1,6 +1,8 @@
+import { getCbethBaseChainlinkTicker } from 'server/services/cbethBaseChainlinkTicker'
 import { getCoinbaseTickers } from 'server/services/coinbase'
 import { getCoingeckoTickers } from 'server/services/coingecko'
 import { getCoinPaprikaTickers } from 'server/services/coinPaprika'
+import { getEthBaseChainlinkTicker } from 'server/services/ethBaseChainlinkTicker'
 import { getSDaiOracleTicker } from 'server/services/sdaiOracle'
 
 export async function tokenTickers() {
@@ -19,6 +21,14 @@ export async function tokenTickers() {
     }),
     getSDaiOracleTicker().catch((error) => {
       console.error('Error getting sDAI oracle price', error)
+      return {}
+    }),
+    getCbethBaseChainlinkTicker().catch((error) => {
+      console.error('Error getting CBETH (BASE) oracle price', error)
+      return {}
+    }),
+    getEthBaseChainlinkTicker().catch((error) => {
+      console.error('Error getting ETH (BASE) oracle price', error)
       return {}
     }),
   ])

--- a/server/services/cbethBaseChainlinkTicker.ts
+++ b/server/services/cbethBaseChainlinkTicker.ts
@@ -1,0 +1,34 @@
+import BigNumber from 'bignumber.js'
+import { getNetworkContracts } from 'blockchain/contracts'
+import { NetworkIds, NetworkNames } from 'blockchain/networks'
+import { CHAIN_LINK_PRECISION } from 'components/constants'
+import { ethers } from 'ethers'
+import { getRpcNode } from 'helpers/getRpcNode'
+import type { PriceServiceResponse } from 'helpers/types'
+import { ChainlinkPriceOracle__factory } from 'types/ethers-contracts'
+
+export async function getCbethBaseChainlinkTicker(): Promise<PriceServiceResponse> {
+  const node = getRpcNode(NetworkNames.baseMainnet)
+  if (!node) {
+    throw new Error('RPC provider is not available')
+  }
+  const rpcProvider = new ethers.providers.JsonRpcProvider(node, {
+    chainId: NetworkIds.BASEMAINNET,
+    name: NetworkNames.baseMainnet,
+  })
+  const cbethPriceOracleContractAddress = getNetworkContracts(NetworkIds.BASEMAINNET)
+    .chainlinkPriceOracle.CBETHUSD.address
+  const cbethPriceOracleContract = ChainlinkPriceOracle__factory.connect(
+    cbethPriceOracleContractAddress,
+    rpcProvider,
+  )
+
+  const response = await cbethPriceOracleContract.latestAnswer()
+  const cbethBaseChainlinkTicker = new BigNumber(response.toString())
+    .div(new BigNumber(CHAIN_LINK_PRECISION))
+    .toNumber()
+
+  return {
+    cbethBaseChainlinkTicker,
+  }
+}

--- a/server/services/ethBaseChainlinkTicker.ts
+++ b/server/services/ethBaseChainlinkTicker.ts
@@ -1,0 +1,34 @@
+import BigNumber from 'bignumber.js'
+import { getNetworkContracts } from 'blockchain/contracts'
+import { NetworkIds, NetworkNames } from 'blockchain/networks'
+import { CHAIN_LINK_PRECISION } from 'components/constants'
+import { ethers } from 'ethers'
+import { getRpcNode } from 'helpers/getRpcNode'
+import type { PriceServiceResponse } from 'helpers/types'
+import { ChainlinkPriceOracle__factory } from 'types/ethers-contracts'
+
+export async function getEthBaseChainlinkTicker(): Promise<PriceServiceResponse> {
+  const node = getRpcNode(NetworkNames.baseMainnet)
+  if (!node) {
+    throw new Error('RPC provider is not available')
+  }
+  const rpcProvider = new ethers.providers.JsonRpcProvider(node, {
+    chainId: NetworkIds.BASEMAINNET,
+    name: NetworkNames.baseMainnet,
+  })
+  const ethPriceOracleContractAddress = getNetworkContracts(NetworkIds.BASEMAINNET)
+    .chainlinkPriceOracle.ETHUSD.address
+  const ethPriceOracleContract = ChainlinkPriceOracle__factory.connect(
+    ethPriceOracleContractAddress,
+    rpcProvider,
+  )
+
+  const response = await ethPriceOracleContract.latestAnswer()
+  const ethBaseChainlinkTicker = new BigNumber(response.toString())
+    .div(new BigNumber(CHAIN_LINK_PRECISION))
+    .toNumber()
+
+  return {
+    ethBaseChainlinkTicker,
+  }
+}


### PR DESCRIPTION

# Chainlink oracle price as price source on BASE

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- moved the `oracleTicker` in `getPrice` so it's gonna get picked first (if defined)
- added two (CBETH/USD and ETH/USD) chainlink price sources similar to `getSDaiOracleTicker`
  
## How to test 🧪
- Go to your Aave V3 on Base position (with ETH or CBETH). The price should not fluctuate (more than the chainlink price source)
