### PR TITLE
:bug: chore(aave yields) Fixed possible undefined yields in Aave

### DIFF
--- a/features/aave/hooks/useAaveEarnYields.ts
+++ b/features/aave/hooks/useAaveEarnYields.ts
@@ -20,8 +20,8 @@ export function useAaveEarnYields(
   useEffect(() => {
     if (!riskRatio) return
     aaveEarnYieldsQuery(riskRatio, yieldFields)
-      .then((yields) => {
-        setYields(yields)
+      .then((yieldsResponse) => {
+        setYields(yieldsResponse)
       })
       .catch((e) => {
         console.error('unable to get yields', e)

--- a/lendingProtocols/aave-like-common/yields/index.ts
+++ b/lendingProtocols/aave-like-common/yields/index.ts
@@ -19,3 +19,23 @@ export interface AaveLikeYieldsResponse {
   annualisedYield1Year?: BigNumber
   annualisedYieldSinceInception?: BigNumber
 }
+
+export function has7daysYield(
+  yields: AaveLikeYieldsResponse,
+): yields is Required<
+  Pick<AaveLikeYieldsResponse, 'annualisedYield7days' | 'annualisedYield7daysOffset'>
+> {
+  return (
+    yields.annualisedYield7days !== undefined && yields.annualisedYield7daysOffset !== undefined
+  )
+}
+
+export function has90daysYield(
+  yields: AaveLikeYieldsResponse,
+): yields is Required<
+  Pick<AaveLikeYieldsResponse, 'annualisedYield90days' | 'annualisedYield90daysOffset'>
+> {
+  return (
+    yields.annualisedYield90days !== undefined && yields.annualisedYield90daysOffset !== undefined
+  )
+}


### PR DESCRIPTION
This commit addresses an issue where `annualisedYield7days` and `annualisedYield90days` variables could possibly be undefined. We are now checking if these fields exist before using them to calculate yield differences and pushing them into the headline details array. This will prevent runtime errors if the said fields are unexpectedly undefined.
