### PR TITLE
Retry tickers request in portfolio handlers

### DIFF
--- a/blockchain/prices.ts
+++ b/blockchain/prices.ts
@@ -96,7 +96,7 @@ function getPrice(tickers: Tickers, tickerServiceLabels: Array<string | undefine
   throw new Error(`No price data for given token - ${JSON.stringify(errorsArray)}`)
 }
 
-export function getTokenPrice(token: string, tickers: Tickers) {
+export function getTokenPriceSources(token: string) {
   const {
     coinpaprikaTicker,
     coinbaseTicker,
@@ -105,13 +105,19 @@ export function getTokenPrice(token: string, tickers: Tickers) {
     oracleTicker,
   } = getToken(token)
 
-  return getPrice(tickers, [
-    coinbaseTicker,
+  return [
     coinpaprikaTicker,
+    coinbaseTicker,
     coinGeckoTicker,
     coinpaprikaFallbackTicker,
     oracleTicker,
-  ])
+  ]
+}
+
+export function getTokenPrice(token: string, tickers: Tickers) {
+  const priceSources = getTokenPriceSources(token)
+
+  return getPrice(tickers, priceSources)
 }
 
 export function createTokenPriceInUSD$(

--- a/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
@@ -1,11 +1,10 @@
 import type { Vault } from '@prisma/client'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { NetworkIds, NetworkNames } from 'blockchain/networks'
-import { getTokenPrice } from 'blockchain/prices'
-import type { Tickers } from 'blockchain/prices.types'
 import { isPoolOracless } from 'features/ajna/common/helpers/isOracless'
 import { OmniProductType } from 'features/omni-kit/types'
 import type { AjnaDpmPositionsPool } from 'handlers/portfolio/positions/handlers/ajna/types'
+import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
 import { getBorrowishPositionType } from 'handlers/portfolio/positions/helpers'
 import { one } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
@@ -15,7 +14,7 @@ interface getAjnaPositionInfoParams {
   isEarn: boolean
   pool: AjnaDpmPositionsPool
   positionId: string
-  tickers: Tickers
+  prices: TokensPrices
 }
 
 export async function getAjnaPositionInfo({
@@ -23,7 +22,7 @@ export async function getAjnaPositionInfo({
   isEarn,
   pool: { address: poolAddress, collateralToken, quoteToken },
   positionId,
-  tickers,
+  prices,
 }: getAjnaPositionInfoParams) {
   // get pool info contract
   const { ajnaPoolInfo } = getNetworkContracts(NetworkIds.MAINNET)
@@ -54,8 +53,8 @@ export async function getAjnaPositionInfo({
   }-${isOracless ? secondaryTokenAddress : secondaryToken}/${positionId}`
 
   // prices for oracle positions is always equal to one
-  const collateralPrice = isOracless ? one : getTokenPrice(primaryToken, tickers)
-  const quotePrice = isOracless ? one : getTokenPrice(secondaryToken, tickers)
+  const collateralPrice = isOracless ? one : prices[primaryToken]
+  const quotePrice = isOracless ? one : prices[secondaryToken]
 
   return {
     ajnaPoolInfo,

--- a/handlers/portfolio/positions/handlers/ajna/index.ts
+++ b/handlers/portfolio/positions/handlers/ajna/index.ts
@@ -17,7 +17,7 @@ export const ajnaPositionsHandler: PortfolioPositionsHandler = async ({
   address,
   apiVaults,
   dpmList,
-  tickers,
+  prices,
 }) => {
   const dpmProxyAddress = dpmList.map(({ id }) => id)
   const subgraphPositions = (await loadSubgraph('Ajna', 'getAjnaDpmPositions', NetworkIds.MAINNET, {
@@ -54,7 +54,7 @@ export const ajnaPositionsHandler: PortfolioPositionsHandler = async ({
           secondaryToken,
           type,
           url,
-        } = await getAjnaPositionInfo({ apiVaults, isEarn, pool, positionId, tickers })
+        } = await getAjnaPositionInfo({ apiVaults, isEarn, pool, positionId, prices })
 
         // proxies with more than one position doesn not support pnl calculation on subgraph so far
         const isProxyWithManyPositions =

--- a/handlers/portfolio/positions/handlers/dsr/index.ts
+++ b/handlers/portfolio/positions/handlers/dsr/index.ts
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { getRpcProvider, NetworkIds, NetworkNames } from 'blockchain/networks'
-import { getTokenPrice } from 'blockchain/prices'
 import { calculateDsrBalance, getYearlyRate } from 'features/dsr/helpers/dsrPot'
 import { OmniProductType } from 'features/omni-kit/types'
 import { notAvailable } from 'handlers/portfolio/constants'
@@ -14,7 +13,7 @@ import { DsProxyRegistry__factory, McdPot__factory } from 'types/ethers-contract
 const PotFactory = McdPot__factory
 const DsProxyFactory = DsProxyRegistry__factory
 
-export const dsrPositionsHandler: PortfolioPositionsHandler = async ({ address, tickers }) => {
+export const dsrPositionsHandler: PortfolioPositionsHandler = async ({ address, prices }) => {
   const rpcProvider = getRpcProvider(NetworkIds.MAINNET)
 
   const DsProxyContractAddress = getNetworkContracts(NetworkIds.MAINNET).dsProxyRegistry.address
@@ -23,7 +22,7 @@ export const dsrPositionsHandler: PortfolioPositionsHandler = async ({ address, 
   const dsProxyAddress = await DsProxyContract.proxies(address)
 
   if (dsProxyAddress) {
-    const daiPrice = getTokenPrice('DAI', tickers)
+    const daiPrice = prices['DAI']
 
     const PotContractAddress = getNetworkContracts(NetworkIds.MAINNET).mcdPot.address
     const PotContract = PotFactory.connect(PotContractAddress, rpcProvider)

--- a/handlers/portfolio/positions/handlers/maker/helpers/getMakerPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/maker/helpers/getMakerPositionInfo.ts
@@ -1,10 +1,9 @@
 import type { Vault } from '@prisma/client'
 import BigNumber from 'bignumber.js'
 import { NetworkIds, NetworkNames } from 'blockchain/networks'
-import { getTokenPrice } from 'blockchain/prices'
-import type { Tickers } from 'blockchain/prices.types'
 import { OmniProductType } from 'features/omni-kit/types'
 import type { MakerDiscoverPositionsIlk } from 'handlers/portfolio/positions/handlers/maker/types'
+import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
 import { getBorrowishPositionType } from 'handlers/portfolio/positions/helpers'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -13,7 +12,7 @@ interface getMakerPositionInfoParams {
   cdp: string
   ilk: MakerDiscoverPositionsIlk
   normalizedDebt: string
-  tickers: Tickers
+  prices: TokensPrices
   type: string
 }
 
@@ -22,7 +21,7 @@ export async function getMakerPositionInfo({
   cdp,
   ilk,
   normalizedDebt,
-  tickers,
+  prices,
   type,
 }: getMakerPositionInfoParams) {
   const {
@@ -45,7 +44,7 @@ export async function getMakerPositionInfo({
 
   // shorhands and formatting for better clarity
   const collateralPrice = new BigNumber(value)
-  const daiPrice = getTokenPrice('DAI', tickers)
+  const daiPrice = prices['DAI']
   const debt = new BigNumber(normalizedDebt).times(rate)
   const [earnToken] = ilkLabel.split('-')
   const primaryToken =

--- a/handlers/portfolio/positions/handlers/maker/index.ts
+++ b/handlers/portfolio/positions/handlers/maker/index.ts
@@ -14,7 +14,7 @@ import { LendingProtocol } from 'lendingProtocols'
 export const makerPositionsHandler: PortfolioPositionsHandler = async ({
   apiVaults,
   address,
-  tickers,
+  prices,
 }) => {
   const subgraphPositions = (await loadSubgraph(
     'Discover',
@@ -46,7 +46,7 @@ export const makerPositionsHandler: PortfolioPositionsHandler = async ({
             cdp,
             ilk,
             normalizedDebt,
-            tickers,
+            prices,
             type: initialType,
           })
 

--- a/handlers/portfolio/positions/helpers/getTokensPrices.ts
+++ b/handlers/portfolio/positions/helpers/getTokensPrices.ts
@@ -1,0 +1,37 @@
+import BigNumber from 'bignumber.js'
+import { getTokenPrice, getTokenPriceSources } from 'blockchain/prices'
+import type { Tickers } from 'blockchain/prices.types'
+import { tokensBySymbol } from 'blockchain/tokensMetadata.constants'
+import { tokenTickers } from 'helpers/api/tokenTickers'
+
+interface TokensPrices {
+  [key: string]: BigNumber
+}
+
+export async function getTokensPrices(): Promise<TokensPrices> {
+  const tickersResponse = await tokenTickers()
+  const tickers = Object.entries(tickersResponse).reduce<Tickers>(
+    (acc, [key, value]) => ({
+      ...acc,
+      [key.toLowerCase()]: new BigNumber(value),
+    }),
+    {},
+  )
+
+  try {
+    return Object.keys(tokensBySymbol)
+      .filter((key) => getTokenPriceSources(key).filter((item) => item !== undefined).length)
+      .reduce<TokensPrices>(
+        (result, current) => ({
+          ...result,
+          [current]: getTokenPrice(current, tickers),
+        }),
+        {},
+      )
+  } catch (e) {
+    console.info('Error loading one of the prices')
+    console.info(e)
+
+    return await getTokensPrices()
+  }
+}

--- a/handlers/portfolio/positions/helpers/getTokensPrices.ts
+++ b/handlers/portfolio/positions/helpers/getTokensPrices.ts
@@ -4,7 +4,7 @@ import type { Tickers } from 'blockchain/prices.types'
 import { tokensBySymbol } from 'blockchain/tokensMetadata.constants'
 import { tokenTickers } from 'helpers/api/tokenTickers'
 
-interface TokensPrices {
+export interface TokensPrices {
   [key: string]: BigNumber
 }
 

--- a/handlers/portfolio/positions/helpers/index.ts
+++ b/handlers/portfolio/positions/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './getBorrowishPositionType'
 export * from './getPositionsAutomations'
 export * from './getPositionsFromDatabase'
+export * from './getTokensPrices'

--- a/handlers/portfolio/positions/index.ts
+++ b/handlers/portfolio/positions/index.ts
@@ -1,14 +1,11 @@
-import BigNumber from 'bignumber.js'
-import type { Tickers } from 'blockchain/prices.types'
 import { aaveV3PositionsHandler } from 'handlers/portfolio/positions/handlers/aaveV3'
 import { ajnaPositionsHandler } from 'handlers/portfolio/positions/handlers/ajna'
 import type { DpmList } from 'handlers/portfolio/positions/handlers/dpm'
 import { getAllDpmsForWallet } from 'handlers/portfolio/positions/handlers/dpm'
 import { dsrPositionsHandler } from 'handlers/portfolio/positions/handlers/dsr'
 import { makerPositionsHandler } from 'handlers/portfolio/positions/handlers/maker'
-import { getPositionsFromDatabase } from 'handlers/portfolio/positions/helpers'
+import { getPositionsFromDatabase, getTokensPrices } from 'handlers/portfolio/positions/helpers'
 import type { PortfolioPosition } from 'handlers/portfolio/types'
-import { tokenTickers } from 'helpers/api/tokenTickers'
 import type { NextApiRequest } from 'next'
 
 type PortfolioPositionsReply = {
@@ -24,21 +21,14 @@ export const portfolioPositionsHandler = async (
   const { address } = req.query as { address: string }
 
   const apiVaults = await getPositionsFromDatabase({ address })
-  const tickersResponse = await tokenTickers()
-  const tickers = Object.entries(tickersResponse).reduce<Tickers>(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key.toLowerCase()]: new BigNumber(value),
-    }),
-    {},
-  )
+  const prices = await getTokensPrices()
 
   const dpmList = await getAllDpmsForWallet({ address })
   const positionsReply = await Promise.all([
-    aaveV3PositionsHandler({ address, dpmList, apiVaults, tickers }),
-    ajnaPositionsHandler({ address, dpmList, apiVaults, tickers }),
-    dsrPositionsHandler({ address, dpmList, apiVaults, tickers }),
-    makerPositionsHandler({ address, dpmList, apiVaults, tickers }),
+    aaveV3PositionsHandler({ address, dpmList, apiVaults, prices }),
+    ajnaPositionsHandler({ address, dpmList, apiVaults, prices }),
+    dsrPositionsHandler({ address, dpmList, apiVaults, prices }),
+    makerPositionsHandler({ address, dpmList, apiVaults, prices }),
   ])
     .then(
       ([

--- a/handlers/portfolio/types.ts
+++ b/handlers/portfolio/types.ts
@@ -1,8 +1,8 @@
 import type { Vault } from '@prisma/client'
 import type { NetworkNames } from 'blockchain/networks'
-import type { Tickers } from 'blockchain/prices.types'
 import type { OmniProductType } from 'features/omni-kit/types'
 import type { DpmList } from 'handlers/portfolio/positions/handlers/dpm'
+import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
 import type { LendingProtocol } from 'lendingProtocols'
 
 type AutomationType = {
@@ -38,12 +38,12 @@ export type PortfolioPositionsHandler = ({
   address,
   apiVaults,
   dpmList,
-  tickers,
+  prices,
 }: {
   address: string
   apiVaults: Vault[]
   dpmList: DpmList
-  tickers: Tickers
+  prices: TokensPrices
 }) => Promise<PortfolioPositionsResponse>
 
 export type PortfolioPositionsResponse = {


### PR DESCRIPTION
# Retry tickers request in portfolio handlers
  
## Changes 👷‍♀️

- Replaced simple token tickers usage with price formatter that repeats loading prices as long as one of two happens:
  - All prices are loaded successfully.
  - Timeout 🤷‍♂️
