### PR TITLE
Fix ajna url on portfolio page

### DIFF
--- a/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
@@ -49,7 +49,7 @@ export async function getAjnaPositionInfo({
     collateralToken: primaryToken,
     quoteToken: secondaryToken,
   })
-  const url = `${NetworkNames.ethereumMainnet}/${LendingProtocol.Ajna}/${type}/${
+  const url = `/${NetworkNames.ethereumMainnet}/${LendingProtocol.Ajna}/${type}/${
     isOracless ? primaryTokenAddress : primaryToken
   }-${isOracless ? secondaryTokenAddress : secondaryToken}/${positionId}`
 


### PR DESCRIPTION
# [Fix ajna url on portfolio page](https://app.shortcut.com/oazo-apps/story/12773)
  
## Changes 👷‍♀️

- Urls to Ajna positions were missing `/` at the beginning of them.