### PR TITLE
Remove unavailable automations from aave like position in portfolio

### DIFF
--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -81,10 +81,7 @@ export const commonDataMapper = (
   automations: {
     ...(dpm.positionType !== OmniProductType.Earn &&
       automations && {
-        autoBuy: { enabled: false },
-        autoSell: { enabled: false },
         stopLoss: { enabled: false },
-        takeProfit: { enabled: false },
         ...getPositionsAutomations({
           networkId: NetworkIds.MAINNET,
           triggers: [automations.triggers],


### PR DESCRIPTION
# [Remove unavailable automations from aave like position in portfolio](https://app.shortcut.com/oazo-apps/story/12766)
  
## Changes 👷‍♀️

- Removed all automation icons from aave-like positions except for stop loss.