### PR TITLE
Replace WETH with ETH on aave in portfolio

### DIFF
--- a/components/TokensGroup.tsx
+++ b/components/TokensGroup.tsx
@@ -32,36 +32,40 @@ export function TokensGroup({ forceSize, network, sx, tokens }: TokensGroupProps
           }),
         }}
       >
-        {tokens.map((token, i) => (
-          <Flex
-            key={i}
-            as="li"
-            sx={{
-              position: 'relative',
-              mr: `-${Math.ceil(forceSize || defaultMultipleSize) * 0.55}px`,
-              zIndex: tokens.length - i,
-              '&:last-child': { mr: 0 },
-            }}
-          >
-            {Object.keys(tokensBySymbol).includes(token) ? (
-              <Icon
-                size={forceSize || (tokens.length > 1 ? defaultMultipleSize : defaultSingleSize)}
-                key={getToken(token).name}
-                icon={getToken(token).iconCircle}
-                sx={{
-                  verticalAlign: 'bottom',
-                  my: tokens.length === 1 ? (forceSize ? 0 : '-4px') : 0,
-                }}
-              />
-            ) : (
-              <GenericTokenIcon
-                key={token}
-                size={forceSize || (tokens.length > 1 ? defaultMultipleSize : defaultSingleSize)}
-                symbol={token}
-              />
-            )}
-          </Flex>
-        ))}
+        {tokens.map((token, i) => {
+          const resolvedToken = token === 'ETH' ? 'WETH' : token
+
+          return (
+            <Flex
+              key={i}
+              as="li"
+              sx={{
+                position: 'relative',
+                mr: `-${Math.ceil(forceSize || defaultMultipleSize) * 0.55}px`,
+                zIndex: tokens.length - i,
+                '&:last-child': { mr: 0 },
+              }}
+            >
+              {Object.keys(tokensBySymbol).includes(resolvedToken) ? (
+                <Icon
+                  size={forceSize || (tokens.length > 1 ? defaultMultipleSize : defaultSingleSize)}
+                  key={getToken(resolvedToken).name}
+                  icon={getToken(resolvedToken).iconCircle}
+                  sx={{
+                    verticalAlign: 'bottom',
+                    my: tokens.length === 1 ? (forceSize ? 0 : '-4px') : 0,
+                  }}
+                />
+              ) : (
+                <GenericTokenIcon
+                  key={resolvedToken}
+                  size={forceSize || (tokens.length > 1 ? defaultMultipleSize : defaultSingleSize)}
+                  symbol={resolvedToken}
+                />
+              )}
+            </Flex>
+          )
+        })}
       </Flex>
       {network && (
         <Image

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -69,40 +69,42 @@ export const commonDataMapper = ({
   const secondaryToken = getTokenName(dpm.networkId, dpm.debtToken)
 
   return {
-    positionId: positionIdAsString ? dpm.vaultId : Number(dpm.vaultId),
-    type: dpm.positionType,
-    network: networksById[dpm.networkId].name,
-    protocol: {
-      AAVE_V3: LendingProtocol.AaveV3,
-      Spark: LendingProtocol.SparkV3,
-      AAVE: LendingProtocol.AaveV2, // this means Aave V2
-    }[dpm.protocol] as LendingProtocol,
-    primaryToken: getTokenDisplayName(primaryToken),
-    primaryTokenPrice: new BigNumber(prices[primaryToken]),
-    secondaryToken: getTokenDisplayName(secondaryToken),
-    secondaryTokenPrice: new BigNumber(prices[secondaryToken]),
-    url: `/${networksById[dpm.networkId].name.toLowerCase()}/${
-      {
-        AAVE_V3: 'aave',
-        Spark: 'spark',
-        AAVE: 'aave',
-      }[dpm.protocol]
-    }/${
-      {
-        AAVE_V3: 'v3',
-        Spark: 'v3',
-        AAVE: 'v2',
-      }[dpm.protocol]
-    }/${dpm.vaultId}`,
-    automations: {
-      ...(dpm.positionType !== OmniProductType.Earn &&
-        automations && {
-          stopLoss: { enabled: false },
-          ...getPositionsAutomations({
-            networkId: NetworkIds.MAINNET,
-            triggers: [automations.triggers],
+    commonData: {
+      positionId: positionIdAsString ? dpm.vaultId : Number(dpm.vaultId),
+      type: dpm.positionType,
+      network: networksById[dpm.networkId].name,
+      protocol: {
+        AAVE_V3: LendingProtocol.AaveV3,
+        Spark: LendingProtocol.SparkV3,
+        AAVE: LendingProtocol.AaveV2, // this means Aave V2
+      }[dpm.protocol] as LendingProtocol,
+      primaryToken: getTokenDisplayName(primaryToken),
+      secondaryToken: getTokenDisplayName(secondaryToken),
+      url: `/${networksById[dpm.networkId].name.toLowerCase()}/${
+        {
+          AAVE_V3: 'aave',
+          Spark: 'spark',
+          AAVE: 'aave',
+        }[dpm.protocol]
+      }/${
+        {
+          AAVE_V3: 'v3',
+          Spark: 'v3',
+          AAVE: 'v2',
+        }[dpm.protocol]
+      }/${dpm.vaultId}`,
+      automations: {
+        ...(dpm.positionType !== OmniProductType.Earn &&
+          automations && {
+            stopLoss: { enabled: false },
+            ...getPositionsAutomations({
+              networkId: NetworkIds.MAINNET,
+              triggers: [automations.triggers],
+            }),
           }),
-        }),
+      },
     },
+    primaryTokenPrice: new BigNumber(prices[primaryToken]),
+    secondaryTokenPrice: new BigNumber(prices[secondaryToken]),
   }
 }

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -1,13 +1,16 @@
+import BigNumber from 'bignumber.js'
 import type { AaveV3SupportedNetwork } from 'blockchain/aave-v3'
 import { getAaveV3ReserveConfigurationData, getAaveV3ReserveData } from 'blockchain/aave-v3'
 import { NetworkIds, networksById } from 'blockchain/networks'
 import type { SparkV3SupportedNetwork } from 'blockchain/spark-v3'
 import { getSparkV3ReserveConfigurationData, getSparkV3ReserveData } from 'blockchain/spark-v3'
 import { OmniProductType } from 'features/omni-kit/types'
+import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
 import { getPositionsAutomations } from 'handlers/portfolio/positions/helpers'
 import type { DpmList } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
 import type { AutomationResponse } from 'handlers/portfolio/positions/helpers/getAutomationData'
 import { getTokenName } from 'handlers/portfolio/positions/helpers/getTokenName'
+import { getTokenDisplayName } from 'helpers/getTokenDisplayName'
 import { LendingProtocol } from 'lendingProtocols'
 
 export const filterAutomation = (dpm: DpmList[number]) => (position: AutomationResponse[number]) =>
@@ -49,42 +52,57 @@ export const getReserveConfigurationDataCall = (dpm: DpmList[number], token: str
   }
 }
 
-export const commonDataMapper = (
-  dpm: DpmList[number],
-  automations?: AutomationResponse[number],
-  positionIdAsString?: boolean,
-) => ({
-  positionId: positionIdAsString ? dpm.vaultId : Number(dpm.vaultId),
-  type: dpm.positionType,
-  network: networksById[dpm.networkId].name,
-  protocol: {
-    AAVE_V3: LendingProtocol.AaveV3,
-    Spark: LendingProtocol.SparkV3,
-    AAVE: LendingProtocol.AaveV2, // this means Aave V2
-  }[dpm.protocol] as LendingProtocol,
-  primaryToken: getTokenName(dpm.networkId, dpm.collateralToken),
-  secondaryToken: getTokenName(dpm.networkId, dpm.debtToken),
-  url: `/${networksById[dpm.networkId].name.toLowerCase()}/${
-    {
-      AAVE_V3: 'aave',
-      Spark: 'spark',
-      AAVE: 'aave',
-    }[dpm.protocol]
-  }/${
-    {
-      AAVE_V3: 'v3',
-      Spark: 'v3',
-      AAVE: 'v2',
-    }[dpm.protocol]
-  }/${dpm.vaultId}`,
-  automations: {
-    ...(dpm.positionType !== OmniProductType.Earn &&
-      automations && {
-        stopLoss: { enabled: false },
-        ...getPositionsAutomations({
-          networkId: NetworkIds.MAINNET,
-          triggers: [automations.triggers],
+interface CommonDataMapperParams {
+  automations?: AutomationResponse[number]
+  dpm: DpmList[number]
+  positionIdAsString?: boolean
+  prices: TokensPrices
+}
+
+export const commonDataMapper = ({
+  automations,
+  dpm,
+  positionIdAsString,
+  prices,
+}: CommonDataMapperParams) => {
+  const primaryToken = getTokenName(dpm.networkId, dpm.collateralToken)
+  const secondaryToken = getTokenName(dpm.networkId, dpm.debtToken)
+
+  return {
+    positionId: positionIdAsString ? dpm.vaultId : Number(dpm.vaultId),
+    type: dpm.positionType,
+    network: networksById[dpm.networkId].name,
+    protocol: {
+      AAVE_V3: LendingProtocol.AaveV3,
+      Spark: LendingProtocol.SparkV3,
+      AAVE: LendingProtocol.AaveV2, // this means Aave V2
+    }[dpm.protocol] as LendingProtocol,
+    primaryToken: getTokenDisplayName(primaryToken),
+    primaryTokenPrice: new BigNumber(prices[primaryToken]),
+    secondaryToken: getTokenDisplayName(secondaryToken),
+    secondaryTokenPrice: new BigNumber(prices[secondaryToken]),
+    url: `/${networksById[dpm.networkId].name.toLowerCase()}/${
+      {
+        AAVE_V3: 'aave',
+        Spark: 'spark',
+        AAVE: 'aave',
+      }[dpm.protocol]
+    }/${
+      {
+        AAVE_V3: 'v3',
+        Spark: 'v3',
+        AAVE: 'v2',
+      }[dpm.protocol]
+    }/${dpm.vaultId}`,
+    automations: {
+      ...(dpm.positionType !== OmniProductType.Earn &&
+        automations && {
+          stopLoss: { enabled: false },
+          ...getPositionsAutomations({
+            networkId: NetworkIds.MAINNET,
+            triggers: [automations.triggers],
+          }),
         }),
-      }),
-  },
-})
+    },
+  }
+}

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -33,7 +33,11 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
   allPositionsAutomations,
 ) => {
   const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
-  const commonData = commonDataMapper({ automations: positionAutomations, dpm, prices })
+  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({
+    automations: positionAutomations,
+    dpm,
+    prices,
+  })
   const [primaryTokenReserveData, secondaryTokenReserveData, onChainPositionData] =
     await Promise.all([
       getReserveDataCall(dpm, commonData.primaryToken),
@@ -49,8 +53,8 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
 
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    commonData.primaryTokenPrice,
-    commonData.secondaryTokenPrice,
+    primaryTokenPrice,
+    secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )
@@ -69,9 +73,9 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
       {
         type: 'liquidationPrice',
         value: `$${formatCryptoBalance(
-          calculations.liquidationPriceInDebt.times(commonData.secondaryTokenPrice),
+          calculations.liquidationPriceInDebt.times(secondaryTokenPrice),
         )}`,
-        subvalue: `Now $${formatCryptoBalance(commonData.primaryTokenPrice)}`,
+        subvalue: `Now $${formatCryptoBalance(primaryTokenPrice)}`,
       },
       {
         type: 'ltv',
@@ -94,7 +98,11 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
   allPositionsAutomations,
 ) => {
   const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
-  const commonData = commonDataMapper({ automations: positionAutomations, dpm, prices })
+  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({
+    automations: positionAutomations,
+    dpm,
+    prices,
+  })
   const [
     primaryTokenReserveConfiguration,
     primaryTokenReserveData,
@@ -115,8 +123,8 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
 
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    commonData.primaryTokenPrice,
-    commonData.secondaryTokenPrice,
+    primaryTokenPrice,
+    secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )
@@ -148,9 +156,9 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
       {
         type: 'liquidationPrice',
         value: `$${formatCryptoBalance(
-          calculations.liquidationPriceInDebt.times(commonData.secondaryTokenPrice),
+          calculations.liquidationPriceInDebt.times(secondaryTokenPrice),
         )}`,
-        subvalue: `Now $${formatCryptoBalance(commonData.primaryTokenPrice)}`,
+        subvalue: `Now $${formatCryptoBalance(primaryTokenPrice)}`,
       },
       {
         type: 'ltv',
@@ -172,7 +180,7 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
   prices,
   allPositionsHistory,
 ) => {
-  const commonData = commonDataMapper({ dpm, prices })
+  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({ dpm, prices })
   const [primaryTokenReserveData, secondaryTokenReserveData, onChainPositionData] =
     await Promise.all([
       getReserveDataCall(dpm, commonData.primaryToken),
@@ -202,8 +210,8 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
   )[0]
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    commonData.primaryTokenPrice,
-    commonData.secondaryTokenPrice,
+    primaryTokenPrice,
+    secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -33,9 +33,7 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
   allPositionsAutomations,
 ) => {
   const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
-  const commonData = commonDataMapper(dpm, positionAutomations)
-  const primaryTokenPrice = new BigNumber(prices[commonData.primaryToken])
-  const secondaryTokenPrice = new BigNumber(prices[commonData.secondaryToken])
+  const commonData = commonDataMapper({ automations: positionAutomations, dpm, prices })
   const [primaryTokenReserveData, secondaryTokenReserveData, onChainPositionData] =
     await Promise.all([
       getReserveDataCall(dpm, commonData.primaryToken),
@@ -51,8 +49,8 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
 
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    primaryTokenPrice,
-    secondaryTokenPrice,
+    commonData.primaryTokenPrice,
+    commonData.secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )
@@ -71,9 +69,9 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
       {
         type: 'liquidationPrice',
         value: `$${formatCryptoBalance(
-          calculations.liquidationPriceInDebt.times(secondaryTokenPrice),
+          calculations.liquidationPriceInDebt.times(commonData.secondaryTokenPrice),
         )}`,
-        subvalue: `Now $${formatCryptoBalance(primaryTokenPrice)}`,
+        subvalue: `Now $${formatCryptoBalance(commonData.primaryTokenPrice)}`,
       },
       {
         type: 'ltv',
@@ -96,9 +94,7 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
   allPositionsAutomations,
 ) => {
   const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
-  const commonData = commonDataMapper(dpm, positionAutomations)
-  const primaryTokenPrice = new BigNumber(prices[commonData.primaryToken])
-  const secondaryTokenPrice = new BigNumber(prices[commonData.secondaryToken])
+  const commonData = commonDataMapper({ automations: positionAutomations, dpm, prices })
   const [
     primaryTokenReserveConfiguration,
     primaryTokenReserveData,
@@ -119,8 +115,8 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
 
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    primaryTokenPrice,
-    secondaryTokenPrice,
+    commonData.primaryTokenPrice,
+    commonData.secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )
@@ -152,9 +148,9 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
       {
         type: 'liquidationPrice',
         value: `$${formatCryptoBalance(
-          calculations.liquidationPriceInDebt.times(secondaryTokenPrice),
+          calculations.liquidationPriceInDebt.times(commonData.secondaryTokenPrice),
         )}`,
-        subvalue: `Now $${formatCryptoBalance(primaryTokenPrice)}`,
+        subvalue: `Now $${formatCryptoBalance(commonData.primaryTokenPrice)}`,
       },
       {
         type: 'ltv',
@@ -176,9 +172,7 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
   prices,
   allPositionsHistory,
 ) => {
-  const commonData = commonDataMapper(dpm)
-  const primaryTokenPrice = new BigNumber(prices[commonData.primaryToken])
-  const secondaryTokenPrice = new BigNumber(prices[commonData.secondaryToken])
+  const commonData = commonDataMapper({ dpm, prices })
   const [primaryTokenReserveData, secondaryTokenReserveData, onChainPositionData] =
     await Promise.all([
       getReserveDataCall(dpm, commonData.primaryToken),
@@ -208,8 +202,8 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
   )[0]
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    primaryTokenPrice,
-    secondaryTokenPrice,
+    commonData.primaryTokenPrice,
+    commonData.secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )

--- a/handlers/portfolio/positions/handlers/aave-v2/ds-proxy-position.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/ds-proxy-position.ts
@@ -1,5 +1,4 @@
 import { getOnChainPosition } from 'actions/aave-like'
-import BigNumber from 'bignumber.js'
 import { getAaveV2ReserveData } from 'blockchain/aave'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { getRpcProvider, NetworkIds } from 'blockchain/networks'
@@ -39,8 +38,8 @@ export const getAaveV2DsProxyPosition: PortfolioPositionsHandler = async ({ addr
   })
 
   if (stEthPosition.collateral.amount.gt(zero)) {
-    const commonData = commonDataMapper(
-      {
+    const commonData = commonDataMapper({
+      dpm: {
         collateralToken: contracts.tokens.STETH.address,
         debtToken: contracts.tokens.ETH.address,
         id: dsProxyAddress,
@@ -50,11 +49,9 @@ export const getAaveV2DsProxyPosition: PortfolioPositionsHandler = async ({ addr
         user: address,
         vaultId: address,
       },
-      undefined,
-      true,
-    )
-    const primaryTokenPrice = new BigNumber(prices[commonData.primaryToken])
-    const secondaryTokenPrice = new BigNumber(prices[commonData.secondaryToken])
+      positionIdAsString: true,
+      prices,
+    })
     const [primaryTokenReserveData, secondaryTokenReserveData, yields] = await Promise.all([
       getAaveV2ReserveData({ token: commonData.primaryToken }),
       getAaveV2ReserveData({ token: commonData.secondaryToken }),
@@ -64,8 +61,8 @@ export const getAaveV2DsProxyPosition: PortfolioPositionsHandler = async ({ addr
     ])
     const calculations = calculateViewValuesForPosition(
       stEthPosition,
-      primaryTokenPrice,
-      secondaryTokenPrice,
+      commonData.primaryTokenPrice,
+      commonData.secondaryTokenPrice,
       primaryTokenReserveData.liquidityRate,
       secondaryTokenReserveData.variableBorrowRate,
     )

--- a/handlers/portfolio/positions/handlers/aave-v2/ds-proxy-position.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/ds-proxy-position.ts
@@ -38,7 +38,7 @@ export const getAaveV2DsProxyPosition: PortfolioPositionsHandler = async ({ addr
   })
 
   if (stEthPosition.collateral.amount.gt(zero)) {
-    const commonData = commonDataMapper({
+    const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({
       dpm: {
         collateralToken: contracts.tokens.STETH.address,
         debtToken: contracts.tokens.ETH.address,
@@ -61,8 +61,8 @@ export const getAaveV2DsProxyPosition: PortfolioPositionsHandler = async ({ addr
     ])
     const calculations = calculateViewValuesForPosition(
       stEthPosition,
-      commonData.primaryTokenPrice,
-      commonData.secondaryTokenPrice,
+      primaryTokenPrice,
+      secondaryTokenPrice,
       primaryTokenReserveData.liquidityRate,
       secondaryTokenReserveData.variableBorrowRate,
     )

--- a/handlers/portfolio/positions/handlers/aave-v2/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/index.ts
@@ -22,9 +22,7 @@ const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
   prices,
   allPositionsHistory,
 ) => {
-  const commonData = commonDataMapper(dpm)
-  const primaryTokenPrice = new BigNumber(prices[commonData.primaryToken])
-  const secondaryTokenPrice = new BigNumber(prices[commonData.secondaryToken])
+  const commonData = commonDataMapper({ dpm, prices })
   const [
     primaryTokenReserveConfiguration,
     primaryTokenReserveData,
@@ -45,8 +43,8 @@ const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
 
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    primaryTokenPrice,
-    secondaryTokenPrice,
+    commonData.primaryTokenPrice,
+    commonData.secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )
@@ -78,9 +76,9 @@ const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
       {
         type: 'liquidationPrice',
         value: `$${formatCryptoBalance(
-          calculations.liquidationPriceInDebt.times(secondaryTokenPrice),
+          calculations.liquidationPriceInDebt.times(commonData.secondaryTokenPrice),
         )}`,
-        subvalue: `Now $${formatCryptoBalance(primaryTokenPrice)}`,
+        subvalue: `Now $${formatCryptoBalance(commonData.primaryTokenPrice)}`,
       },
       {
         type: 'ltv',

--- a/handlers/portfolio/positions/handlers/aave-v2/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/index.ts
@@ -22,7 +22,7 @@ const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
   prices,
   allPositionsHistory,
 ) => {
-  const commonData = commonDataMapper({ dpm, prices })
+  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({ dpm, prices })
   const [
     primaryTokenReserveConfiguration,
     primaryTokenReserveData,
@@ -43,8 +43,8 @@ const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
 
   const calculations = calculateViewValuesForPosition(
     onChainPositionData,
-    commonData.primaryTokenPrice,
-    commonData.secondaryTokenPrice,
+    primaryTokenPrice,
+    secondaryTokenPrice,
     primaryTokenReserveData.liquidityRate,
     secondaryTokenReserveData.variableBorrowRate,
   )
@@ -76,9 +76,9 @@ const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
       {
         type: 'liquidationPrice',
         value: `$${formatCryptoBalance(
-          calculations.liquidationPriceInDebt.times(commonData.secondaryTokenPrice),
+          calculations.liquidationPriceInDebt.times(secondaryTokenPrice),
         )}`,
-        subvalue: `Now $${formatCryptoBalance(commonData.primaryTokenPrice)}`,
+        subvalue: `Now $${formatCryptoBalance(primaryTokenPrice)}`,
       },
       {
         type: 'ltv',

--- a/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
@@ -7,6 +7,7 @@ import { OmniProductType } from 'features/omni-kit/types'
 import type { AjnaDpmPositionsPool } from 'handlers/portfolio/positions/handlers/ajna/types'
 import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
 import { getBorrowishPositionType } from 'handlers/portfolio/positions/helpers'
+import { getTokenDisplayName } from 'helpers/getTokenDisplayName'
 import { one } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -39,10 +40,9 @@ export async function getAjnaPositionInfo({
       })
 
   // shorhands and formatting for better clarity
-  const primaryToken =
-    collateralToken.symbol === 'WETH' ? 'ETH' : collateralToken.symbol.toUpperCase()
+  const primaryToken = collateralToken.symbol.toUpperCase()
   const primaryTokenAddress = collateralToken.address
-  const secondaryToken = quoteToken.symbol === 'WETH' ? 'ETH' : quoteToken.symbol.toUpperCase()
+  const secondaryToken = quoteToken.symbol.toUpperCase()
   const secondaryTokenAddress = quoteToken.address
   const isOracless = isPoolOracless({
     chainId: NetworkIds.MAINNET,
@@ -62,9 +62,9 @@ export async function getAjnaPositionInfo({
     collateralPrice,
     isOracless,
     poolAddress,
-    primaryToken,
+    primaryToken: getTokenDisplayName(primaryToken),
     quotePrice,
-    secondaryToken,
+    secondaryToken: getTokenDisplayName(secondaryToken),
     type,
     url,
   }

--- a/handlers/portfolio/positions/handlers/maker/helpers/getMakerPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/maker/helpers/getMakerPositionInfo.ts
@@ -5,6 +5,7 @@ import { OmniProductType } from 'features/omni-kit/types'
 import type { MakerDiscoverPositionsIlk } from 'handlers/portfolio/positions/handlers/maker/types'
 import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
 import { getBorrowishPositionType } from 'handlers/portfolio/positions/helpers'
+import { getTokenDisplayName } from 'helpers/getTokenDisplayName'
 import { LendingProtocol } from 'lendingProtocols'
 
 interface getMakerPositionInfoParams {
@@ -47,12 +48,7 @@ export async function getMakerPositionInfo({
   const daiPrice = new BigNumber(prices['DAI'])
   const debt = new BigNumber(normalizedDebt).times(rate)
   const [earnToken] = ilkLabel.split('-')
-  const primaryToken =
-    tokenSymbol === 'WETH'
-      ? 'ETH'
-      : resolvedType === OmniProductType.Earn
-      ? earnToken
-      : tokenSymbol.toUpperCase()
+  const primaryToken = resolvedType === OmniProductType.Earn ? earnToken : tokenSymbol.toUpperCase()
   const secondaryToken = resolvedType === OmniProductType.Earn ? earnToken : 'DAI'
   const url = `/${NetworkNames.ethereumMainnet}/${LendingProtocol.Maker}/${cdp}`
 
@@ -60,7 +56,7 @@ export async function getMakerPositionInfo({
     collateralPrice,
     daiPrice,
     debt,
-    primaryToken,
+    primaryToken: getTokenDisplayName(primaryToken),
     secondaryToken,
     type: resolvedType,
     url,

--- a/handlers/portfolio/positions/helpers/getTokenName.ts
+++ b/handlers/portfolio/positions/helpers/getTokenName.ts
@@ -30,8 +30,7 @@ export const getTokenName = memoize(
         )}`,
       )
     }
-
-    return tokenName === 'WETH' ? 'ETH' : tokenName
+    return tokenName
   },
   (networkId, tokenAddress) => JSON.stringify({ networkId, tokenAddress }),
 )

--- a/handlers/portfolio/positions/helpers/getTokenName.ts
+++ b/handlers/portfolio/positions/helpers/getTokenName.ts
@@ -30,7 +30,8 @@ export const getTokenName = memoize(
         )}`,
       )
     }
-    return tokenName
+
+    return tokenName === 'WETH' ? 'ETH' : tokenName
   },
   (networkId, tokenAddress) => JSON.stringify({ networkId, tokenAddress }),
 )

--- a/helpers/getTokenDisplayName.ts
+++ b/helpers/getTokenDisplayName.ts
@@ -1,0 +1,3 @@
+export function getTokenDisplayName(token: string): string {
+  return token === 'WETH' ? 'ETH' : token.toUpperCase()
+}


### PR DESCRIPTION
# [Replace WETH with ETH on aave in portfolio](https://app.shortcut.com/oazo-apps/story/12765)
  
## Changes 👷‍♀️

- Added guard in `TokensList` component to display ETH instead of WETH,
- added guards in all portfolio handlers to cover WETH with ETH only in display parts, not calculations.