### PR TITLE
Treat positions worth less than a cent as empty positions

### DIFF
--- a/components/portfolio/positions/PortfolioPositionsView.tsx
+++ b/components/portfolio/positions/PortfolioPositionsView.tsx
@@ -61,7 +61,7 @@ export const PortfolioPositionsView = ({
     if (!portfolioPositionsData) return undefined
     // empty positions first
     const filteredEmptyPositions = portfolioPositionsData.positions.filter(
-      ({ netValue }) => filterState['showEmptyPositions'] || netValue > 0,
+      ({ netValue }) => filterState['showEmptyPositions'] || netValue >= 0.01,
     )
     // filter by product
     const noneSelected = [0, undefined].includes(filterState['product']?.length) // none selected = "All products"


### PR DESCRIPTION
# [Treat positions worth less than a cent as empty positions](https://app.shortcut.com/oazo-apps/story/12769)
  
## Changes 👷‍♀️

Changed requirements to be considered as non-empty positions from more than 0 to more than 0.01.
