### PR TITLE
Missing multiply positions on portfolio

### DIFF
--- a/features/omni-kit/types.ts
+++ b/features/omni-kit/types.ts
@@ -13,6 +13,8 @@ export enum OmniProductType {
   Multiply = 'multiply',
 }
 
+export type OmniProductBorrowishType = OmniProductType.Borrow | OmniProductType.Multiply
+
 export enum OmniSidebarStep {
   Dpm = 'dpm',
   Manage = 'manage',

--- a/handlers/portfolio/positions/handlers/ajna/index.ts
+++ b/handlers/portfolio/positions/handlers/ajna/index.ts
@@ -54,7 +54,15 @@ export const ajnaPositionsHandler: PortfolioPositionsHandler = async ({
           secondaryToken,
           type,
           url,
-        } = await getAjnaPositionInfo({ apiVaults, isEarn, pool, positionId, prices })
+        } = await getAjnaPositionInfo({
+          apiVaults,
+          dpmList,
+          isEarn,
+          pool,
+          positionId,
+          prices,
+          proxyAddress,
+        })
 
         // proxies with more than one position doesn not support pnl calculation on subgraph so far
         const isProxyWithManyPositions =

--- a/handlers/portfolio/positions/handlers/maker/helpers/getMakerPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/maker/helpers/getMakerPositionInfo.ts
@@ -1,6 +1,7 @@
 import type { Vault } from '@prisma/client'
 import BigNumber from 'bignumber.js'
 import { NetworkIds, NetworkNames } from 'blockchain/networks'
+import type { OmniProductBorrowishType } from 'features/omni-kit/types'
 import { OmniProductType } from 'features/omni-kit/types'
 import type { MakerDiscoverPositionsIlk } from 'handlers/portfolio/positions/handlers/maker/types'
 import type { TokensPrices } from 'handlers/portfolio/positions/helpers'
@@ -38,6 +39,7 @@ export async function getMakerPositionInfo({
       ? OmniProductType.Earn
       : getBorrowishPositionType({
           apiVaults,
+          defaultType: type.toLowerCase() as OmniProductBorrowishType,
           networkId: NetworkIds.MAINNET,
           positionId: Number(cdp),
           protocol: LendingProtocol.Maker,

--- a/handlers/portfolio/positions/helpers/getBorrowishPositionType.ts
+++ b/handlers/portfolio/positions/helpers/getBorrowishPositionType.ts
@@ -1,10 +1,12 @@
 import type { Vault } from '@prisma/client'
 import type { NetworkIds } from 'blockchain/networks'
+import type { OmniProductBorrowishType } from 'features/omni-kit/types'
 import { OmniProductType } from 'features/omni-kit/types'
 import type { LendingProtocol } from 'lendingProtocols'
 
 interface getBorrowishPositionTypeParams {
   apiVaults: Vault[]
+  defaultType?: OmniProductBorrowishType
   networkId: NetworkIds
   positionId: number
   protocol: LendingProtocol
@@ -12,17 +14,17 @@ interface getBorrowishPositionTypeParams {
 
 export function getBorrowishPositionType({
   apiVaults,
+  defaultType,
   networkId,
   positionId,
   protocol,
-}: getBorrowishPositionTypeParams): OmniProductType.Borrow | OmniProductType.Multiply {
-  return apiVaults.filter(
-    ({ chain_id, protocol: _protocol, type, vault_id }) =>
-      chain_id === networkId &&
-      _protocol === protocol &&
-      vault_id === positionId &&
-      type.toLowerCase() === OmniProductType.Multiply.toLowerCase(),
-  ).length > 0
-    ? OmniProductType.Multiply
-    : OmniProductType.Borrow
+}: getBorrowishPositionTypeParams): OmniProductBorrowishType {
+  const [apiVault] = apiVaults.filter(
+    ({ chain_id, protocol: _protocol, vault_id }) =>
+      chain_id === networkId && _protocol === protocol && vault_id === positionId,
+  )
+
+  return apiVault
+    ? (apiVault.type as OmniProductBorrowishType)
+    : defaultType ?? OmniProductType.Borrow
 }

--- a/handlers/portfolio/positions/index.ts
+++ b/handlers/portfolio/positions/index.ts
@@ -37,18 +37,18 @@ export const portfolioPositionsHandler = async ({
 
     const positionsReply = await Promise.all([
       aaveLikePositionsHandler(payload),
+      aaveV2PositionHandler(payload),
       ajnaPositionsHandler(payload),
       dsrPositionsHandler(payload),
       makerPositionsHandler(payload),
-      aaveV2PositionHandler(payload),
     ])
       .then(
         ([
+          { positions: aaveV2Positions },
           { positions: aaveV3Positions },
           { positions: ajnaPositions },
           { positions: dsrPositions },
           { positions: makerPositions },
-          { positions: aaveV2Positions },
         ]) => ({
           positions: [
             ...aaveV2Positions,


### PR DESCRIPTION
# [Missing multiply positions on portfolio](https://app.shortcut.com/oazo-apps/story/12793)

  
## Changes 👷‍♀️

Added default type from subgraph if position type is not found in the database.
