### PR TITLE
fix: [sc-12771] [BUG] - Borrow cost is surfacing only Borrow APY, not cost to borrow (borrow - supply)

### DIFF
--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -94,7 +94,7 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
       },
       {
         type: 'borrowRate',
-        value: formatDecimalAsPercent(secondaryTokenReserveData.variableBorrowRate),
+        value: formatDecimalAsPercent(calculations.netBorrowCostPercentage),
       },
     ],
     netValue: calculations.netValue.toNumber(),


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/12771