### PR TITLE
Non owner notice on portfolio page overhaul

### DIFF
--- a/components/BannerTransparent.tsx
+++ b/components/BannerTransparent.tsx
@@ -1,0 +1,47 @@
+import { Icon } from 'components/Icon'
+import type { IconProps } from 'components/Icon.types'
+import { AppLink } from 'components/Links'
+import type { PropsWithChildren } from 'react'
+import React from 'react'
+import { Button, Flex, Text } from 'theme-ui'
+
+interface BannerTransparentProps {
+  icon: IconProps['icon']
+  title: string
+  cta?: {
+    label: string
+    url: string
+  }
+}
+
+export function BannerTransparent({
+  icon,
+  title,
+  children,
+  cta,
+}: PropsWithChildren<BannerTransparentProps>) {
+  return (
+    <Flex
+      sx={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        p: 3,
+        background: 'linear-gradient(90.61deg, #FFFFFF 0.79%, rgba(255, 255, 255, 0) 99.94%)',
+        borderRadius: 'large',
+        boxShadow: 'cardLanding',
+      }}
+    >
+      <Icon icon={icon} size={60} sx={{ mr: 3 }} />
+      <Flex sx={{ flexDirection: 'column', width: '100%' }}>
+        <Text variant="boldParagraph2">{title}</Text>
+        <Text variant="paragraph3">{children}</Text>
+      </Flex>
+      {cta && (
+        <AppLink href={cta.url} sx={{ flexShrink: 0, ml: 'auto' }}>
+          <Button variant="action">{cta.label}</Button>
+        </AppLink>
+      )}
+    </Flex>
+  )
+}

--- a/components/BannerTransparent.tsx
+++ b/components/BannerTransparent.tsx
@@ -3,14 +3,15 @@ import type { IconProps } from 'components/Icon.types'
 import { AppLink } from 'components/Links'
 import type { PropsWithChildren } from 'react'
 import React from 'react'
-import { Button, Flex, Text } from 'theme-ui'
+import { Box, Button, Flex, Text } from 'theme-ui'
 
 interface BannerTransparentProps {
   icon: IconProps['icon']
   title: string
   cta?: {
     label: string
-    url: string
+    url?: string
+    onClick?: () => void
   }
 }
 
@@ -32,15 +33,24 @@ export function BannerTransparent({
         boxShadow: 'cardLanding',
       }}
     >
-      <Icon icon={icon} size={60} sx={{ mr: 3 }} />
+      <Icon icon={icon} size={60} sx={{ flexShrink: 0, mr: 3 }} />
       <Flex sx={{ flexDirection: 'column', width: '100%' }}>
         <Text variant="boldParagraph2">{title}</Text>
         <Text variant="paragraph3">{children}</Text>
       </Flex>
       {cta && (
-        <AppLink href={cta.url} sx={{ flexShrink: 0, ml: 'auto' }}>
-          <Button variant="action">{cta.label}</Button>
-        </AppLink>
+        <Box sx={{ flexShrink: 0, ml: 'auto' }}>
+          {cta.url && (
+            <AppLink href={cta.url}>
+              <Button variant="action">{cta.label}</Button>
+            </AppLink>
+          )}
+          {cta && cta.onClick && (
+            <Button variant="action" onClick={cta.onClick}>
+              {cta.label}
+            </Button>
+          )}
+        </Box>
       )}
     </Flex>
   )

--- a/components/portfolio/PortfolioNonOwnerNotice.tsx
+++ b/components/portfolio/PortfolioNonOwnerNotice.tsx
@@ -1,14 +1,14 @@
 import BigNumber from 'bignumber.js'
-import { Icon } from 'components/Icon'
-import { AppLink } from 'components/Links'
+import { BannerTransparent } from 'components/BannerTransparent'
 import { usePortfolioMatchingAssets } from 'components/portfolio/helpers/usePortfolioMatchingAssets'
 import { Skeleton } from 'components/Skeleton'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { formatAddress, formatAmount } from 'helpers/formatters/format'
 import { getGradientColor, summerBrandGradient } from 'helpers/getGradientColor'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { non_owner_notice_icon } from 'theme/icons'
-import { Button, Flex, Text } from 'theme-ui'
+import { Text } from 'theme-ui'
 
 import type { PortfolioAsset } from 'lambdas/src/shared/domain-types'
 
@@ -21,42 +21,39 @@ export const PortfolioNonOwnerNotice = ({
 }) => {
   const { t: tPortfolio } = useTranslation('portfolio')
   const { matchingAssetsValue } = usePortfolioMatchingAssets({ assets })
+
   return (
-    <Flex
-      sx={{
-        borderRadius: 'large',
-        p: 3,
-        background: 'linear-gradient(90.61deg, #FFFFFF 0.79%, rgba(255, 255, 255, 0) 99.94%)',
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        boxShadow: 'cardLanding',
-        mb: 4,
-      }}
+    <BannerTransparent
+      icon={non_owner_notice_icon}
+      title={tPortfolio('non-owner-notice.header', { address: formatAddress(address, 6) })}
+      {...(matchingAssetsValue &&
+        matchingAssetsValue > 0 && {
+          cta: {
+            label: tPortfolio('explore'),
+            url: INTERNAL_LINKS.earn,
+          },
+        })}
     >
-      <Icon icon={non_owner_notice_icon} size={60} sx={{ mr: 3 }} />
-      <Flex sx={{ flexDirection: 'column', width: '100%' }}>
-        <Text variant="boldParagraph2">
-          {tPortfolio('non-owner-notice.header', { address: formatAddress(address, 6) })}
-        </Text>
-        <Text variant="paragraph3">
-          {matchingAssetsValue ? (
-            <Trans
-              t={tPortfolio}
-              i18nKey="non-owner-notice.assets-available"
-              components={{
-                span: <Text variant="boldParagraph3" sx={getGradientColor(summerBrandGradient)} />,
-              }}
-              values={{ amount: formatAmount(new BigNumber(matchingAssetsValue), 'USD') }}
-            />
-          ) : (
-            <Skeleton width={440} sx={{ mt: 1 }} />
-          )}
-        </Text>
-      </Flex>
-      <AppLink href={'/earn'} sx={{ flexShrink: 0, ml: 'auto' }}>
-        <Button variant="action">{tPortfolio('explore')}</Button>
-      </AppLink>
-    </Flex>
+      <>
+        {matchingAssetsValue !== undefined ? (
+          <>
+            {matchingAssetsValue > 0 && (
+              <Trans
+                t={tPortfolio}
+                i18nKey="non-owner-notice.connected-assets"
+                components={{
+                  span: (
+                    <Text variant="boldParagraph3" sx={getGradientColor(summerBrandGradient)} />
+                  ),
+                }}
+                values={{ amount: formatAmount(new BigNumber(matchingAssetsValue), 'USD') }}
+              />
+            )}
+          </>
+        ) : (
+          <Skeleton width={440} sx={{ mt: 1, height: '18px' }} />
+        )}
+      </>
+    </BannerTransparent>
   )
 }

--- a/components/portfolio/PortfolioNonOwnerNotice.tsx
+++ b/components/portfolio/PortfolioNonOwnerNotice.tsx
@@ -1,59 +1,110 @@
 import BigNumber from 'bignumber.js'
 import { BannerTransparent } from 'components/BannerTransparent'
 import { usePortfolioMatchingAssets } from 'components/portfolio/helpers/usePortfolioMatchingAssets'
-import { Skeleton } from 'components/Skeleton'
+import { useConnection } from 'features/web3OnBoard/useConnection'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
-import { formatAddress, formatAmount } from 'helpers/formatters/format'
+import { formatAddress, formatCryptoBalance } from 'helpers/formatters/format'
 import { getGradientColor, summerBrandGradient } from 'helpers/getGradientColor'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { non_owner_notice_icon } from 'theme/icons'
-import { Text } from 'theme-ui'
+import { Box, Text } from 'theme-ui'
 
 import type { PortfolioAsset } from 'lambdas/src/shared/domain-types'
 
+interface PortfolioNonOwnerNoticeProps {
+  address: string
+  connectedAssets?: PortfolioAsset[]
+  isConnected: boolean
+  isOwner: boolean
+  ownerAssets?: PortfolioAsset[]
+}
+
+function useNoticeCta(isConnected: boolean, hasAssets: boolean) {
+  const { t: tPortfolio } = useTranslation('portfolio')
+
+  const { connecting, connect } = useConnection()
+
+  if (!isConnected) {
+    return {
+      label: tPortfolio('connect'),
+      onClick: () => connecting || connect(),
+    }
+  } else if (hasAssets) {
+    return {
+      label: tPortfolio('explore'),
+      url: INTERNAL_LINKS.earn,
+    }
+  } else return undefined
+}
+
+function useNoticeContent(
+  isConnected: boolean,
+  {
+    connectedAssetsValue = 0,
+    ownerAssetsValue = 0,
+  }: { connectedAssetsValue?: number; ownerAssetsValue?: number },
+) {
+  const { t: tPortfolio } = useTranslation('portfolio')
+
+  if (!isConnected) {
+    return ownerAssetsValue > 0 ? (
+      <Trans
+        t={tPortfolio}
+        i18nKey="non-owner-notice.disconnected-assets"
+        components={{
+          span: <Text variant="boldParagraph3" sx={getGradientColor(summerBrandGradient)} />,
+        }}
+        values={{ amount: formatCryptoBalance(new BigNumber(ownerAssetsValue)) }}
+      />
+    ) : (
+      tPortfolio('non-owner-notice.disconnected-no-assets')
+    )
+  } else if (isConnected && connectedAssetsValue > 0) {
+    return (
+      <Trans
+        t={tPortfolio}
+        i18nKey="non-owner-notice.connected-assets"
+        components={{
+          span: <Text variant="boldParagraph3" sx={getGradientColor(summerBrandGradient)} />,
+        }}
+        values={{ amount: formatCryptoBalance(new BigNumber(connectedAssetsValue)) }}
+      />
+    )
+  }
+  return undefined
+}
+
 export const PortfolioNonOwnerNotice = ({
   address,
-  assets,
-}: {
-  address: string
-  assets?: PortfolioAsset[]
-}) => {
+  isConnected,
+  isOwner,
+  connectedAssets,
+  ownerAssets,
+}: PortfolioNonOwnerNoticeProps) => {
   const { t: tPortfolio } = useTranslation('portfolio')
-  const { matchingAssetsValue } = usePortfolioMatchingAssets({ assets })
 
-  return (
-    <BannerTransparent
-      icon={non_owner_notice_icon}
-      title={tPortfolio('non-owner-notice.header', { address: formatAddress(address, 6) })}
-      {...(matchingAssetsValue &&
-        matchingAssetsValue > 0 && {
-          cta: {
-            label: tPortfolio('explore'),
-            url: INTERNAL_LINKS.earn,
-          },
-        })}
-    >
-      <>
-        {matchingAssetsValue !== undefined ? (
-          <>
-            {matchingAssetsValue > 0 && (
-              <Trans
-                t={tPortfolio}
-                i18nKey="non-owner-notice.connected-assets"
-                components={{
-                  span: (
-                    <Text variant="boldParagraph3" sx={getGradientColor(summerBrandGradient)} />
-                  ),
-                }}
-                values={{ amount: formatAmount(new BigNumber(matchingAssetsValue), 'USD') }}
-              />
-            )}
-          </>
-        ) : (
-          <Skeleton width={440} sx={{ mt: 1, height: '18px' }} />
-        )}
-      </>
-    </BannerTransparent>
+  const { matchingAssetsValue: connectedAssetsValue } = usePortfolioMatchingAssets({
+    assets: connectedAssets,
+  })
+  const { matchingAssetsValue: ownerAssetsValue } = usePortfolioMatchingAssets({
+    assets: ownerAssets,
+  })
+
+  const cta = useNoticeCta(isConnected, !!(connectedAssetsValue && connectedAssetsValue > 0))
+  const content = useNoticeContent(isConnected, { connectedAssetsValue, ownerAssetsValue })
+
+  return !isConnected || (isConnected && !isOwner) ? (
+    <Box sx={{ mb: 4 }}>
+      <BannerTransparent
+        icon={non_owner_notice_icon}
+        title={tPortfolio('non-owner-notice.header', { address: formatAddress(address, 6) })}
+        cta={cta}
+      >
+        {content}
+      </BannerTransparent>
+    </Box>
+  ) : (
+    <></>
   )
 }

--- a/pages/portfolio/[address].tsx
+++ b/pages/portfolio/[address].tsx
@@ -87,10 +87,12 @@ export default function PortfolioView(props: PortfolioViewProps) {
       <Box sx={{ width: '100%' }}>
         {!isOwner &&
           walletAddress && ( // walletAddress prevents showing the notice when not connected
-            <PortfolioNonOwnerNotice
-              address={address}
-              assets={portfolioConnectedWalletWalletData?.assets}
-            />
+            <Box sx={{ mb: 4 }}>
+              <PortfolioNonOwnerNotice
+                address={address}
+                assets={portfolioConnectedWalletWalletData?.assets}
+              />
+            </Box>
           )}
         <PortfolioHeader address={address} />
         {overviewData && portfolioWalletData ? (

--- a/pages/portfolio/[address].tsx
+++ b/pages/portfolio/[address].tsx
@@ -58,7 +58,7 @@ export async function getServerSideProps(
 export default function PortfolioView(props: PortfolioViewProps) {
   const { t: tPortfolio } = useTranslation('portfolio')
   const { replace } = useRedirect()
-  const { walletAddress } = useAccount()
+  const { isConnected, walletAddress } = useAccount()
 
   const { address, awsInfraUrl, awsInfraHeader } = props
   const isOwner = address === walletAddress
@@ -85,15 +85,13 @@ export default function PortfolioView(props: PortfolioViewProps) {
   return address ? (
     <PortfolioLayout>
       <Box sx={{ width: '100%' }}>
-        {!isOwner &&
-          walletAddress && ( // walletAddress prevents showing the notice when not connected
-            <Box sx={{ mb: 4 }}>
-              <PortfolioNonOwnerNotice
-                address={address}
-                assets={portfolioConnectedWalletWalletData?.assets}
-              />
-            </Box>
-          )}
+        <PortfolioNonOwnerNotice
+          address={address}
+          connectedAssets={portfolioConnectedWalletWalletData?.assets}
+          isConnected={isConnected}
+          isOwner={isOwner}
+          ownerAssets={portfolioWalletData?.assets}
+        />
         <PortfolioHeader address={address} />
         {overviewData && portfolioWalletData ? (
           <PortfolioOverview

--- a/public/locales/en/portfolio.json
+++ b/public/locales/en/portfolio.json
@@ -38,6 +38,7 @@
   "summary": "Summary",
   "top-assets": "Top {{amount}} assets",
   "no-assets": "There are no assets in this wallet.",
+  "connect": "Connect a wallet",
   "explore": "Explore",
   "explore-banner": "You have <span>${{amount}}</span> of assets available to be put to work on Summer.fi",
   "token": "Token",
@@ -97,7 +98,7 @@
   "non-owner-notice": {
     "header": "You are viewing the wallet of {{address}}",
     "connected-assets": "You have <span>${{amount}}</span> worth of reasons to open a position on summer.fi",
-    "disconnected-assets": "They have ${{amount}} worth of reasons to open a position on summer.fi. Connect your wallet to see what positions you could open",
+    "disconnected-assets": "They have <span>${{amount}}</span> worth of reasons to open a position on summer.fi. Connect your wallet to see what positions you could open",
     "disconnected-no-assets": "Connect your wallet to see what positions you could open"
   }
 }

--- a/public/locales/en/portfolio.json
+++ b/public/locales/en/portfolio.json
@@ -96,6 +96,8 @@
   },
   "non-owner-notice": {
     "header": "You are viewing the wallet of {{address}}",
-    "assets-available": "You have <span>${{amount}}</span> worth of reasons to open a position on summer.fi"
+    "connected-assets": "You have <span>${{amount}}</span> worth of reasons to open a position on summer.fi",
+    "disconnected-assets": "They have ${{amount}} worth of reasons to open a position on summer.fi. Connect your wallet to see what positions you could open",
+    "disconnected-no-assets": "Connect your wallet to see what positions you could open"
   }
 }


### PR DESCRIPTION
# Non owner notice on portfolio page overhaul
  
## Changes 👷‍♀️

- Extracted banner to external parameterized component `BannerTransparent`,
- created separated displaying variant for different cases:
  - Disconnected user, owner has assets,
  - disconnected user, owner has no assets,
  - connected user, connected wallet has assets,
  - connected user, connected wallet has no assets.
