### PR TITLE
Constant multiply trigger type fix

### DIFF
--- a/blockchain/calls/automationBotAggregator.ts
+++ b/blockchain/calls/automationBotAggregator.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import type { ContextConnected } from 'blockchain/network.types'
 import { NetworkIds } from 'blockchain/networks'
@@ -19,7 +20,9 @@ export function getAddAutomationAggregatotTriggerCallData(
     getNetworkContracts(NetworkIds.MAINNET, chainId).automationBotAggregator,
   ).methods.addTriggerGroup(
     CONSTANT_MULTIPLE_GROUP_TYPE,
-    data.replacedTriggerIds,
+    data.replacedTriggerIds.map((id: BigNumber) =>
+      BigNumber.isBigNumber(id) ? id.toString() : id,
+    ),
     data.triggersData,
   )
 }


### PR DESCRIPTION
# [Constant multiply trigger type fix](https://app.shortcut.com/oazo-apps/story/12872)
  
## Changes 👷‍♀️

Replaced `replacedTriggerIds` to strings array in automation tx data.
  
## How to test 🧪

Position to test: `/ethereum/maker/31078`.
