### PR TITLE
Make entire position block a link

### DIFF
--- a/components/assetsTable/cellComponents/AssetsTableDataCellAsset.tsx
+++ b/components/assetsTable/cellComponents/AssetsTableDataCellAsset.tsx
@@ -28,7 +28,7 @@ export function AssetsTableDataCellAsset({
     <Flex sx={{ alignItems: 'center' }}>
       {icons.length > 0 && allDefined(...icons) && <TokensGroup tokens={icons} />}
       <Flex sx={{ flexDirection: 'column', ml: '10px' }}>
-        <Text as="span" sx={{ fontSize: 4, fontWeight: 'semiBold' }}>
+        <Text as="span" variant="boldParagraph1">
           {prefix && (
             <Text as="span" sx={{ fontWeight: 'regular' }}>
               {prefix}{' '}
@@ -43,7 +43,11 @@ export function AssetsTableDataCellAsset({
           )}
         </Text>
         {(positionId || description) && (
-          <Text as="span" sx={{ fontSize: 2, color: 'neutral80', whiteSpace: 'pre' }}>
+          <Text
+            as="span"
+            variant="paragraph3"
+            sx={{ color: 'neutral80', fontWeight: 'regular', whiteSpace: 'pre' }}
+          >
             {positionId && (
               <>
                 {t('position')} {!positionId.toString().includes('...') && '#'}

--- a/components/portfolio/positions/PortfolioPositionAutomationIcons.tsx
+++ b/components/portfolio/positions/PortfolioPositionAutomationIcons.tsx
@@ -1,36 +1,25 @@
 import { AutomationIcon } from 'components/AutomationIcon'
-import { AppLink } from 'components/Links'
 import type { PortfolioPosition } from 'handlers/portfolio/types'
 import React from 'react'
 
 export const PortfolioPositionAutomationIcons = ({
   automations = {},
-  url,
 }: {
   automations: PortfolioPosition['automations']
-  url: string
 }) => {
   return (
     <>
       {automations.stopLoss && (
-        <AppLink href={url} hash="protection">
-          <AutomationIcon enabled={automations.stopLoss.enabled} type="stopLoss" />
-        </AppLink>
+        <AutomationIcon enabled={automations.stopLoss.enabled} type="stopLoss" />
       )}
       {automations.autoBuy && (
-        <AppLink href={url} hash="optimization">
-          <AutomationIcon enabled={automations.autoBuy.enabled} type="autoBuy" />
-        </AppLink>
+        <AutomationIcon enabled={automations.autoBuy.enabled} type="autoBuy" />
       )}
       {automations.autoSell && (
-        <AppLink href={url} hash="protection">
-          <AutomationIcon enabled={automations.autoSell.enabled} type="autoSell" />
-        </AppLink>
+        <AutomationIcon enabled={automations.autoSell.enabled} type="autoSell" />
       )}
       {automations.takeProfit && (
-        <AppLink href={url} hash="optimization">
-          <AutomationIcon enabled={automations.takeProfit.enabled} type="takeProfit" />
-        </AppLink>
+        <AutomationIcon enabled={automations.takeProfit.enabled} type="takeProfit" />
       )}
     </>
   )

--- a/components/portfolio/positions/PortfolioPositionBlock.tsx
+++ b/components/portfolio/positions/PortfolioPositionBlock.tsx
@@ -92,10 +92,7 @@ export const PortfolioPositionBlock = ({ position }: { position: PortfolioPositi
                     {tPortfolio('automations')}
                   </Text>
                   <Flex sx={{ justifyContent: 'space-between', columnGap: 1 }}>
-                    <PortfolioPositionAutomationIcons
-                      automations={position.automations}
-                      url={position.url}
-                    />
+                    <PortfolioPositionAutomationIcons automations={position.automations} />
                   </Flex>
                 </>
               )}

--- a/components/portfolio/positions/PortfolioPositionBlock.tsx
+++ b/components/portfolio/positions/PortfolioPositionBlock.tsx
@@ -10,7 +10,7 @@ import { LendingProtocolLabel } from 'lendingProtocols'
 import { upperFirst } from 'lodash'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Box, Button, Flex, Text } from 'theme-ui'
+import { Button, Flex, Text } from 'theme-ui'
 
 export const PortfolioPositionBlock = ({ position }: { position: PortfolioPosition }) => {
   const { t: tPortfolio } = useTranslation('portfolio')
@@ -25,13 +25,21 @@ export const PortfolioPositionBlock = ({ position }: { position: PortfolioPositi
       : [position.primaryToken, position.secondaryToken]
 
   return (
-    <Box
+    <AppLink
+      href={position.url}
       sx={{
         width: '100%',
+        p: 3,
         border: '1px solid',
         borderColor: 'neutral20',
         borderRadius: 'large',
-        p: 3,
+        transition: 'border-color 200ms',
+        '&:hover': {
+          borderColor: 'neutral70',
+          '.position-action-button': {
+            bg: 'secondary100',
+          },
+        },
       }}
     >
       <Flex sx={{ alignItems: 'center', justifyContent: 'space-between', mb: '24px' }}>
@@ -105,12 +113,12 @@ export const PortfolioPositionBlock = ({ position }: { position: PortfolioPositi
             </Flex>
           )}
           <Flex sx={{ alignSelf: 'flex-end' }}>
-            <AppLink href={position.url}>
-              <Button variant="tertiary">{tPortfolio('view-position')}</Button>
-            </AppLink>
+            <Button className="position-action-button" variant="tertiary">
+              {tPortfolio('view-position')}
+            </Button>
           </Flex>
         </Flex>
       )}
-    </Box>
+    </AppLink>
   )
 }

--- a/components/portfolio/positions/PortfolioPositionBlockDetail.tsx
+++ b/components/portfolio/positions/PortfolioPositionBlockDetail.tsx
@@ -1,31 +1,13 @@
 import { Icon } from 'components/Icon'
-import { AppLink } from 'components/Links'
 import { getPortfolioAccentColor } from 'components/portfolio/helpers/getPortfolioAccentColor'
 import { PortfolioPositionBlockLendingRangeDetail } from 'components/portfolio/positions/PortfolioPositionBlockLendingRangeDetail'
 import { StatefulTooltip } from 'components/Tooltip'
-import { WithArrow } from 'components/WithArrow'
 import type { DetailsType, PositionDetail } from 'handlers/portfolio/types'
-import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import type { TranslateStringType } from 'helpers/translateStringType'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { question_o } from 'theme/icons'
 import { Box, Flex, Text } from 'theme-ui'
-
-const MainDetailComponent = ({ detail }: { detail: PositionDetail }) => {
-  switch (detail.type) {
-    case 'apyLink':
-      return (
-        <AppLink href={EXTERNAL_LINKS.AAVE_SDAI_YIELD_DUNE}>
-          <WithArrow>APY</WithArrow>
-        </AppLink>
-      )
-    case 'lendingRange':
-      return <PortfolioPositionBlockLendingRangeDetail detail={detail} />
-    default:
-      return <>{detail.value}</>
-  }
-}
 
 export const PortfolioPositionBlockDetail = ({ detail }: { detail: PositionDetail }) => {
   const { t: tPortfolio } = useTranslation('portfolio')
@@ -38,7 +20,6 @@ export const PortfolioPositionBlockDetail = ({ detail }: { detail: PositionDetai
     borrowRate: tPortfolio('details-tooltips.borrowRate'),
     lendingRange: tPortfolio('details-tooltips.lendingRange'),
     apy: tPortfolio('details-tooltips.apy'),
-    apyLink: tPortfolio('details-tooltips.apy'),
     '90dApy': tPortfolio('details-tooltips.90dApy'),
     suppliedTokenBalance: tPortfolio('details-tooltips.suppliedTokenBalance'),
     borrowedTokenBalance: tPortfolio('details-tooltips.borrowedTokenBalance'),
@@ -86,7 +67,11 @@ export const PortfolioPositionBlockDetail = ({ detail }: { detail: PositionDetai
         variant="boldParagraph1"
         color={detail.accent ? getPortfolioAccentColor(detail.accent) : 'neutral100'}
       >
-        <MainDetailComponent detail={detail} />
+        {detail.type === 'lendingRange' ? (
+          <PortfolioPositionBlockLendingRangeDetail detail={detail} />
+        ) : (
+          detail.value
+        )}
       </Text>
       {detail.subvalue && (
         <Text variant="paragraph4" color="neutral80">

--- a/components/portfolio/positions/PortfolioPositionLearn.tsx
+++ b/components/portfolio/positions/PortfolioPositionLearn.tsx
@@ -1,7 +1,6 @@
 import { Icon } from 'components/Icon'
 import { AppLink } from 'components/Links'
 import { Skeleton } from 'components/Skeleton'
-import { WithArrow } from 'components/WithArrow'
 import dayjs from 'dayjs'
 import type { ParsedBlogPost } from 'helpers/types/blog-posts.types'
 import React from 'react'
@@ -24,57 +23,58 @@ export const PortfolioPositionLearn = ({ posts }: PortfolioPositionLearnProps) =
       {posts ? (
         <>
           {posts.map(({ date, image, readingTime, title, url }, i) => (
-            <Flex
-              key={`post-${i}`}
-              as="li"
-              sx={{
-                flexDirection: 'column',
-                flex: '0 1 100%',
-                border: '1px solid',
-                borderColor: 'neutral20',
-                borderRadius: 'large',
-                overflow: 'hidden',
-              }}
-            >
-              <Box sx={{ aspectRatio: '2 / 1' }}>
-                <Image
-                  src={image}
-                  alt={title}
-                  sx={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover' }}
-                />
-              </Box>
-              <Flex sx={{ flexDirection: 'column', alignItems: 'flex-start', flexGrow: 1, p: 3 }}>
-                <Flex
-                  variant="text.paragraph4"
-                  sx={{
-                    alignItems: 'center',
-                    columnGap: 1,
-                    mb: 2,
-                    px: 3,
-                    py: 1,
-                    color: 'neutral80',
-                    border: '1px solid',
-                    borderColor: 'neutral20',
-                    borderRadius: 'large',
-                  }}
-                >
-                  <Icon icon={clock} size="14px" />
-                  {readingTime} min.
-                </Flex>
-                <Text as="p" variant="boldParagraph2">
-                  {title}
-                </Text>
-                <Flex sx={{ justifyContent: 'space-between', width: '100%', mt: 'auto', pt: 3 }}>
-                  <Text variant="paragraph3" sx={{ color: 'neutral80' }}>
-                    {dayjs(date).format('MMMM DD, YYYY')}
+            <Flex key={`post-${i}`} as="li" sx={{ flex: '0 1 100%' }}>
+              <AppLink
+                href={url}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  border: '1px solid',
+                  borderColor: 'neutral20',
+                  borderRadius: 'large',
+                  overflow: 'hidden',
+                  transition: 'border-color 200ms',
+                  '&:hover': {
+                    borderColor: 'neutral70',
+                  },
+                }}
+              >
+                <Box sx={{ aspectRatio: '2 / 1' }}>
+                  <Image
+                    src={image}
+                    alt={title}
+                    sx={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover' }}
+                  />
+                </Box>
+                <Flex sx={{ flexDirection: 'column', alignItems: 'flex-start', flexGrow: 1, p: 3 }}>
+                  <Flex
+                    variant="text.paragraph4"
+                    sx={{
+                      alignItems: 'center',
+                      columnGap: 1,
+                      mb: 2,
+                      px: 3,
+                      py: 1,
+                      color: 'neutral80',
+                      border: '1px solid',
+                      borderColor: 'neutral20',
+                      borderRadius: 'large',
+                    }}
+                  >
+                    <Icon icon={clock} size="14px" />
+                    {readingTime} min.
+                  </Flex>
+                  <Text as="p" variant="boldParagraph2">
+                    {title}
                   </Text>
-                  <AppLink href={url} sx={{ mr: 3 }}>
-                    <WithArrow sx={{ color: 'interactive100' }}>
-                      {tPortfolio('read-article')}
-                    </WithArrow>
-                  </AppLink>
+                  <Flex sx={{ justifyContent: 'space-between', width: '100%', mt: 'auto', pt: 3 }}>
+                    <Text variant="paragraph3" sx={{ fontWeight: 'regular', color: 'neutral80' }}>
+                      {dayjs(date).format('MMMM DD, YYYY')}
+                    </Text>
+                    {tPortfolio('read-article')} →
+                  </Flex>
                 </Flex>
-              </Flex>
+              </AppLink>
             </Flex>
           ))}
         </>

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -19,7 +19,6 @@ import type { GetAaveLikePositionHandlerType } from 'handlers/portfolio/position
 import { getAutomationData } from 'handlers/portfolio/positions/helpers/getAutomationData'
 import { getHistoryData } from 'handlers/portfolio/positions/helpers/getHistoryData'
 import type { PortfolioPositionsHandler, PositionDetail } from 'handlers/portfolio/types'
-import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import {
   formatCryptoBalance,
   formatDecimalAsPercent,
@@ -212,7 +211,6 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
         proxyAddress: dpm.id.toLowerCase(),
       }),
     ])
-  const isSDAIEarn = commonData.primaryToken === 'SDAI'
   const isWstethEthEarn =
     commonData.primaryToken === 'WSTETH' && commonData.secondaryToken === 'WETH'
   let wstEthYield
@@ -256,18 +254,12 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
             : notAvailable
         }`,
       },
-      wstEthYield?.annualisedYield7days
-        ? {
-            type: 'apy',
-            value: formatDecimalAsPercent(wstEthYield.annualisedYield7days.div(100)),
-          }
-        : undefined,
-      isSDAIEarn
-        ? {
-            type: 'apyLink',
-            value: EXTERNAL_LINKS.AAVE_SDAI_YIELD_DUNE,
-          }
-        : undefined,
+      {
+        type: 'apy',
+        value: wstEthYield?.annualisedYield7days
+          ? formatDecimalAsPercent(wstEthYield.annualisedYield7days.div(100))
+          : notAvailable,
+      },
       {
         type: 'ltv',
         value: formatDecimalAsPercent(onChainPositionData.riskRatio.loanToValue),

--- a/handlers/portfolio/types.ts
+++ b/handlers/portfolio/types.ts
@@ -62,7 +62,6 @@ export type PortfolioPositionsResponse = {
 type DetailsTypeCommon =
   | '90dApy'
   | 'apy'
-  | 'apyLink'
   | 'borrowedToken'
   | 'borrowedTokenBalance'
   | 'borrowRate'


### PR DESCRIPTION
# [Make entire position block a link](https://app.shortcut.com/oazo-apps/story/12870)
  
## Changes 👷‍♀️

- Made entire position block link,
- same for blocks in Learn with Summer.fi section,
- removed all interactive elements that could be placed in position block before,
- fixed formatting as wrapping entire block in `AppLink` was changing text styles.