### PR TITLE
chore: [sc-12876] Separated request for amount of positions

### DIFF
--- a/blockchain/vaults.ts
+++ b/blockchain/vaults.ts
@@ -70,7 +70,6 @@ export function createVaults$(
   cdpIdResolvers: CdpIdsResolver[],
   address: string,
 ): Observable<VaultWithType[]> {
-  console.log('createVaults')
   return combineLatest(refreshInterval, context$).pipe(
     switchMap(([_, context]) =>
       combineLatest(cdpIdResolvers.map((resolver) => resolver(address))).pipe(

--- a/blockchain/vaults.ts
+++ b/blockchain/vaults.ts
@@ -70,6 +70,7 @@ export function createVaults$(
   cdpIdResolvers: CdpIdsResolver[],
   address: string,
 ): Observable<VaultWithType[]> {
+  console.log('createVaults')
   return combineLatest(refreshInterval, context$).pipe(
     switchMap(([_, context]) =>
       combineLatest(cdpIdResolvers.map((resolver) => resolver(address))).pipe(

--- a/components/navigation/content/MyPositionsLink.tsx
+++ b/components/navigation/content/MyPositionsLink.tsx
@@ -1,3 +1,5 @@
+import { usePortfolioPositionsCount } from 'helpers/clients/portfolio-positions-count'
+import { getLocalAppConfig } from 'helpers/config'
 import { useAccount } from 'helpers/useAccount'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -6,7 +8,12 @@ import { Spinner } from 'theme-ui'
 
 export function MyPositionsLink() {
   const { t } = useTranslation()
-  const { amountOfPositions } = useAccount()
+  const { NewPortfolio } = getLocalAppConfig('features')
+  const { amountOfPositions: oldAmountOfPositions, walletAddress } = useAccount()
+  const { amountOfPositions: newAmountOfPositions } = usePortfolioPositionsCount({
+    address: walletAddress?.toLowerCase(),
+  })
+  const amountOfPositions = NewPortfolio ? newAmountOfPositions : oldAmountOfPositions
 
   return (
     <>

--- a/components/navigation/content/MyPositionsOrb.tsx
+++ b/components/navigation/content/MyPositionsOrb.tsx
@@ -1,11 +1,18 @@
 import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
+import { usePortfolioPositionsCount } from 'helpers/clients/portfolio-positions-count'
+import { getLocalAppConfig } from 'helpers/config'
 import { getPortfolioLink } from 'helpers/get-portfolio-link'
 import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 import { home } from 'theme/icons'
 
 export function MyPositionsOrb() {
-  const { amountOfPositions, walletAddress } = useAccount()
+  const { NewPortfolio } = getLocalAppConfig('features')
+  const { amountOfPositions: oldAmountOfPositions, walletAddress } = useAccount()
+  const { amountOfPositions: newAmountOfPositions } = usePortfolioPositionsCount({
+    address: walletAddress?.toLowerCase(),
+  })
+  const amountOfPositions = NewPortfolio ? newAmountOfPositions : oldAmountOfPositions
 
   return (
     <NavigationOrb

--- a/features/account/AccountData.ts
+++ b/features/account/AccountData.ts
@@ -3,9 +3,10 @@ import type { ContextConnected } from 'blockchain/network.types'
 import type { Vault } from 'blockchain/vaults.types'
 import type { PositionCreated } from 'features/aave/services'
 import type { Web3Context } from 'features/web3Context'
+import { getLocalAppConfig } from 'helpers/config'
 import { startWithDefault } from 'helpers/operators'
 import type { Observable } from 'rxjs'
-import { combineLatest } from 'rxjs'
+import { combineLatest, of } from 'rxjs'
 import { filter, map, shareReplay, switchMap } from 'rxjs/operators'
 
 export interface AccountDetails {
@@ -22,26 +23,33 @@ export function createAccountData(
   readPositionCreatedEvents$: (wallet: string) => Observable<PositionCreated[]>,
   ensName$: (address: string) => Observable<string>,
 ): Observable<AccountDetails> {
+  const { NewPortfolio } = getLocalAppConfig('features')
   return context$.pipe(
     filter((context): context is ContextConnected => context.status === 'connected'),
     switchMap((context) =>
       combineLatest(
         startWithDefault(balance$('DAI', context.account), undefined),
-        startWithDefault(vaults$(context.account).pipe(map((vault) => vault.length)), undefined),
+        startWithDefault(
+          NewPortfolio ? of(0) : vaults$(context.account).pipe(map((vault) => vault.length)),
+          undefined,
+        ),
         startWithDefault(ensName$(context.account), null),
         startWithDefault(hasActiveDsProxyAavePosition$, false),
-        startWithDefault(readPositionCreatedEvents$(context.account), []),
+        startWithDefault(
+          NewPortfolio ? of(undefined) : readPositionCreatedEvents$(context.account),
+          [],
+        ),
       ).pipe(
         map(([balance, numberOfVaults, ensName, hasAavePosition, dpmPositionCreatedEvents]) => {
           // dpm valuts contains aave & ajna positions
-          const numberOfDpmVaults = dpmPositionCreatedEvents.length
+          const numberOfDpmVaults = dpmPositionCreatedEvents?.length
             ? dpmPositionCreatedEvents.length
             : 0
           // only one position per user is allowed on ds proxys
           const numberOfAavePositions = hasAavePosition ? 1 : 0
 
           return {
-            numberOfVaults: (numberOfVaults || 0) + numberOfDpmVaults + numberOfAavePositions,
+            numberOfVaults: (numberOfVaults ?? 0) + numberOfDpmVaults + numberOfAavePositions,
             daiBalance: balance,
             ensName,
           }

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -270,8 +270,17 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
   }
 }
 
-export const aaveLikePositionsHandler: PortfolioPositionsHandler = async ({ dpmList, prices }) => {
+export const aaveLikePositionsHandler: PortfolioPositionsHandler = async ({
+  dpmList,
+  prices,
+  positionsCount,
+}) => {
   const aaveLikeDpmList = dpmList.filter(({ protocol }) => ['AAVE_V3', 'Spark'].includes(protocol))
+  if (positionsCount) {
+    return {
+      positions: aaveLikeDpmList.map(({ vaultId }) => ({ positionId: vaultId })),
+    }
+  }
   const uniqueDpmNetworks = Array.from(new Set(aaveLikeDpmList.map(({ networkId }) => networkId)))
   const [allPositionsHistory, allPositionsAutomations] = await Promise.all([
     Promise.all(

--- a/handlers/portfolio/positions/handlers/aave-v2/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/index.ts
@@ -100,9 +100,19 @@ export const aaveV2PositionHandler: PortfolioPositionsHandler = async ({
   address,
   prices,
   dpmList,
+  positionsCount,
   ...rest
 }) => {
   const aaveV2DpmList = dpmList.filter(({ protocol }) => ['AAVE'].includes(protocol))
+  if (positionsCount) {
+    const dsProxyPosition = await getAaveV2DsProxyPosition({ address, prices, dpmList, ...rest })
+    return {
+      positions: [
+        ...aaveV2DpmList.map(({ vaultId }) => ({ positionId: vaultId })),
+        ...dsProxyPosition.positions.map(({ positionId }) => ({ positionId: positionId })),
+      ],
+    }
+  }
   const [allPositionsHistory, dsProxyPositions] = await Promise.all([
     getHistoryData({
       network: NetworkIds.MAINNET,

--- a/handlers/portfolio/positions/handlers/ajna/index.ts
+++ b/handlers/portfolio/positions/handlers/ajna/index.ts
@@ -18,6 +18,7 @@ export const ajnaPositionsHandler: PortfolioPositionsHandler = async ({
   apiVaults,
   dpmList,
   prices,
+  positionsCount,
 }) => {
   const dpmProxyAddress = dpmList.map(({ id }) => id)
   const subgraphPositions = (await loadSubgraph('Ajna', 'getAjnaDpmPositions', NetworkIds.MAINNET, {
@@ -34,6 +35,11 @@ export const ajnaPositionsHandler: PortfolioPositionsHandler = async ({
       ...earnPositions.map((position) => ({ ...position, proxyAddress, isEarn: true, positionId })),
     ],
   )
+  if (positionsCount || !apiVaults) {
+    return {
+      positions: positionsArray.map(({ positionId }) => ({ positionId })),
+    }
+  }
 
   const positions = await Promise.all(
     positionsArray.map(

--- a/handlers/portfolio/positions/handlers/maker/index.ts
+++ b/handlers/portfolio/positions/handlers/maker/index.ts
@@ -15,6 +15,7 @@ export const makerPositionsHandler: PortfolioPositionsHandler = async ({
   apiVaults,
   address,
   prices,
+  positionsCount,
 }) => {
   const subgraphPositions = (await loadSubgraph(
     'Discover',
@@ -24,6 +25,12 @@ export const makerPositionsHandler: PortfolioPositionsHandler = async ({
       walletAddress: address,
     },
   )) as SubgraphsResponses['Discover']['getMakerDiscoverPositions']
+
+  if (positionsCount || !apiVaults) {
+    return {
+      positions: subgraphPositions.response.cdps.map(({ cdp }) => ({ positionId: cdp })),
+    }
+  }
 
   const positions = await Promise.all(
     subgraphPositions.response.cdps.map(

--- a/handlers/portfolio/types.ts
+++ b/handlers/portfolio/types.ts
@@ -40,24 +40,34 @@ export type PortfolioPosition = {
   type: OmniProductType
   url: string
 }
+interface PortfolioPositionsCommonReply {
+  error?: boolean | string
+  errorJson?: boolean | string
+}
+
+export interface PortfolioPositionsCountReply extends PortfolioPositionsCommonReply {
+  positions: {
+    positionId: PortfolioPosition['positionId']
+  }[]
+}
+
+export interface PortfolioPositionsReply extends PortfolioPositionsCommonReply {
+  positions: PortfolioPosition[]
+}
 
 export type PortfolioPositionsHandler = ({
   address,
   apiVaults,
   dpmList,
   prices,
+  positionsCount,
 }: {
   address: string
-  apiVaults: Vault[]
+  apiVaults?: Vault[]
   dpmList: DpmList
   prices: TokensPrices
-}) => Promise<PortfolioPositionsResponse>
-
-export type PortfolioPositionsResponse = {
-  positions: PortfolioPosition[]
-  error?: boolean | string
-  errorJson?: boolean | string
-}
+  positionsCount?: boolean
+}) => Promise<PortfolioPositionsReply | PortfolioPositionsCountReply>
 
 type DetailsTypeCommon =
   | '90dApy'

--- a/helpers/clients/portfolio-client-data.ts
+++ b/helpers/clients/portfolio-client-data.ts
@@ -1,4 +1,4 @@
-import type { PortfolioPositionsResponse } from 'handlers/portfolio/types'
+import type { PortfolioPositionsReply } from 'handlers/portfolio/types'
 import { usePortfolioClient } from 'helpers/clients/portfolio-client'
 import type { BlogPostsReply } from 'helpers/types/blog-posts.types'
 import { useEffect, useState } from 'react'
@@ -24,7 +24,7 @@ export const usePortfolioClientData = ({
   const portfolioClient = usePortfolioClient(awsInfraUrl, awsInfraHeader)
   const { data: blogPosts } = useFetch<BlogPostsReply>(`/api/blog-posts`)
   const [overviewData, setOverviewData] = useState<PortfolioOverviewResponse>()
-  const [portfolioPositionsData, setPortfolioPositionsData] = useState<PortfolioPositionsResponse>()
+  const [portfolioPositionsData, setPortfolioPositionsData] = useState<PortfolioPositionsReply>()
   const [portfolioWalletData, setPortfolioWalletData] = useState<PortfolioAssetsResponse>()
   const [portfolioConnectedWalletWalletData, setPortfolioConnectedWalletWalletData] =
     useState<PortfolioAssetsResponse>()

--- a/helpers/clients/portfolio-client.ts
+++ b/helpers/clients/portfolio-client.ts
@@ -1,4 +1,7 @@
-import type { PortfolioPositionsResponse } from 'handlers/portfolio/types'
+import type {
+  PortfolioPositionsCountReply,
+  PortfolioPositionsReply,
+} from 'handlers/portfolio/types'
 import { useCallback, useMemo } from 'react'
 
 import type {
@@ -12,16 +15,27 @@ import type {
  * @param headers
  * @returns getters for portfolio data
  */
-export const usePortfolioClient = (baseUrl: string, headers: HeadersInit) => {
+export const usePortfolioClient = (baseUrl?: string, headers?: HeadersInit) => {
   const fetchPortfolioGeneric = useCallback(
     async <ResponseType>(
-      section: 'overview' | 'assets' | 'positions',
+      section: 'overview' | 'assets' | 'positions' | 'positionsCount',
       address: string,
     ): Promise<ResponseType> => {
-      const callUrl =
-        section === 'positions'
-          ? `/api/positions/${address}`
-          : `${baseUrl}/portfolio-${section}?address=${address}`
+      let callUrl
+      switch (section) {
+        case 'positions':
+          callUrl = `/api/positions/${address}`
+          break
+        case 'positionsCount':
+          callUrl = `/api/positions/${address}?positionsCount`
+          break
+        case 'overview':
+        case 'assets':
+          callUrl = `${baseUrl}/portfolio-${section}?address=${address}`
+          break
+        default:
+          throw new Error('Invalid usePortfolioClient section')
+      }
       const response = await fetch(callUrl, {
         headers,
       })
@@ -39,7 +53,9 @@ export const usePortfolioClient = (baseUrl: string, headers: HeadersInit) => {
       fetchPortfolioAssets: (address: string) =>
         fetchPortfolioGeneric<PortfolioAssetsResponse>('assets', address),
       fetchPortfolioPositions: (address: string) =>
-        fetchPortfolioGeneric<PortfolioPositionsResponse>('positions', address),
+        fetchPortfolioGeneric<PortfolioPositionsReply>('positions', address),
+      fetchPortfolioPositionsCount: (address: string) =>
+        fetchPortfolioGeneric<PortfolioPositionsCountReply>('positionsCount', address),
     }),
     [fetchPortfolioGeneric],
   )

--- a/helpers/clients/portfolio-positions-count.ts
+++ b/helpers/clients/portfolio-positions-count.ts
@@ -1,0 +1,19 @@
+import { usePortfolioClient } from 'helpers/clients/portfolio-client'
+import { useEffect, useState } from 'react'
+
+export const usePortfolioPositionsCount = ({ address }: { address?: string }) => {
+  const portfolioClient = usePortfolioClient()
+  const [amountOfPositions, setAmountOfPositions] = useState<number>()
+  useEffect(() => {
+    setAmountOfPositions(undefined)
+  }, [address])
+  useEffect(() => {
+    address &&
+      void portfolioClient.fetchPortfolioPositionsCount(address).then((data) => {
+        setAmountOfPositions(data.positions.length)
+      })
+  }, [address, portfolioClient])
+  return {
+    amountOfPositions,
+  }
+}

--- a/pages/portfolio/[address].tsx
+++ b/pages/portfolio/[address].tsx
@@ -48,7 +48,7 @@ export async function getServerSideProps(
   return {
     props: {
       ...(await serverSideTranslations(ctx.locale ?? 'en', ['portfolio', 'common'])),
-      address,
+      address: address.toLowerCase(),
       awsInfraUrl,
       awsInfraHeader,
     },
@@ -68,7 +68,6 @@ export default function PortfolioView(props: PortfolioViewProps) {
       replace('/')
     }
   }, [address, replace])
-  const parsedAddress = address.toLowerCase()
   const {
     overviewData,
     portfolioConnectedWalletWalletData,
@@ -76,24 +75,23 @@ export default function PortfolioView(props: PortfolioViewProps) {
     portfolioWalletData,
     blogPosts,
   } = usePortfolioClientData({
-    address: parsedAddress,
+    address,
     awsInfraHeader,
     awsInfraUrl,
-    walletAddress,
   })
-  const isOwner = !!walletAddress && parsedAddress === walletAddress.toLowerCase()
+  const isOwner = !!walletAddress && address === walletAddress.toLowerCase()
 
   return address ? (
     <PortfolioLayout>
       <Box sx={{ width: '100%' }}>
         <PortfolioNonOwnerNotice
-          address={parsedAddress}
+          address={address}
           connectedAssets={portfolioConnectedWalletWalletData?.assets}
           isConnected={isConnected}
           isOwner={isOwner}
           ownerAssets={portfolioWalletData?.assets}
         />
-        <PortfolioHeader address={parsedAddress} />
+        <PortfolioHeader address={address} />
         {overviewData && portfolioWalletData ? (
           <PortfolioOverview
             overviewData={overviewData}
@@ -110,7 +108,7 @@ export default function PortfolioView(props: PortfolioViewProps) {
               label: tPortfolio('positions-tab'),
               content: (
                 <PortfolioPositionsView
-                  address={parsedAddress}
+                  address={address}
                   blogPosts={blogPosts}
                   isOwner={isOwner}
                   portfolioPositionsData={portfolioPositionsData}
@@ -122,7 +120,7 @@ export default function PortfolioView(props: PortfolioViewProps) {
               label: tPortfolio('wallet-tab'),
               content: (
                 <PortfolioWalletView
-                  address={parsedAddress}
+                  address={address}
                   blogPosts={blogPosts}
                   isOwner={isOwner}
                   portfolioWalletData={portfolioWalletData}

--- a/public/locales/en/portfolio.json
+++ b/public/locales/en/portfolio.json
@@ -21,7 +21,8 @@
   "net-value-mobile-descending": "Net Value ▼",
   "net-value-mobile-ascending": "Net Value ▲",
   "show-empty-positions": {
-    "label": "Show empty positions",
+    "label": "Show {{count}} empty positions",
+    "showing-all": "Showing all positions",
     "tooltip": "Positions valued at $0 are hidden by default. Toggle 'Show Empty Positions' to view or use them. You still own these and can utilize them without incurring new position costs."
   },
   "automations": "Automations",

--- a/public/locales/en/portfolio.json
+++ b/public/locales/en/portfolio.json
@@ -22,7 +22,6 @@
   "net-value-mobile-ascending": "Net Value ▲",
   "show-empty-positions": {
     "label": "Show {{count}} empty positions",
-    "showing-all": "Showing all positions",
     "tooltip": "Positions valued at $0 are hidden by default. Toggle 'Show Empty Positions' to view or use them. You still own these and can utilize them without incurring new position costs."
   },
   "automations": "Automations",


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/12876

Changes:
- portfolio positions parameter `positionsCount`, replies with simple positions list (ids)
- used that with a pipe feedback
- added checks to the owner page pipes (checks if NewPortfolio is enabled, doesn't run them if not)
- changed the label on "Show empty positions" for a more descriptive one
- - that required a separation of filtering and sorting steps in the positions list