### PR TITLE
chore: [sc-12875] Aave V2 steth earn shows APY, but the Aave V3 doesn't

### DIFF
--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -212,7 +212,7 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
       }),
     ])
   const isWstethEthEarn =
-    commonData.primaryToken === 'WSTETH' && commonData.secondaryToken === 'WETH'
+    commonData.primaryToken === 'WSTETH' && commonData.secondaryToken === 'ETH'
   let wstEthYield
   if (isWstethEthEarn) {
     const contracts = getNetworkContracts(NetworkIds.MAINNET)


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/12875