### PR TITLE
feature: [sc-13019] Add WBTC-DAI Long strategy to Spark

### DIFF
--- a/features/aave/strategies/ethereum-spark-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-spark-v3-strategies.ts
@@ -176,7 +176,21 @@ const availableTokenPairs: TokenPairConfig[] = [
     productTypes: {
       [ProductType.Multiply]: {
         featureToggle: undefined,
-        additionalManageActions: [],
+        additionalManageActions: [
+          {
+            action: 'switch-to-borrow',
+            featureToggle: undefined,
+          },
+        ],
+      },
+      [ProductType.Borrow]: {
+        featureToggle: undefined,
+        additionalManageActions: [
+          {
+            action: 'switch-to-multiply',
+            featureToggle: undefined,
+          },
+        ],
       },
     },
   },

--- a/features/aave/strategies/ethereum-spark-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-spark-v3-strategies.ts
@@ -169,6 +169,17 @@ const availableTokenPairs: TokenPairConfig[] = [
       },
     },
   },
+  {
+    collateral: 'WBTC',
+    debt: 'DAI',
+    strategyType: StrategyType.Long,
+    productTypes: {
+      [ProductType.Multiply]: {
+        featureToggle: undefined,
+        additionalManageActions: [],
+      },
+    },
+  },
 ]
 
 const borrowStrategies: IStrategyConfig[] = availableTokenPairs

--- a/features/automation/common/consts.ts
+++ b/features/automation/common/consts.ts
@@ -84,6 +84,7 @@ export const aaveTokenPairsAllowedAutomation = [
   ['WSTETH', 'DAI'],
   ['RETH', 'DAI'],
   ['CBETH', 'DAI'],
+  ['WBTC', 'DAI'],
 ]
 
 export const vaultIdsThatAutoBuyTriggerShouldBeRecreated = [

--- a/features/automation/common/consts.ts
+++ b/features/automation/common/consts.ts
@@ -84,7 +84,6 @@ export const aaveTokenPairsAllowedAutomation = [
   ['WSTETH', 'DAI'],
   ['RETH', 'DAI'],
   ['CBETH', 'DAI'],
-  ['WBTC', 'DAI'],
 ]
 
 export const vaultIdsThatAutoBuyTriggerShouldBeRecreated = [

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Handler.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Handler.ts
@@ -158,8 +158,12 @@ export default async function (tickers: Tickers): ProductHubHandlerResponse {
           tokensReserveConfigurationData.find((data) => data[primaryToken]),
         )[primaryToken]
         const tokensAddresses = getNetworkContracts(NetworkIds.MAINNET).tokens
-        // rewards are available for the ETH-like/DAI pairs
-        const hasRewards = primaryTokenGroup === 'ETH' && secondaryToken === 'DAI'
+        // rewards are available for the ETH-like+ BTC-like/DAI pairs
+        const hasRewards =
+          primaryTokenGroup &&
+          secondaryToken &&
+          ['ETH', 'BTC'].includes(primaryTokenGroup) &&
+          secondaryToken === 'DAI'
 
         return {
           ...product,

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Handler.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Handler.ts
@@ -160,8 +160,8 @@ export default async function (tickers: Tickers): ProductHubHandlerResponse {
         const tokensAddresses = getNetworkContracts(NetworkIds.MAINNET).tokens
         // rewards are available for the ETH-like+ BTC-like/DAI pairs
         const hasRewards =
-          primaryTokenGroup &&
-          secondaryToken &&
+          !!primaryTokenGroup &&
+          !!secondaryToken &&
           ['ETH', 'BTC'].includes(primaryTokenGroup) &&
           secondaryToken === 'DAI'
 

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
@@ -145,4 +145,16 @@ export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
     earnStrategyDescription: 'SDAI/USDT Yield Loop',
     managementType: 'active',
   },
+  {
+    product: [ProductHubProductType.Multiply],
+    primaryToken: 'WBTC',
+    primaryTokenGroup: 'BTC',
+    secondaryToken: 'DAI',
+    depositToken: 'DAI',
+    network: NetworkNames.ethereumMainnet,
+    protocol: LendingProtocol.SparkV3,
+    label: 'WBTC/DAI',
+    multiplyStrategyType: 'short',
+    multiplyStrategy: 'Long WBTC',
+  },
 ]

--- a/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
+++ b/handlers/product-hub/update-handlers/sparkV3/sparkV3Products.ts
@@ -154,7 +154,7 @@ export const sparkV3ProductHubProducts: ProductHubItemWithoutAddress[] = [
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.SparkV3,
     label: 'WBTC/DAI',
-    multiplyStrategyType: 'short',
+    multiplyStrategyType: 'long',
     multiplyStrategy: 'Long WBTC',
   },
 ]


### PR DESCRIPTION
# Add WBTC-DAI Long strategy to Spark

Story details: https://app.shortcut.com/oazo-apps/story/13019/spark-v3-add-wbtc-dai-multiply-strat