### PR TITLE
Redirect from old rewards to main domain

### DIFF
--- a/pages/ajna/rewards.tsx
+++ b/pages/ajna/rewards.tsx
@@ -1,33 +1,17 @@
-import { WithConnection } from 'components/connectWallet'
-import { FunctionalContextHandler } from 'components/context'
-import { AjnaRewardsController } from 'features/ajna/common/controls/AjnaRewardsController'
-import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
-import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
-import { WithWalletAssociatedRisk } from 'features/walletAssociatedRisk/WalletAssociatedRisk'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import React from 'react'
 
 function AjnaRewardsPage() {
-  return (
-    <FunctionalContextHandler>
-      <WithConnection>
-        <WithTermsOfService>
-          <WithWalletAssociatedRisk>
-            <AjnaRewardsController />
-          </WithWalletAssociatedRisk>
-        </WithTermsOfService>
-      </WithConnection>
-    </FunctionalContextHandler>
-  )
+  return <></>
 }
-
-AjnaRewardsPage.layout = AjnaLayout
-AjnaRewardsPage.seoTags = ajnaPageSeoTags
 
 export default AjnaRewardsPage
 
-export const getStaticProps = async ({ locale }: { locale: string }) => ({
-  props: {
-    ...(await serverSideTranslations(locale, ['common'])),
-  },
-})
+export async function getStaticProps() {
+  return {
+    redirect: {
+      permanent: true,
+      destination: `${INTERNAL_LINKS.appUrl}/${INTERNAL_LINKS.ajnaRewards}`,
+    },
+  }
+}


### PR DESCRIPTION
# [Redirect from old rewards to main domain](https://app.shortcut.com/oazo-apps/story/13059)
  
## Changes 👷‍♀️

- Added redirect from `/ajna/rewards` page to the prod.