### PR TITLE
Adjust maker vault api handling

### DIFF
--- a/features/shared/vaultApi.ts
+++ b/features/shared/vaultApi.ts
@@ -52,6 +52,10 @@ export interface ApiVault {
   tokenPair: string
 }
 
+interface ApiVaultFallback {
+  type: VaultType.Borrow
+}
+
 export interface ApiVaultsParams {
   vaultIds: number[]
   chainId: NetworkIds
@@ -114,7 +118,7 @@ export function getVaultFromApi$(
   vaultId: number,
   chainId: number,
   protocol: LendingProtocol,
-): Observable<ApiVault> {
+): Observable<ApiVault | ApiVaultFallback> {
   if (chainId === 0 || chainId < 1) {
     console.error('Invalid chainId')
     return EMPTY
@@ -131,6 +135,12 @@ export function getVaultFromApi$(
     },
   }).pipe(
     map((resp) => {
+      if (!resp.response.type) {
+        return {
+          type: VaultType.Borrow,
+        }
+      }
+
       const { vaultId, type, chainId, ownerAddress, protocol, tokenPair } = resp.response as {
         vaultId: number
         type: VaultType

--- a/handlers/vault/get.ts
+++ b/handlers/vault/get.ts
@@ -21,7 +21,7 @@ export async function getVault(req: NextApiRequest, res: NextApiResponse) {
   })
 
   if (vault === undefined || vault == null) {
-    return res.status(404).send('Not Found')
+    return res.status(200).send({})
   } else {
     return res.status(200).json({
       vaultId: vault.vault_id,


### PR DESCRIPTION
# Adjust maker vault api handling

In reference to following story [link](https://app.shortcut.com/oazo-apps/story/13164/prod-p-2-3-viewing-other-people-s-maker-positions-is-failing)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- handled properly maker api vault request with recently adjusted empty response
  
## How to test 🧪
  <Please explain how to test your changes>

- maker position, for example `29810` should load without any issue
