### PR TITLE
Fix issue with loading wrong positions in Ajna

### DIFF
--- a/components/vault/VaultHeadline.tsx
+++ b/components/vault/VaultHeadline.tsx
@@ -20,7 +20,7 @@ import { VaultHeadlineDetails } from './VaultHeadlineDetails'
 export type VaultHeadlineProps = {
   details: HeadlineDetailsProp[]
   followButton?: FollowButtonControlProps
-  header: ReactNode
+  header?: ReactNode
   loading?: boolean
   shareButton?: boolean
   tokens?: string[]

--- a/features/aave/services/read-position-created-events.ts
+++ b/features/aave/services/read-position-created-events.ts
@@ -22,6 +22,7 @@ export type PositionCreated = {
   debtTokenAddress: string
   positionType: PositionType
   protocol: LendingProtocol
+  protocolRaw: string
   chainId: NetworkIds
   proxyAddress: string
 }
@@ -74,6 +75,7 @@ function mapEvent(
         debtTokenSymbol: getTokenSymbolBasedOnAddress(chainId, e.args.debtToken),
         debtTokenAddress: e.args.debtToken,
         protocol: extractLendingProtocolFromPositionCreatedEvent(e),
+        protocolRaw: e.args.protocol,
         chainId,
         proxyAddress: e.args.proxyAddress,
       }
@@ -140,6 +142,7 @@ export async function getLastCreatedPositionForProxy(
     debtTokenSymbol: getTokenSymbolBasedOnAddress(chainId, lastEvent!.args.debtToken),
     debtTokenAddress: lastEvent!.args.debtToken,
     protocol: extractLendingProtocolFromPositionCreatedEvent(lastEvent!),
+    protocolRaw: lastEvent.args.protocol,
     chainId,
     proxyAddress: lastEvent!.args.proxyAddress,
   }

--- a/features/omni-kit/controllers/OmniProductController.tsx
+++ b/features/omni-kit/controllers/OmniProductController.tsx
@@ -43,13 +43,14 @@ export interface OmniCustomStateParams<Auction, History, Position> {
 }
 
 interface OmniProductControllerProps<Auction, History, Position> {
-  collateralToken?: string
+  collateralToken: string
   customState?: (params: OmniCustomStateParams<Auction, History, Position>) => ReactNode
   isOracless?: boolean
   networkName: NetworkNames
   positionId?: string
-  productType?: OmniProductType
+  productType: OmniProductType
   protocol: LendingProtocol
+  protocolRaw: string
   protocolHook: (params: ProductDataProps) => {
     data: {
       aggregatedData: { auction: Auction; history: History } | undefined
@@ -59,7 +60,7 @@ interface OmniProductControllerProps<Auction, History, Position> {
     isOracless: boolean
     redirect: string | undefined
   }
-  quoteToken?: string
+  quoteToken: string
   seoTags: {
     productKey: string
     descriptionKey: string
@@ -75,6 +76,7 @@ export const OmniProductController = <Auction, History, Position>({
   positionId,
   productType,
   protocol,
+  protocolRaw,
   protocolHook,
   quoteToken,
   seoTags,
@@ -115,6 +117,7 @@ export const OmniProductController = <Auction, History, Position>({
     isOracless,
     productType,
     protocol,
+    protocolRaw,
     quoteToken,
     networkId: resolvedNetwork.id,
   })

--- a/features/omni-kit/helpers/getOmniHeadlineProps.ts
+++ b/features/omni-kit/helpers/getOmniHeadlineProps.ts
@@ -44,6 +44,6 @@ export function getOmniHeadlineProps({
             protocol,
           },
         }
-      : { header: '' }),
+      : {}),
   }
 }

--- a/features/omni-kit/hooks/useOmniProtocolData.ts
+++ b/features/omni-kit/hooks/useOmniProtocolData.ts
@@ -14,12 +14,13 @@ import { useMemo } from 'react'
 import { EMPTY } from 'rxjs'
 
 interface OmniProtocolDataProps {
-  collateralToken?: string
+  collateralToken: string
   isOracless?: boolean
   positionId?: string
-  productType?: OmniProductType
+  productType: OmniProductType
   protocol: LendingProtocol
-  quoteToken?: string
+  protocolRaw: string
+  quoteToken: string
   networkId: OmniSupportedNetworkIds
 }
 
@@ -29,6 +30,7 @@ export function useOmniProtocolData({
   positionId,
   productType,
   protocol,
+  protocolRaw,
   quoteToken,
   networkId,
 }: OmniProtocolDataProps) {
@@ -68,6 +70,8 @@ export function useOmniProtocolData({
               collateralToken,
               quoteToken,
               productType,
+              protocol,
+              protocolRaw,
             )
           : !isOracless && productType && collateralToken && quoteToken
           ? getStaticDpmPositionData$({

--- a/features/omni-kit/protocols/ajna/constants.ts
+++ b/features/omni-kit/protocols/ajna/constants.ts
@@ -6,6 +6,8 @@ import {
 } from 'features/omni-kit/constants'
 import { OmniSidebarStep, type OmniSidebarStepsSet } from 'features/omni-kit/types'
 
+export const AJNA_RAW_PROTOCOL_NAME = 'Ajna_rc10'
+
 export const ajnaOmniSteps: OmniSidebarStepsSet = {
   borrow: {
     setup: [OmniSidebarStep.Risk, ...omniSidebarSetupSteps],

--- a/helpers/context/ProductContext.ts
+++ b/helpers/context/ProductContext.ts
@@ -633,11 +633,13 @@ export function setupProductContext(
     (
       positionId: PositionId,
       chainId: NetworkIds,
-      collateralToken?: string,
-      quoteToken?: string,
-      product?: string,
+      collateralToken: string,
+      quoteToken: string,
+      product: string,
+      protocol: LendingProtocol,
+      protocolRaw: string,
     ) =>
-      `${positionId.walletAddress}-${positionId.vaultId}-${chainId}-${collateralToken}-${quoteToken}-${product}`,
+      `${positionId.walletAddress}-${positionId.vaultId}-${chainId}-${collateralToken}-${quoteToken}-${product}-${protocol}-${protocolRaw}`,
   )
 
   const ajnaPosition$ = memoize(

--- a/pages/[networkOrProduct]/ajna/omni/[...position].tsx
+++ b/pages/[networkOrProduct]/ajna/omni/[...position].tsx
@@ -6,7 +6,7 @@ import { isAddress } from 'ethers/lib/utils'
 import { ajnaSeoTags } from 'features/ajna/common/consts'
 import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
 import { OmniProductController } from 'features/omni-kit/controllers'
-import { ajnaOmniSteps } from 'features/omni-kit/protocols/ajna/constants'
+import { AJNA_RAW_PROTOCOL_NAME, ajnaOmniSteps } from 'features/omni-kit/protocols/ajna/constants'
 import { isPoolOracless } from 'features/omni-kit/protocols/ajna/helpers'
 import type { AjnaUnifiedHistoryEvent } from 'features/omni-kit/protocols/ajna/history'
 import { useAjnaData } from 'features/omni-kit/protocols/ajna/hooks/useAjnaData'
@@ -43,6 +43,7 @@ function AjnaPositionPage(props: AjnaPositionPageProps) {
             isOracless={isOracless}
             protocol={LendingProtocol.Ajna}
             protocolHook={useAjnaData}
+            protocolRaw={AJNA_RAW_PROTOCOL_NAME}
             seoTags={ajnaSeoTags}
             steps={ajnaOmniSteps}
           />

--- a/pages/[networkOrProduct]/morpho/[...position].tsx
+++ b/pages/[networkOrProduct]/morpho/[...position].tsx
@@ -43,6 +43,7 @@ function MorphoPositionPage(props: MorphoPositionPageProps) {
               customState={MorphoOmniCustomStateProvider}
               protocol={LendingProtocol.MorphoBlue}
               protocolHook={useMorphoOmniData}
+              protocolRaw={LendingProtocol.MorphoBlue}
               seoTags={morphoSeoTags}
               steps={morphoOmniSteps}
             />


### PR DESCRIPTION
# [Fix issue with loading wrong positions in Ajna](https://app.shortcut.com/oazo-apps/story/13138/bug-goerli-borrow-usdc-eth-after-creating-borrow-position-it-is-displayed-as-earn)
  
## Changes 👷‍♀️

- Added filtering by protocol and raw protocol name to position created events list.
- Fixed improper position header skeleton loading bug - it's not connected to this story, but it was annoying me so I fixed it.
  
## How to test 🧪

This position was created on Ajna RC10, so it should load: `/ethereum/ajna/omni/borrow/ETH-USDC/2`. Any other position created before that will stuck on infinity loading. Next step is to create nice redirect for when there was old position found and 404 when there was not position at all.