### PR TITLE
Bump dma lib to 0.5.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "^0.1.16",
     "@oasisdex/automation": "^1.5.8",
-    "@oasisdex/dma-library": "0.5.22",
+    "@oasisdex/dma-library": "0.5.23",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.5.22":
-  version "0.5.22"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.22.tgz#3fad5753a9548fb00235d255b480f29bf453adcd"
-  integrity sha512-fypOzZgwPgxIVkCFS3D+Svv0+J8bXq60ug2niu1gQ6FejMrZDmsha06gG842T/yvipQuVcs76qKrcYpxXIOHKA==
+"@oasisdex/dma-library@0.5.23":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.23.tgz#8097de529624b215919afd858121ded6fd47cd39"
+  integrity sha512-Xw7GuNEKDT6dobRq6+l0BdDAZesBLv40BUq1hs2NYqZ1PjsSvTgtxFkyo2E3Q5SUsef7EkKZI95GComieKDpZQ==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Ajna open position simulation fix](https://app.shortcut.com/oazo-apps/story/13172/bug-goerli-borrow-pools-with-no-liquidity-borrow-input-field-is-not-validated-and-confirm-button-is-enabled)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- Bumped dma lib to 0.5.23
- fixed issue in lib which were responsible for error on UI
  
## How to test 🧪
  <Please explain how to test your changes>

- while trying to open borrow position on empty pool, a error regarding liquidity should popup
