### PR TITLE
Ajna payback user balance fix

### DIFF
--- a/features/omni-kit/components/sidebars/OmniFormFields.tsx
+++ b/features/omni-kit/components/sidebars/OmniFormFields.tsx
@@ -207,7 +207,6 @@ export function OmniFormFieldPayback({
       hasError={false}
       disabled={isDisabled || isFormFrozen}
       showMax={true}
-      // TODO: should be quoteBalance or total debt, whatever is lower, but debt is not yet available
       maxAmount={maxAmount}
       maxAuxiliaryAmount={maxAmount?.times(quotePrice)}
       maxAmountLabel={t(maxAmountLabel)}

--- a/features/omni-kit/helpers/getOmniBorrowPaybackMax.ts
+++ b/features/omni-kit/helpers/getOmniBorrowPaybackMax.ts
@@ -3,14 +3,12 @@ import BigNumber from 'bignumber.js'
 
 interface OmniBorrowPaybackMaxParams {
   balance: BigNumber
-  digits: number
   position: LendingPosition
 }
 
 export function getOmniBorrowPaybackMax({
   balance,
-  digits,
   position: { debtAmount },
 }: OmniBorrowPaybackMaxParams) {
-  return BigNumber.min(debtAmount, balance).decimalPlaces(digits, BigNumber.ROUND_UP)
+  return BigNumber.min(debtAmount, balance)
 }

--- a/features/omni-kit/protocols/ajna/helpers/getAjnaParameters.ts
+++ b/features/omni-kit/protocols/ajna/helpers/getAjnaParameters.ts
@@ -44,6 +44,7 @@ interface AjnaTxHandlerInput {
   quotePrecision: number
   quotePrice: BigNumber
   quoteToken: string
+  quoteBalance: BigNumber
   rpcProvider: ethers.providers.Provider
   simulation?: AjnaGenericPosition
   slippage: BigNumber
@@ -64,6 +65,7 @@ export async function getAjnaParameters({
   quotePrecision,
   quotePrice,
   quoteToken,
+  quoteBalance,
   rpcProvider,
   simulation,
   slippage,
@@ -127,6 +129,7 @@ export async function getAjnaParameters({
         dependencies,
         position,
         simulation,
+        quoteBalance,
       })
     }
 
@@ -221,6 +224,7 @@ export async function getAjnaParameters({
         dependencies,
         position,
         simulation,
+        quoteBalance,
       })
     }
     case OmniMultiplyFormAction.DepositQuoteMultiply: {

--- a/features/omni-kit/protocols/ajna/hooks/useAjnaTxHandler.ts
+++ b/features/omni-kit/protocols/ajna/hooks/useAjnaTxHandler.ts
@@ -20,6 +20,7 @@ export function useAjnaTxHandler(): () => void {
       quoteToken,
       productType,
       slippage,
+      quoteBalance,
     },
   } = useOmniGeneralContext()
   const {
@@ -55,6 +56,7 @@ export function useAjnaTxHandler(): () => void {
         quotePrecision,
         quotePrice,
         quoteToken,
+        quoteBalance,
         rpcProvider: getRpcProvider(context.chainId),
         slippage,
         state,

--- a/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
@@ -92,7 +92,6 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
       productType,
       quoteAddress,
       quoteBalance,
-      quoteDigits,
       quotePrecision,
       quotePrice,
       quoteToken,
@@ -228,7 +227,6 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
           }),
           paybackMax: getOmniBorrowPaybackMax({
             balance: quoteBalance,
-            digits: quoteDigits,
             position,
           }),
           sidebarTitle: getAjnaSidebarTitle({

--- a/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
+++ b/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
@@ -30,7 +30,6 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
       productType,
       quoteAddress,
       quoteBalance,
-      quoteDigits,
       quotePrice,
       quoteToken,
     },
@@ -85,7 +84,6 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
           collateralMax: new BigNumber(50),
           paybackMax: getOmniBorrowPaybackMax({
             balance: quoteBalance,
-            digits: quoteDigits,
             position,
           }),
           sidebarTitle: useMorphoSidebarTitle({


### PR DESCRIPTION
# [Ajna payback user balance fix](https://app.shortcut.com/oazo-apps/story/13211/bug-goerli-borrow-with-mandatory-minimum-debt-pay-back-all-debt-clicking-on-balance-will-not-show-error)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue related to payback max handling in ajna payback form step, when user didn't have enough quote balance to payback max, `getMaxIncreasedValue` calcs were performed on user quote balance and therefore user was not able to proceed because calculated amount of payback was higher than user balance
  
## How to test 🧪
  <Please explain how to test your changes>

- try to click on payback max while having not enough quote amount to payback whole debt, it should be possible to send tx unless other error (for example not enough debt) will popup
