### PR TITLE
Fix oracless mode loading on borrow positions

### DIFF
--- a/features/omni-kit/protocols/ajna/components/details-section/parsers/useAjnaCardCardThresholdPrice.tsx
+++ b/features/omni-kit/protocols/ajna/components/details-section/parsers/useAjnaCardCardThresholdPrice.tsx
@@ -6,6 +6,7 @@ import type {
 } from 'features/omni-kit/components/details-section'
 import { AjnaCardDataThresholdPriceModal } from 'features/omni-kit/protocols/ajna/components/details-section'
 import { formatCryptoBalance } from 'helpers/formatters/format'
+import { zero } from 'helpers/zero'
 import React from 'react'
 
 interface OmniCardDataLtvParams {
@@ -40,8 +41,11 @@ export function useAjnaCardCardThresholdPrice({
       ],
     }),
     tooltips: {
-      value: `${thresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${unit}`,
-      change: afterThresholdPrice && `${afterThresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${unit}`,
+      value: thresholdPrice.gt(zero) && `${thresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${unit}`,
+      change:
+        afterThresholdPrice &&
+        afterThresholdPrice.gt(zero) &&
+        `${afterThresholdPrice.dp(DEFAULT_TOKEN_DIGITS)} ${unit}`,
       footnote: lup && `${lup.dp(DEFAULT_TOKEN_DIGITS)} ${unit}`,
     },
     modal: (

--- a/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
@@ -1,6 +1,5 @@
 import type { AjnaEarnPosition, AjnaPosition } from '@oasisdex/dma-library'
 import { getPoolLiquidity, negativeToZero, protocols } from '@oasisdex/dma-library'
-import { getToken } from 'blockchain/tokensMetadata'
 import { useGasEstimationContext } from 'components/context/GasEstimationContextProvider'
 import { HighlightedOrderInformation } from 'components/HighlightedOrderInformation'
 import { PillAccordion } from 'components/PillAccordion'
@@ -92,6 +91,7 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
       productType,
       quoteAddress,
       quoteBalance,
+      quoteDigits,
       quotePrecision,
       quotePrice,
       quoteToken,
@@ -211,9 +211,9 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
           isFormEmpty,
           afterBuyingPower,
           shouldShowDynamicLtv,
-          debtMin: getAjnaBorrowDebtMin({ digits: getToken(quoteToken).digits, position }),
+          debtMin: getAjnaBorrowDebtMin({ digits: quoteDigits, position }),
           debtMax: getAjnaBorrowDebtMax({
-            digits: getToken(quoteToken).precision,
+            digits: quotePrecision,
             position,
             simulation,
           }),
@@ -221,7 +221,7 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
           afterAvailableToBorrow,
           afterPositionDebt,
           collateralMax: getAjnaBorrowCollateralMax({
-            digits: getToken(collateralToken).digits,
+            digits: quoteDigits,
             position,
             simulation,
           }),


### PR DESCRIPTION
# [Fix oracless mode loading on borrow positions](https://app.shortcut.com/oazo-apps/story/13221/bug-goerli-oracless-pool-creator-new-oracless-borrow-page-returns-error-no-meta-information-for-token)
  
## Changes 👷‍♀️

- Fixed and issue where oracless mode wasn't working on borrow positions because of the usage of `getToken` on unknow token,
- fixed unrelated issue where Threshold price tooltip was shown on content card even when price was zero.