### PR TITLE
Ajna neutral price calcs adjust

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "^0.1.18",
     "@oasisdex/automation": "^1.5.8",
-    "@oasisdex/dma-library": "0.5.24",
+    "@oasisdex/dma-library": "0.5.25",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.5.24":
-  version "0.5.24"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.24.tgz#4979de329f7095df5fba25f98a357b4396127943"
-  integrity sha512-/5jwvt/+Cejm02LscD+p5PUPVowFX7WWozUpmtfn2aSf12fRshNvAXDv/L1FoOi6OdRee3d0UHx13sTh5QfcVA==
+"@oasisdex/dma-library@0.5.25":
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.25.tgz#163423f0ab0fd98a6e95bd99783d335a2c1c8106"
+  integrity sha512-FQXKo5n6A/ErP2+9pHPwnMWFJGoy9shpD0t/FuOWn8llI71NVlz5qPLQJIV+VuO5RLz8mHM5+ex9xkdWy19yew==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Ajna neutral price calcs adjust](https://app.shortcut.com/oazo-apps/story/13251/bug-goerli-borrow-liquidation-price-in-simulation-does-not-match-with-final-value)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bump dma lib version
  
## How to test 🧪
  <Please explain how to test your changes>

- liquidation price simulation in ajna borrow position should be in line with liquidation price after sending tx
