### PR TITLE
Bump dma library 0.5.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "^0.1.18",
     "@oasisdex/automation": "^1.5.8",
-    "@oasisdex/dma-library": "0.5.25",
+    "@oasisdex/dma-library": "0.5.26",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.5.25":
-  version "0.5.25"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.25.tgz#163423f0ab0fd98a6e95bd99783d335a2c1c8106"
-  integrity sha512-FQXKo5n6A/ErP2+9pHPwnMWFJGoy9shpD0t/FuOWn8llI71NVlz5qPLQJIV+VuO5RLz8mHM5+ex9xkdWy19yew==
+"@oasisdex/dma-library@0.5.26":
+  version "0.5.26"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.26.tgz#13b313550cfc30025ce00542dd3d22118ee02dbe"
+  integrity sha512-+lxwc2DFDzkxMbRHee2Hnit4DDqe4wx617bawwldwlcWGWZzPfJtB0BcoutlqHtWamhNFiWP2Z2vdzCSNdcMeQ==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# Bump dma library 0.5.26

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bumped dma lib version with fix for liquidation price NaN value in ajna borrow position
  
## How to test 🧪
  <Please explain how to test your changes>

- no liqudation price NaN value when withdrawing all and payback all in ajna borrow position
