### PR TITLE
Fix issue with loading wrong type of position on Ajna

### DIFF
--- a/features/omni-kit/observables/getDpmPositionData.ts
+++ b/features/omni-kit/observables/getDpmPositionData.ts
@@ -61,9 +61,10 @@ const filterPositionWhenUrlParamsDefined = ({
         proxyAddress.toLowerCase() === proxy.toLowerCase() &&
         [collateralTokenAddress.toLowerCase(), collateralTokenSymbol].includes(collateralToken) &&
         [debtTokenAddress.toLowerCase(), debtTokenSymbol].includes(quoteToken) &&
-        (product.toLowerCase() === 'earn'
-          ? positionType.toLowerCase() === product.toLowerCase()
-          : true),
+        ((product.toLowerCase() === 'earn' &&
+          positionType.toLowerCase() === product.toLowerCase()) ||
+          (['borrow', 'multiply'].includes(product.toLocaleLowerCase()) &&
+            ['borrow', 'multiply'].includes(positionType.toLocaleLowerCase()))),
     )
 
 export function getDpmPositionDataV2$(

--- a/features/omni-kit/protocols/ajna/components/details-section/AjnaContentFooterBorrow.tsx
+++ b/features/omni-kit/protocols/ajna/components/details-section/AjnaContentFooterBorrow.tsx
@@ -103,7 +103,9 @@ export function AjnaContentFooterBorrow({
         {...borrowRateContentCardCommonData}
         {...borrowRateContentCardAjnaData}
       />
-      <OmniContentCard {...commonContentCardData} {...netValueContentCardCommonData} />
+      {!isOracless && (
+        <OmniContentCard {...commonContentCardData} {...netValueContentCardCommonData} />
+      )}
       <OmniContentCard
         {...commonContentCardData}
         {...availableToWithdrawContentCardCommonData}

--- a/features/omni-kit/protocols/ajna/metadata/AjnaLendingDetailsSectionContent.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/AjnaLendingDetailsSectionContent.tsx
@@ -85,8 +85,10 @@ export const AjnaLendingDetailsSectionContent: FC<AjnaDetailsSectionContentProps
   const liquidationPriceContentCardCommonData = useOmniCardDataLiquidationPrice({
     afterLiquidationPrice,
     liquidationPrice,
-    ratioToCurrentPrice,
     unit: priceFormat,
+    ...(!isOracless && {
+      ratioToCurrentPrice,
+    }),
   })
   const liquidationPriceContentCardAjnaData = useAjnaCardDataLiquidationPrice({
     afterLiquidationPrice,


### PR DESCRIPTION
# [Fix issue with loading wrong type of position on Ajna](https://app.shortcut.com/oazo-apps/story/13138/bug-goerli-borrow-usdc-eth-after-creating-borrow-position-it-is-displayed-as-earn)

Second try of fixing that issue.
  
## Changes 👷‍♀️

- Fixed issue where position type was filtered incorrectly on DPM identifying level.
- Fixed unrelated issue where oracless positions where displaying relation of liquidation price to market price.
- Fixed unrelated issue where oracless positions where displaying net value.