### PR TITLE
Adjusted withdraw close to max ltv warning while doing payback

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "^0.1.18",
     "@oasisdex/automation": "^1.5.8",
-    "@oasisdex/dma-library": "0.5.27",
+    "@oasisdex/dma-library": "0.5.28",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.5.27":
-  version "0.5.27"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.27.tgz#5fc090d9dd9c21037ac49fb7c258988000025514"
-  integrity sha512-dw3grvuNmsL9EQKDj6nVjJWC+wIos4nB5130mBThXRBILX5OVGgd0VZ5HKcSAFhWopT/mmKTYkTjiYHzOxPTKQ==
+"@oasisdex/dma-library@0.5.28":
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.28.tgz#a170540389158a80ef3785345eebaba756934267"
+  integrity sha512-cyahD50W1eNur8XyyUgQ0KCmpHiEx3TiOBxbbzHHDeyG58mbkFqqPEAFoeBeWw+DbmFb3ziXnKOIgwEpi79kNw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Adjusted withdraw close to max ltv warning while doing payback](https://app.shortcut.com/oazo-apps/story/13298/bug-oracless-goerli-borrow-paying-back-debt-triggers-withdrawing-warning-message)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bump dma lib version with adjusted withdraw close to max ltv warning logic update

## How to test 🧪
  <Please explain how to test your changes>

- while trying to payback some amount in ajna borrow position and current ltv is within range of 5% to max ltv no warning message about withdrawing should popup unless user will try to withdraw some amount as well
