### PR TITLE
Set icon size in network switcher

### DIFF
--- a/components/navigation/NavigationNetworkSwitcherButton.tsx
+++ b/components/navigation/NavigationNetworkSwitcherButton.tsx
@@ -98,8 +98,8 @@ export const NetworkButton = ({
               src={network.icon}
               sx={{
                 mr: 3,
-                minWidth: 4,
-                minHeight: 4,
+                width: 4,
+                height: 4,
                 position: 'relative',
                 zIndex: '2',
               }}


### PR DESCRIPTION
# Set icon size in network switcher

all your base are belong to us

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/a47a2263-6d79-4fd5-b974-8d3f14c4d571)
