### PR TITLE
chore: Add missing Spark event names in borrow [sc-13325]

### DIFF
--- a/features/positionHistory/getHistoryEventLabel.ts
+++ b/features/positionHistory/getHistoryEventLabel.ts
@@ -20,8 +20,10 @@ export const getHistoryEventLabel = ({ kind, isOpen }: { kind?: string; isOpen?:
     case 'AjnaOpenMultiplyPosition':
       return t('position-history.open-position')
     case 'AjnaAdjustRiskUp':
+    case 'SparkAdjustRiskUp':
       return t('position-history.increase-multiple')
     case 'AjnaAdjustRiskDown':
+    case 'SparkAdjustRiskDown':
       return t('position-history.decrease-multiple')
     case 'AjnaCloseToQuotePosition':
     case 'AjnaCloseToCollateralPosition':
@@ -56,32 +58,46 @@ export const getHistoryEventLabel = ({ kind, isOpen }: { kind?: string; isOpen?:
 
     // Aave
     case 'AAVEDeposit':
+    case 'SparkDeposit':
       return t('position-history.deposit')
+    case 'SparkDepositBorrow':
+      return t('position-history.deposit-generate')
     case 'AAVEPaybackWithdraw':
+    case 'SparkPaybackWithdraw':
       return t('position-history.repay-withdraw')
     case 'AAVEBorrow':
+    case 'SparkBorrow':
       return t('position-history.borrow')
     case 'AAVEOpenDepositBorrow':
+    case 'SparkOpenDepositBorrow':
       return t('position-history.open-position')
     case 'CloseAAVEPosition':
+    case 'SparkClosePosition':
       return t('position-history.close-position')
     case 'IncreaseAAVEPosition':
       return t('position-history.increase-multiple')
     case 'OpenAAVEPosition':
+    case 'SparkOpenPosition':
       return t('position-history.open-position')
     case 'DecreaseAAVEPosition':
       return t('position-history.decrease-multiple')
     case 'AutomationAdded-AaveStopLossToCollateralV2':
+    case 'AutomationAdded-SparkStopLossCommandV2':
       return t('position-history.automation.stop-loss-collateral-added')
     case 'AutomationExecuted-AaveStopLossToCollateralV2':
+    case 'AutomationExecuted-SparkStopLossCommandV2':
       return t('position-history.automation.stop-loss-collateral-executed')
     case 'AutomationRemoved-AaveStopLossToCollateralV2':
+    case 'AutomationRemoved-SparkStopLossCommandV2':
       return t('position-history.automation.stop-loss-collateral-removed')
     case 'AutomationAdded-AaveStopLossToDebtV2':
+    case 'AutomationAdded-SparkStopLossDebtCommandV2':
       return t('position-history.automation.stop-loss-debt-added')
     case 'AutomationExecuted-AaveStopLossToDebtV2':
+    case 'AutomationExecuted-SparkStopLossDebtCommandV2':
       return t('position-history.automation.stop-loss-debt-executed')
     case 'AutomationRemoved-AaveStopLossToDebtV2':
+    case 'AutomationRemoved-SparkStopLossDebtCommandV2':
       return t('position-history.automation.stop-loss-debt-removed')
     case 'Liquidation':
       return t('position-history.liquidation')


### PR DESCRIPTION
# [Title](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- added missing spark event names : Add missing Spark event names in borrow [sc-13325]
  
![image](https://github.com/OasisDEX/oasis-borrow/assets/6533433/0841df9e-79a2-4340-a0a8-5ddd0f18092c)

## How to test 🧪
(localhost:3000/ethereum/spark/v3/1701#history)