### PR TITLE
Pool finder support for Base/other L2 chains

### DIFF
--- a/blockchain/identifyTokens.ts
+++ b/blockchain/identifyTokens.ts
@@ -33,6 +33,18 @@ export const identifyTokens$ = (
     switchMap(() => {
       const contracts = getNetworkContracts(networkId)
 
+      console.log('---')
+      console.log('---')
+      console.log('---')
+      console.log('---')
+      console.log('---')
+      console.log({ tokensAddresses, networkId })
+      console.log('---')
+      console.log('---')
+      console.log('---')
+      console.log('---')
+      console.log('---')
+
       let identifiedTokens: Tokens[] = []
       let localTokensAddresses: string[] = []
 

--- a/blockchain/identifyTokens.ts
+++ b/blockchain/identifyTokens.ts
@@ -33,18 +33,6 @@ export const identifyTokens$ = (
     switchMap(() => {
       const contracts = getNetworkContracts(networkId)
 
-      console.log('---')
-      console.log('---')
-      console.log('---')
-      console.log('---')
-      console.log('---')
-      console.log({ tokensAddresses, networkId })
-      console.log('---')
-      console.log('---')
-      console.log('---')
-      console.log('---')
-      console.log('---')
-
       let identifiedTokens: Tokens[] = []
       let localTokensAddresses: string[] = []
 

--- a/features/aave/services/read-position-created-events.ts
+++ b/features/aave/services/read-position-created-events.ts
@@ -164,10 +164,16 @@ export function createReadPositionCreatedEvents$(
     switchMap((positionCreatedEvents) =>
       combineLatest(
         context$,
+        of(positionCreatedEvents)
+      ),
+    ),
+    switchMap(([{ chainId }, positionCreatedEvents]) =>
+      combineLatest(
+        of(chainId),
         of(positionCreatedEvents),
         identifyTokens$(
-          context$,
           of(undefined),
+          chainId,
           uniq(
             positionCreatedEvents
               .flatMap((e) => e)
@@ -176,7 +182,7 @@ export function createReadPositionCreatedEvents$(
         ),
       ),
     ),
-    switchMap(([{ chainId }, positionCreatedEvents]) =>
+    switchMap(([chainId, positionCreatedEvents]) =>
       of(mapEvent(positionCreatedEvents, chainId)),
     ),
     shareReplay(1),

--- a/features/aave/services/read-position-created-events.ts
+++ b/features/aave/services/read-position-created-events.ts
@@ -161,12 +161,9 @@ export function createReadPositionCreatedEvents$(
         ),
       ),
     ),
-    switchMap((positionCreatedEvents) =>
-      combineLatest(
-        context$,
-        of(positionCreatedEvents)
-      ),
-    ),
+    // TODO: remove context when switched to getting network from parameter
+    // this is temporary workaround
+    switchMap((positionCreatedEvents) => combineLatest(context$, of(positionCreatedEvents))),
     switchMap(([{ chainId }, positionCreatedEvents]) =>
       combineLatest(
         of(chainId),
@@ -182,9 +179,7 @@ export function createReadPositionCreatedEvents$(
         ),
       ),
     ),
-    switchMap(([chainId, positionCreatedEvents]) =>
-      of(mapEvent(positionCreatedEvents, chainId)),
-    ),
+    switchMap(([chainId, positionCreatedEvents]) => of(mapEvent(positionCreatedEvents, chainId))),
     shareReplay(1),
   )
 }

--- a/features/ajna/pool-creator/hooks/usePoolCreatorData.tsx
+++ b/features/ajna/pool-creator/hooks/usePoolCreatorData.tsx
@@ -4,7 +4,7 @@ import { deployAjnaPool } from 'blockchain/calls/ajnaErc20PoolFactory.constants'
 import { TxMetaKind } from 'blockchain/calls/txMeta'
 import { getNetworkContracts } from 'blockchain/contracts'
 import type { IdentifiedTokens } from 'blockchain/identifyTokens.types'
-import { NetworkIds } from 'blockchain/networks'
+import { NetworkIds, networksById } from 'blockchain/networks'
 import { amountToWad } from 'blockchain/utils'
 import type CancelablePromise from 'cancelable-promise'
 import { cancelable } from 'cancelable-promise'
@@ -133,11 +133,11 @@ export function usePoolCreatorData({
         const promise = cancelable(
           Promise.all([
             searchAjnaPool(chainId, {
-              collateralToken: [collateralAddress],
-              poolAddress: [],
-              quoteToken: [quoteAddress],
+              collateralToken: collateralAddress,
+              poolAddress: '',
+              quoteToken: quoteAddress,
             }),
-            identifiedTokens$([collateralAddress, quoteAddress]).pipe(first()).toPromise(),
+            identifiedTokens$(chainId, [collateralAddress, quoteAddress]).pipe(first()).toPromise(),
           ]),
         )
         setCancelablePromise(promise)
@@ -164,7 +164,8 @@ export function usePoolCreatorData({
                                 <AppLink
                                   sx={{ color: 'inherit' }}
                                   href={getOraclessProductUrl({
-                                    chainId: context.chainId,
+                                    networkId: context.chainId,
+                                    networkName: networksById[context.chainId].name,
                                     collateralAddress,
                                     collateralToken:
                                       identifiedTokens[collateralAddress.toLowerCase()].symbol,
@@ -176,7 +177,8 @@ export function usePoolCreatorData({
                                 <AppLink
                                   sx={{ color: 'inherit' }}
                                   href={getOraclessProductUrl({
-                                    chainId: context.chainId,
+                                    networkId: context.chainId,
+                                    networkName: networksById[context.chainId].name,
                                     collateralAddress,
                                     collateralToken:
                                       identifiedTokens[collateralAddress.toLowerCase()].symbol,

--- a/features/ajna/pool-creator/hooks/usePoolCreatorData.tsx
+++ b/features/ajna/pool-creator/hooks/usePoolCreatorData.tsx
@@ -133,9 +133,9 @@ export function usePoolCreatorData({
         const promise = cancelable(
           Promise.all([
             searchAjnaPool(chainId, {
-              collateralAddress: [collateralAddress],
+              collateralToken: [collateralAddress],
               poolAddress: [],
-              quoteAddress: [quoteAddress],
+              quoteToken: [quoteAddress],
             }),
             identifiedTokens$([collateralAddress, quoteAddress]).pipe(first()).toPromise(),
           ]),

--- a/features/ajna/pool-finder/components/PoolFinderAddressInput.tsx
+++ b/features/ajna/pool-finder/components/PoolFinderAddressInput.tsx
@@ -1,32 +1,20 @@
-import { getNetworkContracts } from 'blockchain/contracts'
-import { NetworkIds } from 'blockchain/networks'
-import { Icon } from 'components/Icon'
-import { AppLink } from 'components/Links'
-import { isAddress } from 'ethers/lib/utils'
 import type { FC } from 'react'
 import React from 'react'
-import { link } from 'theme/icons'
 import { Flex, Input, Label } from 'theme-ui'
 
 interface PoolFinderAddressInputProps {
   label: string
-  chainId?: NetworkIds
   placeholder: string
-  type: 'address' | 'token'
   value: string
   onChange: (value: string) => void
 }
 
 export const PoolFinderAddressInput: FC<PoolFinderAddressInputProps> = ({
   label,
-  chainId,
   placeholder,
-  type,
   value,
   onChange,
 }) => {
-  const etherscanUrl = getNetworkContracts(NetworkIds.MAINNET, chainId).etherscan.url
-
   return (
     <Flex
       sx={{
@@ -51,31 +39,6 @@ export const PoolFinderAddressInput: FC<PoolFinderAddressInputProps> = ({
     >
       <Label htmlFor={label} variant="text.paragraph4" sx={{ position: 'relative', width: 'auto' }}>
         {label}
-        <AppLink
-          href={`${etherscanUrl}/${type}/${value}`}
-          sx={{
-            position: 'absolute',
-            top: '-2px',
-            left: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '24px',
-            height: '24px',
-            ml: 2,
-            border: '1px solid',
-            borderColor: 'neutral20',
-            borderRadius: 'ellipse',
-            opacity: isAddress(value) ? 1 : 0,
-            pointerEvents: isAddress(value) ? 'auto' : 'none',
-            transition: 'opacity 100ms, border-color 200ms',
-            '&:hover': {
-              borderColor: 'primary100',
-            },
-          }}
-        >
-          <Icon icon={link} size={16} color="primary100" sx={{ verticalAlign: 'bottom' }} />
-        </AppLink>
       </Label>
       <Input
         id={label}

--- a/features/ajna/pool-finder/controls/PoolFinderContentController.tsx
+++ b/features/ajna/pool-finder/controls/PoolFinderContentController.tsx
@@ -1,4 +1,3 @@
-import type { NetworkIds } from 'blockchain/networks'
 import { AssetsResponsiveTable } from 'components/assetsTable/AssetsResponsiveTable'
 import { AssetsTableContainer } from 'components/assetsTable/AssetsTableContainer'
 import { AssetsTableNoResults } from 'components/assetsTable/AssetsTableNoResults'
@@ -14,23 +13,18 @@ import { Trans, useTranslation } from 'react-i18next'
 
 interface PoolFinderContentControllerProps {
   addresses: PoolFinderFormState
-  chainId: NetworkIds
   selectedProduct: ProductHubProductType
   tableData: OraclessPoolResult[]
 }
 
 export const PoolFinderContentController: FC<PoolFinderContentControllerProps> = ({
   addresses: { collateralToken, quoteToken },
-  chainId,
   selectedProduct,
   tableData,
 }) => {
   const { t } = useTranslation()
 
-  const rows = useMemo(
-    () => parseRows(chainId, tableData, selectedProduct),
-    [chainId, tableData, selectedProduct],
-  )
+  const rows = useMemo(() => parseRows(tableData, selectedProduct), [tableData, selectedProduct])
 
   return (
     <AssetsTableContainer>

--- a/features/ajna/pool-finder/controls/PoolFinderContentController.tsx
+++ b/features/ajna/pool-finder/controls/PoolFinderContentController.tsx
@@ -20,7 +20,7 @@ interface PoolFinderContentControllerProps {
 }
 
 export const PoolFinderContentController: FC<PoolFinderContentControllerProps> = ({
-  addresses: { collateralAddress, quoteAddress },
+  addresses: { collateralToken, quoteToken },
   chainId,
   selectedProduct,
   tableData,
@@ -42,8 +42,8 @@ export const PoolFinderContentController: FC<PoolFinderContentControllerProps> =
           content={
             <Trans
               i18nKey={
-                (collateralAddress && !isAddress(collateralAddress)) ||
-                (quoteAddress && !isAddress(quoteAddress))
+                (collateralToken && !isAddress(collateralToken)) ||
+                (quoteToken && !isAddress(quoteToken))
                   ? 'pool-finder.validation.no-results-suggest-address'
                   : 'pool-finder.validation.no-results-description'
               }

--- a/features/ajna/pool-finder/controls/PoolFinderFormController.tsx
+++ b/features/ajna/pool-finder/controls/PoolFinderFormController.tsx
@@ -21,9 +21,9 @@ export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({
 }) => {
   const { t } = useTranslation()
   const [addresses, setAddresses] = useState<PoolFinderFormState>({
-    collateralAddress: '',
+    collateralToken: '',
     poolAddress: '',
-    quoteAddress: '',
+    quoteToken: '',
   })
 
   return (
@@ -76,47 +76,47 @@ export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({
           placeholder={t('pool-finder.form.token-placeholder')}
           type="token"
           chainId={chainId}
-          value={addresses.collateralAddress}
+          value={addresses.collateralToken}
           onChange={(value) => {
             setAddresses({
               ...addresses,
-              collateralAddress: value,
+              collateralToken: value,
             })
             onChange({
               ...addresses,
-              collateralAddress: value,
+              collateralToken: value,
             })
           }}
         />
         <PoolFinderAddressInput
           label={t('pool-finder.form.quote-token')}
           placeholder={t('pool-finder.form.token-placeholder')}
-          value={addresses.quoteAddress}
+          value={addresses.quoteToken}
           type="token"
           chainId={chainId}
           onChange={(value) => {
             setAddresses({
               ...addresses,
-              quoteAddress: value,
+              quoteToken: value,
             })
             onChange({
               ...addresses,
-              quoteAddress: value,
+              quoteToken: value,
             })
           }}
         />
         <PoolFinderReplacer
-          isVisible={Boolean(addresses.collateralAddress || addresses.quoteAddress)}
+          isVisible={Boolean(addresses.collateralToken || addresses.quoteToken)}
           onClick={() => {
             setAddresses({
               ...addresses,
-              collateralAddress: addresses.quoteAddress,
-              quoteAddress: addresses.collateralAddress,
+              collateralToken: addresses.quoteToken,
+              quoteToken: addresses.collateralToken,
             })
             onChange({
               ...addresses,
-              collateralAddress: addresses.quoteAddress,
-              quoteAddress: addresses.collateralAddress,
+              collateralToken: addresses.quoteToken,
+              quoteToken: addresses.collateralToken,
             })
           }}
         />

--- a/features/ajna/pool-finder/controls/PoolFinderFormController.tsx
+++ b/features/ajna/pool-finder/controls/PoolFinderFormController.tsx
@@ -11,14 +11,10 @@ import React, { useState } from 'react'
 import { Box, Flex, Grid, Image } from 'theme-ui'
 
 interface PoolFinderFormControllerProps {
-  chainId: NetworkIds
   onChange: (addresses: PoolFinderFormState) => void
 }
 
-export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({
-  chainId,
-  onChange,
-}) => {
+export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({ onChange }) => {
   const { t } = useTranslation()
   const [addresses, setAddresses] = useState<PoolFinderFormState>({
     collateralToken: '',
@@ -57,8 +53,6 @@ export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({
           placeholder={formatAddress(
             getNetworkContracts(NetworkIds.MAINNET).ajnaPoolPairs['ETH-USDC'].address,
           )}
-          type="address"
-          chainId={chainId}
           value={addresses.poolAddress}
           onChange={(value) => {
             setAddresses({
@@ -74,8 +68,6 @@ export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({
         <PoolFinderAddressInput
           label={t('pool-finder.form.collateral-token')}
           placeholder={t('pool-finder.form.token-placeholder')}
-          type="token"
-          chainId={chainId}
           value={addresses.collateralToken}
           onChange={(value) => {
             setAddresses({
@@ -92,8 +84,6 @@ export const PoolFinderFormController: FC<PoolFinderFormControllerProps> = ({
           label={t('pool-finder.form.quote-token')}
           placeholder={t('pool-finder.form.token-placeholder')}
           value={addresses.quoteToken}
-          type="token"
-          chainId={chainId}
           onChange={(value) => {
             setAddresses({
               ...addresses,

--- a/features/ajna/pool-finder/helpers/getOraclessProductUrl.ts
+++ b/features/ajna/pool-finder/helpers/getOraclessProductUrl.ts
@@ -3,23 +3,23 @@ import { isPoolOracless } from 'features/omni-kit/protocols/ajna/helpers'
 import type { OmniProductType } from 'features/omni-kit/types'
 
 interface GetOraclessUrlParams {
-  chainId: NetworkIds
   collateralAddress: string
   collateralToken: string
+  networkId: NetworkIds
   productType: OmniProductType
   quoteAddress: string
   quoteToken: string
 }
 
 export function getOraclessProductUrl({
-  chainId,
   collateralAddress,
   collateralToken,
+  networkId,
   productType,
   quoteAddress,
   quoteToken,
 }: GetOraclessUrlParams) {
-  return !isPoolOracless({ chainId, collateralToken, quoteToken })
+  return !isPoolOracless({ networkId, collateralToken, quoteToken })
     ? `/ethereum/ajna/${productType}/${collateralToken}-${quoteToken}`
     : `/ethereum/ajna/${productType}/${collateralAddress}-${quoteAddress}`
 }

--- a/features/ajna/pool-finder/helpers/getOraclessProductUrl.ts
+++ b/features/ajna/pool-finder/helpers/getOraclessProductUrl.ts
@@ -1,4 +1,4 @@
-import type { NetworkIds } from 'blockchain/networks'
+import type { NetworkIds, NetworkNames } from 'blockchain/networks'
 import { isPoolOracless } from 'features/omni-kit/protocols/ajna/helpers'
 import type { OmniProductType } from 'features/omni-kit/types'
 
@@ -6,6 +6,7 @@ interface GetOraclessUrlParams {
   collateralAddress: string
   collateralToken: string
   networkId: NetworkIds
+  networkName: NetworkNames
   productType: OmniProductType
   quoteAddress: string
   quoteToken: string
@@ -15,11 +16,12 @@ export function getOraclessProductUrl({
   collateralAddress,
   collateralToken,
   networkId,
+  networkName,
   productType,
   quoteAddress,
   quoteToken,
 }: GetOraclessUrlParams) {
   return !isPoolOracless({ networkId, collateralToken, quoteToken })
-    ? `/ethereum/ajna/${productType}/${collateralToken}-${quoteToken}`
-    : `/ethereum/ajna/${productType}/${collateralAddress}-${quoteAddress}`
+    ? `/${networkName}/ajna/${productType}/${collateralToken}-${quoteToken}`
+    : `/${networkName}/ajna/${productType}/${collateralAddress}-${quoteAddress}`
 }

--- a/features/ajna/pool-finder/helpers/parsePoolResponse.ts
+++ b/features/ajna/pool-finder/helpers/parsePoolResponse.ts
@@ -18,93 +18,96 @@ import { formatCryptoBalance } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
 
 export function parsePoolResponse(
-  chainId: NetworkIds,
+  networkId: NetworkIds,
   identifiedTokens: IdentifiedTokens,
   pools: SearchAjnaPoolData[],
   prices: Tickers,
 ): OraclessPoolResult[] {
-  return pools
-    .filter(
-      ({ collateralAddress, quoteTokenAddress }) =>
-        Object.keys(identifiedTokens).includes(collateralAddress) &&
-        Object.keys(identifiedTokens).includes(quoteTokenAddress),
-    )
-    .map(
-      ({
-        buckets,
-        collateralAddress,
-        debt,
-        interestRate,
-        lendApr,
-        lowestUtilizedPrice,
-        lowestUtilizedPriceIndex,
-        quoteTokenAddress,
-      }) => {
-        const collateralToken = identifiedTokens[collateralAddress.toLowerCase()].symbol
-        const quoteToken = identifiedTokens[quoteTokenAddress.toLowerCase()].symbol
-        const isPoolNotEmpty = lowestUtilizedPriceIndex > 0
-        const isOracless = isPoolOracless({ chainId, collateralToken, quoteToken })
-        const collateralPrice = isOracless ? one : prices[collateralToken]
-        const quotePrice = isOracless ? one : prices[quoteToken]
-        const marketPrice = collateralPrice.div(quotePrice)
-        const maxLtv = lowestUtilizedPrice.div(marketPrice).toString()
-        const liquidity = formatCryptoBalance(
-          getPoolLiquidity({
-            buckets: buckets.map((bucket) => ({
-              ...bucket,
-              index: new BigNumber(bucket.index),
-              quoteTokens: new BigNumber(bucket.quoteTokens),
-            })),
-            debt: debt.shiftedBy(WAD_PRECISION),
-          }).shiftedBy(NEGATIVE_WAD_PRECISION),
-        )
-        const fee = interestRate.toString()
-        const weeklyNetApy = lendApr.toString()
+  return (
+    pools
+      .filter(
+        ({ collateralAddress, quoteTokenAddress }) =>
+          Object.keys(identifiedTokens).includes(collateralAddress) &&
+          Object.keys(identifiedTokens).includes(quoteTokenAddress),
+      )
+      .map(
+        ({
+          buckets,
+          collateralAddress,
+          debt,
+          interestRate,
+          lendApr,
+          lowestUtilizedPrice,
+          lowestUtilizedPriceIndex,
+          quoteTokenAddress,
+        }) => {
+          const collateralToken = identifiedTokens[collateralAddress.toLowerCase()].symbol
+          const quoteToken = identifiedTokens[quoteTokenAddress.toLowerCase()].symbol
+          const isPoolNotEmpty = lowestUtilizedPriceIndex > 0
+          const isOracless = isPoolOracless({ networkId, collateralToken, quoteToken })
+          const collateralPrice = isOracless ? one : prices[collateralToken]
+          const quotePrice = isOracless ? one : prices[quoteToken]
+          const marketPrice = collateralPrice.div(quotePrice)
+          const maxLtv = lowestUtilizedPrice.div(marketPrice).toString()
+          const liquidity = formatCryptoBalance(
+            getPoolLiquidity({
+              buckets: buckets.map((bucket) => ({
+                ...bucket,
+                index: new BigNumber(bucket.index),
+                quoteTokens: new BigNumber(bucket.quoteTokens),
+              })),
+              debt: debt.shiftedBy(WAD_PRECISION),
+            }).shiftedBy(NEGATIVE_WAD_PRECISION),
+          )
+          const fee = interestRate.toString()
+          const weeklyNetApy = lendApr.toString()
 
-        return {
-          ...(isPoolNotEmpty &&
-            !isOracless && {
-              maxLtv,
-            }),
-          ...(isPoolNotEmpty && {
-            weeklyNetApy,
-          }),
-          liquidity,
-          earnStrategy: EarnStrategies.liquidity_provision,
-          earnStrategyDescription: `${collateralToken}/${quoteToken} LP`,
-          fee,
-          managementType: 'active',
-          collateralAddress: collateralAddress,
-          collateralToken: identifiedTokens[collateralAddress.toLowerCase()].symbol,
-          collateralIcon:
-            identifiedTokens[collateralAddress.toLowerCase()].source === 'blockchain'
-              ? collateralAddress
-              : collateralToken,
-          quoteAddress: quoteTokenAddress,
-          quoteToken: identifiedTokens[quoteTokenAddress.toLowerCase()].symbol,
-          quoteIcon:
-            identifiedTokens[quoteTokenAddress.toLowerCase()].source === 'blockchain'
-              ? quoteTokenAddress
-              : quoteToken,
-          tooltips: {
-            ...(isPoolWithRewards({ collateralToken, networkId: chainId, quoteToken }) && {
-              fee: productHubAjnaRewardsTooltip,
-              ...(isPoolNotEmpty && {
-                weeklyNetApy: productHubAjnaRewardsTooltip,
+          return {
+            ...(isPoolNotEmpty &&
+              !isOracless && {
+                maxLtv,
               }),
+            ...(isPoolNotEmpty && {
+              weeklyNetApy,
             }),
-            ...(!isOracless &&
-              !isPoolNotEmpty && {
-                maxLtv: productHubEmptyPoolMaxLtvTooltip,
+            liquidity,
+            earnStrategy: EarnStrategies.liquidity_provision,
+            earnStrategyDescription: `${collateralToken}/${quoteToken} LP`,
+            fee,
+            managementType: 'active',
+            networkId,
+            collateralAddress: collateralAddress,
+            collateralToken: identifiedTokens[collateralAddress.toLowerCase()].symbol,
+            collateralIcon:
+              identifiedTokens[collateralAddress.toLowerCase()].source === 'blockchain'
+                ? collateralAddress
+                : collateralToken,
+            quoteAddress: quoteTokenAddress,
+            quoteToken: identifiedTokens[quoteTokenAddress.toLowerCase()].symbol,
+            quoteIcon:
+              identifiedTokens[quoteTokenAddress.toLowerCase()].source === 'blockchain'
+                ? quoteTokenAddress
+                : quoteToken,
+            tooltips: {
+              ...(isPoolWithRewards({ collateralToken, networkId, quoteToken }) && {
+                fee: productHubAjnaRewardsTooltip,
+                ...(isPoolNotEmpty && {
+                  weeklyNetApy: productHubAjnaRewardsTooltip,
+                }),
               }),
-            ...(!isPoolNotEmpty && {
-              weeklyNetApy: productHubEmptyPoolWeeklyApyTooltip,
-            }),
-            ...(isOracless && {
-              maxLtv: productHubOraclessLtvTooltip,
-            }),
-          },
-        }
-      },
-    )
+              ...(!isOracless &&
+                !isPoolNotEmpty && {
+                  maxLtv: productHubEmptyPoolMaxLtvTooltip,
+                }),
+              ...(!isPoolNotEmpty && {
+                weeklyNetApy: productHubEmptyPoolWeeklyApyTooltip,
+              }),
+              ...(isOracless && {
+                maxLtv: productHubOraclessLtvTooltip,
+              }),
+            },
+          }
+        },
+      )
+  )
 }

--- a/features/ajna/pool-finder/helpers/parseRows.tsx
+++ b/features/ajna/pool-finder/helpers/parseRows.tsx
@@ -1,5 +1,4 @@
-import type { NetworkIds } from 'blockchain/networks'
-import { NetworkNames } from 'blockchain/networks'
+import { getNetworkById } from 'blockchain/networks'
 import { AssetsTableDataCellAction } from 'components/assetsTable/cellComponents/AssetsTableDataCellAction'
 import { AssetsTableDataCellAsset } from 'components/assetsTable/cellComponents/AssetsTableDataCellAsset'
 import type { AssetsTableRowData } from 'components/assetsTable/types'
@@ -14,7 +13,6 @@ import { upperFirst } from 'lodash'
 import React from 'react'
 
 export function parseRows(
-  chainId: NetworkIds,
   rows: OraclessPoolResult[],
   product: ProductHubProductType,
 ): AssetsTableRowData[] {
@@ -29,6 +27,7 @@ export function parseRows(
       liquidity,
       managementType,
       maxLtv,
+      networkId,
       quoteAddress,
       quoteIcon,
       quoteToken,
@@ -38,9 +37,9 @@ export function parseRows(
 
     const label = `${collateralToken}/${quoteToken}`
     const url = getOraclessProductUrl({
-      chainId,
       collateralAddress,
       collateralToken,
+      networkId,
       productType: product as unknown as OmniProductType,
       quoteAddress,
       quoteToken,
@@ -66,7 +65,7 @@ export function parseRows(
         quoteToken,
       ),
       protocolNetwork: (
-        <ProtocolLabel network={NetworkNames.ethereumMainnet} protocol={LendingProtocol.Ajna} />
+        <ProtocolLabel network={getNetworkById(networkId).name} protocol={LendingProtocol.Ajna} />
       ),
       action: <AssetsTableDataCellAction cta={upperFirst(product)} link={url} />,
     }

--- a/features/ajna/pool-finder/helpers/parseRows.tsx
+++ b/features/ajna/pool-finder/helpers/parseRows.tsx
@@ -36,10 +36,12 @@ export function parseRows(
     } = row
 
     const label = `${collateralToken}/${quoteToken}`
+    const networkName = getNetworkById(networkId).name
     const url = getOraclessProductUrl({
       collateralAddress,
       collateralToken,
       networkId,
+      networkName,
       productType: product as unknown as OmniProductType,
       quoteAddress,
       quoteToken,

--- a/features/ajna/pool-finder/helpers/searchAjnaPool.ts
+++ b/features/ajna/pool-finder/helpers/searchAjnaPool.ts
@@ -1,3 +1,4 @@
+import type { Bucket } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 import type { NetworkIds } from 'blockchain/networks'
 import { NEGATIVE_WAD_PRECISION } from 'components/constants'
@@ -7,13 +8,7 @@ import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
 
 export interface SearchAjnaPoolResponse {
   address: string
-  buckets: {
-    price: string
-    index: string
-    quoteTokens: string
-    collateral: string
-    bucketLPs: string
-  }
+  buckets: Bucket[]
   collateralAddress: string
   collateralToken: {
     symbol: string

--- a/features/ajna/pool-finder/types.ts
+++ b/features/ajna/pool-finder/types.ts
@@ -9,8 +9,8 @@ export interface SearchTokensResponse {
 
 export interface PoolFinderFormState {
   poolAddress: string
-  collateralAddress: string
-  quoteAddress: string
+  collateralToken: string
+  quoteToken: string
 }
 
 export interface OraclessPoolResult extends ProductHubItemTooltips {

--- a/features/ajna/pool-finder/types.ts
+++ b/features/ajna/pool-finder/types.ts
@@ -1,3 +1,4 @@
+import type { NetworkIds } from 'blockchain/networks'
 import type { ProductHubItemTooltips, ProductHubManagementType } from 'features/productHub/types'
 
 import type { EarnStrategies } from '.prisma/client'
@@ -22,6 +23,7 @@ export interface OraclessPoolResult extends ProductHubItemTooltips {
   liquidity?: string
   managementType?: ProductHubManagementType
   maxLtv?: string
+  networkId: NetworkIds
   quoteAddress: string
   quoteToken: string
   weeklyNetApy?: string

--- a/features/ajna/pool-finder/views/PoolFinderView.tsx
+++ b/features/ajna/pool-finder/views/PoolFinderView.tsx
@@ -12,6 +12,7 @@ import type { OraclessPoolResult, PoolFinderFormState } from 'features/ajna/pool
 import { AJNA_SUPPORTED_NETWORKS } from 'features/omni-kit/protocols/ajna/constants'
 import { ProductHubIntro } from 'features/productHub/components/ProductHubIntro'
 import type { ProductHubProductType } from 'features/productHub/types'
+import { useAppConfig } from 'helpers/config'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
@@ -27,6 +28,8 @@ interface PoolFinderViewProps {
 }
 
 export const PoolFinderView: FC<PoolFinderViewProps> = ({ product }) => {
+  const { AjnaBase: ajnaBaseEnabled } = useAppConfig('features')
+
   const { identifiedTokens$, tokenPriceUSDStatic$ } = useProductContext()
 
   const { chainId: walletNetworkId } = useAccount()
@@ -61,6 +64,8 @@ export const PoolFinderView: FC<PoolFinderViewProps> = ({ product }) => {
                 walletNetworkId,
               ]
           }
+          if (!ajnaBaseEnabled)
+            networkIds = networkIds.filter((networkId) => networkId !== NetworkIds.BASEMAINNET)
 
           const pools = await Promise.all(
             networkIds.map(

--- a/features/ajna/pool-finder/views/PoolFinderView.tsx
+++ b/features/ajna/pool-finder/views/PoolFinderView.tsx
@@ -12,7 +12,6 @@ import {
   PoolFinderNaturalLanguageSelectorController,
 } from 'features/ajna/pool-finder/controls'
 import {
-  getOraclessTokenAddress,
   parsePoolResponse,
   searchAjnaPool,
 } from 'features/ajna/pool-finder/helpers'
@@ -48,24 +47,19 @@ export const PoolFinderView: FC<PoolFinderViewProps> = ({ product }) => {
   const [results, setResults] = useState<{ [key: string]: OraclessPoolResult[] }>({})
   const [resultsKey, setResultsKey] = useState<string>('')
   const [addresses, setAddresses] = useState<PoolFinderFormState>({
-    collateralAddress: '',
+    collateralToken: '',
     poolAddress: '',
-    quoteAddress: '',
+    quoteToken: '',
   })
 
   useDebouncedEffect(
     async () => {
       if (context?.chainId && tokenPriceUSDData && resultsKey && !results[resultsKey]) {
-        const { collateralToken, quoteToken } = await getOraclessTokenAddress({
-          collateralToken: addresses.collateralAddress,
-          quoteToken: addresses.quoteAddress,
-        })
-
-        if (addresses.poolAddress || collateralToken.length || quoteToken.length) {
+        if (addresses.poolAddress || addresses.collateralToken || addresses.quoteToken) {
           const pools = await searchAjnaPool(context.chainId, {
-            collateralAddress: collateralToken,
-            poolAddress: addresses.poolAddress ? [addresses.poolAddress] : [],
-            quoteAddress: quoteToken,
+            collateralToken: addresses.collateralToken,
+            poolAddress: addresses.poolAddress,
+            quoteToken: addresses.quoteToken,
           })
 
           if (pools.length) {
@@ -140,7 +134,7 @@ export const PoolFinderView: FC<PoolFinderViewProps> = ({ product }) => {
                   onChange={(addresses) => {
                     setAddresses(addresses)
                     setResultsKey(
-                      addresses.collateralAddress || addresses.poolAddress || addresses.quoteAddress
+                      addresses.collateralToken || addresses.poolAddress || addresses.quoteToken
                         ? Object.values(addresses).join('-')
                         : '',
                     )

--- a/features/omni-kit/components/OmniDupePositionModal.tsx
+++ b/features/omni-kit/components/OmniDupePositionModal.tsx
@@ -1,4 +1,4 @@
-import { NetworkIds } from 'blockchain/networks'
+import { NetworkIds, networksById } from 'blockchain/networks'
 import type { UserDpmAccount } from 'blockchain/userDpmProxies.types'
 import { AppLink } from 'components/Links'
 import { Modal, ModalCloseIcon } from 'components/Modal'
@@ -14,11 +14,11 @@ import { Box, Button, Flex, Heading, Image, Text, ThemeUIProvider } from 'theme-
 import type { CreatePositionEvent } from 'types/ethers-contracts/AjnaProxyActions'
 
 export interface OmniDupePositionModalProps {
-  chainId?: NetworkIds
   collateralAddress: string
   collateralToken: string
   dpmAccounts: UserDpmAccount[]
   events: CreatePositionEvent[]
+  networkId?: NetworkIds
   productType: OmniProductType
   quoteAddress: string
   quoteToken: string
@@ -26,11 +26,11 @@ export interface OmniDupePositionModalProps {
 }
 
 export function OmniDupePositionModal({
-  chainId = NetworkIds.MAINNET,
   collateralAddress,
   collateralToken,
   dpmAccounts,
   events,
+  networkId = NetworkIds.MAINNET,
   productType,
   quoteAddress,
   quoteToken,
@@ -47,14 +47,16 @@ export function OmniDupePositionModal({
   )
 
   const hasMultiplyPositions = positionIds.length > 1
+  const networkName = networksById[networkId].name
   const amount = hasMultiplyPositions ? 'plural' : 'singular'
   const type = productType === OmniProductType.Earn ? 'lender' : 'borrower'
   const primaryLink = hasMultiplyPositions
     ? `/owner/${walletAddress}`
     : `${getOraclessProductUrl({
-        chainId,
         collateralAddress,
         collateralToken,
+        networkId,
+        networkName,
         productType,
         quoteAddress,
         quoteToken,

--- a/features/omni-kit/hooks/useOmniProtocolData.ts
+++ b/features/omni-kit/hooks/useOmniProtocolData.ts
@@ -35,7 +35,8 @@ export function useOmniProtocolData({
   networkId,
 }: OmniProtocolDataProps) {
   const { walletAddress } = useAccount()
-  const { gasPrice$ } = useMainContext()
+  // TODO: remove context when switched to getting network from parameter
+  const { context$, gasPrice$ } = useMainContext()
   const { userSettings$ } = useAccountContext()
   const {
     balancesFromAddressInfoArray$,
@@ -45,6 +46,7 @@ export function useOmniProtocolData({
     tokenPriceUSD$,
   } = useProductContext()
 
+  const [context] = useObservable(context$)
   const [userSettingsData, userSettingsError] = useObservable(userSettings$)
   const [gasPriceData, gasPriceError] = useObservable(gasPrice$)
 
@@ -53,10 +55,10 @@ export function useOmniProtocolData({
   const [identifiedTokensData] = useObservable(
     useMemo(
       () =>
-        isOracless && collateralToken && quoteToken
-          ? identifiedTokens$(networkId, [collateralToken, quoteToken])
+        context && isOracless && collateralToken && quoteToken
+          ? identifiedTokens$(context.chainId, [collateralToken, quoteToken])
           : EMPTY,
-      [isOracless, collateralToken, quoteToken],
+      [context, isOracless, collateralToken, quoteToken],
     ),
   )
 

--- a/features/omni-kit/hooks/useOmniProtocolData.ts
+++ b/features/omni-kit/hooks/useOmniProtocolData.ts
@@ -54,7 +54,7 @@ export function useOmniProtocolData({
     useMemo(
       () =>
         isOracless && collateralToken && quoteToken
-          ? identifiedTokens$([collateralToken, quoteToken])
+          ? identifiedTokens$(networkId, [collateralToken, quoteToken])
           : EMPTY,
       [isOracless, collateralToken, quoteToken],
     ),

--- a/features/omni-kit/protocols/ajna/constants.ts
+++ b/features/omni-kit/protocols/ajna/constants.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { NetworkIds } from 'blockchain/networks'
 import {
   omniSidebarManageBorrowishSteps,
   omniSidebarManageSteps,
@@ -7,6 +8,7 @@ import {
 import { OmniSidebarStep, type OmniSidebarStepsSet } from 'features/omni-kit/types'
 
 export const AJNA_RAW_PROTOCOL_NAME = 'Ajna_rc10'
+export const AJNA_SUPPORTED_NETWORKS = [NetworkIds.MAINNET, NetworkIds.BASEMAINNET]
 
 export const ajnaOmniSteps: OmniSidebarStepsSet = {
   borrow: {

--- a/features/omni-kit/protocols/ajna/helpers/isPoolOracless.ts
+++ b/features/omni-kit/protocols/ajna/helpers/isPoolOracless.ts
@@ -3,17 +3,17 @@ import { NetworkIds } from 'blockchain/networks'
 import { isAddress } from 'ethers/lib/utils'
 
 interface IsPoolOraclessParams {
-  chainId?: NetworkIds
   collateralToken: string
+  networkId?: NetworkIds
   quoteToken: string
 }
 
 export function isPoolOracless({
-  chainId,
   collateralToken,
+  networkId,
   quoteToken,
 }: IsPoolOraclessParams): boolean {
-  const { ajnaPoolPairs } = getNetworkContracts(NetworkIds.MAINNET, chainId)
+  const { ajnaPoolPairs } = getNetworkContracts(NetworkIds.MAINNET, networkId)
 
   return isAddress(collateralToken) && isAddress(quoteToken)
     ? true

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -114,7 +114,7 @@ export function OmniFormView({
       if (!hasDupePosition && filteredEvents.length) {
         setHasDupePosition(true)
         openModal(dupeModal, {
-          chainId: context?.chainId,
+          networkId: context?.chainId,
           collateralAddress,
           collateralToken,
           dpmAccounts,

--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -44,7 +44,7 @@ export const getAaveLikeViewStrategyUrl = ({
 
 export function getActionUrl({
   bypassFeatureFlag = false,
-  chainId,
+  networkId,
   earnStrategy,
   label,
   network,
@@ -54,7 +54,7 @@ export function getActionUrl({
   protocol,
   secondaryToken,
   secondaryTokenAddress,
-}: ProductHubItem & { bypassFeatureFlag?: boolean; chainId?: NetworkIds }): string {
+}: ProductHubItem & { bypassFeatureFlag?: boolean; networkId?: NetworkIds }): string {
   switch (protocol) {
     case LendingProtocol.Ajna:
       const isEarnProduct = product[0] === ProductHubProductType.Earn
@@ -65,7 +65,7 @@ export function getActionUrl({
       const isOracless = isPoolOracless({
         collateralToken,
         quoteToken,
-        chainId,
+        networkId,
       })
       const productInUrl =
         isEarnProduct && earnStrategy === EarnStrategies.yield_loop

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -22,7 +22,7 @@ export function parseRows(
 
     if (reverseTokens) icons.reverse()
 
-    const url = getActionUrl({ ...row, networkId, product: [product] })
+    const url = getActionUrl({ ...row, networkId: chainId, product: [product] })
     const urlDisabled = url === '/'
 
     return {

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -22,7 +22,7 @@ export function parseRows(
 
     if (reverseTokens) icons.reverse()
 
-    const url = getActionUrl({ ...row, chainId, product: [product] })
+    const url = getActionUrl({ ...row, networkId, product: [product] })
     const urlDisabled = url === '/'
 
     return {

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -345,12 +345,18 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
           bucketLPs
         }
         collateralAddress
+        collateralToken {
+          symbol
+        }
         debt
         interestRate
         lendApr
         lup
         lupIndex
         quoteTokenAddress
+        quoteToken {
+          symbol
+        }
       }
     }
   `,

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -328,14 +328,9 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
       }
     }
   `,
-    searchAjnaPool: gql`
-    query searchPool(
-      $where: Pool_filter
-    ) {
-      pools(
-        first: 111
-        where: $where
-      ) {
+  searchAjnaPool: gql`
+    query searchPool($where: Pool_filter) {
+      pools(first: 111, where: $where) {
         address
         buckets {
           price

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -328,17 +328,13 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
       }
     }
   `,
-  searchAjnaPool: gql`
-    query searchPool($collateralAddress: [ID]!, $poolAddress: [ID]!, $quoteAddress: [ID]!) {
+    searchAjnaPool: gql`
+    query searchPool(
+      $where: Pool_filter
+    ) {
       pools(
         first: 111
-        where: {
-          or: [
-            { address_in: $poolAddress }
-            { collateralAddress_in: $collateralAddress }
-            { quoteTokenAddress_in: $quoteAddress }
-          ]
-        }
+        where: $where
       ) {
         address
         buckets {

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -1,5 +1,8 @@
 import type { NetworkIds } from 'blockchain/networks'
-import type { SearchAjnaPoolResponse } from 'features/ajna/pool-finder/helpers'
+import type {
+  SearchAjnaPoolFilters,
+  SearchAjnaPoolResponse,
+} from 'features/ajna/pool-finder/helpers'
 import type { AjnaClaimedReward } from 'features/ajna/rewards/helpers'
 import type { AjnaPoolDataResponse } from 'features/omni-kit/protocols/ajna/helpers'
 import type { AjnaPoolsDataResponse } from 'features/omni-kit/protocols/ajna/helpers/getAjnaPoolsData'
@@ -26,7 +29,9 @@ export type Subgraphs = {
     getAjnaPoolsData: {}
     getAjnaClaimedRewards: { walletAddress: string }
     getAjnaDpmPositions: { dpmProxyAddress: string[] }
-    searchAjnaPool: { collateralAddress: string[]; poolAddress: string[]; quoteAddress: string[] }
+    searchAjnaPool: {
+      where: SearchAjnaPoolFilters
+    }
   }
   Aave: {
     getAaveHistory: { dpmProxyAddress: string }

--- a/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
@@ -55,7 +55,7 @@ export async function getAjnaPositionInfo({
   const secondaryToken = getTokenDisplayName(quoteToken.symbol)
   const secondaryTokenAddress = quoteToken.address
   const isOracless = isPoolOracless({
-    chainId: NetworkIds.MAINNET,
+    networkId: NetworkIds.MAINNET,
     collateralToken: primaryToken,
     quoteToken: secondaryToken,
   })

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -91,7 +91,7 @@ async function getAjnaPoolData(
           },
         ) => {
           const isPoolNotEmpty = lowestUtilizedPriceIndex > 0
-          const isOracless = isPoolOracless({ chainId: networkId, collateralToken, quoteToken })
+          const isOracless = isPoolOracless({ networkId: networkId, collateralToken, quoteToken })
           const isShort = isShortPosition({ collateralToken })
           // Temporary hidden yield loops products until APY solution is found
           // const isYieldLoop = isYieldLoopPool({ collateralToken, quoteToken })

--- a/handlers/tokens-info/get.ts
+++ b/handlers/tokens-info/get.ts
@@ -17,18 +17,6 @@ const paramsSchema = z.object({
 export async function get(req: NextApiRequest, res: NextApiResponse) {
   const { addresses, chainId } = paramsSchema.parse(req.body)
 
-  console.log('---')
-  console.log('---')
-  console.log('---')
-  console.log('---')
-  console.log('---')
-  console.log({ addresses, chainId })
-  console.log('---')
-  console.log('---')
-  console.log('---')
-  console.log('---')
-  console.log('---')
-
   const lowerCasedAddresses = addresses
     .filter((address) => ethers.utils.isAddress(address))
     .map((address) => address.toLowerCase())

--- a/handlers/tokens-info/get.ts
+++ b/handlers/tokens-info/get.ts
@@ -17,6 +17,18 @@ const paramsSchema = z.object({
 export async function get(req: NextApiRequest, res: NextApiResponse) {
   const { addresses, chainId } = paramsSchema.parse(req.body)
 
+  console.log('---')
+  console.log('---')
+  console.log('---')
+  console.log('---')
+  console.log('---')
+  console.log({ addresses, chainId })
+  console.log('---')
+  console.log('---')
+  console.log('---')
+  console.log('---')
+  console.log('---')
+
   const lowerCasedAddresses = addresses
     .filter((address) => ethers.utils.isAddress(address))
     .map((address) => address.toLowerCase())

--- a/helpers/context/ProductContext.ts
+++ b/helpers/context/ProductContext.ts
@@ -664,8 +664,9 @@ export function setupProductContext(
         .toString()}`,
   )
 
-  const identifiedTokens$ = memoize(curry(identifyTokens$)(context$, once$), (tokens: string[]) =>
-    tokens.join(),
+  const identifiedTokens$ = memoize(
+    curry(identifyTokens$)(once$),
+    (networkId: NetworkIds, tokens: string[]) => `${networkId}-${tokens.join()}`,
   )
 
   return {


### PR DESCRIPTION
# [Pool finder support for Base/other L2 chains](https://app.shortcut.com/oazo-apps/story/13126/pool-finder-support-for-base-other-l2-chains)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/1d4602e2-b521-46df-b99a-e5bc06a0471d)
  
## Changes 👷‍♀️

- Refactored Pool Creator to allow searching for pools across list of networks instead of the one coming from context,
- Modified `identifyTokens$` observable so it does not require entire context as parameter, just network id.

Please note that this PR contains two temporary workarounds to make entire Ajna feature works with changes to `identifyTokens$`. As entire Ajna is currently being refactored to handle multiple networks, it's not work working on perfect solution here, knowing that it's going to be purged in next day or two.