### PR TITLE
Fix etherscan url on Pool Creator

### DIFF
--- a/blockchain/contracts/arbitrum.ts
+++ b/blockchain/contracts/arbitrum.ts
@@ -187,6 +187,7 @@ export const arbitrumContracts: MainnetContractsWithOptional = {
     url: 'https://arbiscan.io/',
     apiUrl: 'https://api.arbiscan.io/api',
     apiKey: etherscanAPIKey || '',
+    name: 'Arbiscan',
   },
   ethtx: {
     url: '',

--- a/blockchain/contracts/base.ts
+++ b/blockchain/contracts/base.ts
@@ -179,9 +179,10 @@ export const baseContracts: MainnetContractsWithOptional = {
   openVaultSafeConfirmations: 6,
   taxProxyRegistries: [],
   etherscan: {
-    url: '',
-    apiUrl: '',
+    url: 'https://basescan.org/',
+    apiUrl: 'https://api.basescan.org/api',
     apiKey: etherscanAPIKey || '',
+    name: 'Basescan',
   },
   ethtx: {
     url: '',

--- a/blockchain/contracts/goerli.ts
+++ b/blockchain/contracts/goerli.ts
@@ -204,6 +204,7 @@ export const goerliContracts: MainnetContractsWithOptional = {
     url: 'https://goerli.etherscan.io',
     apiUrl: 'https://api-goerli.etherscan.io/api',
     apiKey: etherscanAPIKey || '',
+    name: 'Etherscan',
   },
   ethtx: {
     url: 'https://ethtx.info/goerli',

--- a/blockchain/contracts/mainnet.ts
+++ b/blockchain/contracts/mainnet.ts
@@ -217,6 +217,7 @@ export const mainnetContracts = {
     url: 'https://etherscan.io',
     apiUrl: 'https://api.etherscan.io/api',
     apiKey: etherscanAPIKey || '',
+    name: 'Etherscan',
   },
   ethtx: {
     url: 'https://ethtx.info/mainnet',

--- a/blockchain/contracts/optimism.ts
+++ b/blockchain/contracts/optimism.ts
@@ -209,6 +209,7 @@ export const optimismContracts: OptimismContracts = {
     url: 'https://optimistic.etherscan.io/',
     apiUrl: 'https://api-optimistic.etherscan.io/api',
     apiKey: etherscanAPIKey || '',
+    name: 'Optimistic Etherscan',
   },
   ethtx: {
     url: '',

--- a/components/sidebar/SidebarSectionStatus.tsx
+++ b/components/sidebar/SidebarSectionStatus.tsx
@@ -22,6 +22,7 @@ export interface SidebarSectionStatusProps {
   text: string
   txHash: string
   etherscan: string
+  etherscanName?: string
   type: SidebarSectionStatusTypes
   description?: TranslateStringType
   icon?: IconProps['icon']
@@ -31,6 +32,7 @@ export function SidebarSectionStatus({
   text,
   txHash,
   etherscan,
+  etherscanName,
   type,
   description,
   icon,
@@ -89,7 +91,9 @@ export function SidebarSectionStatus({
                 variant="paragraph4"
                 sx={{ fontWeight: 'semiBold', color: types[type].color }}
               >
-                {t('view-on-etherscan')}
+                {etherscanName
+                  ? t('view-on-etherscan-custom', { etherscanName })
+                  : t('view-on-etherscan')}
               </Text>
             </Link>
           )}

--- a/features/ajna/pool-creator/hooks/usePoolCreatorData.tsx
+++ b/features/ajna/pool-creator/hooks/usePoolCreatorData.tsx
@@ -64,6 +64,8 @@ export function usePoolCreatorData({
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
   const [isOnSupportedNetwork, setIsOnSupportedNetwork] = useState<boolean>(false)
 
+  const networkContracts = getNetworkContracts(context?.chainId ?? NetworkIds.MAINNET)
+
   const onSubmit = () => {
     txHelpers
       ?.sendWithGasEstimation(deployAjnaPool, {
@@ -83,8 +85,12 @@ export function usePoolCreatorData({
   }
 
   const txStatuses = getOmniTxStatuses(txDetails?.txStatus)
+
   const txSidebarStatus = getOmniSidebarTransactionStatus({
-    etherscan: getNetworkContracts(NetworkIds.MAINNET, context?.chainId).etherscan.url,
+    ...('etherscan' in networkContracts && {
+      etherscan: networkContracts.etherscan.url,
+      etherscanName: networkContracts.etherscan.name,
+    }),
     isTxInProgress: txStatuses.isTxInProgress,
     isTxSuccess: txStatuses.isTxSuccess,
     text: t(

--- a/features/omni-kit/helpers/getOmniSidebarTransactionStatus.ts
+++ b/features/omni-kit/helpers/getOmniSidebarTransactionStatus.ts
@@ -3,12 +3,14 @@ import type { TxDetails } from 'helpers/handleTransaction'
 
 export function getOmniSidebarTransactionStatus({
   etherscan = '',
+  etherscanName,
   isTxInProgress,
   isTxSuccess,
   text,
   txDetails,
 }: {
   etherscan?: string
+  etherscanName?: string
   isTxInProgress: boolean
   isTxSuccess: boolean
   text: string
@@ -18,6 +20,7 @@ export function getOmniSidebarTransactionStatus({
     ? [
         {
           etherscan,
+          etherscanName,
           text,
           txHash: txDetails.txHash,
           type: isTxInProgress ? 'progress' : 'success',

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -215,6 +215,7 @@ export function OmniFormView({
   }
   const status = getOmniSidebarTransactionStatus({
     etherscan: getNetworkContracts(networkId).etherscan.url,
+    etherscanName: getNetworkContracts(networkId).etherscan.name,
     isTxInProgress,
     isTxSuccess,
     text: t(

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1583,6 +1583,7 @@
   "view": "View",
   "view-more": "View more",
   "view-on-etherscan": "View on Etherscan",
+  "view-on-etherscan-custom": "View on {{etherscanName}}",
   "view-on-ethtx": "View on Ethtx",
   "waiting-approval": "Waiting for approval",
   "waiting-confirmation": "Waiting for transaction confirmation",


### PR DESCRIPTION
# [Fix etherscan url on Pool Creator](https://app.shortcut.com/oazo-apps/story/13340/bug-base-when-submitting-a-transaction-on-base-network-in-pool-creator-it-still-shows-etherscan-to-track-and-links-to-mainnet)
  
## Changes 👷‍♀️

- Fixed an issue where etherscan link on base was taking user to mainnet etherscan.
- Added names for Etherscan forks for each network. 