### PR TITLE
Add support for network forks in getNetworkByName function

### DIFF
--- a/blockchain/networks/network-helpers.ts
+++ b/blockchain/networks/network-helpers.ts
@@ -163,7 +163,8 @@ export function getNetworksHexIdsByHexId(networkHexId: NetworkConfigHexId): Netw
 }
 
 export function getNetworkByName(networkName: NetworkNames) {
-  const base = networkSetByName[networkName]
+  // with forks we need to also check for {networkname}-test
+  const base = networkSetByName[networkName] || networkSetByName[`${networkName}-test`]
   if (!base) throw new Error('Invalid network name provided or not implemented yet')
 
   const parent = base.getParentNetwork()


### PR DESCRIPTION
This pull request adds support for network forks in the getNetworkByName function. Previously, the function only checked for the base network name, but now it also checks for the network name followed by "-test". This ensures that the function can handle network forks properly.