### PR TITLE
Max generate on unutilized pool fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.22",
     "@oasisdex/automation": "^1.5.8",
-    "@oasisdex/dma-library": "0.5.29",
+    "@oasisdex/dma-library": "0.5.30",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.5.29":
-  version "0.5.29"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.29.tgz#14d19bbee69362dd47a11b557e5595166f0a9c59"
-  integrity sha512-9lzjnGwtt/kbyOgXg/iaV1ulDC0rAjFZEmch9Hwt0cbnwfeWHa2gUHrstNkjSHkjtS+g6FIGVMdBcEnPnfiIEQ==
+"@oasisdex/dma-library@0.5.30":
+  version "0.5.30"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.5.30.tgz#481e2e30551732255cf4999d1e78a8cf6503650d"
+  integrity sha512-Sq1aM7FvdGmHUcwE2WCUjLPe3QPnf0RYJZhEJsNsOpxNvPC8Xyd9HGXwdYmNb3Z/MMPo94kcLZNX3wYuTAjplA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "5.6.2"


### PR DESCRIPTION
# [Max generate on unutilized pool fix](https://app.shortcut.com/oazo-apps/story/13352/bug-base-maybe-all-the-max-amount-to-borrow-when-opening-a-borrow-position-is-greater-than-the-liquidity-in-the-pool)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bumped dma lib version with fix for max generate on unutilized pools
  
## How to test 🧪
  <Please explain how to test your changes>

- max generate on unutilized pools should be capped on pool liquidity
