### PR TITLE
Lending price color adjustment

### DIFF
--- a/features/omni-kit/protocols/ajna/helpers/getLendingPriceColor.ts
+++ b/features/omni-kit/protocols/ajna/helpers/getLendingPriceColor.ts
@@ -14,5 +14,6 @@ export const getLendingPriceColor = ({
 }: GetLendingPriceColorParams): { color: string; index: number } => {
   if (price.lt(highestThresholdPrice)) return { color: omniLendingPriceColors[0], index: 0 }
   if (price.lt(lowestUtilizedPrice)) return { color: omniLendingPriceColors[1], index: 1 }
-  else return { color: omniLendingPriceColors[0], index: 2 }
+  if (price.gte(lowestUtilizedPrice)) return { color: omniLendingPriceColors[2], index: 2 }
+  else return { color: omniLendingPriceColors[0], index: 0 }
 }


### PR DESCRIPTION
# [Lending price color adjustment](https://app.shortcut.com/oazo-apps/story/13391/bug-position-lending-price-is-grey-on-earn-when-it-is-utilised-and-only-partial-amount-is-withdrawable)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed color of lending price value in overview section
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
