### PR TITLE
Fix network switching in Omnikit

### DIFF
--- a/features/omni-kit/components/sidebars/borrow/OmniBorrowFormContentDeposit.tsx
+++ b/features/omni-kit/components/sidebars/borrow/OmniBorrowFormContentDeposit.tsx
@@ -10,7 +10,13 @@ import React from 'react'
 
 export function OmniBorrowFormContentDeposit() {
   const {
-    environment: { collateralBalance, collateralDigits, collateralPrice, collateralToken },
+    environment: {
+      collateralBalance,
+      collateralDigits,
+      collateralPrice,
+      collateralToken,
+      shouldSwitchNetwork,
+    },
   } = useOmniGeneralContext()
   const {
     form: {
@@ -28,11 +34,11 @@ export function OmniBorrowFormContentDeposit() {
     <>
       <OmniFormFieldDeposit
         dispatchAmount={dispatch}
-        maxAmount={collateralBalance}
         resetOnClear
         token={collateralToken}
         tokenPrice={collateralPrice}
         tokenDigits={collateralDigits}
+        {...(!shouldSwitchNetwork && { maxAmount: collateralBalance })}
       />
       <OmniFormFieldGenerate dispatchAmount={dispatch} maxAmount={debtMax} minAmount={debtMin} />
       {highlighterOrderInformation}

--- a/features/omni-kit/components/sidebars/borrow/OmniBorrowFormContentGenerate.tsx
+++ b/features/omni-kit/components/sidebars/borrow/OmniBorrowFormContentGenerate.tsx
@@ -10,7 +10,13 @@ import React from 'react'
 
 export function OmniBorrowFormContentGenerate() {
   const {
-    environment: { collateralBalance, collateralDigits, collateralPrice, collateralToken, shouldSwitchNetwork },
+    environment: {
+      collateralBalance,
+      collateralDigits,
+      collateralPrice,
+      collateralToken,
+      shouldSwitchNetwork,
+    },
   } = useOmniGeneralContext()
   const {
     form: {

--- a/features/omni-kit/components/sidebars/borrow/OmniBorrowFormContentGenerate.tsx
+++ b/features/omni-kit/components/sidebars/borrow/OmniBorrowFormContentGenerate.tsx
@@ -10,7 +10,7 @@ import React from 'react'
 
 export function OmniBorrowFormContentGenerate() {
   const {
-    environment: { collateralBalance, collateralDigits, collateralPrice, collateralToken },
+    environment: { collateralBalance, collateralDigits, collateralPrice, collateralToken, shouldSwitchNetwork },
   } = useOmniGeneralContext()
   const {
     form: {
@@ -33,10 +33,10 @@ export function OmniBorrowFormContentGenerate() {
       />
       <OmniFormFieldDeposit
         dispatchAmount={dispatch}
-        maxAmount={collateralBalance}
         token={collateralToken}
         tokenPrice={collateralPrice}
         tokenDigits={collateralDigits}
+        {...(!shouldSwitchNetwork && { maxAmount: collateralBalance })}
       />
       {highlighterOrderInformation}
       {(generateAmount || depositAmount) && (

--- a/features/omni-kit/components/sidebars/earn/OmniEarnFormContentDeposit.tsx
+++ b/features/omni-kit/components/sidebars/earn/OmniEarnFormContentDeposit.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 export function OmniEarnFormContentDeposit() {
   const {
-    environment: { quotePrice, quoteToken, quoteBalance, quoteDigits },
+    environment: { quotePrice, quoteToken, quoteBalance, quoteDigits, shouldSwitchNetwork },
   } = useOmniGeneralContext()
   const {
     form: { dispatch },
@@ -22,8 +22,8 @@ export function OmniEarnFormContentDeposit() {
         resetOnClear
         token={quoteToken}
         tokenPrice={quotePrice}
-        maxAmount={quoteBalance}
         tokenDigits={quoteDigits}
+        {...(!shouldSwitchNetwork && { maxAmount: quoteBalance })}
       />
       {extraEarnInputDeposit}
       {isFormValid && <OmniFormContentSummary>{earnFormOrder}</OmniFormContentSummary>}

--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormContentDepositCollateral.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormContentDepositCollateral.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 
 export function OmniMultiplyFormContentDepositCollateral() {
   const {
-    environment: { collateralBalance, collateralPrice, collateralToken },
+    environment: { collateralBalance, collateralPrice, collateralToken, shouldSwitchNetwork },
   } = useOmniGeneralContext()
   const {
     form: {
@@ -19,10 +19,10 @@ export function OmniMultiplyFormContentDepositCollateral() {
     <>
       <OmniFormFieldDeposit
         dispatchAmount={dispatch}
-        maxAmount={collateralBalance}
         resetOnClear
         token={collateralToken}
         tokenPrice={collateralPrice}
+        {...(!shouldSwitchNetwork && { maxAmount: collateralBalance })}
       />
       {/* DISABLED: We're currently unable to support this operation
        * in the library based on existing operation if the LTV decreases

--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormContentOpen.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormContentOpen.tsx
@@ -10,7 +10,7 @@ import React from 'react'
 
 export function OmniMultiplyFormContentOpen() {
   const {
-    environment: { collateralBalance, collateralPrice, collateralToken },
+    environment: { collateralBalance, collateralPrice, collateralToken, shouldSwitchNetwork },
   } = useOmniGeneralContext()
   const {
     form: {
@@ -27,6 +27,7 @@ export function OmniMultiplyFormContentOpen() {
         resetOnClear
         token={collateralToken}
         tokenPrice={collateralPrice}
+        {...(!shouldSwitchNetwork && { maxAmount: collateralBalance })}
       />
       <OmniAdjustSlider disabled={!depositAmount} />
       {depositAmount && (

--- a/features/omni-kit/helpers/getOmniPrimaryButtonLabelKey.ts
+++ b/features/omni-kit/helpers/getOmniPrimaryButtonLabelKey.ts
@@ -4,7 +4,6 @@ interface GetPrimaryButtonLabelKeyParams {
   currentStep: OmniSidebarStep
   hasAllowance: boolean
   hasDpmAddress: boolean
-  isFormEmpty: boolean
   isOpening: boolean
   isTransitionInProgress: boolean
   isTxError: boolean
@@ -17,7 +16,6 @@ export function getOmniPrimaryButtonLabelKey({
   currentStep,
   hasAllowance,
   hasDpmAddress,
-  isFormEmpty,
   isOpening,
   isTransitionInProgress,
   isTxError,
@@ -37,8 +35,8 @@ export function getOmniPrimaryButtonLabelKey({
       if (isTransitionInProgress) return 'borrow-to-multiply.button-progress'
       else return 'confirm'
     default:
-      if (shouldSwitchNetwork) return 'switch-network'
-      else if (isFormEmpty || (walletAddress && hasDpmAddress && hasAllowance)) return 'confirm'
+      if (walletAddress && shouldSwitchNetwork) return 'switch-network'
+      else if (walletAddress && hasDpmAddress && hasAllowance) return 'confirm'
       else if (walletAddress && hasDpmAddress) return 'set-token-allowance'
       else if (walletAddress) return 'dpm.create-flow.welcome-screen.create-button'
       else return 'connect-wallet-button'

--- a/features/omni-kit/helpers/getOmniSidebarButtonsStatus.ts
+++ b/features/omni-kit/helpers/getOmniSidebarButtonsStatus.ts
@@ -24,6 +24,7 @@ interface GetOmniSidebarButtonsStatusParams {
   isTxStarted: boolean
   isTxWaitingForApproval: boolean
   safetySwitch: boolean
+  shouldSwitchNetwork: boolean
   walletAddress?: string
 }
 
@@ -45,10 +46,12 @@ export function getOmniSidebarButtonsStatus({
   isTxStarted,
   isTxWaitingForApproval,
   safetySwitch,
+  shouldSwitchNetwork,
   walletAddress,
 }: GetOmniSidebarButtonsStatusParams) {
   const isPrimaryButtonDisabled =
     !!walletAddress &&
+    !shouldSwitchNetwork &&
     (!isFormValid ||
       hasErrors ||
       isFormFrozen ||
@@ -60,6 +63,7 @@ export function getOmniSidebarButtonsStatus({
 
   const isPrimaryButtonLoading =
     !!walletAddress &&
+    !shouldSwitchNetwork &&
     (isAllowanceLoading ||
       isSimulationLoading ||
       isTxInProgress ||

--- a/features/omni-kit/helpers/getOmniSidebarPrimaryButtonActions.ts
+++ b/features/omni-kit/helpers/getOmniSidebarPrimaryButtonActions.ts
@@ -15,16 +15,16 @@ interface GetOmniSidebarPrimaryButtonActionsParams {
   onDefault: () => void
   onDisconnected: () => void
   onSelectTransition: () => void
+  onSwitchNetwork: () => void
   onTransition: () => void
   onUpdated: () => void
   productType: string
   protocol: LendingProtocol
   quoteAddress: string
   quoteToken: string
-  shouldSwitchNetwork: boolean
   resolvedId?: string
+  shouldSwitchNetwork: boolean
   walletAddress?: string
-  onSwitchNetwork: () => void
 }
 
 export function getOmniSidebarPrimaryButtonActions({
@@ -42,6 +42,7 @@ export function getOmniSidebarPrimaryButtonActions({
   onDefault,
   onDisconnected,
   onSelectTransition,
+  onSwitchNetwork,
   onTransition,
   onUpdated,
   productType,
@@ -49,14 +50,13 @@ export function getOmniSidebarPrimaryButtonActions({
   quoteAddress,
   quoteToken,
   resolvedId,
-  walletAddress,
   shouldSwitchNetwork,
-  onSwitchNetwork,
+  walletAddress,
 }: GetOmniSidebarPrimaryButtonActionsParams) {
   switch (true) {
     case !walletAddress && currentStep === editingStep:
       return { action: onDisconnected }
-    case shouldSwitchNetwork:
+    case shouldSwitchNetwork && currentStep === editingStep:
       return { action: onSwitchNetwork }
     case isTxSuccess && isOpening:
       const resolvedCollateralUrl = isOracless ? collateralAddress : collateralToken

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -77,7 +77,7 @@ export function OmniFormView({
     form: { dispatch, state },
     position: { isSimulationLoading, resolvedId },
     dynamicMetadata: {
-      values: { interestRate, sidebarTitle, isFormEmpty },
+      values: { interestRate, sidebarTitle },
       validations: { isFormValid, isFormFrozen, hasErrors },
       filters: { flowStateFilter },
       elements: { dupeModal },
@@ -162,13 +162,13 @@ export function OmniFormView({
     isTxStarted,
     isTxWaitingForApproval,
     safetySwitch,
+    shouldSwitchNetwork,
     walletAddress,
   })
   const primaryButtonLabel = getOmniPrimaryButtonLabelKey({
     currentStep,
     hasAllowance: flowState.isAllowanceReady,
     hasDpmAddress: flowState.isProxyReady,
-    isFormEmpty,
     isOpening,
     isTransitionInProgress,
     isTxError,
@@ -205,9 +205,9 @@ export function OmniFormView({
     protocol,
     quoteAddress,
     quoteToken,
+    shouldSwitchNetwork,
     resolvedId,
     walletAddress,
-    shouldSwitchNetwork,
   })
   const textButtonAction = () => {
     setisTransitionWaitingForApproval(false)


### PR DESCRIPTION
# Fix network switching in Omnikit
  
## Changes 👷‍♀️

- Fixed an issue where form was trying to switch network on "Risk" step,
- fixed an issue where "Switch network" button was disabled on any of editing steps,
- fixed an issue with primary button label displaying gibberish in some edge cases,
- hidden token balances until user is connected to correct network to avoid confusion.