### PR TITLE
Redirect Ajna position from multiply to borrow

### DIFF
--- a/features/omni-kit/protocols/ajna/hooks/index.ts
+++ b/features/omni-kit/protocols/ajna/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useAjnaData'
+export * from './useAjnaRedirect'
 export * from './useAjnaTxHandler'

--- a/features/omni-kit/protocols/ajna/hooks/useAjnaData.ts
+++ b/features/omni-kit/protocols/ajna/hooks/useAjnaData.ts
@@ -3,7 +3,10 @@ import type { Tickers } from 'blockchain/prices.types'
 import { useProductContext } from 'components/context/ProductContextProvider'
 import type { DpmPositionData } from 'features/omni-kit/observables'
 import { isPoolOracless } from 'features/omni-kit/protocols/ajna/helpers'
+import { useAjnaRedirect } from 'features/omni-kit/protocols/ajna/hooks'
 import { getAjnaPositionAggregatedData$ } from 'features/omni-kit/protocols/ajna/observables'
+import type { AjnaSupportedNetworksIds } from 'features/omni-kit/protocols/ajna/types'
+import type { OmniProductType } from 'features/omni-kit/types'
 import { useObservable } from 'helpers/observableHook'
 import { one } from 'helpers/zero'
 import { useMemo } from 'react'
@@ -32,6 +35,14 @@ export function useAjnaData({
     quoteToken &&
     isPoolOracless({ collateralToken, quoteToken, networkId })
   )
+
+  void useAjnaRedirect({
+    collateralToken,
+    isOracless,
+    networkId: networkId as AjnaSupportedNetworksIds,
+    productType: dpmPositionData?.product as OmniProductType,
+    quoteToken,
+  })
 
   const [ajnaPositionData, ajnaPositionError] = useObservable(
     useMemo(

--- a/features/omni-kit/protocols/ajna/hooks/useAjnaRedirect.ts
+++ b/features/omni-kit/protocols/ajna/hooks/useAjnaRedirect.ts
@@ -1,0 +1,35 @@
+import { networksById } from 'blockchain/networks'
+import { isPoolSupportingMultiply } from 'features/omni-kit/protocols/ajna/helpers'
+import type { AjnaSupportedNetworksIds } from 'features/omni-kit/protocols/ajna/types'
+import { OmniProductType } from 'features/omni-kit/types'
+import { useRouter } from 'next/router'
+
+// TODO this interface won't be protocol specific and could be easily extended with the rest of protocol data
+export interface AjnaRedirectProps {
+  collateralToken?: string
+  isOracless: boolean
+  networkId: AjnaSupportedNetworksIds
+  productType?: OmniProductType
+  quoteToken?: string
+}
+
+export function useAjnaRedirect({
+  collateralToken,
+  isOracless,
+  networkId,
+  productType,
+  quoteToken,
+}: AjnaRedirectProps) {
+  const { replace } = useRouter()
+
+  // check redirects only if dpmPosition is loaded
+  if (productType && collateralToken && quoteToken) {
+    // redirect to borrow is multiply is open when it's not allowed
+    if (
+      isOracless ||
+      (productType === OmniProductType.Multiply &&
+        !isPoolSupportingMultiply({ collateralToken, networkId, quoteToken }))
+    )
+      void replace(`/${networksById[networkId].name}/ajna/borrow/${collateralToken}-${quoteToken}`)
+  }
+}


### PR DESCRIPTION
# [Redirect Ajna position from multiply to borrow](https://app.shortcut.com/oazo-apps/story/13345)
  
## Changes 👷‍♀️

- Brought back `useAjnaData` hook that redirects multiply UI to borrow if multiply is not supported for given token.