### PR TITLE
Adjust Omni dupe modal filtering

### DIFF
--- a/features/omni-kit/components/OmniDupePositionModal.tsx
+++ b/features/omni-kit/components/OmniDupePositionModal.tsx
@@ -6,6 +6,7 @@ import { getOraclessProductUrl } from 'features/ajna/pool-finder/helpers'
 import { OmniProductType } from 'features/omni-kit/types'
 import { useModalContext } from 'helpers/modalHook'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
+import type { LendingProtocol } from 'lendingProtocols'
 import { startCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -20,6 +21,7 @@ export interface OmniDupePositionModalProps {
   events: CreatePositionEvent[]
   networkId?: NetworkIds
   productType: OmniProductType
+  protocol: LendingProtocol
   quoteAddress: string
   quoteToken: string
   walletAddress?: string
@@ -32,6 +34,7 @@ export function OmniDupePositionModal({
   events,
   networkId = NetworkIds.MAINNET,
   productType,
+  protocol,
   quoteAddress,
   quoteToken,
   walletAddress,
@@ -62,7 +65,7 @@ export function OmniDupePositionModal({
         quoteToken,
       })}/${positionIds[0]}`
   const primaryText = hasMultiplyPositions
-    ? t('ajna.position-page.common.dupe-modal.cta-primary')
+    ? t('omni-kit.dupe-modal.cta-primary')
     : `${t('system.go-to-position')} #${positionIds[0]}`
 
   return (
@@ -73,15 +76,16 @@ export function OmniDupePositionModal({
           <Flex sx={{ flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
             <Image src={staticFilesRuntimeUrl('/static/img/safe.svg')} />
             <Heading variant="header5" sx={{ pt: 3, pb: 2 }}>
-              {t('ajna.position-page.common.dupe-modal.title', {
+              {t('omni-kit.dupe-modal.title', {
                 collateralToken,
                 productType: startCase(productType),
+                protocol: startCase(protocol),
                 quoteToken,
               })}
             </Heading>
             <Text as="p" variant="paragraph3" sx={{ pb: 4, color: 'neutral80' }}>
-              {t(`ajna.position-page.common.dupe-modal.description-${type}-${amount}`)}{' '}
-              {t('ajna.position-page.common.dupe-modal.help')}
+              {t(`omni-kit.dupe-modal.description-${type}-${amount}`)}{' '}
+              {t('omni-kit.dupe-modal.help')}
             </Text>
             <AppLink href={primaryLink} onClick={closeModal} sx={{ width: '100%' }}>
               <Button variant="primary" sx={{ width: '100%' }}>
@@ -89,7 +93,7 @@ export function OmniDupePositionModal({
               </Button>
             </AppLink>
             <Button variant="textual" onClick={closeModal} sx={{ mt: '24px', p: 0 }}>
-              {t('ajna.position-page.common.dupe-modal.cta-textual')}
+              {t('omni-kit.dupe-modal.cta-textual')}
             </Button>
           </Flex>
         </Box>

--- a/features/omni-kit/components/OmniDupePositionModal.tsx
+++ b/features/omni-kit/components/OmniDupePositionModal.tsx
@@ -10,7 +10,7 @@ import type { LendingProtocol } from 'lendingProtocols'
 import { startCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
-import { ajnaExtensionTheme } from 'theme'
+import type { Theme } from 'theme-ui'
 import { Box, Button, Flex, Heading, Image, Text, ThemeUIProvider } from 'theme-ui'
 import type { CreatePositionEvent } from 'types/ethers-contracts/AjnaProxyActions'
 
@@ -24,6 +24,7 @@ export interface OmniDupePositionModalProps {
   protocol: LendingProtocol
   quoteAddress: string
   quoteToken: string
+  theme?: Theme
   walletAddress?: string
 }
 
@@ -37,6 +38,7 @@ export function OmniDupePositionModal({
   protocol,
   quoteAddress,
   quoteToken,
+  theme = {},
   walletAddress,
 }: OmniDupePositionModalProps) {
   const { t } = useTranslation()
@@ -69,7 +71,7 @@ export function OmniDupePositionModal({
     : `${t('system.go-to-position')} #${positionIds[0]}`
 
   return (
-    <ThemeUIProvider theme={ajnaExtensionTheme}>
+    <ThemeUIProvider theme={theme}>
       <Modal sx={{ maxWidth: '445px', mx: 'auto' }} close={closeModal}>
         <Box sx={{ px: 4, pt: 5, pb: '24px' }}>
           <ModalCloseIcon close={closeModal} />

--- a/features/omni-kit/contexts/OmniProductContext.tsx
+++ b/features/omni-kit/contexts/OmniProductContext.tsx
@@ -5,7 +5,6 @@ import { useProductContext } from 'components/context/ProductContextProvider'
 import type { DetailsSectionNotificationItem } from 'components/DetailsSectionNotification'
 import type { SidebarSectionHeaderSelectItem } from 'components/sidebar/SidebarSectionHeaderSelect'
 import type { HeadlineDetailsProp } from 'components/vault/VaultHeadlineDetails'
-import type { OmniDupePositionModalProps } from 'features/omni-kit/components'
 import { useOmniGeneralContext } from 'features/omni-kit/contexts'
 import { formatSwapData } from 'features/omni-kit/protocols/ajna/helpers'
 import type { OmniBorrowFormState, useOmniBorrowFormReducto } from 'features/omni-kit/state/borrow'
@@ -24,15 +23,9 @@ import { OmniProductType } from 'features/omni-kit/types'
 import type { PositionHistoryEvent } from 'features/positionHistory/types'
 import { useObservable } from 'helpers/observableHook'
 import { useAccount } from 'helpers/useAccount'
-import type {
-  Dispatch,
-  FC,
-  PropsWithChildren,
-  ReactElement,
-  ReactNode,
-  SetStateAction,
-} from 'react'
+import type { Dispatch, FC, PropsWithChildren, ReactNode, SetStateAction } from 'react'
 import React, { useContext, useMemo, useState } from 'react'
+import type { Theme } from 'theme-ui'
 import type { CreatePositionEvent } from 'types/ethers-contracts/PositionCreated'
 
 interface OmniFeatureToggles {
@@ -66,7 +59,6 @@ interface CommonMetadataValues {
   sidebarTitle: string
 }
 interface CommonMetadataElements {
-  dupeModal: (props: OmniDupePositionModalProps) => ReactElement
   faq: ReactNode
   overviewBanner?: ReactNode
   overviewContent: ReactNode
@@ -90,6 +82,7 @@ export type LendingMetadata = CommonMetadata & {
   elements: CommonMetadataElements & {
     highlighterOrderInformation: ReactNode
   }
+  theme?: Theme
 }
 
 export type SupplyMetadata = CommonMetadata & {
@@ -107,6 +100,7 @@ export type SupplyMetadata = CommonMetadata & {
     extraEarnInputDeposit?: ReactNode
     extraEarnInputWithdraw?: ReactNode
   }
+  theme?: Theme
 }
 
 export type OmniMetadataParams =

--- a/features/omni-kit/protocols/ajna/helpers/getFlowStateFilter.ts
+++ b/features/omni-kit/protocols/ajna/helpers/getFlowStateFilter.ts
@@ -1,5 +1,6 @@
 import { extractLendingProtocolFromPositionCreatedEvent } from 'features/aave/services'
 import { omniBorrowishProducts } from 'features/omni-kit/constants'
+import { AJNA_RAW_PROTOCOL_NAME } from 'features/omni-kit/protocols/ajna/constants'
 import type { OmniProductType } from 'features/omni-kit/types'
 import { LendingProtocol } from 'lendingProtocols'
 import type { CreatePositionEvent } from 'types/ethers-contracts/AjnaProxyActions'
@@ -22,11 +23,15 @@ export function ajnaFlowStateFilter({
 }: AjnaFlowStateFilterParams): boolean {
   return (
     extractLendingProtocolFromPositionCreatedEvent(event) === LendingProtocol.Ajna &&
+    event.args.protocol === AJNA_RAW_PROTOCOL_NAME &&
     collateralAddress.toLowerCase() === event.args.collateralToken.toLowerCase() &&
     quoteAddress.toLocaleLowerCase() === event.args.debtToken.toLowerCase() &&
-    (productType.toLowerCase() === event.args.positionType.toLowerCase() ||
-      (omniBorrowishProducts.includes(productType) &&
-        omniBorrowishProducts.includes(event.args.positionType.toLowerCase() as OmniProductType)))
+    ((productType.toLowerCase() === 'earn' &&
+      productType.toLowerCase() === event.args.positionType.toLowerCase()) ||
+      (omniBorrowishProducts.includes(productType.toLocaleLowerCase() as OmniProductType) &&
+        omniBorrowishProducts.includes(
+          event.args.positionType.toLocaleLowerCase() as OmniProductType,
+        )))
   )
 }
 

--- a/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
@@ -5,7 +5,6 @@ import { PillAccordion } from 'components/PillAccordion'
 import faqBorrow from 'features/content/faqs/ajna/borrow/en'
 import faqEarn from 'features/content/faqs/ajna/earn/en'
 import faqMultiply from 'features/content/faqs/ajna/multiply/en'
-import { OmniDupePositionModal } from 'features/omni-kit/components/OmniDupePositionModal'
 import type {
   GetOmniMetadata,
   LendingMetadata,
@@ -61,6 +60,7 @@ import {
 import { zero } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { ajnaExtensionTheme } from 'theme'
 import type { CreatePositionEvent } from 'types/ethers-contracts/AjnaProxyActions'
 
 export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
@@ -157,7 +157,6 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
   }
 
   const riskSidebar = <AjnaFormContentRisk />
-  const dupeModal = OmniDupePositionModal
 
   switch (productType) {
     case OmniProductType.Borrow:
@@ -292,8 +291,8 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
             <AjnaTokensBannerController isOpening={isOpening} />
           ) : undefined,
           riskSidebar,
-          dupeModal,
         },
+        theme: ajnaExtensionTheme,
         featureToggles,
       } as LendingMetadata
 
@@ -440,7 +439,6 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
             <AjnaTokensBannerController isOpening={isOpening} isPriceBelowLup={isPriceBelowLup} />
           ) : undefined,
           riskSidebar,
-          dupeModal,
           extraEarnInput: (
             <AjnaEarnSlider
               isDisabled={
@@ -487,6 +485,7 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
             />
           ),
         },
+        theme: ajnaExtensionTheme,
         featureToggles,
       } as SupplyMetadata
     }

--- a/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
+++ b/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
@@ -121,7 +121,6 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
               productType={productType}
             />
           ),
-          dupeModal: () => <>Morpho dupe modal</>,
         },
         featureToggles: {
           safetySwitch: MorphoSafetySwitch,

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -110,12 +110,13 @@ export function OmniFormView({
       if (!hasDupePosition && filteredEvents.length) {
         setHasDupePosition(true)
         openModal(dupeModal, {
-          networkId,
           collateralAddress,
           collateralToken,
           dpmAccounts,
           events: filteredEvents,
+          networkId,
           productType,
+          protocol,
           quoteAddress,
           quoteToken,
           walletAddress,

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -4,6 +4,7 @@ import type { SidebarSectionProps } from 'components/sidebar/SidebarSection'
 import { SidebarSection } from 'components/sidebar/SidebarSection'
 import type { SidebarSectionHeaderDropdown } from 'components/sidebar/SidebarSectionHeader'
 import { ethers } from 'ethers'
+import { OmniDupePositionModal } from 'features/omni-kit/components'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import {
   getOmniFlowStateConfig,
@@ -80,8 +81,8 @@ export function OmniFormView({
       values: { interestRate, sidebarTitle },
       validations: { isFormValid, isFormFrozen, hasErrors },
       filters: { flowStateFilter },
-      elements: { dupeModal },
       featureToggles: { suppressValidation, safetySwitch },
+      theme,
     },
   } = useOmniProductContext(productType)
 
@@ -109,7 +110,7 @@ export function OmniFormView({
 
       if (!hasDupePosition && filteredEvents.length) {
         setHasDupePosition(true)
-        openModal(dupeModal, {
+        openModal(OmniDupePositionModal, {
           collateralAddress,
           collateralToken,
           dpmAccounts,
@@ -119,6 +120,7 @@ export function OmniFormView({
           protocol,
           quoteAddress,
           quoteToken,
+          theme,
           walletAddress,
         })
       }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2711,6 +2711,16 @@
         "success-open": "Your {{collateralToken}}/{{quoteToken}} {{protocol}} Position was created",
         "success-manage": "Your {{collateralToken}}/{{quoteToken}} {{protocol}} Position was updated"
       }
+    },
+    "dupe-modal": {
+      "title": "Are you sure you want to open a new {{collateralToken}}/{{quoteToken}} {{productType}} position on {{protocol}}?",
+      "description-borrower-singular": "You already have borrower position of this type.",
+      "description-borrower-plural": "You already have borrower positions of this type.",
+      "description-lender-singular": "You already have lender position of this type.",
+      "description-lender-plural": "You already have lender positions of this type.",
+      "help": "You can either create a new position or go to the existing one.",
+      "cta-primary": "Go to your Portfolio",
+      "cta-textual": "Open new position"
     }
   },
   "ajna": {
@@ -2855,16 +2865,6 @@
               ]
             }
           }
-        },
-        "dupe-modal": {
-          "title": "Are you sure you want to open a new {{productType}} position in the Ajna {{collateralToken}}/{{quoteToken}} pool?",
-          "description-borrower-singular": "You already have borrower position in this pool.",
-          "description-borrower-plural": "You already have borrower positions in this pool.",
-          "description-lender-singular": "You already have lender position in this pool.",
-          "description-lender-plural": "You already have lender positions in this pool.",
-          "help": "You can either create a new position in this pool or go to your existing position.",
-          "cta-primary": "Go to your Portfolio",
-          "cta-textual": "Open new position"
         },
         "notifications": {
           "being-liquidated": {


### PR DESCRIPTION
# [Adjust Omni dupe modal filtering](https://app.shortcut.com/oazo-apps/story/13433)
  
## Changes 👷‍♀️

- Updated `ajnaFlowStateFilter` to filter out positions that were open on old versions of Ajna.
- Set `OmniDupePositionModal` as default component with generic translation instead of Ajna ones.
- Added `theme` prop to `OmniDupePositionModal`.