### PR TITLE
Add notification-dummy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "packageManager": "yarn@1.22.21",
   "scripts": {
-    "start": "yarn get-config-types && next dev",
+    "start": "yarn get-config-types && next dev & node ./scripts/notification-dummy",
     "get-config-types": "node scripts/get-config-types.js",
     "start:debug": "NODE_OPTIONS='--inspect' next dev",
     "start:prod": "yarn migrate && next start",

--- a/scripts/notification-dummy.js
+++ b/scripts/notification-dummy.js
@@ -1,0 +1,14 @@
+const createServer = require('http').createServer
+const Server = require('socket.io').Server
+
+const httpServer = createServer()
+const io = new Server(httpServer, {})
+
+io.on('connection', (_socket) => {
+  console.log('Notification socket connected.')
+  io.on('message', (data) => {
+    console.log('Notification socket received message: ', data)
+  })
+})
+
+httpServer.listen(3001)


### PR DESCRIPTION
This pull request includes the addition of a notification-dummy file that sets up a socket.io server for handling notifications. This will allow for real-time communication between the server and clients.

Requires:
```
NOTIFICATIONS_HOST="http://localhost:3001"
```