### PR TITLE
Configurable aave/spark risk slider minimum/default values

### DIFF
--- a/features/aave/services/risk-slider-config.tsx
+++ b/features/aave/services/risk-slider-config.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 
 const getRiskRatio = (type: keyof ConfigResponseType['parameters']['aaveLike']['riskRatios']) => {
   const { aaveLike } = getLocalAppConfig('parameters')
-  return new BigNumber(aaveLike.riskRatios[type] || 5) // 5 as fallback
+  return new BigNumber(aaveLike?.riskRatios[type] || 5) // 5 as fallback, optional for the tests to pass
 }
 
 export const adjustRiskSliderConfig: AdjustRiskViewConfig = {

--- a/features/aave/services/risk-slider-config.tsx
+++ b/features/aave/services/risk-slider-config.tsx
@@ -1,8 +1,15 @@
 import { RiskRatio } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 import type { AdjustRiskViewConfig } from 'features/aave/components'
+import type { ConfigResponseType } from 'helpers/config'
+import { getLocalAppConfig } from 'helpers/config'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import React from 'react'
+
+const getRiskRatio = (type: keyof ConfigResponseType['parameters']['aaveLike']['riskRatios']) => {
+  const { aaveLike } = getLocalAppConfig('parameters')
+  return new BigNumber(aaveLike.riskRatios[type] || 5) // 5 as fallback
+}
 
 export const adjustRiskSliderConfig: AdjustRiskViewConfig = {
   liquidationPriceFormatter: (qty, token) => {
@@ -22,7 +29,7 @@ export const adjustRiskSliderConfig: AdjustRiskViewConfig = {
     translationKey: 'vault-changes.loan-to-value',
   },
   riskRatios: {
-    minimum: new RiskRatio(new BigNumber(5), RiskRatio.TYPE.COL_RATIO),
-    default: new RiskRatio(new BigNumber(5), RiskRatio.TYPE.COL_RATIO),
+    minimum: new RiskRatio(getRiskRatio('minimum'), RiskRatio.TYPE.COL_RATIO),
+    default: new RiskRatio(getRiskRatio('default'), RiskRatio.TYPE.COL_RATIO),
   },
 }

--- a/features/aave/services/risk-slider-config.tsx
+++ b/features/aave/services/risk-slider-config.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 
 const getRiskRatio = (type: keyof ConfigResponseType['parameters']['aaveLike']['riskRatios']) => {
   const { aaveLike } = getLocalAppConfig('parameters')
-  return new BigNumber(aaveLike?.riskRatios[type] || 5) // 5 as fallback, optional for the tests to pass
+  return new BigNumber(aaveLike?.riskRatios[type] ?? 5) // 5 as fallback, optional for the tests to pass
 }
 
 export const adjustRiskSliderConfig: AdjustRiskViewConfig = {


### PR DESCRIPTION
This pull request adds the ability to configure the risk slider configuration for aave/spark. It introduces a new function, `getRiskRatio`, which retrieves the risk ratio from the local app configuration. The risk ratios are now dynamically set based on the configuration values.