### PR TITLE
Navigation update

### DIFF
--- a/components/navigation/NavigationMenuDropdownContentListItem.tsx
+++ b/components/navigation/NavigationMenuDropdownContentListItem.tsx
@@ -18,7 +18,7 @@ export function NavigationMenuDropdownContentListItem({
   tags,
   title,
 }: NavigationMenuDropdownContentListItemProps) {
-  const textHoverEffect = {
+  const textHoverEffect: ThemeUIStyleObject = {
     content: 'attr(data-value)',
     position: 'absolute',
     top: 0,
@@ -29,7 +29,7 @@ export function NavigationMenuDropdownContentListItem({
   }
 
   return (
-    <Flex sx={{ alignItems: 'center', columnGap: '12px' }}>
+    <Flex sx={{ alignItems: 'center', columnGap: '12px', lineHeight: '24px',  }}>
       {icon && icon.position === 'global' && <NavigationMenuDropdownContentIcon {...icon} />}
       <Box>
         <Flex sx={{ alignItems: 'center', columnGap: 2 }}>
@@ -41,19 +41,17 @@ export function NavigationMenuDropdownContentListItem({
               'data-value': title,
               className: 'heading-with-effect',
             })}
-            sx={
-              {
-                color: 'primary100',
-                ...(hoverColor && {
-                  position: 'relative',
-                  transition: 'color 200ms',
-                  '&::after': {
-                    ...textHoverEffect,
-                    backgroundImage: hoverColor,
-                  },
-                }),
-              } as ThemeUIStyleObject
-            }
+            sx={{
+              color: 'primary100',
+              ...(hoverColor && {
+                position: 'relative',
+                transition: 'color 200ms',
+                '&::after': {
+                  ...textHoverEffect,
+                  backgroundImage: hoverColor,
+                },
+              }),
+            }}
           >
             {promoted && (
               <Box as="span" className="star-with-effect" sx={{ transition: 'color 200ms' }}>

--- a/components/navigation/NavigationMenuDropdownContentListItem.tsx
+++ b/components/navigation/NavigationMenuDropdownContentListItem.tsx
@@ -29,7 +29,7 @@ export function NavigationMenuDropdownContentListItem({
   }
 
   return (
-    <Flex sx={{ alignItems: 'center', columnGap: '12px', lineHeight: '24px',  }}>
+    <Flex sx={{ alignItems: 'center', columnGap: '12px', lineHeight: '24px' }}>
       {icon && icon.position === 'global' && <NavigationMenuDropdownContentIcon {...icon} />}
       <Box>
         <Flex sx={{ alignItems: 'center', columnGap: 2 }}>

--- a/features/navigation/controls/NavigationActionsController.tsx
+++ b/features/navigation/controls/NavigationActionsController.tsx
@@ -1,12 +1,10 @@
 import { MyPositionsOrb } from 'components/navigation/content/MyPositionsOrb'
 import { NotificationsOrb } from 'components/navigation/content/NotificationsOrb'
-import { SwapWidgetOrb } from 'components/navigation/content/SwapWidgetOrb'
 import { WalletOrb } from 'components/navigation/content/WalletOrb'
 import { WalletPanelMobile } from 'components/navigation/content/WalletPanelMobile'
 import { navigationBreakpoints } from 'components/navigation/Navigation.constants'
 import { NavigationNetworkSwitcherOrb } from 'components/navigation/NavigationNetworkSwitcher'
 import { ConnectButton } from 'features/web3OnBoard/connect-button'
-import { useAppConfig } from 'helpers/config'
 import React from 'react'
 import { useMediaQuery } from 'usehooks-ts'
 
@@ -15,7 +13,6 @@ interface NavigationActionsControllerProps {
 }
 
 export function NavigationActionsController({ isConnected }: NavigationActionsControllerProps) {
-  const { NewNavigation: isNewNavigationEnabled } = useAppConfig('features')
   const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3] - 1}px)`)
   const isViewBelowL = useMediaQuery(`(max-width: ${navigationBreakpoints[2] - 1}px)`)
   const isViewBelowM = useMediaQuery(`(max-width: ${navigationBreakpoints[1] - 1}px)`)
@@ -24,7 +21,6 @@ export function NavigationActionsController({ isConnected }: NavigationActionsCo
     <>
       {isConnected ? (
         <>
-          {!isNewNavigationEnabled && isViewBelowXl && <SwapWidgetOrb />}
           {isViewBelowXl && <MyPositionsOrb />}
           <NotificationsOrb />
           {<NavigationNetworkSwitcherOrb />}

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -8,16 +8,10 @@ import { getNavProductsPanel } from 'features/navigation/panels/getNavProductsPa
 import { getNavProtocolsPanel } from 'features/navigation/panels/getNavProtocolsPanel'
 import { getNavTokensPanel } from 'features/navigation/panels/getNavTokensPanel'
 import { getNavUseCasesPanel } from 'features/navigation/panels/getNavUseCasesPanel'
-import {
-  SWAP_WIDGET_CHANGE_SUBJECT,
-  type SwapWidgetChangeAction,
-} from 'features/swapWidget/SwapWidgetChange'
 import { useConnection } from 'features/web3OnBoard/useConnection'
 import { PROMO_CARD_COLLECTIONS_PARSERS } from 'handlers/product-hub/promo-cards'
-import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAppConfig } from 'helpers/config'
 import { getPortfolioLink } from 'helpers/get-portfolio-link'
-import { uiChanges } from 'helpers/uiChanges'
 import { useAccount } from 'helpers/useAccount'
 import { useTranslation } from 'next-i18next'
 import React, { useMemo } from 'react'
@@ -25,7 +19,6 @@ import { useMediaQuery } from 'usehooks-ts'
 
 export function NavigationController() {
   const { t } = useTranslation()
-  const { NewNavigation: isNewNavigationEnabled } = useAppConfig('features')
   const {
     productHub,
     config: { navigation },
@@ -56,34 +49,6 @@ export function NavigationController() {
     <>
       <Navigation
         links={[
-          ...(!isNewNavigationEnabled
-            ? [
-                {
-                  label: 'Borrow',
-                  link: INTERNAL_LINKS.borrow,
-                },
-                {
-                  label: 'Multiply',
-                  link: INTERNAL_LINKS.multiply,
-                },
-                {
-                  label: 'Earn',
-                  link: INTERNAL_LINKS.earn,
-                },
-              ]
-            : []),
-          ...(!isNewNavigationEnabled && isConnected && !isViewBelowXl
-            ? [
-                {
-                  label: 'Swap',
-                  onClick: () => {
-                    uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
-                      type: 'open',
-                    })
-                  },
-                },
-              ]
-            : []),
           ...(isConnected && !isViewBelowXl
             ? [
                 {
@@ -93,9 +58,7 @@ export function NavigationController() {
               ]
             : []),
         ]}
-        {...(isNewNavigationEnabled && {
-          panels: [navProductsPanel, navProtocolsPanel, navTokensPanel, navUseCasesPanel],
-        })}
+        panels={[navProductsPanel, navProtocolsPanel, navTokensPanel, navUseCasesPanel]}
         actions={<NavigationActionsController isConnected={isConnected} />}
       />
       <SwapWidgetShowHide />

--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -93,7 +93,10 @@ export const getNavProductsPanel = ({
                           protocol: item.protocol.toUpperCase(),
                         }),
                   tags: [
-                    [capitalize(item.protocol), lendingProtocolsByName[item.protocol].gradient],
+                    [
+                      lendingProtocolsByName[item.protocol].label,
+                      lendingProtocolsByName[item.protocol].gradient,
+                    ],
                     [capitalize(item.network), networksByName[item.network].gradient],
                   ] as NavigationMenuPanelListTags,
                   url: item.url,
@@ -119,7 +122,10 @@ export const getNavProductsPanel = ({
                   }),
                   description: t('nav.increase-your-exposure-against', { token: item.debtToken }),
                   tags: [
-                    [capitalize(item.protocol), lendingProtocolsByName[item.protocol].gradient],
+                    [
+                      lendingProtocolsByName[item.protocol].label,
+                      lendingProtocolsByName[item.protocol].gradient,
+                    ],
                     [capitalize(item.network), networksByName[item.network].gradient],
                   ] as NavigationMenuPanelListTags,
                   url: item.url,
@@ -149,7 +155,7 @@ export const getNavProductsPanel = ({
                   description: t('nav.discover-the-highest-ltv'),
                   tags: [
                     [
-                      capitalize(productBorrowNavItems.maxLtv.protocol),
+                      lendingProtocolsByName[productBorrowNavItems.maxLtv.protocol].label,
                       lendingProtocolsByName[productBorrowNavItems.maxLtv.protocol].gradient,
                     ],
                     [
@@ -174,7 +180,7 @@ export const getNavProductsPanel = ({
                   description: t('nav.find-the-lowest-rates'),
                   tags: [
                     [
-                      capitalize(productBorrowNavItems.fee.protocol),
+                      lendingProtocolsByName[productBorrowNavItems.fee.protocol].label,
                       lendingProtocolsByName[productBorrowNavItems.fee.protocol].gradient,
                     ],
                     [
@@ -196,7 +202,7 @@ export const getNavProductsPanel = ({
                   description: t('nav.get-paid-to-borrow'),
                   tags: [
                     [
-                      capitalize(productBorrowNavItems.liquidity.protocol),
+                      lendingProtocolsByName[productBorrowNavItems.liquidity.protocol].label,
                       lendingProtocolsByName[productBorrowNavItems.liquidity.protocol].gradient,
                     ],
                     [

--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -39,9 +39,8 @@ export const getNavProductsPanel = ({
   isConnected: boolean
   connect: () => void
 }): NavigationMenuPanelType => {
-  const productMultiplyNavItems = getProductMultiplyNavItems(promoCardsData, productHubItems)
-
   const productEarnNavItems = getProductEarnNavItems(promoCardsData, productHubItems)
+  const productMultiplyNavItems = getProductMultiplyNavItems(promoCardsData, productHubItems)
   const productBorrowNavItems = getProductBorrowNavItems(productHubItems)
 
   const widgetCallback = (variant: 'swap' | 'bridge') => {

--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -60,6 +60,7 @@ export const getNavProductsPanel = ({
           {
             title: t('nav.earn'),
             description: t('nav.products-earn'),
+            url: INTERNAL_LINKS.earn,
             list: {
               items: [
                 ...productEarnNavItems.map((item) => ({
@@ -99,15 +100,12 @@ export const getNavProductsPanel = ({
                   url: item.url,
                 })),
               ],
-              link: {
-                label: t('nav.products-more', { product: t('nav.earn') }),
-                url: INTERNAL_LINKS.earn,
-              },
             },
           },
           {
             title: t('nav.multiply'),
             description: t('nav.products-multiply'),
+            url: INTERNAL_LINKS.multiply,
             list: {
               items: [
                 ...productMultiplyNavItems.map((item) => ({
@@ -128,15 +126,12 @@ export const getNavProductsPanel = ({
                   url: item.url,
                 })),
               ],
-              link: {
-                label: t('nav.products-more', { product: t('nav.multiply') }),
-                url: INTERNAL_LINKS.multiply,
-              },
             },
           },
           {
             title: t('nav.borrow'),
             description: t('nav.products-borrow'),
+            url: INTERNAL_LINKS.borrow,
             list: {
               items: [
                 {
@@ -213,10 +208,6 @@ export const getNavProductsPanel = ({
                   url: productBorrowNavItems.liquidity.url,
                 },
               ],
-              link: {
-                label: t('nav.products-more', { product: t('nav.borrow') }),
-                url: INTERNAL_LINKS.borrow,
-              },
             },
           },
           {

--- a/handlers/product-hub/promo-cards/collections/aaveV3.ts
+++ b/handlers/product-hub/promo-cards/collections/aaveV3.ts
@@ -21,6 +21,10 @@ export function getAaveV3PromoCards(table: ProductHubItem[]) {
     ({ network, protocol }) =>
       protocol === LendingProtocol.AaveV3 && network === NetworkNames.optimismMainnet,
   )
+  const aaveV3ArbitrumProducts = table.filter(
+    ({ network, protocol }) =>
+      protocol === LendingProtocol.AaveV3 && network === NetworkNames.arbitrumMainnet,
+  )
   const aaveV3EthereumMultiplyProducts = aaveV3EthereumProducts.filter(({ product }) =>
     product.includes(ProductHubProductType.Multiply),
   )
@@ -28,6 +32,9 @@ export function getAaveV3PromoCards(table: ProductHubItem[]) {
     product.includes(ProductHubProductType.Earn),
   )
   const aaveV3OptimismMultiplyProducts = aaveV3OptimismProducts.filter(({ product }) =>
+    product.includes(ProductHubProductType.Multiply),
+  )
+  const aaveV3ArbitrumMultiplyProducts = aaveV3ArbitrumProducts.filter(({ product }) =>
     product.includes(ProductHubProductType.Multiply),
   )
 
@@ -52,6 +59,10 @@ export function getAaveV3PromoCards(table: ProductHubItem[]) {
     'USDC',
   ])
   const WBTCUSDCAaveV3OptimismMultiplyProduct = findByTokenPair(aaveV3OptimismMultiplyProducts, [
+    'WBTC',
+    'USDC',
+  ])
+  const WBTCUSDCAaveV3ArbitrumMultiplyProduct = findByTokenPair(aaveV3ArbitrumMultiplyProducts, [
     'WBTC',
     'USDC',
   ])
@@ -105,6 +116,14 @@ export function getAaveV3PromoCards(table: ProductHubItem[]) {
     protocol: LendingProtocol.AaveV3,
     network: NetworkNames.optimismMainnet,
   })
+  const promoCardWBTCUSDCAaveV3ArbitrumMultiply = parseMultiplyPromoCard({
+    collateralToken: 'WBTC',
+    debtToken: 'USDC',
+    pills: [getHighestMultiplePill(), getLongTokenPill('WBTC')],
+    product: WBTCUSDCAaveV3ArbitrumMultiplyProduct,
+    protocol: LendingProtocol.AaveV3,
+    network: NetworkNames.arbitrumMainnet,
+  })
 
   const promoCardWSTETHUSDCAaveV3EthereumEarn = parseEarnYieldLoopPromoCard({
     collateralToken: 'WSTETH',
@@ -123,5 +142,6 @@ export function getAaveV3PromoCards(table: ProductHubItem[]) {
     promoCardETHUSDCAaveV3OptimismMultiply,
     promoCardWSTETHUSDCAaveV3EthereumEarn,
     promoCardWBTCUSDCAaveV3OptimismMultiply,
+    promoCardWBTCUSDCAaveV3ArbitrumMultiply,
   }
 }

--- a/handlers/product-hub/promo-cards/home.ts
+++ b/handlers/product-hub/promo-cards/home.ts
@@ -27,7 +27,7 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     promoCardWBTCUSDCAaveV3EthereumMultiply,
     promoCardWSTETHUSDCAaveV3EthereumMultiply,
     promoCardETHUSDCAaveV3OptimismMultiply,
-    promoCardWBTCUSDCAaveV3OptimismMultiply,
+    promoCardWBTCUSDCAaveV3ArbitrumMultiply,
     promoCardWSTETHUSDCAaveV3EthereumEarn,
   } = getAaveV3PromoCards(table)
 
@@ -42,7 +42,7 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
     [ProductHubProductType.Multiply]: {
       default: [
         promoCardETHUSDCAaveV3EthereumMultiply,
-        promoCardWBTCUSDCAaveV3OptimismMultiply,
+        promoCardWBTCUSDCAaveV3ArbitrumMultiply,
         promoCardETHBMakerMultiply,
       ],
       tokens: {
@@ -54,7 +54,7 @@ export default function (table: ProductHubItem[]): ProductHubPromoCards {
         BTC: [
           promoCardWBTCBMakerMultiply,
           promoCardWBTCUSDCAaveV3EthereumMultiply,
-          promoCardWBTCUSDCAaveV3OptimismMultiply,
+          promoCardWBTCUSDCAaveV3ArbitrumMultiply,
         ],
         USDC: [
           promoCardETHUSDCAaveV3EthereumMultiply,


### PR DESCRIPTION
# [Navigation update](https://app.shortcut.com/oazo-apps/story/13400)
  
## Changes 👷‍♀️

- Made product types in Product tab clickable and removed "View all {{productType}} strategies" link.
- Fixed the way protocol names are displayed in navigation, e.g. "Aave V3" instead of "Aavev3".
- Replaced Optimism Aave WBTC/USDC multiply promo card with same thing, but on Arbitrum.
- Removed usage of `NewNavigation` feature flag.