### PR TITLE
Add AaveLikeLendingProtocol to AaveContext and getStrategyConfig

### DIFF
--- a/features/aave/aave-context.ts
+++ b/features/aave/aave-context.ts
@@ -4,6 +4,7 @@ import type { NetworkIds, NetworkNames } from 'blockchain/networks'
 import type { VaultType } from 'features/generalManageVault/vaultType.types'
 import type { DPMAccountStateMachine } from 'features/stateMachines/dpmAccount'
 import type { VaultHistoryEvent } from 'features/vaultHistory/vaultHistory.types'
+import type { AaveLikeLendingProtocol } from 'lendingProtocols'
 import type {
   AaveLikeReserveConfigurationData,
   AaveLikeServices,
@@ -34,6 +35,7 @@ export type AaveContext = AaveLikeServices & {
     networkName: NetworkNames,
     /* Accepts vaultType to further filter retrieved strategy assuming the product type has changed since position creation */
     vaultType: VaultType,
+    protocol: AaveLikeLendingProtocol,
   ) => Observable<IStrategyConfig>
   updateStrategyConfig?: (
     positionId: PositionId,

--- a/features/aave/helpers/getStrategyConfig.test.ts
+++ b/features/aave/helpers/getStrategyConfig.test.ts
@@ -2,6 +2,7 @@ import { NetworkNames } from 'blockchain/networks'
 import type { PositionCreated } from 'features/aave/services'
 import type { PositionId } from 'features/aave/types/position-id'
 import { VaultType } from 'features/generalManageVault/vaultType.types'
+import { LendingProtocol } from 'lendingProtocols'
 import type { AaveUserConfigurationResults } from 'lendingProtocols/aave-v2/pipelines'
 import type { Observable } from 'rxjs'
 import { of } from 'rxjs'
@@ -28,6 +29,7 @@ describe('getStrategyConfig', () => {
       { walletAddress: '0x123' },
       NetworkNames.ethereumMainnet,
       VaultType.Earn,
+      LendingProtocol.AaveV2,
     )
 
     observable$.subscribe((strategy) => {

--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -11,6 +11,7 @@ import {
 import type { IStrategyConfig, PositionId } from 'features/aave/types'
 import { VaultType } from 'features/generalManageVault/vaultType.types'
 import { productToVaultType } from 'helpers/productToVaultType'
+import type { AaveLikeLendingProtocol } from 'lendingProtocols'
 import { LendingProtocol } from 'lendingProtocols'
 import type { AaveUserConfigurationResults } from 'lendingProtocols/aave-v2/pipelines'
 import { isEqual } from 'lodash'
@@ -33,6 +34,7 @@ export function getStrategyConfig$(
   positionId: PositionId,
   networkName: NetworkNames,
   vaultType: VaultType,
+  protocol: AaveLikeLendingProtocol,
 ): Observable<IStrategyConfig> {
   const networkConfig = getNetworkByName(networkName)
 
@@ -51,9 +53,7 @@ export function getStrategyConfig$(
       )
     }),
     map(([aaveUserConfigurations, positions]) => {
-      const filteredPositions = positions?.filter((position) =>
-        aaveLikeProtocols.includes(position.protocol),
-      )
+      const filteredPositions = positions?.filter((position) => position.protocol === protocol)
 
       const lastCreatedPosition = filteredPositions?.pop()
       const vaultTypeIsUnknown = vaultType === VaultType.Unknown

--- a/pages/[networkOrProduct]/aave/[version]/[vault].tsx
+++ b/pages/[networkOrProduct]/aave/[version]/[vault].tsx
@@ -79,7 +79,7 @@ function WithAaveStrategy({
   } = useAaveContext(protocol, network)
   const [strategyConfig, strategyConfigError] = useObservable(
     /* If VaultType.Unknown specified then when loading config it'll try to respect position created type */
-    strategyConfig$(positionId, network, apiVaults[0]?.type || VaultType.Unknown),
+    strategyConfig$(positionId, network, apiVaults[0]?.type || VaultType.Unknown, protocol),
   )
   const [proxiesRelatedWithPosition, proxiesRelatedWithPositionError] = useObservable(
     proxiesRelatedWithPosition$(positionId, networkId),

--- a/pages/[networkOrProduct]/spark/[version]/[vault].tsx
+++ b/pages/[networkOrProduct]/spark/[version]/[vault].tsx
@@ -78,7 +78,7 @@ function WithSparkStrategy({
   } = useAaveContext(protocol, network)
   const [strategyConfig, strategyConfigError] = useObservable(
     /* If VaultType.Unknown specified then when loading config it'll try to respect position created type */
-    strategyConfig$(positionId, network, apiVaults[0]?.type || VaultType.Unknown),
+    strategyConfig$(positionId, network, apiVaults[0]?.type || VaultType.Unknown, protocol),
   )
   const [proxiesRelatedWithPosition, proxiesRelatedWithPositionError] = useObservable(
     proxiesRelatedWithPosition$(positionId, networkId),


### PR DESCRIPTION
This pull request adds the AaveLikeLendingProtocol to the AaveContext and getStrategyConfig functions. This allows for better integration with the Aave lending protocol.