### PR TITLE
Update Aave cumulative data and net value calculation

### DIFF
--- a/features/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/aave/components/AaveMultiplyPositionData.tsx
@@ -95,15 +95,16 @@ export function AaveMultiplyPositionData({
     aaveHistory[0].autoKind === 'aave-stop-loss' &&
     currentPosition.debt.amount.isZero()
 
-  const netValue =
-    strategyType === StrategyType.Long
-      ? currentPositionThings.netValueInDebtToken
-      : currentPositionThings.netValueInCollateralToken
+  const isLongPosition = strategyType === StrategyType.Long
 
-  const pnlWithoutFees = cumulatives?.cumulativeWithdraw
-    .plus(netValue)
-    .minus(cumulatives.cumulativeDeposit)
-    .div(cumulatives.cumulativeDeposit)
+  const netValueUsd = isLongPosition
+    ? currentPositionThings.netValueInDebtToken.times(debtTokenPrice)
+    : currentPositionThings.netValueInCollateralToken.times(collateralTokenPrice)
+
+  const pnlWithoutFees = cumulatives?.cumulativeWithdrawUSD
+    .plus(netValueUsd)
+    .minus(cumulatives.cumulativeDepositUSD)
+    .div(cumulatives.cumulativeDepositUSD)
 
   const isSparkPosition = lendingProtocol === LendingProtocol.SparkV3
   const isElligibleSparkPosition = checkElligibleSparkPosition(
@@ -166,16 +167,14 @@ export function AaveMultiplyPositionData({
               modal={
                 cumulatives ? (
                   <OmniMultiplyNetValueModal
-                    collateralPrice={collateralTokenPrice}
-                    collateralToken={collateralToken.symbol}
-                    cumulatives={{
-                      cumulativeDepositUSD: cumulatives.cumulativeDeposit,
-                      cumulativeWithdrawUSD: cumulatives.cumulativeWithdraw,
-                      cumulativeFeesUSD: cumulatives.cumulativeFees,
-                    }}
-                    netValue={netValue}
+                    netValueTokenPrice={collateralTokenPrice}
+                    netValueToken={collateralToken.symbol}
+                    cumulatives={cumulatives}
+                    netValueUSD={netValueUsd}
                     pnl={pnlWithoutFees}
-                    pnlUSD={pnlWithoutFees && cumulatives.cumulativeDeposit.times(pnlWithoutFees)}
+                    pnlUSD={
+                      pnlWithoutFees && cumulatives.cumulativeDepositUSD.times(pnlWithoutFees)
+                    }
                   />
                 ) : undefined
               }

--- a/features/aave/components/PositionInfoComponent.tsx
+++ b/features/aave/components/PositionInfoComponent.tsx
@@ -124,20 +124,12 @@ export const PositionInfoComponent = ({
             modal={
               cumulatives && (
                 <OmniMultiplyNetValueModal
-                  cumulatives={{
-                    cumulativeDepositUSD: cumulatives?.cumulativeDeposit,
-                    cumulativeWithdrawUSD: cumulatives.cumulativeWithdraw,
-                    cumulativeFeesUSD: cumulatives.cumulativeFees,
-                    cumulativeDeposit: cumulatives?.cumulativeDepositInQuoteToken,
-                    cumulativeWithdraw: cumulatives.cumulativeWithdrawInCollateralToken,
-                    cumulativeFees: cumulatives.cumulativeFeesInQuoteToken,
-                  }}
-                  netValue={netValueUsd}
+                  cumulatives={cumulatives}
+                  netValueUSD={netValueUsd}
                   pnl={pnlWithoutFees}
-                  pnlInCollateralToken
-                  pnlUSD={pnlWithoutFees && cumulatives.cumulativeDeposit.times(pnlWithoutFees)}
-                  collateralPrice={debtTokenPrice}
-                  collateralToken={position.debt.symbol}
+                  pnlUSD={pnlWithoutFees && cumulatives.cumulativeDepositUSD.times(pnlWithoutFees)}
+                  netValueTokenPrice={debtTokenPrice}
+                  netValueToken={position.debt.symbol}
                 />
               )
             }

--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -50,10 +50,13 @@ export function getStrategyConfig$(
         effectiveProxyAddress && effectiveProxyAddress === dpmProxy?.proxy && dpmProxy.user
           ? readPositionCreatedEvents$(dpmProxy.user, networkConfig.id)
           : of(undefined),
+        of(effectiveProxyAddress),
       )
     }),
-    map(([aaveUserConfigurations, positions]) => {
-      const filteredPositions = positions?.filter((position) => position.protocol === protocol)
+    map(([aaveUserConfigurations, positions, proxyAddress]) => {
+      const filteredPositions = positions?.filter(
+        (position) => position.protocol === protocol && position.proxyAddress === proxyAddress,
+      )
 
       const lastCreatedPosition = filteredPositions?.pop()
       const vaultTypeIsUnknown = vaultType === VaultType.Unknown

--- a/features/aave/services/get-aave-history-events.ts
+++ b/features/aave/services/get-aave-history-events.ts
@@ -86,21 +86,24 @@ export async function getAaveHistoryEvents(
         .sort((a, b) => b.timestamp - a.timestamp),
       positionCumulatives: positions[0]
         ? {
-            cumulativeDeposit: new BigNumber(positions[0].cumulativeDeposit),
-            cumulativeWithdraw: new BigNumber(positions[0].cumulativeWithdraw),
-            cumulativeFees: new BigNumber(positions[0].cumulativeFees),
-            cumulativeFeesInQuoteToken: new BigNumber(positions[0].cumulativeFeesInQuoteToken),
+            cumulativeDepositUSD: new BigNumber(positions[0].cumulativeDepositUSD),
             cumulativeDepositInQuoteToken: new BigNumber(
               positions[0].cumulativeDepositInQuoteToken,
-            ),
-            cumulativeWithdrawInQuoteToken: new BigNumber(
-              positions[0].cumulativeWithdrawInQuoteToken,
             ),
             cumulativeDespositInCollateralToken: new BigNumber(
               positions[0].cumulativeDespositInCollateralToken,
             ),
+            cumulativeWithdrawUSD: new BigNumber(positions[0].cumulativeWithdrawUSD),
+            cumulativeWithdrawInQuoteToken: new BigNumber(
+              positions[0].cumulativeWithdrawInQuoteToken,
+            ),
             cumulativeWithdrawInCollateralToken: new BigNumber(
               positions[0].cumulativeWithdrawInCollateralToken,
+            ),
+            cumulativeFeesUSD: new BigNumber(positions[0].cumulativeFeesUSD),
+            cumulativeFeesInQuoteToken: new BigNumber(positions[0].cumulativeFeesInQuoteToken),
+            cumulativeFeesInCollateralToken: new BigNumber(
+              positions[0].cumulativeFeesInCollateralToken,
             ),
           }
         : undefined,

--- a/features/omni-kit/components/details-section/modals/OmniMultiplyNetValueModal.tsx
+++ b/features/omni-kit/components/details-section/modals/OmniMultiplyNetValueModal.tsx
@@ -8,21 +8,18 @@ import type { Theme } from 'theme-ui'
 import { Box, Card, Divider, Flex, Grid, Text } from 'theme-ui'
 
 interface OmniMultiplyNetValueModalProps {
-  collateralPrice: BigNumber
-  collateralToken: string
+  netValueTokenPrice: BigNumber
+  netValueToken: string
   cumulatives: {
     cumulativeDepositUSD: BigNumber
     cumulativeWithdrawUSD: BigNumber
     cumulativeFeesUSD: BigNumber
-    cumulativeDeposit?: BigNumber
-    cumulativeWithdraw?: BigNumber
-    cumulativeFees?: BigNumber
+    cumulativeDepositInQuoteToken?: BigNumber
   }
-  netValue: BigNumber
+  netValueUSD: BigNumber
   pnl?: BigNumber
   pnlUSD?: BigNumber
   theme?: Theme
-  pnlInCollateralToken?: boolean
 }
 
 interface OmniMultiplyNetValueModalGridRowProps {
@@ -54,18 +51,17 @@ function OmniMultiplyNetValueModalGridRow({
 }
 
 export function OmniMultiplyNetValueModal({
-  collateralPrice,
-  collateralToken,
+  netValueTokenPrice,
+  netValueToken,
   cumulatives,
-  netValue,
+  netValueUSD,
   pnl,
   pnlUSD,
   theme,
-  pnlInCollateralToken = false,
 }: OmniMultiplyNetValueModalProps) {
   const { t } = useTranslation()
 
-  const netValueInCollateralToken = netValue.div(collateralPrice)
+  const netValueInCollateralToken = netValueUSD.div(netValueTokenPrice)
 
   return (
     <DetailsSectionContentSimpleModal
@@ -73,7 +69,7 @@ export function OmniMultiplyNetValueModal({
       description={
         <Trans
           i18nKey="omni-kit.content-card.net-value-modal.modal-description"
-          values={{ collateralPrice: formatCryptoBalance(collateralPrice) }}
+          values={{ netValueTokenPrice: formatCryptoBalance(netValueTokenPrice) }}
           components={{ strong: <Text sx={{ fontWeight: 'semiBold' }} /> }}
         />
       }
@@ -96,8 +92,8 @@ export function OmniMultiplyNetValueModal({
         </Text>
         <OmniMultiplyNetValueModalGridRow
           label={t('omni-kit.content-card.net-value-modal.modal-table-row-1')}
-          firstColumn={`${formatCryptoBalance(netValueInCollateralToken)} ${collateralToken}`}
-          secondColumn={`$${formatCryptoBalance(netValue)}`}
+          firstColumn={`${formatCryptoBalance(netValueInCollateralToken)} ${netValueToken}`}
+          secondColumn={`$${formatCryptoBalance(netValueUSD)}`}
         />
       </Grid>
       <Divider />
@@ -112,28 +108,22 @@ export function OmniMultiplyNetValueModal({
         <OmniMultiplyNetValueModalGridRow
           label={t('omni-kit.content-card.net-value-modal.modal-table-row-2')}
           firstColumn={`${formatCryptoBalance(
-            cumulatives.cumulativeDeposit
-              ? cumulatives.cumulativeDeposit
-              : cumulatives.cumulativeDepositUSD.div(collateralPrice),
-          )} ${collateralToken}`}
+            cumulatives.cumulativeDepositUSD.div(netValueTokenPrice),
+          )} ${netValueToken}`}
           secondColumn={`$${formatCryptoBalance(cumulatives.cumulativeDepositUSD)}`}
         />
         <OmniMultiplyNetValueModalGridRow
           label={t('omni-kit.content-card.net-value-modal.modal-table-row-3')}
           firstColumn={`${formatCryptoBalance(
-            cumulatives.cumulativeWithdraw
-              ? cumulatives.cumulativeWithdraw
-              : cumulatives.cumulativeWithdrawUSD.div(collateralPrice),
-          )} ${collateralToken}`}
+            cumulatives.cumulativeWithdrawUSD.div(netValueTokenPrice),
+          )} ${netValueToken}`}
           secondColumn={`$${formatCryptoBalance(cumulatives.cumulativeWithdrawUSD)}`}
         />
         <OmniMultiplyNetValueModalGridRow
           label={t('omni-kit.content-card.net-value-modal.modal-table-row-4')}
           firstColumn={`${formatCryptoBalance(
-            cumulatives.cumulativeFees
-              ? cumulatives.cumulativeFees
-              : cumulatives.cumulativeFeesUSD.div(collateralPrice),
-          )} ${collateralToken}`}
+            cumulatives.cumulativeFeesUSD.div(netValueTokenPrice),
+          )} ${netValueToken}`}
           secondColumn={`$${formatCryptoBalance(cumulatives.cumulativeFeesUSD)}`}
         />
       </Grid>
@@ -145,12 +135,7 @@ export function OmniMultiplyNetValueModal({
             </Text>
             <Text as="p" variant="paragraph1" sx={{ fontWeight: 'regular' }}>
               {pnlUSD.gte(zero) && '+'}
-              {formatDecimalAsPercent(pnl)} /
-              {pnlInCollateralToken && cumulatives.cumulativeDeposit
-                ? ` ${formatCryptoBalance(
-                    netValueInCollateralToken.minus(cumulatives.cumulativeDeposit),
-                  )} ${collateralToken}`
-                : ` $${formatCryptoBalance(pnlUSD)}`}
+              {formatDecimalAsPercent(pnl)} /{` $${formatCryptoBalance(pnlUSD)}`}
             </Text>
           </Card>
 

--- a/features/omni-kit/protocols/aave/history/types.ts
+++ b/features/omni-kit/protocols/aave/history/types.ts
@@ -15,12 +15,13 @@ export interface AaveHistoryEvent extends PositionHistoryEvent {
 }
 
 export type AaveCumulativeData = {
-  cumulativeDeposit: BigNumber
-  cumulativeWithdraw: BigNumber
-  cumulativeFees: BigNumber
-  cumulativeFeesInQuoteToken: BigNumber
+  cumulativeDepositUSD: BigNumber
   cumulativeDepositInQuoteToken: BigNumber
-  cumulativeWithdrawInQuoteToken: BigNumber
   cumulativeDespositInCollateralToken: BigNumber
+  cumulativeWithdrawUSD: BigNumber
+  cumulativeWithdrawInQuoteToken: BigNumber
   cumulativeWithdrawInCollateralToken: BigNumber
+  cumulativeFeesUSD: BigNumber
+  cumulativeFeesInQuoteToken: BigNumber
+  cumulativeFeesInCollateralToken: BigNumber
 }

--- a/features/omni-kit/protocols/ajna/components/details-section/parsers/useAjnaCardDataNetValueLending.tsx
+++ b/features/omni-kit/protocols/ajna/components/details-section/parsers/useAjnaCardDataNetValueLending.tsx
@@ -25,14 +25,14 @@ export function useAjnaCardDataNetValueLending({
   return {
     modal: (
       <OmniMultiplyNetValueModal
-        collateralPrice={collateralPrice}
-        collateralToken={collateralToken}
+        netValueTokenPrice={collateralPrice}
+        netValueToken={collateralToken}
         cumulatives={{
           cumulativeDepositUSD: cumulatives.borrowCumulativeDepositUSD,
           cumulativeWithdrawUSD: cumulatives.borrowCumulativeWithdrawUSD,
           cumulativeFeesUSD: cumulatives.borrowCumulativeFeesUSD,
         }}
-        netValue={netValue}
+        netValueUSD={netValue}
         pnl={pnl}
         pnlUSD={pnlUSD}
         theme={ajnaExtensionTheme}

--- a/features/positionHistory/types.ts
+++ b/features/positionHistory/types.ts
@@ -62,14 +62,15 @@ export interface PositionHistoryResponse {
 
 export type AaveCumulativesResponse = {
   id: string
-  cumulativeDeposit: string
-  cumulativeWithdraw: string
-  cumulativeFees: string
-  cumulativeFeesInQuoteToken: string
+  cumulativeDepositUSD: string
   cumulativeDepositInQuoteToken: string
-  cumulativeWithdrawInQuoteToken: string
   cumulativeDespositInCollateralToken: string
+  cumulativeWithdrawUSD: string
+  cumulativeWithdrawInQuoteToken: string
   cumulativeWithdrawInCollateralToken: string
+  cumulativeFeesUSD: string
+  cumulativeFeesInQuoteToken: string
+  cumulativeFeesInCollateralToken: string
 }
 export interface AavePositionHistoryResponse {
   depositTransfers: {

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -362,14 +362,15 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
     query AavePositionHistory($dpmProxyAddress: String) {
       positions(where: { account: $dpmProxyAddress }) {
         id
-        cumulativeDeposit
-        cumulativeWithdraw
-        cumulativeFees
-        cumulativeFeesInQuoteToken
+        cumulativeDepositUSD
         cumulativeDepositInQuoteToken
-        cumulativeWithdrawInQuoteToken
         cumulativeDespositInCollateralToken
+        cumulativeWithdrawUSD
+        cumulativeWithdrawInQuoteToken
         cumulativeWithdrawInCollateralToken
+        cumulativeFeesUSD
+        cumulativeFeesInQuoteToken
+        cumulativeFeesInCollateralToken
       }
       positionEvents(where: { account: $dpmProxyAddress }) {
         depositTransfers {

--- a/pages/[networkOrProduct]/aave/[version]/[vault].tsx
+++ b/pages/[networkOrProduct]/aave/[version]/[vault].tsx
@@ -18,7 +18,7 @@ import { VaultContainerSpinner, WithLoadingIndicator } from 'helpers/AppSpinner'
 import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { useObservable } from 'helpers/observableHook'
 import type { AaveLendingProtocol } from 'lendingProtocols'
-import { checkIfAave } from 'lendingProtocols'
+import { checkIfAave, LendingProtocol } from 'lendingProtocols'
 import type { GetServerSidePropsContext } from 'next'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
@@ -121,7 +121,13 @@ function WithAaveStrategy({
                 token2: _strategyConfig.tokens.debt,
               }}
               description="seo.multiply.description"
-              url={`/aave/v3/${positionId}`}
+              url={`/aave/${
+                {
+                  [LendingProtocol.AaveV2]: 'v2',
+                  [LendingProtocol.AaveV3]: 'v3',
+                  [LendingProtocol.SparkV3]: 'v3',
+                }[_strategyConfig.protocol]
+              }/${positionId}`}
             />
             <Grid gap={0} sx={{ width: '100%' }}>
               <BackgroundLight />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2703,7 +2703,7 @@
       },
       "net-value-modal": {
         "modal-title": "Net Value & Profit and Loss",
-        "modal-description": "The current net value is calculated based on the market price of <strong>${{collateralPrice}}</strong>",
+        "modal-description": "The current net value is calculated based on the market price of <strong>${{netValueTokenPrice}}</strong>",
         "modal-table-col-1": "Collateral Value",
         "modal-table-col-2": "$ Value",
         "modal-table-row-1": "Net Value",


### PR DESCRIPTION
This PR updates the Aave cumulative data and net value calculation. It includes changes to the `AaveCumulativeData` and `AaveCumulativesResponse` interfaces, as well as updates to the `useAjnaCardDataNetValueLending` and `getStrategyConfig$` functions. The changes ensure that the net value is calculated correctly based on the market price of the token and include improvements to the cumulative deposit, withdrawal, and fees calculations.