### PR TITLE
fix: warn on missing env

### DIFF
--- a/pages/api/rpcGateway.tsx
+++ b/pages/api/rpcGateway.tsx
@@ -2,7 +2,6 @@ import { NetworkNames } from 'blockchain/networks'
 import { getRemoteConfigWithCache } from 'helpers/config'
 import { configCacheTime, type ConfigResponseType } from 'helpers/config'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import getConfig from 'next/config'
 import type { AppConfigType } from 'types/config'
 
 /**
@@ -93,10 +92,10 @@ export default rpc
  * @throws If the RPC Gateway URL is not defined.
  */
 export function getRpcGatewayBaseUrl() {
-  const rpcGatewayUrl = getConfig()?.publicRuntimeConfig.rpcGatewayUrl ?? process.env.RPC_GATEWAY
+  const rpcGatewayUrl = process.env.RPC_GATEWAY
 
   if (!rpcGatewayUrl) {
-    throw new Error('RPC Gateway URL is not defined')
+    console.warn('RPC Gateway URL is not defined')
   }
 
   const rpcBase = `${rpcGatewayUrl}`


### PR DESCRIPTION
# [Title](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
warn instead of throw
  
## How to test 🧪
  <Please explain how to test your changes>
- step 1 ...
