### PR TITLE
Ensure precision while stetting allowance

### DIFF
--- a/features/omni-kit/helpers/getOmniFlowStateConfig.ts
+++ b/features/omni-kit/helpers/getOmniFlowStateConfig.ts
@@ -1,6 +1,9 @@
 import type BigNumber from 'bignumber.js'
 import { paybackAllAmountAllowanceMaxMultiplier } from 'features/omni-kit/constants'
-import { getMaxIncreasedValue } from 'features/omni-kit/protocols/ajna/helpers'
+import {
+  getMaxIncreasedValue,
+  INCREASED_VALUE_PRECISSION,
+} from 'features/omni-kit/protocols/ajna/helpers'
 import {
   OmniBorrowFormAction,
   OmniEarnFormAction,
@@ -89,7 +92,9 @@ export function getOmniFlowStateConfig({
 
       return {
         amount: getMaxIncreasedValue(state.paybackAmount, fee),
-        allowanceAmount: getMaxIncreasedValue(state.paybackAmount, fee).times(allowanceMultiplier),
+        allowanceAmount: getMaxIncreasedValue(state.paybackAmount, fee)
+          .times(allowanceMultiplier)
+          .dp(INCREASED_VALUE_PRECISSION),
         token: quoteToken,
       }
     case OmniBorrowFormAction.WithdrawBorrow:

--- a/features/omni-kit/protocols/ajna/helpers/getMaxIncreasedValue.ts
+++ b/features/omni-kit/protocols/ajna/helpers/getMaxIncreasedValue.ts
@@ -1,7 +1,7 @@
 import type BigNumber from 'bignumber.js'
 
 const FEE_FRACTION = 0.05
-const INCREASED_VALUE_PRECISSION = 6
+export const INCREASED_VALUE_PRECISSION = 6
 
 export function getMaxIncreasedValue(value: BigNumber, fee: BigNumber) {
   return value.plus(value.times(fee.times(FEE_FRACTION))).dp(INCREASED_VALUE_PRECISSION)


### PR DESCRIPTION
# Ensure precision while stetting allowance

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- allowance multiplier led to unwanted decimals, added `dp()`
  
## How to test 🧪
  <Please explain how to test your changes>

- try to set allowance while doing payback operation in ajna
