### PR TITLE
Ensure proper UX after closing position

### DIFF
--- a/features/omni-kit/controllers/borrow/OmniBorrowFormController.tsx
+++ b/features/omni-kit/controllers/borrow/OmniBorrowFormController.tsx
@@ -109,6 +109,12 @@ export function OmniBorrowFormController({ txHandler }: { txHandler: () => () =>
         },
       })}
       txHandler={txHandler}
+      txSuccessAction={() => {
+        if (uiDropdown === OmniSidebarBorrowPanel.Close) {
+          updateState('uiDropdown', OmniSidebarBorrowPanel.Collateral)
+          updateState('action', OmniBorrowFormAction.DepositBorrow)
+        }
+      }}
     >
       {currentStep === OmniSidebarStep.Risk && riskSidebar}
       {currentStep === OmniSidebarStep.Setup && <OmniBorrowFormContentDeposit />}

--- a/features/omni-kit/controllers/multiply/OmniMultiplyFormController.tsx
+++ b/features/omni-kit/controllers/multiply/OmniMultiplyFormController.tsx
@@ -108,6 +108,12 @@ export function OmniMultiplyFormController({ txHandler }: { txHandler: () => () 
         },
       })}
       txHandler={txHandler}
+      txSuccessAction={() => {
+        if (uiDropdown === OmniMultiplyPanel.Close) {
+          updateState('uiDropdown', OmniMultiplyPanel.Adjust)
+          updateState('action', OmniMultiplyFormAction.AdjustMultiply)
+        }
+      }}
     >
       {currentStep === OmniSidebarStep.Risk && riskSidebar}
       {currentStep === OmniSidebarStep.Setup && <OmniMultiplyFormContentOpen />}


### PR DESCRIPTION
# Ensure proper UX after closing position

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- after closing position TX is completed, Confirm button redirects to default form action
  
## How to test 🧪
  <Please explain how to test your changes>

- close multiply or borrow position, after clicking confirm user should moved to adjust or deposit & borrow action
