### PR TITLE
Product Finder filtering fixes

### DIFF
--- a/features/productHub/controls/ProductHubFiltersController.tsx
+++ b/features/productHub/controls/ProductHubFiltersController.tsx
@@ -58,12 +58,12 @@ export const ProductHubFiltersController: FC<ProductHubFiltersControllerProps> =
   const debtTokens = useMemo(
     () =>
       uniq(data.map((item) => item.secondaryToken))
+        .sort()
         .map((item) => ({
           label: item,
           value: item,
           token: item,
-        }))
-        .sort((a, b) => (a.value > b.value ? 1 : -1)),
+        })),
     [data],
   )
   const secondaryTokens = useMemo(
@@ -77,11 +77,13 @@ export const ProductHubFiltersController: FC<ProductHubFiltersControllerProps> =
             ? [item.primaryToken]
             : []),
         ]),
-      ).map((item) => ({
-        label: item,
-        value: item,
-        token: item,
-      })),
+      )
+        .sort()
+        .map((item) => ({
+          label: item,
+          value: item,
+          token: item,
+        })),
     [data, selectedToken],
   )
 

--- a/features/productHub/helpers/getStrippedQueryString.ts
+++ b/features/productHub/helpers/getStrippedQueryString.ts
@@ -1,25 +1,19 @@
 import type { ProductHubQueryString } from 'features/productHub/types'
-import { ProductHubProductType } from 'features/productHub/types'
 
 interface GetStrippedQueryString {
-  selectedProduct: ProductHubProductType
   queryString: ProductHubQueryString
 }
 
 export function getStrippedQueryString({
-  selectedProduct,
   queryString,
 }: GetStrippedQueryString): ProductHubQueryString {
   return Object.keys(queryString).reduce<ProductHubQueryString>(
     (sum, key) => ({
       ...sum,
-      ...(!(
-        (key === 'debtToken' && selectedProduct !== ProductHubProductType.Borrow) ||
-        ((key === 'secondaryToken' || key === 'strategy') &&
-          selectedProduct !== ProductHubProductType.Multiply)
-      ) && {
-        [key]: queryString[key as keyof typeof queryString],
-      }),
+      ...(key !== 'debtToken' &&
+        key !== 'secondaryToken' && {
+          [key]: queryString[key as keyof typeof queryString],
+        }),
     }),
     {},
   )

--- a/features/productHub/meta.ts
+++ b/features/productHub/meta.ts
@@ -67,7 +67,7 @@ export const productHubTokenOptions: { [key: string]: HeaderSelectorOption } = {
   },
   ETH: {
     title: 'Ether',
-    description: 'ETH/stETH/rETH',
+    description: 'ETH/stETH/cbETH/rETH',
     value: 'ETH',
     icon: getToken('ETH').iconCircle,
   },
@@ -79,7 +79,7 @@ export const productHubTokenOptions: { [key: string]: HeaderSelectorOption } = {
   },
   USDC: {
     title: 'USDCoin',
-    description: 'USDC',
+    description: 'USDC/USDbC',
     value: 'USDC',
     icon: getToken('USDC').iconCircle,
   },

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -131,9 +131,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
                 token,
               }),
             )
-            setQueryString(
-              getStrippedQueryString({ selectedProduct: _selectedProduct, queryString }),
-            )
+            setQueryString(getStrippedQueryString({ queryString }))
           }}
         />
         {intro ? (

--- a/handlers/product-hub/helpers/get-token-group.ts
+++ b/handlers/product-hub/helpers/get-token-group.ts
@@ -16,6 +16,8 @@ export function getTokenGroup(token: string): string {
       return 'BTC'
     case 'SDAI':
       return 'DAI'
+    case 'USDBC':
+      return 'USDC'
     default:
       return token
   }

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/arbitrum-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/arbitrum-mainnet.ts
@@ -1,107 +1,92 @@
 import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
-import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
-import { ProductHubProductType } from 'features/productHub/types'
+import { type ProductHubItemWithoutAddress, ProductHubProductType } from 'features/productHub/types'
+import { getTokenGroup } from 'handlers/product-hub/helpers'
+import type { AaveProductHubItemSeed } from 'handlers/product-hub/update-handlers/aaveV3/aave-v3-products/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {
     collateral: 'ETH',
     debt: 'USDC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wstETH',
     debt: 'USDC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wBTC',
     debt: 'USDC',
-    group: 'BTC',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'ETH',
     debt: 'DAI',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wstETH',
     debt: 'DAI',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'rETH',
     debt: 'DAI',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'rETH',
     debt: 'USDC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wBTC',
     debt: 'DAI',
-    group: 'BTC',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wstETH',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'earn'],
   },
   {
     collateral: 'rETH',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'earn'],
   },
   {
     collateral: 'DAI',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'DAI',
     debt: 'wBTC',
-    group: 'BTC',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'USDC',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'USDC',
     debt: 'wBTC',
-    group: 'BTC',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
@@ -113,8 +98,9 @@ const borrowProducts = aaveSeed
     return {
       product: [ProductHubProductType.Borrow],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       depositToken: strategy.deposit?.toUpperCase() ?? strategy.collateral.toUpperCase(),
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.arbitrumMainnet,
@@ -128,8 +114,9 @@ const earnProducts = aaveSeed
     return {
       product: [ProductHubProductType.Earn],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.arbitrumMainnet,
       protocol: LendingProtocol.AaveV3,
@@ -145,8 +132,9 @@ const multiplyProducts = aaveSeed
     return {
       product: [ProductHubProductType.Multiply],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       network: NetworkNames.arbitrumMainnet,
       protocol: LendingProtocol.AaveV3,
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/base-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/base-mainnet.ts
@@ -1,30 +1,26 @@
 import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
-import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
-import { ProductHubProductType } from 'features/productHub/types'
+import { type ProductHubItemWithoutAddress, ProductHubProductType } from 'features/productHub/types'
+import { getTokenGroup } from 'handlers/product-hub/helpers'
+import type { AaveProductHubItemSeed } from 'handlers/product-hub/update-handlers/aaveV3/aave-v3-products/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {
     collateral: 'ETH',
     debt: 'USDbC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'cbETH',
     debt: 'USDbC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'cbETH',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'long',
     types: ['earn'],
   },
@@ -36,8 +32,9 @@ const borrowProducts = aaveSeed
     return {
       product: [ProductHubProductType.Borrow],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       depositToken: strategy.deposit?.toUpperCase() ?? strategy.collateral.toUpperCase(),
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.baseMainnet,
@@ -51,8 +48,9 @@ const earnProducts = aaveSeed
     return {
       product: [ProductHubProductType.Earn],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.baseMainnet,
       protocol: LendingProtocol.AaveV3,
@@ -68,8 +66,9 @@ const multiplyProducts = aaveSeed
     return {
       product: [ProductHubProductType.Multiply],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       network: NetworkNames.baseMainnet,
       protocol: LendingProtocol.AaveV3,
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/ethereum-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/ethereum-mainnet.ts
@@ -1,7 +1,6 @@
 import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
-import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
-import { ProductHubProductType } from 'features/productHub/types'
+import { type ProductHubItemWithoutAddress, ProductHubProductType } from 'features/productHub/types'
 import { LendingProtocol } from 'lendingProtocols'
 
 export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddress[] = [
@@ -76,7 +75,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Multiply],
     primaryToken: 'ETH',
-    primaryTokenGroup: 'ETH',
     secondaryToken: 'USDC',
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
@@ -87,7 +85,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Borrow],
     primaryToken: 'ETH',
-    primaryTokenGroup: 'ETH',
     secondaryToken: 'USDC',
     depositToken: 'ETH',
     label: 'ETH/USDC',
@@ -175,7 +172,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Multiply],
     primaryToken: 'DAI',
-    primaryTokenGroup: 'DAI',
     secondaryToken: 'ETH',
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
@@ -186,7 +182,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Borrow],
     primaryToken: 'DAI',
-    primaryTokenGroup: 'DAI',
     secondaryToken: 'ETH',
     depositToken: 'DAI',
     label: 'DAI/ETH',
@@ -196,8 +191,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Multiply],
     primaryToken: 'DAI',
-    primaryTokenGroup: 'DAI',
     secondaryToken: 'WBTC',
+    secondaryTokenGroup: 'BTC',
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'DAI/WBTC',
@@ -207,8 +202,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Borrow],
     primaryToken: 'DAI',
-    primaryTokenGroup: 'DAI',
     secondaryToken: 'WBTC',
+    secondaryTokenGroup: 'BTC',
     depositToken: 'DAI',
     label: 'DAI/WBTC',
     network: NetworkNames.ethereumMainnet,
@@ -217,7 +212,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Multiply],
     primaryToken: 'ETH',
-    primaryTokenGroup: 'ETH',
     secondaryToken: 'DAI',
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
@@ -228,7 +222,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Borrow],
     primaryToken: 'ETH',
-    primaryTokenGroup: 'ETH',
     secondaryToken: 'DAI',
     depositToken: 'ETH',
     label: 'ETH/DAI',
@@ -280,7 +273,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Multiply],
     primaryToken: 'USDC',
-    primaryTokenGroup: 'USDC',
     secondaryToken: 'ETH',
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
@@ -291,7 +283,6 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Borrow],
     primaryToken: 'USDC',
-    primaryTokenGroup: 'USDC',
     secondaryToken: 'ETH',
     depositToken: 'USDC',
     label: 'USDC/ETH',
@@ -301,8 +292,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Multiply],
     primaryToken: 'USDC',
-    primaryTokenGroup: 'USDC',
     secondaryToken: 'WBTC',
+    secondaryTokenGroup: 'BTC',
     network: NetworkNames.ethereumMainnet,
     protocol: LendingProtocol.AaveV3,
     label: 'USDC/WBTC',
@@ -312,8 +303,8 @@ export const aaveV3EthereumMainnetProductHubProducts: ProductHubItemWithoutAddre
   {
     product: [ProductHubProductType.Borrow],
     primaryToken: 'USDC',
-    primaryTokenGroup: 'USDC',
     secondaryToken: 'WBTC',
+    secondaryTokenGroup: 'BTC',
     depositToken: 'USDC',
     label: 'USDC/WBTC',
     network: NetworkNames.ethereumMainnet,

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/optimims-mainnet.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/optimims-mainnet.ts
@@ -1,86 +1,74 @@
 import { EarnStrategies } from '@prisma/client'
 import { NetworkNames } from 'blockchain/networks'
-import type { ProductHubItemWithoutAddress } from 'features/productHub/types'
-import { ProductHubProductType } from 'features/productHub/types'
+import { type ProductHubItemWithoutAddress, ProductHubProductType } from 'features/productHub/types'
+import { getTokenGroup } from 'handlers/product-hub/helpers'
+import type { AaveProductHubItemSeed } from 'handlers/product-hub/update-handlers/aaveV3/aave-v3-products/types'
 import { LendingProtocol } from 'lendingProtocols'
-
-import type { AaveProductHubItemSeed } from './aave-product-hub-item-seed'
 
 const aaveSeed: AaveProductHubItemSeed[] = [
   {
     collateral: 'ETH',
     debt: 'USDC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wstETH',
     debt: 'USDC',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wBTC',
     debt: 'USDC',
-    group: 'BTC',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'ETH',
     debt: 'DAI',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wstETH',
     debt: 'DAI',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wBTC',
     debt: 'DAI',
-    group: 'BTC',
     strategyType: 'long',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'wstETH',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'long',
     types: ['borrow', 'earn'],
   },
   {
     collateral: 'DAI',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'DAI',
     debt: 'wBTC',
-    group: 'BTC',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'USDC',
     debt: 'ETH',
-    group: 'ETH',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
   {
     collateral: 'USDC',
     debt: 'wBTC',
-    group: 'BTC',
     strategyType: 'short',
     types: ['borrow', 'multiply'],
   },
@@ -92,8 +80,9 @@ const borrowProducts = aaveSeed
     return {
       product: [ProductHubProductType.Borrow],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       depositToken: strategy.deposit?.toUpperCase() ?? strategy.collateral.toUpperCase(),
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.optimismMainnet,
@@ -107,8 +96,9 @@ const earnProducts = aaveSeed
     return {
       product: [ProductHubProductType.Earn],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,
       network: NetworkNames.optimismMainnet,
       protocol: LendingProtocol.AaveV3,
@@ -124,8 +114,9 @@ const multiplyProducts = aaveSeed
     return {
       product: [ProductHubProductType.Multiply],
       primaryToken: strategy.collateral.toUpperCase(),
-      primaryTokenGroup: strategy.group.toUpperCase(),
+      primaryTokenGroup: getTokenGroup(strategy.collateral.toUpperCase()),
       secondaryToken: strategy.debt.toUpperCase(),
+      secondaryTokenGroup: getTokenGroup(strategy.debt.toUpperCase()),
       network: NetworkNames.optimismMainnet,
       protocol: LendingProtocol.AaveV3,
       label: `${strategy.collateral.toUpperCase()}/${strategy.debt.toUpperCase()}`,

--- a/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/types.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aave-v3-products/types.ts
@@ -3,6 +3,5 @@ export interface AaveProductHubItemSeed {
   debt: string
   deposit?: string
   strategyType: 'long' | 'short'
-  group: string
   types: Array<'borrow' | 'earn' | 'multiply'>
 }


### PR DESCRIPTION
# [Product Finder filtering fixes](https://app.shortcut.com/oazo-apps/story/13446)
  
## Changes 👷‍♀️

- Fixed an issue where selecting an option on natural language caused to app crash - from now on selecting token in NLS resets debt/secondary token filter. Keeping those filters sometimes lead to a situation where selected debt token wasn't even available on a list of possible debt tokens for selected collateral.
- Fixed an issue where a lot of Aave products weren't displayed properly in filters because of wrong configuration.
- Simplified sorting in debt token and added same kind of sorting to secondary token filter.
- Added USDC group that contains USDBC.