### PR TITLE
Fix net value calculation for long Aave earn products

### DIFF
--- a/features/aave/components/ManageSectionComponent.tsx
+++ b/features/aave/components/ManageSectionComponent.tsx
@@ -89,6 +89,7 @@ export function ManageSectionComponent({
             collateralTokenReserveData={_collateralTokenReserveData}
             debtTokenReserveData={_debtTokenReserveData}
             productType={strategyConfig.type}
+            strategyType={strategyConfig.strategyType}
           />
         )}
       </WithLoadingIndicator>


### PR DESCRIPTION
This pull request adds the `strategyType` prop to the `ManageSectionComponent` and `PositionInfoComponent` components. It also fixes the net value calculation for long Aave earn products.