### PR TITLE
Omni redirect when lack of url params

### DIFF
--- a/features/omni-kit/server/getOmniServerSideProps.ts
+++ b/features/omni-kit/server/getOmniServerSideProps.ts
@@ -16,6 +16,16 @@ export async function getOmniServerSideProps({
 }) {
   const networkName = query.networkOrProduct as NetworkNames
   const [productType, pair, positionId = undefined] = query.position as string[]
+
+  if (!productType || !pair) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/not-found',
+      },
+    }
+  }
+
   const [collateralToken, quoteToken] = pair.split('-')
 
   const castedProductType = productType as OmniProductType


### PR DESCRIPTION
# Omni redirect when lack of url params

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added condition when getting server side props to check whether required params are defined, if not redirect to not-found
  
## How to test 🧪
  <Please explain how to test your changes>

- visit `/ethereum/ajna/680`, you should be redirected to not found page
