### PR TITLE
Filter out 'earnings' and 'pnl' details in PortfolioPositionBlock

### DIFF
--- a/components/portfolio/positions/PortfolioPositionBlock.tsx
+++ b/components/portfolio/positions/PortfolioPositionBlock.tsx
@@ -78,9 +78,11 @@ export const PortfolioPositionBlock = ({ position }: { position: PortfolioPositi
           }),
         }}
       >
-        {position.details.map((detail) => (
-          <PortfolioPositionBlockDetail detail={detail} key={detail.type} />
-        ))}
+        {position.details
+          .filter((detail) => !['earnings', 'pnl'].includes(detail.type))
+          .map((detail) => (
+            <PortfolioPositionBlockDetail detail={detail} key={detail.type} />
+          ))}
       </Flex>
       {!position.availableToMigrate && (
         <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>


### PR DESCRIPTION
This pull request filters out the 'earnings' and 'pnl' details in the PortfolioPositionBlock component.