### PR TITLE
Liquidation price ratio as abs value

### DIFF
--- a/features/omni-kit/components/details-section/parsers/useOmniCardDataLiquidationPrice.ts
+++ b/features/omni-kit/components/details-section/parsers/useOmniCardDataLiquidationPrice.ts
@@ -28,7 +28,7 @@ export function useOmniCardDataLiquidationPrice({
       !ratioToCurrentPrice.isZero() && {
         footnote: [
           '',
-          formatDecimalAsPercent(ratioToCurrentPrice),
+          formatDecimalAsPercent(ratioToCurrentPrice.abs()),
           {
             key: `omni-kit.content-card.liquidation-price.footnote-${
               ratioToCurrentPrice.gt(zero) ? 'below' : 'above'

--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
@@ -65,7 +65,7 @@ export function OmniMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
     },
     position: { cachedPosition, isSimulationLoading, currentPosition, swap },
     dynamicMetadata: {
-      values: { shouldShowDynamicLtv },
+      values: { shouldShowDynamicLtv, afterPositionDebt },
     },
   } = useOmniProductContext(OmniProductType.Multiply)
 
@@ -143,8 +143,7 @@ export function OmniMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
     slippageLimit: formatDecimalAsPercent(slippage),
     positionDebt: `${formatCryptoBalance(positionData.debtAmount)} ${quoteToken}`,
     afterPositionDebt:
-      simulationData?.debtAmount &&
-      `${formatCryptoBalance(simulationData?.debtAmount)} ${quoteToken}`,
+      afterPositionDebt && `${formatCryptoBalance(afterPositionDebt)} ${quoteToken}`,
     loanToValue: formatDecimalAsPercent(positionData.riskRatio.loanToValue),
     afterLoanToValue:
       simulationData?.riskRatio &&


### PR DESCRIPTION
# [Liquidation price ratio as abs value](https://app.shortcut.com/oazo-apps/story/13699/away-from-current-price-in-liquidation-shown-as-negative-in-short-position?vc_group_by=day&ct_workflow=all&cf_workflow=500000053)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- since we are using 'above' or 'below', liquidation ratio should be display as absolute value
- use resolved after position debt in multiply form order
  
## How to test 🧪
  <Please explain how to test your changes>

- on Ajna lending position liquidation ratio in card footer should be displayed as absolute value
