### PR TITLE
Fixed issue with persisting after label

### DIFF
--- a/features/omni-kit/protocols/ajna/components/details-section/AjnaContentFooterBorrow.tsx
+++ b/features/omni-kit/protocols/ajna/components/details-section/AjnaContentFooterBorrow.tsx
@@ -27,7 +27,6 @@ interface AjnaContentFooterBorrowProps {
   position: AjnaPosition
   quotePrice: BigNumber
   quoteToken: string
-  afterAvailableToBorrow?: BigNumber
   simulation?: AjnaPosition
 }
 
@@ -43,7 +42,6 @@ export function AjnaContentFooterBorrow({
   position,
   quotePrice,
   quoteToken,
-  afterAvailableToBorrow,
   simulation,
 }: AjnaContentFooterBorrowProps) {
   const netValue = position.collateralAmount
@@ -92,7 +90,7 @@ export function AjnaContentFooterBorrow({
   })
 
   const availableToBorrowContentCardCommonData = useOmniCardDataTokensValue({
-    afterTokensAmount: afterAvailableToBorrow,
+    afterTokensAmount: simulation?.debtAvailable(),
     tokensAmount: position.debtAvailable(),
     tokensSymbol: quoteToken,
     translationCardName: 'available-to-borrow',

--- a/features/omni-kit/protocols/ajna/components/details-section/AjnaLendingDetailsSectionFooter.tsx
+++ b/features/omni-kit/protocols/ajna/components/details-section/AjnaLendingDetailsSectionFooter.tsx
@@ -39,7 +39,6 @@ export const AjnaLendingDetailsSectionFooter: FC<AjnaLendingDetailsSectionFooter
   productType,
   quotePrice,
   quoteToken,
-  afterAvailableToBorrow,
   simulation,
 }) => {
   return productType === OmniProductType.Borrow ? (
@@ -55,7 +54,6 @@ export const AjnaLendingDetailsSectionFooter: FC<AjnaLendingDetailsSectionFooter
       position={position}
       quotePrice={quotePrice}
       quoteToken={quoteToken}
-      afterAvailableToBorrow={afterAvailableToBorrow}
       simulation={simulation}
     />
   ) : (


### PR DESCRIPTION
# Fixed issue with persisting after label

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue where after available to borrow value in details footer section was based on cached value from simulation
  
## How to test 🧪
  <Please explain how to test your changes>

- no after label after tx is finished in details footer section
