### PR TITLE
Fix Dynamic max LTV in post tx order information

### DIFF
--- a/features/omni-kit/components/sidebars/OmniFormContentTransaction.tsx
+++ b/features/omni-kit/components/sidebars/OmniFormContentTransaction.tsx
@@ -1,6 +1,5 @@
 import { MessageCard } from 'components/MessageCard'
 import { useOmniGeneralContext } from 'features/omni-kit/contexts'
-import type { OmniIsCachedPosition } from 'features/omni-kit/types'
 import { LendingProtocolLabel } from 'lendingProtocols'
 import { upperFirst } from 'lodash'
 import { useTranslation } from 'next-i18next'
@@ -10,7 +9,7 @@ import { OpenVaultAnimation } from 'theme/animations'
 import { Text } from 'theme-ui'
 
 interface OmniFormContentTransactionProps {
-  orderInformation: FC<OmniIsCachedPosition>
+  orderInformation: FC
 }
 
 export function OmniFormContentTransaction({
@@ -40,7 +39,7 @@ export function OmniFormContentTransaction({
       {isTxInProgress && <OpenVaultAnimation />}
       {isTxSuccess && (
         <>
-          <OrderInformation cached />
+          <OrderInformation />
           <MessageCard messages={[t('heads-up')]} type="warning" withBullet={false} />
         </>
       )}

--- a/features/omni-kit/components/sidebars/borrow/OmniBorrowFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/borrow/OmniBorrowFormOrder.tsx
@@ -13,7 +13,7 @@ import { one } from 'helpers/zero'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-export function OmniBorrowFormOrder({ cached = false }: { cached?: boolean }) {
+export function OmniBorrowFormOrder() {
   const { t } = useTranslation()
   const {
     environment: { collateralToken, isOracless, isShort, priceFormat, quoteToken },
@@ -28,7 +28,7 @@ export function OmniBorrowFormOrder({ cached = false }: { cached?: boolean }) {
   } = useOmniProductContext(OmniProductType.Borrow)
 
   const { positionData, simulationData } = resolveIfCachedPosition({
-    cached,
+    cached: isTxSuccess,
     cachedPosition,
     currentPosition,
   })
@@ -42,7 +42,7 @@ export function OmniBorrowFormOrder({ cached = false }: { cached?: boolean }) {
       ? normalizeValue(one.div(simulationData.liquidationPrice))
       : simulationData.liquidationPrice)
 
-  const isLoading = !cached && isSimulationLoading
+  const isLoading = !isTxSuccess && isSimulationLoading
   const formatted = {
     collateralLocked: `${formatCryptoBalance(positionData.collateralAmount)} ${collateralToken}`,
     afterCollateralLocked:
@@ -127,7 +127,7 @@ export function OmniBorrowFormOrder({ cached = false }: { cached?: boolean }) {
           change: formatted.afterAvailableToBorrow,
           isLoading,
         },
-        ...(isTxSuccess && cached
+        ...(isTxSuccess
           ? [
               {
                 label: t('system.total-cost'),

--- a/features/omni-kit/components/sidebars/borrow/OmniBorrowFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/borrow/OmniBorrowFormOrder.tsx
@@ -99,7 +99,7 @@ export function OmniBorrowFormOrder() {
               },
             ]
           : []),
-        ...(!isOracless && shouldShowDynamicLtv
+        ...(!isOracless && shouldShowDynamicLtv({ includeCache: true })
           ? [
               {
                 label: t('system.dynamic-max-ltv'),

--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
@@ -250,7 +250,7 @@ export function OmniMultiplyFormOrder() {
           change: formatted.afterLoanToValue,
           isLoading,
         },
-        ...(shouldShowDynamicLtv
+        ...(shouldShowDynamicLtv({ includeCache: true })
           ? [
               {
                 label: t('system.dynamic-max-ltv'),

--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
@@ -44,7 +44,7 @@ const actionsWithFee = [
   OmniMultiplyFormAction.WithdrawMultiply,
 ]
 
-export function OmniMultiplyFormOrder({ cached = false }: { cached?: boolean }) {
+export function OmniMultiplyFormOrder() {
   const { t } = useTranslation()
   const {
     environment: {
@@ -70,13 +70,13 @@ export function OmniMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
   } = useOmniProductContext(OmniProductType.Multiply)
 
   const { positionData, simulationData } = resolveIfCachedPosition({
-    cached,
+    cached: isTxSuccess,
     cachedPosition,
     currentPosition,
   })
 
   const swapData = resolveIfCachedSwap({
-    cached,
+    cached: isTxSuccess,
     currentSwap: swap?.current,
     cachedSwap: swap?.cached,
   })
@@ -132,7 +132,7 @@ export function OmniMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
     ? buyingOrSellingCollateral.times(OAZO_FEE.times(collateralPrice))
     : zero
 
-  const isLoading = !cached && isSimulationLoading
+  const isLoading = !isTxSuccess && isSimulationLoading
   const formatted = {
     totalExposure: `${formatCryptoBalance(positionData.collateralAmount)} ${collateralToken}`,
     afterTotalExposure:
@@ -260,7 +260,7 @@ export function OmniMultiplyFormOrder({ cached = false }: { cached?: boolean }) 
               },
             ]
           : []),
-        ...(isTxSuccess && cached
+        ...(isTxSuccess
           ? [
               {
                 label: t('system.total-cost'),

--- a/features/omni-kit/contexts/OmniProductContext.tsx
+++ b/features/omni-kit/contexts/OmniProductContext.tsx
@@ -15,7 +15,6 @@ import type {
 } from 'features/omni-kit/state/multiply'
 import type {
   OmniGenericPosition,
-  OmniIsCachedPosition,
   OmniSimulationCommon,
   OmniValidations,
 } from 'features/omni-kit/types'
@@ -95,7 +94,7 @@ export type SupplyMetadata = CommonMetadata & {
   elements: CommonMetadataElements & {
     earnExtraUiDropdownContent?: ReactNode
     earnFormOrder: ReactNode
-    earnFormOrderAsElement: FC<OmniIsCachedPosition>
+    earnFormOrderAsElement: FC
     extraEarnInput?: ReactNode
     extraEarnInputDeposit?: ReactNode
     extraEarnInputWithdraw?: ReactNode

--- a/features/omni-kit/contexts/OmniProductContext.tsx
+++ b/features/omni-kit/contexts/OmniProductContext.tsx
@@ -65,6 +65,8 @@ interface CommonMetadataElements {
   riskSidebar?: ReactNode
 }
 
+export type ShouldShowDynamicLtvMetadata = (params: { includeCache: boolean }) => boolean
+
 export type LendingMetadata = CommonMetadata & {
   handlers?: OmniLendingMetadataHandlers
   values: CommonMetadataValues & {
@@ -76,7 +78,7 @@ export type LendingMetadata = CommonMetadata & {
     debtMax: BigNumber
     debtMin: BigNumber
     paybackMax: BigNumber
-    shouldShowDynamicLtv: boolean
+    shouldShowDynamicLtv: ShouldShowDynamicLtvMetadata
   }
   elements: CommonMetadataElements & {
     highlighterOrderInformation: ReactNode

--- a/features/omni-kit/protocols/ajna/metadata/AjnaClaimCollateralFormOrderInformation.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/AjnaClaimCollateralFormOrderInformation.tsx
@@ -3,16 +3,13 @@ import { InfoSection } from 'components/infoSection/InfoSection'
 import { OmniGasEstimation } from 'features/omni-kit/components/sidebars'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { resolveIfCachedPosition } from 'features/omni-kit/protocols/ajna/helpers'
-import type { AjnaIsCachedPosition } from 'features/omni-kit/protocols/ajna/types'
 import { OmniProductType } from 'features/omni-kit/types'
 import { formatCryptoBalance, formatUsdValue } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import type { FC } from 'react'
 import React from 'react'
 
-export const AjnaClaimCollateralFormOrderInformation: FC<AjnaIsCachedPosition> = ({
-  cached = false,
-}) => {
+export const AjnaClaimCollateralFormOrderInformation: FC = () => {
   const { t } = useTranslation()
   const {
     environment: { quoteToken, collateralToken },
@@ -23,12 +20,12 @@ export const AjnaClaimCollateralFormOrderInformation: FC<AjnaIsCachedPosition> =
   } = useOmniProductContext(OmniProductType.Earn)
 
   const { positionData, simulationData } = resolveIfCachedPosition({
-    cached,
+    cached: isTxSuccess,
     cachedPosition,
     currentPosition,
   })
 
-  const isLoading = !cached && isSimulationLoading
+  const isLoading = !isTxSuccess && isSimulationLoading
   const formatted = {
     totalDeposited: `${formatCryptoBalance(
       (positionData as AjnaEarnPosition).collateralTokenAmount.times(
@@ -58,7 +55,7 @@ export const AjnaClaimCollateralFormOrderInformation: FC<AjnaIsCachedPosition> =
           label: t('ajna.position-page.earn.common.form.collateral-available-to-withdraw'),
           value: formatted.availableToWithdraw,
         },
-        ...(isTxSuccess && cached
+        ...(isTxSuccess
           ? [
               {
                 label: t('system.total-cost'),

--- a/features/omni-kit/protocols/ajna/metadata/AjnaEarnFormOrder.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/AjnaEarnFormOrder.tsx
@@ -3,15 +3,11 @@ import {
   AjnaClaimCollateralFormOrderInformation,
   AjnaEarnFormOrderInformation,
 } from 'features/omni-kit/protocols/ajna/metadata'
-import {
-  OmniEarnFormAction,
-  type OmniIsCachedPosition,
-  OmniProductType,
-} from 'features/omni-kit/types'
+import { OmniEarnFormAction, OmniProductType } from 'features/omni-kit/types'
 import type { FC } from 'react'
 import React from 'react'
 
-export const AjnaEarnFormOrder: FC<OmniIsCachedPosition> = ({ cached = false }) => {
+export const AjnaEarnFormOrder: FC = () => {
   const {
     form: {
       state: { action },
@@ -19,8 +15,8 @@ export const AjnaEarnFormOrder: FC<OmniIsCachedPosition> = ({ cached = false }) 
   } = useOmniProductContext(OmniProductType.Earn)
 
   return action === OmniEarnFormAction.ClaimEarn ? (
-    <AjnaClaimCollateralFormOrderInformation cached={cached} />
+    <AjnaClaimCollateralFormOrderInformation />
   ) : (
-    <AjnaEarnFormOrderInformation cached={cached} />
+    <AjnaEarnFormOrderInformation />
   )
 }

--- a/features/omni-kit/protocols/ajna/metadata/AjnaEarnFormOrderInformation.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/AjnaEarnFormOrderInformation.tsx
@@ -4,7 +4,6 @@ import { InfoSection } from 'components/infoSection/InfoSection'
 import { OmniGasEstimation } from 'features/omni-kit/components/sidebars'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { resolveIfCachedPosition } from 'features/omni-kit/protocols/ajna/helpers'
-import type { AjnaIsCachedPosition } from 'features/omni-kit/protocols/ajna/types'
 import { OmniProductType } from 'features/omni-kit/types'
 import {
   formatCryptoBalance,
@@ -16,7 +15,7 @@ import { useTranslation } from 'next-i18next'
 import type { FC } from 'react'
 import React from 'react'
 
-export const AjnaEarnFormOrderInformation: FC<AjnaIsCachedPosition> = ({ cached = false }) => {
+export const AjnaEarnFormOrderInformation: FC = () => {
   const { t } = useTranslation()
 
   const {
@@ -29,7 +28,7 @@ export const AjnaEarnFormOrderInformation: FC<AjnaIsCachedPosition> = ({ cached 
   } = useOmniProductContext(OmniProductType.Earn)
 
   const { positionData: _positionData, simulationData: _simulationData } = resolveIfCachedPosition({
-    cached,
+    cached: isTxSuccess,
     cachedPosition,
     currentPosition,
   })
@@ -47,7 +46,7 @@ export const AjnaEarnFormOrderInformation: FC<AjnaIsCachedPosition> = ({ cached 
   const withAjnaFee =
     earnDepositFee?.gt(zero) && !positionData.pool.lowestUtilizedPriceIndex.isZero()
 
-  const isLoading = !cached && isSimulationLoading
+  const isLoading = !isTxSuccess && isSimulationLoading
   const formatted = {
     amountToLend: `${formatCryptoBalance(positionData.quoteTokenAmount)} ${quoteToken}`,
     afterAmountToLend:
@@ -109,7 +108,7 @@ export const AjnaEarnFormOrderInformation: FC<AjnaIsCachedPosition> = ({ cached 
               },
             ]
           : []),
-        ...(isTxSuccess && cached
+        ...(isTxSuccess
           ? [
               {
                 label: t('system.total-cost'),

--- a/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
@@ -10,6 +10,7 @@ import type {
   LendingMetadata,
   ProductContextWithBorrow,
   ProductContextWithEarn,
+  ShouldShowDynamicLtvMetadata,
   SupplyMetadata,
 } from 'features/omni-kit/contexts'
 import { useOmniGeneralContext } from 'features/omni-kit/contexts'
@@ -182,12 +183,15 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
       )})`
 
       const lendingContext = productContext as ProductContextWithBorrow
-      const shouldShowDynamicLtv =
-        resolveIfCachedPosition({
-          cached: isTxSuccess,
-          cachedPosition: { position: cachedPosition, simulation: cachedSimulation },
-          currentPosition: { position, simulation },
-        }).positionData?.pool.lowestUtilizedPriceIndex.gt(zero) ?? false
+      const shouldShowDynamicLtv: ShouldShowDynamicLtvMetadata = ({ includeCache }) => {
+        return (
+          resolveIfCachedPosition({
+            cached: includeCache && isTxSuccess,
+            cachedPosition: { position: cachedPosition, simulation: cachedSimulation },
+            currentPosition: { position, simulation },
+          }).positionData?.pool.lowestUtilizedPriceIndex.gt(zero) ?? false
+        )
+      }
 
       const resolvedSimulation = simulation || cachedSimulation
       const afterPositionDebt = resolvedSimulation?.debtAmount.plus(originationFee)
@@ -274,7 +278,7 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
               productType={productType}
               quotePrice={quotePrice}
               quoteToken={quoteToken}
-              shouldShowDynamicLtv={shouldShowDynamicLtv}
+              shouldShowDynamicLtv={shouldShowDynamicLtv({ includeCache: false })}
               simulation={simulation}
             />
           ),

--- a/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/useAjnaMetadata.tsx
@@ -38,6 +38,7 @@ import {
   getAjnaValidation,
   getOriginationFee,
   isPoolWithRewards,
+  resolveIfCachedPosition,
 } from 'features/omni-kit/protocols/ajna/helpers'
 import {
   AjnaEarnFormOrder,
@@ -100,7 +101,7 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
       gasEstimation,
     },
     steps: { currentStep },
-    tx: { txDetails },
+    tx: { isTxSuccess, txDetails },
   } = useOmniGeneralContext()
 
   const {
@@ -166,6 +167,9 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
         | AjnaPosition
         | undefined
 
+      const cachedPosition = productContext.position.cachedPosition?.position as
+        | AjnaPosition
+        | undefined
       const cachedSimulation = productContext.position.cachedPosition?.simulation as
         | AjnaPosition
         | undefined
@@ -178,7 +182,12 @@ export const useAjnaMetadata: GetOmniMetadata = (productContext) => {
       )})`
 
       const lendingContext = productContext as ProductContextWithBorrow
-      const shouldShowDynamicLtv = position.pool.lowestUtilizedPriceIndex.gt(zero)
+      const shouldShowDynamicLtv =
+        resolveIfCachedPosition({
+          cached: isTxSuccess,
+          cachedPosition: { position: cachedPosition, simulation: cachedSimulation },
+          currentPosition: { position, simulation },
+        }).positionData?.pool.lowestUtilizedPriceIndex.gt(zero) ?? false
 
       const resolvedSimulation = simulation || cachedSimulation
       const afterPositionDebt = resolvedSimulation?.debtAmount.plus(originationFee)

--- a/features/omni-kit/protocols/ajna/types.ts
+++ b/features/omni-kit/protocols/ajna/types.ts
@@ -5,10 +5,6 @@ export type AjnaGenericPosition = AjnaPosition | AjnaEarnPosition
 
 export type AjnaUpdateState<T> = (key: keyof T, value: T[keyof T]) => void
 
-export interface AjnaIsCachedPosition {
-  cached?: boolean
-}
-
 export type AjnaSupportedNetworksIds =
   | NetworkIds.MAINNET
   | NetworkIds.GOERLI

--- a/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
+++ b/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
@@ -59,7 +59,6 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
         | undefined
 
       const changeVariant = getOmniBorrowishChangeVariant({ simulation, isOracless })
-      const shouldShowDynamicLtv = true
 
       return {
         notifications,
@@ -75,7 +74,7 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
           interestRate,
           isFormEmpty: false,
           afterBuyingPower: simulation ? simulation.buyingPower : undefined,
-          shouldShowDynamicLtv,
+          shouldShowDynamicLtv: () => true,
           debtMin: new BigNumber(20),
           debtMax: new BigNumber(3000),
           changeVariant,

--- a/features/omni-kit/types.ts
+++ b/features/omni-kit/types.ts
@@ -38,10 +38,6 @@ export type OmniSidebarStepsSet = {
 
 export type OmniCloseTo = 'collateral' | 'quote'
 
-export interface OmniIsCachedPosition {
-  cached?: boolean
-}
-
 export enum OmniSidebarBorrowPanel {
   Adjust = 'adjust',
   Close = 'close',


### PR DESCRIPTION
# [Fix Dynamic max LTV in post tx order information](https://app.shortcut.com/oazo-apps/story/13692/dynamic-max-ltv-value-is-really-big)
  
## Changes 👷‍♀️

- Removed `cached` prop from form order components.
- Included `shouldShowDynamicLtv` value to use `resolveIfCachedPosition`.