### PR TITLE
Cap max value of multiply slider to 0.99

### DIFF
--- a/features/omni-kit/components/sidebars/OmniAdjustSlider.tsx
+++ b/features/omni-kit/components/sidebars/OmniAdjustSlider.tsx
@@ -13,7 +13,7 @@ import { arrow_right } from 'theme/icons'
 import { Flex, Text } from 'theme-ui'
 
 const min = new BigNumber(0.01)
-const max = new BigNumber(1)
+const max = new BigNumber(0.99)
 const openFlowInitialLtv = new BigNumber(0.1)
 
 interface OmniAdjustSliderProps {


### PR DESCRIPTION
# Cap max value of multiply slider to 0.99

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- Cap max value of multiply slider to 0.99
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory