### PR TITLE
Use ETH_ACTUAL address instead of ETH in Morpho Blue dependencies

### DIFF
--- a/features/omni-kit/protocols/morpho-blue/helpers/getMorphoParameters.ts
+++ b/features/omni-kit/protocols/morpho-blue/helpers/getMorphoParameters.ts
@@ -76,7 +76,7 @@ export const getMorphoParameters = async ({
       tokens: {
         WETH: addressesConfig.tokens.WETH.address,
         DAI: addressesConfig.tokens.DAI.address,
-        ETH: addressesConfig.tokens.ETH.address,
+        ETH: addressesConfig.tokens.ETH_ACTUAL.address,
         USDC: addressesConfig.tokens.USDC.address,
         USDT: addressesConfig.tokens.USDT.address,
         WBTC: addressesConfig.tokens.WBTC.address,


### PR DESCRIPTION
# Use ETH_ACTUAL address instead of ETH in Morpho Blue dependencies

Context: https://discord.com/channels/837076147694207067/1168506682691821578/1197197062375211018
  
## Changes 👷‍♀️

- Changed address of ETH in `getMorphoParameters` method.