### PR TITLE
Bump addresses 0.1.34

### DIFF
--- a/blockchain/tokens/base.ts
+++ b/blockchain/tokens/base.ts
@@ -7,7 +7,7 @@ const { base } = ADDRESSES
 
 export const tokensBase = {
   ETH: contractDesc(erc20, base.common.WETH),
-  ETH_ACTUAL: contractDesc(erc20, base.common.WETH), // most likely to be updated
+  ETH_ACTUAL: contractDesc(erc20, base.common.ETH),
   CBETH: contractDesc(erc20, base.common.CBETH),
   DAI: contractDesc(erc20, base.common.DAI),
   FRAX: contractDesc(erc20, base.common.FRAX),

--- a/features/omni-kit/protocols/ajna/actions/multiply.ts
+++ b/features/omni-kit/protocols/ajna/actions/multiply.ts
@@ -71,7 +71,7 @@ export const ajnaActionOpenMultiply = ({
       addresses: {
         DAI: getNetworkContracts(networkId).tokens.DAI.address,
         // Currently tokens.ETH is being mapped to WETH
-        ETH: getNetworkContracts(networkId, 1).tokens.ETH_ACTUAL.address,
+        ETH: getNetworkContracts(networkId).tokens.ETH_ACTUAL.address,
         WSTETH: getNetworkContracts(networkId).tokens.WSTETH.address,
         USDC: getNetworkContracts(networkId).tokens.USDC.address,
         WBTC: getNetworkContracts(networkId).tokens.WBTC.address,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@lifi/wallet-management": "^2.3.4",
     "@lifi/widget": "2.4.6",
     "@metamask/eth-sig-util": "^5.0.2",
-    "@oasisdex/addresses": "0.1.32",
+    "@oasisdex/addresses": "0.1.34",
     "@oasisdex/automation": "^1.5.9-alpha5",
     "@oasisdex/dma-library": "0.6.3",
     "@oasisdex/multiply": "^0.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,10 +2373,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oasisdex/addresses@0.1.32":
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.1.32.tgz#6453127482c24fd18366a24ad30c9f1d37c56a1b"
-  integrity sha512-tTbpxa334KkegJ7DgvTpC7N1y0UZ4o1eb0+ZHNNdh3AerFaHmq3lc/astLHo+z7IycSzt3dhi08cTIxFrWnnjA==
+"@oasisdex/addresses@0.1.34":
+  version "0.1.34"
+  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.1.34.tgz#b6fd87da7ff10896cd7f38ddd7a385cd85f8e7a2"
+  integrity sha512-GrDzoK4ONSlrdgtCgHNXqcYXzgkKOYnFWoF7Uuwxslce9UYi1Slzl/KZHlQdla9WI1cKNnHwCHETgyw+E9zrvg==
 
 "@oasisdex/automation@^1.5.9-alpha5":
   version "1.5.9-alpha5"


### PR DESCRIPTION
# Bump addresses 0.1.34

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bumped addresses 0.1.34
- updated base multiply actions to use ETH_ACTUAL
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
