### PR TITLE
Fix Morpho Blue url in Product Finder

### DIFF
--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -106,7 +106,7 @@ export function getActionUrl({
 
       return `/vaults/${openUrl}/${ilkInUrl}`
     case LendingProtocol.MorphoBlue:
-      return `/${network}/morpho/${product[0]}/${primaryToken}-${secondaryToken}`
+      return `/${network}/${LendingProtocol.MorphoBlue}/${product[0]}/${primaryToken}-${secondaryToken}`
     case LendingProtocol.SparkV3:
       return getAaveLikeViewStrategyUrl({
         version: 'v3',


### PR DESCRIPTION
# Fix Morpho Blue url in Product Finder
  
## Changes 👷‍♀️

- Used `LendingProtocol.MorphoBlue` instead of hardcoded value.