### PR TITLE
Morph Blue positions in Portfolio

### DIFF
--- a/features/omni-kit/helpers/getOmniPositionUrl.ts
+++ b/features/omni-kit/helpers/getOmniPositionUrl.ts
@@ -7,6 +7,7 @@ interface GetOmniPositionUrlParams {
   collateralToken: string
   isPoolOracless?: boolean
   networkName: NetworkNames
+  positionId?: string
   productType: OmniProductType
   protocol: LendingProtocol
   quoteAddress?: string
@@ -18,12 +19,15 @@ export function getOmniPositionUrl({
   collateralToken,
   isPoolOracless,
   networkName,
+  positionId,
   productType,
   protocol,
   quoteAddress,
   quoteToken,
 }: GetOmniPositionUrlParams) {
-  return isPoolOracless
+  const productUrl = isPoolOracless
     ? `/${networkName}/${protocol}/${productType}/${collateralAddress}-${quoteAddress}`
     : `/${networkName}/${protocol}/${productType}/${collateralToken}-${quoteToken}`
+
+  return `${productUrl}${positionId ? `/${positionId}` : ''}`
 }

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -34,7 +34,6 @@ export const subgraphsRecord: SubgraphsRecord = {
     [NetworkIds.OPTIMISMGOERLI]: '',
     [NetworkIds.EMPTYNET]: '',
   },
-
   Discover: {
     [NetworkIds.MAINNET]: `oasis/discover`,
     [NetworkIds.HARDHAT]: `oasis/discover`,
@@ -49,10 +48,9 @@ export const subgraphsRecord: SubgraphsRecord = {
     [NetworkIds.OPTIMISMGOERLI]: '',
     [NetworkIds.EMPTYNET]: '',
   },
-
-  TempGraph: {
-    [NetworkIds.MAINNET]: '',
-    [NetworkIds.HARDHAT]: '',
+  Morpho: {
+    [NetworkIds.MAINNET]: 'summer/morpho-blue',
+    [NetworkIds.HARDHAT]: 'summer/morpho-blue',
     [NetworkIds.GOERLI]: '',
     [NetworkIds.ARBITRUMMAINNET]: '',
     [NetworkIds.ARBITRUMGOERLI]: '',
@@ -455,6 +453,14 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
       }
     }
   `,
+  getMorphoDpmPositions: gql`
+    query getDpmPositions($dpmProxyAddress: [String!]) {
+      accounts(where: { address_in: $dpmProxyAddress }) {
+        address
+        vaultId
+      }
+    }
+  `,
   getMakerDiscoverPositions: gql`
     query getDiscoverPositions($walletAddress: Bytes!) {
       cdps(where: { owner_: { address: $walletAddress } }) {
@@ -486,7 +492,6 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
       }
     }
   `,
-  tempMethod: '',
   getClaimedReferralRewards: gql`
     query getClaimed($walletAddress: String!) {
       claimeds(where: { user: $walletAddress }) {

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -457,6 +457,25 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
     query getDpmPositions($dpmProxyAddress: [String!]) {
       accounts(where: { address_in: $dpmProxyAddress }) {
         address
+        borrowPositions {
+          market {
+            collateralToken {
+              address
+              decimals
+              symbol
+            }
+            id
+            latestInterestRates {
+              rate
+            }
+            liquidataionLTV
+            quoteToken {
+              address
+              decimals
+              symbol
+            }
+          }
+        }
         vaultId
       }
     }

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -17,6 +17,7 @@ import type {
 import type { ClaimedReferralRewards } from 'features/referralOverview/getClaimedReferralRewards.types'
 import type { AjnaDpmPositionsResponse } from 'handlers/portfolio/positions/handlers/ajna/types'
 import type { MakerDiscoverPositionsResponse } from 'handlers/portfolio/positions/handlers/maker/types'
+import type { MorphoDpmPositionsResponse } from 'handlers/portfolio/positions/handlers/morpho-blue/types'
 
 export type Subgraphs = {
   Ajna: {
@@ -42,8 +43,8 @@ export type Subgraphs = {
   Discover: {
     getMakerDiscoverPositions: { walletAddress: string }
   }
-  TempGraph: {
-    tempMethod: undefined
+  Morpho: {
+    getMorphoDpmPositions: { dpmProxyAddress: string[] }
   }
   Referral: {
     getClaimedReferralRewards: { walletAddress: string }
@@ -144,8 +145,8 @@ export type SubgraphsResponses = {
   Discover: {
     getMakerDiscoverPositions: SubgraphBaseResponse<MakerDiscoverPositionsResponse>
   }
-  TempGraph: {
-    tempMethod: SubgraphBaseResponse<undefined>
+  Morpho: {
+    getMorphoDpmPositions: SubgraphBaseResponse<MorphoDpmPositionsResponse>
   }
   Referral: {
     getClaimedReferralRewards: SubgraphBaseResponse<{
@@ -174,6 +175,6 @@ export type SubgraphMethodsRecord = {
   [key in keyof (Subgraphs['Aave'] &
     Subgraphs['Ajna'] &
     Subgraphs['Discover'] &
-    Subgraphs['TempGraph'] &
+    Subgraphs['Morpho'] &
     Subgraphs['Referral'])]: string
 }

--- a/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaPositionInfo.ts
@@ -2,20 +2,22 @@ import type { Vault } from '@prisma/client'
 import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { networksById } from 'blockchain/networks'
-import { omniBorrowishProducts } from 'features/omni-kit/constants'
 import { isPoolOracless } from 'features/omni-kit/protocols/ajna/helpers'
 import { settings as ajnaSettings } from 'features/omni-kit/protocols/ajna/settings'
-import type { OmniProductBorrowishType, OmniSupportedNetworkIds } from 'features/omni-kit/types'
+import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
 import { OmniProductType } from 'features/omni-kit/types'
 import type { AjnaDpmPositionsPool } from 'handlers/portfolio/positions/handlers/ajna/types'
 import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
-import { getBorrowishPositionType } from 'handlers/portfolio/positions/helpers'
+import {
+  getBorrowishPositionType,
+  getDefaultBorrowishPositionType,
+} from 'handlers/portfolio/positions/helpers'
 import type { DpmSubgraphData } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
 import { getTokenDisplayName } from 'helpers/getTokenDisplayName'
 import { one } from 'helpers/zero'
 import { LendingProtocol } from 'lendingProtocols'
 
-interface getAjnaPositionInfoParams {
+interface GetAjnaPositionInfoParams {
   apiVaults: Vault[]
   dpmList: DpmSubgraphData[]
   isEarn: boolean
@@ -35,29 +37,19 @@ export async function getAjnaPositionInfo({
   positionId,
   prices,
   proxyAddress,
-}: getAjnaPositionInfoParams) {
+}: GetAjnaPositionInfoParams) {
   // get pool info contract
   const { ajnaPoolInfo } = getNetworkContracts(networkId)
 
   // determine position type based on subgraph and db responses
-  const defaultType = dpmList
-    .find(({ id }) => id === proxyAddress)
-    ?.createEvents.find(
-      ({
-        collateralToken: eventCollateralToken,
-        debtToken: eventDebtToken,
-        positionType: eventPositionType,
-        protocol: eventProtocol,
-      }) => {
-        return (
-          eventCollateralToken === collateralToken.address &&
-          eventDebtToken === quoteToken.address &&
-          eventProtocol === ajnaSettings.rawName &&
-          ((isEarn && eventPositionType === OmniProductType.Earn) ||
-            (!isEarn && omniBorrowishProducts.includes(eventPositionType)))
-        )
-      },
-    )?.positionType as OmniProductBorrowishType
+  const defaultType = getDefaultBorrowishPositionType({
+    collateralTokenAddress: collateralToken.address,
+    dpmList,
+    protocolRaw: ajnaSettings.rawName,
+    proxyAddress,
+    quoteTokenAddress: quoteToken.address,
+    isEarn,
+  })
 
   const type = isEarn
     ? OmniProductType.Earn

--- a/handlers/portfolio/positions/handlers/morpho-blue/helpers/getMorphoPositionDetails.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/helpers/getMorphoPositionDetails.ts
@@ -1,0 +1,75 @@
+import type { MorphoBluePosition } from '@oasisdex/dma-library'
+import { normalizeValue } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
+import { isShortPosition } from 'features/omni-kit/helpers'
+import { OmniProductType } from 'features/omni-kit/types'
+import { type PositionDetail } from 'handlers/portfolio/types'
+import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
+import { one } from 'helpers/zero'
+
+interface GetMorphoPositionDetailsParam {
+  collateralPrice: BigNumber
+  liquidataionLtv: BigNumber
+  position: MorphoBluePosition
+  primaryToken: string
+  quotePrice: BigNumber
+  rate: BigNumber
+  secondaryToken: string
+  type: OmniProductType
+}
+
+export function getMorphoPositionDetails({
+  collateralPrice,
+  liquidataionLtv,
+  position,
+  primaryToken,
+  quotePrice,
+  rate,
+  secondaryToken,
+  type,
+}: GetMorphoPositionDetailsParam): PositionDetail[] {
+  const isShort = isShortPosition({ collateralToken: primaryToken })
+  const priceFormat = isShort
+    ? `${secondaryToken}/${primaryToken}`
+    : `${primaryToken}/${secondaryToken}`
+  const marketPrice = isShort ? quotePrice.div(collateralPrice) : collateralPrice.div(quotePrice)
+
+  switch (type) {
+    case OmniProductType.Borrow: {
+      const { collateralAmount, debtAmount, liquidationPrice, riskRatio } = position
+
+      const formattedLiquidationPrice = isShort
+        ? normalizeValue(one.div(liquidationPrice))
+        : liquidationPrice
+
+      return [
+        {
+          type: 'collateralLocked',
+          value: `${formatCryptoBalance(new BigNumber(collateralAmount))} ${primaryToken}`,
+        },
+        {
+          type: 'totalDebt',
+          value: `${formatCryptoBalance(new BigNumber(debtAmount))} ${secondaryToken}`,
+        },
+        {
+          type: 'liquidationPrice',
+          value: `${formatCryptoBalance(new BigNumber(formattedLiquidationPrice))} ${priceFormat}`,
+          subvalue: `Now ${formatCryptoBalance(new BigNumber(marketPrice))} ${priceFormat}`,
+        },
+        {
+          type: 'ltv',
+          value: formatDecimalAsPercent(riskRatio.loanToValue),
+          subvalue: `Max ${formatDecimalAsPercent(liquidataionLtv)}`,
+        },
+        {
+          type: 'borrowRate',
+          value: formatDecimalAsPercent(rate),
+        },
+      ]
+    }
+    case OmniProductType.Multiply:
+    default: {
+      return []
+    }
+  }
+}

--- a/handlers/portfolio/positions/handlers/morpho-blue/helpers/getMorphoPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/helpers/getMorphoPositionInfo.ts
@@ -52,7 +52,7 @@ export function getMorphoPositionInfo({
     defaultType,
     networkId,
     positionId: Number(positionId),
-    protocol: LendingProtocol.Ajna,
+    protocol: LendingProtocol.MorphoBlue,
   })
   const url = getOmniPositionUrl({
     collateralToken: primaryToken,

--- a/handlers/portfolio/positions/handlers/morpho-blue/helpers/getMorphoPositionInfo.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/helpers/getMorphoPositionInfo.ts
@@ -1,0 +1,75 @@
+import type { Vault } from '@prisma/client'
+import BigNumber from 'bignumber.js'
+import { networksById } from 'blockchain/networks'
+import { getOmniPositionUrl } from 'features/omni-kit/helpers'
+import { settings as morphoSettings } from 'features/omni-kit/protocols/morpho-blue/settings'
+import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
+import type { MorphoDpmPositionsMarket } from 'handlers/portfolio/positions/handlers/morpho-blue/types'
+import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
+import {
+  getBorrowishPositionType,
+  getDefaultBorrowishPositionType,
+} from 'handlers/portfolio/positions/helpers'
+import type { DpmSubgraphData } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
+import { getTokenDisplayName } from 'helpers/getTokenDisplayName'
+import { LendingProtocol } from 'lendingProtocols'
+
+interface GetMorphoPositionInfoParams {
+  apiVaults: Vault[]
+  dpmList: DpmSubgraphData[]
+  market: MorphoDpmPositionsMarket
+  networkId: OmniSupportedNetworkIds
+  positionId: string
+  prices: TokensPricesList
+  proxyAddress: string
+}
+
+export function getMorphoPositionInfo({
+  apiVaults,
+  dpmList,
+  market: { collateralToken, quoteToken },
+  networkId,
+  positionId,
+  prices,
+  proxyAddress,
+}: GetMorphoPositionInfoParams) {
+  const primaryToken = getTokenDisplayName(collateralToken.symbol)
+  const secondaryToken = getTokenDisplayName(quoteToken.symbol)
+  const collateralPrice = new BigNumber(prices[collateralToken.symbol.toUpperCase()])
+  const quotePrice = new BigNumber(prices[quoteToken.symbol.toUpperCase()])
+  const networkName = networksById[networkId].name
+
+  const defaultType = getDefaultBorrowishPositionType({
+    collateralTokenAddress: collateralToken.address,
+    dpmList,
+    protocolRaw: morphoSettings.rawName,
+    proxyAddress,
+    quoteTokenAddress: quoteToken.address,
+  })
+
+  const type = getBorrowishPositionType({
+    apiVaults,
+    defaultType,
+    networkId,
+    positionId: Number(positionId),
+    protocol: LendingProtocol.Ajna,
+  })
+  const url = getOmniPositionUrl({
+    collateralToken: primaryToken,
+    networkName,
+    positionId,
+    productType: type,
+    protocol: LendingProtocol.MorphoBlue,
+    quoteToken: secondaryToken,
+  })
+
+  return {
+    collateralPrice,
+    networkName,
+    primaryToken,
+    quotePrice,
+    secondaryToken,
+    type,
+    url,
+  }
+}

--- a/handlers/portfolio/positions/handlers/morpho-blue/helpers/index.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './getMorphoPositionDetails'
+export * from './getMorphoPositionInfo'

--- a/handlers/portfolio/positions/handlers/morpho-blue/index.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/index.ts
@@ -1,15 +1,26 @@
+import { views } from '@oasisdex/dma-library'
 import type { Vault } from '@prisma/client'
-import { NetworkIds } from 'blockchain/networks'
-import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
-import { SubgraphsResponses } from 'features/subgraphLoader/types'
+import BigNumber from 'bignumber.js'
+import { getNetworkContracts } from 'blockchain/contracts'
+import { getRpcProvider, NetworkIds } from 'blockchain/networks'
+import { NEGATIVE_WAD_PRECISION } from 'components/constants'
+import { getMorphoCumulatives } from 'features/omni-kit/protocols/morpho-blue/helpers'
+import { type OmniSupportedNetworkIds } from 'features/omni-kit/types'
+import type { SubgraphsResponses } from 'features/subgraphLoader/types'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
-import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
+import {
+  getMorphoPositionDetails,
+  getMorphoPositionInfo,
+} from 'handlers/portfolio/positions/handlers/morpho-blue/helpers'
+import { type TokensPricesList } from 'handlers/portfolio/positions/helpers'
 import type { DpmSubgraphData } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
 import type {
+  PortfolioPosition,
   PortfolioPositionsCountReply,
   PortfolioPositionsHandler,
   PortfolioPositionsReply,
 } from 'handlers/portfolio/types'
+import { LendingProtocol } from 'lendingProtocols'
 
 interface GetMorphoPositionsParams {
   apiVaults?: Vault[]
@@ -30,16 +41,97 @@ async function getMorphoPositions({
   const subgraphPositions = (await loadSubgraph('Morpho', 'getMorphoDpmPositions', networkId, {
     dpmProxyAddress,
   })) as SubgraphsResponses['Morpho']['getMorphoDpmPositions']
-
-  console.log(dpmProxyAddress)
-  console.log(subgraphPositions)
+  const positionsArray = subgraphPositions.response.accounts.flatMap(
+    ({ address: proxyAddress, borrowPositions, vaultId: positionId }) =>
+      borrowPositions.map((position) => ({
+        ...position,
+        proxyAddress,
+        positionId,
+      })),
+  )
 
   if (positionsCount || !apiVaults) {
     return {
-      positions: [],
+      positions: positionsArray.map(({ positionId }) => ({ positionId })),
     }
   } else {
-    return { positions: [] }
+    const positions = await Promise.all(
+      positionsArray.map(
+        async ({ market, positionId, proxyAddress }): Promise<PortfolioPosition> => {
+          const {
+            collateralToken,
+            id: marketId,
+            latestInterestRates: [{ rate }],
+            liquidataionLTV,
+            quoteToken,
+          } = market
+  
+          const {
+            collateralPrice,
+            networkName,
+            primaryToken,
+            quotePrice,
+            secondaryToken,
+            type,
+            url,
+          } = getMorphoPositionInfo({
+            apiVaults,
+            dpmList,
+            market,
+            networkId,
+            positionId,
+            prices,
+            proxyAddress,
+          })
+
+          const position = await views.morpho.getPosition(
+            {
+              collateralPrecision: Number(collateralToken.decimals),
+              collateralPriceUSD: collateralPrice,
+              marketId,
+              proxyAddress: proxyAddress,
+              quotePrecision: Number(quoteToken.decimals),
+              quotePriceUSD: quotePrice,
+            },
+            {
+              getCumulatives: getMorphoCumulatives(),
+              morphoAddress: getNetworkContracts(networkId).morphoBlue.address,
+              provider: getRpcProvider(networkId),
+            },
+          )
+
+          const netValue = position.collateralAmount
+            .times(collateralPrice)
+            .minus(position.debtAmount.times(quotePrice))
+            .toNumber()
+
+          return {
+            availableToMigrate: false,
+            automations: {},
+            details: getMorphoPositionDetails({
+              collateralPrice,
+              liquidataionLtv: new BigNumber(liquidataionLTV).shiftedBy(NEGATIVE_WAD_PRECISION),
+              position,
+              primaryToken,
+              quotePrice,
+              rate: new BigNumber(rate),
+              secondaryToken,
+              type,
+            }),
+            network: networkName,
+            netValue,
+            positionId: Number(positionId),
+            primaryToken,
+            protocol: LendingProtocol.MorphoBlue,
+            secondaryToken,
+            type,
+            url,
+          }
+        },
+      ),
+    )
+
+    return { positions }
   }
 }
 

--- a/handlers/portfolio/positions/handlers/morpho-blue/index.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/index.ts
@@ -1,0 +1,67 @@
+import type { Vault } from '@prisma/client'
+import { NetworkIds } from 'blockchain/networks'
+import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
+import { SubgraphsResponses } from 'features/subgraphLoader/types'
+import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
+import type { DpmSubgraphData } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
+import type {
+  PortfolioPositionsCountReply,
+  PortfolioPositionsHandler,
+  PortfolioPositionsReply,
+} from 'handlers/portfolio/types'
+
+interface GetMorphoPositionsParams {
+  apiVaults?: Vault[]
+  dpmList: DpmSubgraphData[]
+  prices: TokensPricesList
+  networkId: OmniSupportedNetworkIds
+  positionsCount?: boolean
+}
+
+async function getMorphoPositions({
+  apiVaults,
+  dpmList,
+  networkId,
+  positionsCount,
+  prices,
+}: GetMorphoPositionsParams): Promise<PortfolioPositionsReply | PortfolioPositionsCountReply> {
+  const dpmProxyAddress = dpmList.map(({ id }) => id)
+  const subgraphPositions = (await loadSubgraph('Morpho', 'getMorphoDpmPositions', networkId, {
+    dpmProxyAddress,
+  })) as SubgraphsResponses['Morpho']['getMorphoDpmPositions']
+
+  console.log(dpmProxyAddress)
+  console.log(subgraphPositions)
+
+  if (positionsCount || !apiVaults) {
+    return {
+      positions: [],
+    }
+  } else {
+    return { positions: [] }
+  }
+}
+
+export const morphoPositionsHandler: PortfolioPositionsHandler = async ({
+  address,
+  apiVaults,
+  dpmList,
+  prices,
+  positionsCount,
+}) => {
+  return Promise.all([
+    getMorphoPositions({
+      apiVaults,
+      dpmList,
+      networkId: NetworkIds.MAINNET,
+      prices,
+      positionsCount,
+    }),
+  ]).then((responses) => {
+    return {
+      address,
+      positions: responses.flatMap(({ positions }) => positions),
+    }
+  })
+}

--- a/handlers/portfolio/positions/handlers/morpho-blue/index.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/index.ts
@@ -65,7 +65,7 @@ async function getMorphoPositions({
             liquidataionLTV,
             quoteToken,
           } = market
-  
+
           const {
             collateralPrice,
             networkName,

--- a/handlers/portfolio/positions/handlers/morpho-blue/types.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/types.ts
@@ -1,0 +1,6 @@
+export interface MorphoDpmPositionsResponse {
+  accounts: {
+    address: string
+    vaultId: string
+  }[]
+}

--- a/handlers/portfolio/positions/handlers/morpho-blue/types.ts
+++ b/handlers/portfolio/positions/handlers/morpho-blue/types.ts
@@ -1,6 +1,32 @@
+export interface MorphoDpmPositionsMarket {
+  collateralToken: {
+    address: string
+    decimals: string
+    symbol: string
+  }
+  id: string
+  latestInterestRates: [
+    {
+      rate: string
+    },
+    {
+      rate: string
+    },
+  ]
+  liquidataionLTV: string
+  quoteToken: {
+    address: string
+    decimals: string
+    symbol: string
+  }
+}
+
 export interface MorphoDpmPositionsResponse {
   accounts: {
     address: string
+    borrowPositions: {
+      market: MorphoDpmPositionsMarket
+    }[]
     vaultId: string
   }[]
 }

--- a/handlers/portfolio/positions/helpers/getDefaultBorrowishPositionType.ts
+++ b/handlers/portfolio/positions/helpers/getDefaultBorrowishPositionType.ts
@@ -1,0 +1,41 @@
+import { omniBorrowishProducts } from 'features/omni-kit/constants'
+import type { OmniProductBorrowishType } from 'features/omni-kit/types'
+import { OmniProductType } from 'features/omni-kit/types'
+import type { DpmSubgraphData } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
+
+interface GetDefaultBorrowishPositionTypeParams {
+  dpmList: DpmSubgraphData[]
+  proxyAddress: string
+  collateralTokenAddress: string
+  quoteTokenAddress: string
+  protocolRaw: string
+  isEarn?: boolean
+}
+
+export function getDefaultBorrowishPositionType({
+  dpmList,
+  collateralTokenAddress,
+  quoteTokenAddress,
+  proxyAddress,
+  protocolRaw,
+  isEarn,
+}: GetDefaultBorrowishPositionTypeParams): OmniProductBorrowishType {
+  return dpmList
+    .find(({ id }) => id === proxyAddress)
+    ?.createEvents.find(
+      ({
+        collateralToken: eventCollateralToken,
+        debtToken: eventDebtToken,
+        positionType: eventPositionType,
+        protocol: eventProtocol,
+      }) => {
+        return (
+          eventCollateralToken === collateralTokenAddress &&
+          eventDebtToken === quoteTokenAddress &&
+          eventProtocol === protocolRaw &&
+          ((isEarn && eventPositionType === OmniProductType.Earn) ||
+            (!isEarn && omniBorrowishProducts.includes(eventPositionType)))
+        )
+      },
+    )?.positionType as OmniProductBorrowishType
+}

--- a/handlers/portfolio/positions/helpers/index.ts
+++ b/handlers/portfolio/positions/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './getBorrowishPositionType'
+export * from './getDefaultBorrowishPositionType'
 export * from './getPositionsAutomations'
 export * from './getPositionsFromDatabase'
 export * from './getTokensPrices'

--- a/handlers/portfolio/positions/index.ts
+++ b/handlers/portfolio/positions/index.ts
@@ -1,9 +1,9 @@
 import { aaveLikePositionsHandler } from 'handlers/portfolio/positions/handlers/aave-like'
 import { aaveV2PositionHandler } from 'handlers/portfolio/positions/handlers/aave-v2'
 import { ajnaPositionsHandler } from 'handlers/portfolio/positions/handlers/ajna'
-import { morphoPositionsHandler } from 'handlers/portfolio/positions/handlers/morpho-blue'
 import { dsrPositionsHandler } from 'handlers/portfolio/positions/handlers/dsr'
 import { makerPositionsHandler } from 'handlers/portfolio/positions/handlers/maker'
+import { morphoPositionsHandler } from 'handlers/portfolio/positions/handlers/morpho-blue'
 import { getPositionsFromDatabase, getTokensPrices } from 'handlers/portfolio/positions/helpers'
 import { getAllDpmsForWallet } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
 import type {
@@ -56,28 +56,28 @@ export const portfolioPositionsHandler = async ({
     }
 
     const positionsReply = await Promise.all([
-      // aaveLikePositionsHandler(payload),
-      // aaveV2PositionHandler(payload),
-      // ajnaPositionsHandler(payload),
-      // dsrPositionsHandler(payload),
-      // makerPositionsHandler(payload),
-      morphoPositionsHandler(payload)
+      aaveLikePositionsHandler(payload),
+      aaveV2PositionHandler(payload),
+      ajnaPositionsHandler(payload),
+      dsrPositionsHandler(payload),
+      makerPositionsHandler(payload),
+      morphoPositionsHandler(payload),
     ])
       .then(
         ([
-          // { positions: aaveLikePositions },
-          // { positions: aaveV2Positions },
-          // { positions: ajnaPositions },
-          // { positions: dsrPositions },
-          // { positions: makerPositions },
+          { positions: aaveLikePositions },
+          { positions: aaveV2Positions },
+          { positions: ajnaPositions },
+          { positions: dsrPositions },
+          { positions: makerPositions },
           { positions: morphoPositions },
         ]) => ({
           positions: [
-            // ...aaveLikePositions,
-            // ...aaveV2Positions,
-            // ...ajnaPositions,
-            // ...dsrPositions,
-            // ...makerPositions,
+            ...aaveLikePositions,
+            ...aaveV2Positions,
+            ...ajnaPositions,
+            ...dsrPositions,
+            ...makerPositions,
             ...morphoPositions,
           ],
           error: false,

--- a/handlers/portfolio/positions/index.ts
+++ b/handlers/portfolio/positions/index.ts
@@ -1,6 +1,7 @@
 import { aaveLikePositionsHandler } from 'handlers/portfolio/positions/handlers/aave-like'
 import { aaveV2PositionHandler } from 'handlers/portfolio/positions/handlers/aave-v2'
 import { ajnaPositionsHandler } from 'handlers/portfolio/positions/handlers/ajna'
+import { morphoPositionsHandler } from 'handlers/portfolio/positions/handlers/morpho-blue'
 import { dsrPositionsHandler } from 'handlers/portfolio/positions/handlers/dsr'
 import { makerPositionsHandler } from 'handlers/portfolio/positions/handlers/maker'
 import { getPositionsFromDatabase, getTokensPrices } from 'handlers/portfolio/positions/helpers'
@@ -55,26 +56,29 @@ export const portfolioPositionsHandler = async ({
     }
 
     const positionsReply = await Promise.all([
-      aaveLikePositionsHandler(payload),
-      aaveV2PositionHandler(payload),
-      ajnaPositionsHandler(payload),
-      dsrPositionsHandler(payload),
-      makerPositionsHandler(payload),
+      // aaveLikePositionsHandler(payload),
+      // aaveV2PositionHandler(payload),
+      // ajnaPositionsHandler(payload),
+      // dsrPositionsHandler(payload),
+      // makerPositionsHandler(payload),
+      morphoPositionsHandler(payload)
     ])
       .then(
         ([
-          { positions: aaveLikePositions },
-          { positions: aaveV2Positions },
-          { positions: ajnaPositions },
-          { positions: dsrPositions },
-          { positions: makerPositions },
+          // { positions: aaveLikePositions },
+          // { positions: aaveV2Positions },
+          // { positions: ajnaPositions },
+          // { positions: dsrPositions },
+          // { positions: makerPositions },
+          { positions: morphoPositions },
         ]) => ({
           positions: [
-            ...aaveLikePositions,
-            ...aaveV2Positions,
-            ...ajnaPositions,
-            ...dsrPositions,
-            ...makerPositions,
+            // ...aaveLikePositions,
+            // ...aaveV2Positions,
+            // ...ajnaPositions,
+            // ...dsrPositions,
+            // ...makerPositions,
+            ...morphoPositions,
           ],
           error: false,
           ...(debug && {


### PR DESCRIPTION
# [Morph Blue positions in Portfolio](https://app.shortcut.com/oazo-apps/story/13643/add-support-for-displaying-morpho-blue-positions-in-portfolio)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/e05994df-a8eb-49c6-b14a-41ea76a2dc70)
  
## Changes 👷‍♀️

- Added Morpho Blue subgraph to the config and removed `TempGraph` which was long overdue.
- Created `getMorphoDpmPositions` subgraph query.
- Created `getMorphoPositions` handler for Portfolio.
- Added `positionId` to `getOmniPositionUrl` so it can be used for generating urls to existing positions.
  
## How to test 🧪

Wallet address: `0xbEf4befb4F230F43905313077e3824d7386E09F8`.