### PR TITLE
Fix liquidity validation issue in Morpho Blue position

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.34",
     "@oasisdex/automation": "^1.5.9-alpha5",
-    "@oasisdex/dma-library": "0.6.4",
+    "@oasisdex/dma-library": "0.6.6",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3000,7 +3000,7 @@
       "debt-less-then-dust-limit": "The minimum debt for a position in this pool is {{minDebtAmount}}. Please update the parameters of this action to ensure the position has debt above {{minDebtAmount}} or no debt",
       "debt-less-then-dust-limit-multiply": "Minimum debt generated is below the pool minimum. Please increase your deposit size or increase the LTV (if available).",
       "repay-more-then-debt": "You cannot repay more than the total debt amount {{amount}} {{quoteToken}}.",
-      "not-enough-liquidity": "You cannot generate more debt than is available in the pool {{amount}} {{collateralToken}}/{{quoteToken}}.",
+      "not-enough-liquidity": "You cannot generate more debt than available liquidity. Current liquidity for {{collateralToken}}/{{quoteToken}} is {{amount}} {{quoteToken}}.",
       "withdraw-close-to-max-ltv": "Withdrawing {{amount}} {{collateralToken}}, would take your position close to the maximum LTV. To reduce your risk of liquidation, please enter a lower amount.",
       "generate-close-to-max-ltv": "Generating {{amount}} {{quoteToken}} of debt, would take your position close to the maximum LTV. To reduce your risk of liquidation, please enter a lower amount.",
       "liquidation-price-close-to-market-price": "Warning your Liquidation Price is close to Market price please check that your liquidation Price is not above Market price to avoid being liquidated with this action.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,10 +2385,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.4.tgz#0402ee3a4cc5062a79d9546e82aaa8fd9979a046"
-  integrity sha512-9SRIzSZG+D0rREmN9kmN8ILb4gukrtxFIG3Mxz96ITcpbnjnWQj3l6H2Xmblyt6kk/1RWjOQyqWoYty4SAjA6Q==
+"@oasisdex/dma-library@0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.6.tgz#c86efa98282a82d61c711442a5eaf336e520fdf3"
+  integrity sha512-UsMZeqJnuzosCFGHeph+krVqzcCp4eOQp3teACk+WL8BMjLGxQn6MTOsYOXyR3xSbWzKSxO6fC4msY+limSFcw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
# [Fix liquidity validation issue in Morpho Blue position](https://app.shortcut.com/oazo-apps/story/13864/library-incorrectly-says-that-there-is-not-enough-liquidity-for-wsteth-usdc-market)
  
## Changes 👷‍♀️

- Fixed validation translation.
- Updated package to the version that contains a fix.