### PR TITLE
Remove dynamic LTV from order information

### DIFF
--- a/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
+++ b/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
@@ -79,7 +79,7 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
             txStatus: txDetails?.txStatus,
           }),
           afterBuyingPower: simulation?.buyingPower,
-          shouldShowDynamicLtv: () => true,
+          shouldShowDynamicLtv: () => false,
           debtMin: zero,
           debtMax: getOmniBorrowDebtMax({
             digits: quotePrecision,


### PR DESCRIPTION
# [Remove dynamic LTV from order information](https://app.shortcut.com/oazo-apps/story/13854/remove-dynamic-max-ltv-from-order)
  
## Changes 👷‍♀️

- Hardcoded `shouldShowDynamicLtv` to return `false` at all time in Morpho Blue metadata as it shouldn't be visible at any point for that protocol.