### PR TITLE
Hide links to multiply and earn for Morpho Blue in navigation

### DIFF
--- a/features/navigation/panels/getNavProtocolsPanel.tsx
+++ b/features/navigation/panels/getNavProtocolsPanel.tsx
@@ -188,18 +188,18 @@ export const getNavProtocolsPanel = ({
                         url: `${INTERNAL_LINKS.borrow}`,
                         query: query.morphoBlue,
                       },
-                      {
-                        title: t('nav.multiply'),
-                        description: navigation.protocols.morphoBlue.multiply.description,
-                        url: `${INTERNAL_LINKS.multiply}`,
-                        query: query.morphoBlue,
-                      },
-                      {
-                        title: t('nav.earn'),
-                        description: navigation.protocols.morphoBlue.earn.description,
-                        url: `${INTERNAL_LINKS.earn}`,
-                        query: query.morphoBlue,
-                      },
+                      // {
+                      //   title: t('nav.multiply'),
+                      //   description: navigation.protocols.morphoBlue.multiply.description,
+                      //   url: `${INTERNAL_LINKS.multiply}`,
+                      //   query: query.morphoBlue,
+                      // },
+                      // {
+                      //   title: t('nav.earn'),
+                      //   description: navigation.protocols.morphoBlue.earn.description,
+                      //   url: `${INTERNAL_LINKS.earn}`,
+                      //   query: query.morphoBlue,
+                      // },
                       {
                         title: navigation.protocols.morphoBlue.extra.title,
                         promoted: true,


### PR DESCRIPTION
# [Hide links to multiply and earn for Morpho Blue in navigation](https://app.shortcut.com/oazo-apps/story/13950/bug-remove-links-to-multiply-and-earn-from-top-navigation)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/1063f333-e501-4024-8b55-f7e2857ad3ea)
  
## Changes 👷‍♀️

As in title.
