### PR TITLE
Fix issue when clicking go to position keeps state of order info

### DIFF
--- a/components/sidebar/SidebarSectionFooterButton.tsx
+++ b/components/sidebar/SidebarSectionFooterButton.tsx
@@ -1,30 +1,38 @@
 import { AppLink } from 'components/Links'
 import React from 'react'
-import { Button, Spinner } from 'theme-ui'
+import { Button, Link, Spinner } from 'theme-ui'
 
 export interface SidebarSectionFooterButtonProps {
-  variant?: string
-  label: string
-  steps?: [number, number]
   disabled?: boolean
   hidden?: boolean
   isLoading?: boolean
-  action?: () => void
+  label: string
+  steps?: [number, number]
   url?: string
+  variant?: string
+  withoutNextLink?: boolean
+  action?: () => void
 }
 
 export function SidebarSectionFooterButton({
   hidden,
   url,
+  withoutNextLink,
   ...rest
 }: SidebarSectionFooterButtonProps) {
   return (
     <>
       {!hidden &&
         (url ? (
-          <AppLink href={url} sx={{ display: 'block' }}>
-            <SidebarSectionFooterButtonIner {...rest} />
-          </AppLink>
+          withoutNextLink ? (
+            <Link href={url} sx={{ display: 'block', bg: 'red' }}>
+              <SidebarSectionFooterButtonIner {...rest} />
+            </Link>
+          ) : (
+            <AppLink href={url} sx={{ display: 'block' }}>
+              <SidebarSectionFooterButtonIner {...rest} />
+            </AppLink>
+          )
         ) : (
           <SidebarSectionFooterButtonIner {...rest} />
         ))}

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -241,6 +241,7 @@ export function OmniFormView({
       disabled: suppressValidation ? false : isPrimaryButtonDisabled,
       isLoading: isPrimaryButtonLoading,
       hidden: isPrimaryButtonHidden,
+      withoutNextLink: true,
       ...primaryButtonActions,
     },
     textButton: {


### PR DESCRIPTION
# [Fix issue when clicking go to position keeps state of order info](https://app.shortcut.com/oazo-apps/story/13933/bug-clicking-go-to-position-keeps-state-of-order-info)
  
## Changes 👷‍♀️

- Added `withoutNextLink` prop to sidebar that allows to use theme.ui `Link` component skipping Next.js one which clears cache and state when moving between linked pages.