### PR TITLE
Max borrow when open morpho fix

### DIFF
--- a/features/omni-kit/protocols/ajna/helpers/getAjnaParameters.ts
+++ b/features/omni-kit/protocols/ajna/helpers/getAjnaParameters.ts
@@ -138,7 +138,7 @@ export async function getAjnaParameters({
                 })
               : state.paybackAmount,
           withdrawAmount:
-            state.withdrawAmount && state.withdrawAmountMax && !position.pool.interestRate.isZero()
+            state.withdrawAmount && state.withdrawAmountMax
               ? getMaxIncreasedOrDecreasedValue({
                   value: state.withdrawAmount,
                   apy: position.pool.interestRate,
@@ -233,7 +233,7 @@ export async function getAjnaParameters({
               })
             : state.paybackAmount,
         withdrawAmount:
-          state.withdrawAmount && state.withdrawAmountMax && !position.pool.interestRate.isZero()
+          state.withdrawAmount && state.withdrawAmountMax
             ? getMaxIncreasedOrDecreasedValue({
                 value: state.withdrawAmount,
                 apy: position.pool.interestRate,

--- a/features/omni-kit/protocols/ajna/helpers/getMaxIncreasedOrDecreasedValue.ts
+++ b/features/omni-kit/protocols/ajna/helpers/getMaxIncreasedOrDecreasedValue.ts
@@ -18,12 +18,14 @@ export function getMaxIncreasedOrDecreasedValue({
   apy,
   precision,
   mode = MaxValueResolverMode.INCREASED,
+  customDayApy = 5,
 }: {
   value: BigNumber
   apy: BigNumber
   precision: number
+  customDayApy?: number
   mode?: MaxValueResolverMode
 }) {
-  // simplified 5 days apy to calculate offset from given value
-  return value[modeMap[mode]](value.times(apy.div(365).times(5))).dp(precision)
+  // simplified 5 days apy to calculate offset from given value (or custom days)
+  return value[modeMap[mode]](value.times(apy.div(365).times(customDayApy))).dp(precision)
 }

--- a/features/omni-kit/protocols/morpho-blue/helpers/getMorphoParameters.ts
+++ b/features/omni-kit/protocols/morpho-blue/helpers/getMorphoParameters.ts
@@ -90,7 +90,22 @@ export const getMorphoParameters = async ({
 
   switch (action) {
     case OmniBorrowFormAction.OpenBorrow: {
-      return morphoActionOpenBorrow({ state, commonPayload, dependencies })
+      return morphoActionOpenBorrow({
+        state: {
+          ...state,
+          generateAmount:
+            state.generateAmount && state.generateAmountMax
+              ? getMaxIncreasedOrDecreasedValue({
+                  value: state.generateAmount,
+                  apy: position.borrowRate,
+                  mode: MaxValueResolverMode.DECREASED,
+                  precision: quotePrecision,
+                })
+              : state.generateAmount,
+        },
+        commonPayload,
+        dependencies,
+      })
     }
     case OmniBorrowFormAction.DepositBorrow:
     case OmniBorrowFormAction.GenerateBorrow: {
@@ -122,12 +137,13 @@ export const getMorphoParameters = async ({
           //     ? getMaxIncreasedOrDecreasedValue(state.paybackAmount, position.borrowRate)
           //     : state.paybackAmount,
           withdrawAmount:
-            state.withdrawAmount && state.withdrawAmountMax && !position.debtAmount.isZero()
+            state.withdrawAmount && state.withdrawAmountMax
               ? getMaxIncreasedOrDecreasedValue({
                   value: state.withdrawAmount,
                   apy: position.borrowRate,
                   mode: MaxValueResolverMode.DECREASED,
                   precision: collateralPrecision,
+                  customDayApy: 1,
                 })
               : state.withdrawAmount,
         },


### PR DESCRIPTION
# [Max borrow when open morpho fix](https://app.shortcut.com/oazo-apps/story/13944/bug-clicking-on-max-borrowing-amount-will-fail-to-create-position)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added offset to generating value while opening morpho position
- removed unnecessary condition form ajna logic
- minimalized offset while withdrawing collateral
  
## How to test 🧪
  <Please explain how to test your changes>

- is should be possible to deposit for example 20 collateral token and click max generate
