### PR TITLE
Icons with configurable main color

### DIFF
--- a/features/marketing-layouts/components/IconWithPalette.tsx
+++ b/features/marketing-layouts/components/IconWithPalette.tsx
@@ -1,0 +1,27 @@
+import type { IconPalette } from 'features/marketing-layouts/types'
+import type { FC, ReactNode } from 'react'
+
+interface IconWithPaletteProps extends IconPalette {
+  size: number
+  contents: (params: IconPalette) => ReactNode
+}
+
+export const IconWithPalette: FC<IconWithPaletteProps> = ({
+  size,
+  backgroundGradient,
+  contents,
+  foregroundGradient,
+  symbolGradient,
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {contents({ backgroundGradient, foregroundGradient, symbolGradient })}
+    </svg>
+  )
+}

--- a/features/marketing-layouts/components/IconWithPalette.tsx
+++ b/features/marketing-layouts/components/IconWithPalette.tsx
@@ -1,9 +1,9 @@
-import type { IconPalette } from 'features/marketing-layouts/types'
+import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
 import type { FC, ReactNode } from 'react'
 
-interface IconWithPaletteProps extends IconPalette {
+interface IconWithPaletteProps extends MarketingLayoutIconPalette {
   size: number
-  contents: (params: IconPalette) => ReactNode
+  contents: (params: MarketingLayoutIconPalette) => ReactNode
 }
 
 export const IconWithPalette: FC<IconWithPaletteProps> = ({

--- a/features/marketing-layouts/components/IconWithPalette.tsx
+++ b/features/marketing-layouts/components/IconWithPalette.tsx
@@ -1,5 +1,5 @@
 import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
-import type { FC, ReactNode } from 'react'
+import React, { type FC, type ReactNode } from 'react'
 
 interface IconWithPaletteProps extends MarketingLayoutIconPalette {
   size: number

--- a/features/marketing-layouts/components/index.ts
+++ b/features/marketing-layouts/components/index.ts
@@ -1,0 +1,1 @@
+export * from './IconWithPalette'

--- a/features/marketing-layouts/helpers/index.ts
+++ b/features/marketing-layouts/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './renderLinearGradientStops'

--- a/features/marketing-layouts/helpers/renderLinearGradientStops.tsx
+++ b/features/marketing-layouts/helpers/renderLinearGradientStops.tsx
@@ -1,0 +1,5 @@
+export function renderLinearGradientStops(gradient: string[]) {
+  return gradient.map((item, i) => (
+    <stop offset={(1 / (gradient.length - 1)) * i} stop-color={item} />
+  ))
+}

--- a/features/marketing-layouts/helpers/renderLinearGradientStops.tsx
+++ b/features/marketing-layouts/helpers/renderLinearGradientStops.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export function renderLinearGradientStops(gradient: string[]) {
   return gradient.map((item, i) => (
     <stop offset={(1 / (gradient.length - 1)) * i} stop-color={item} />

--- a/features/marketing-layouts/icons/index.ts
+++ b/features/marketing-layouts/icons/index.ts
@@ -1,0 +1,3 @@
+export * from './loop'
+export * from './sleep'
+export * from './stack'

--- a/features/marketing-layouts/icons/loop.tsx
+++ b/features/marketing-layouts/icons/loop.tsx
@@ -1,0 +1,38 @@
+import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
+import type { IconPalette } from 'features/marketing-layouts/types'
+
+export function loop({ backgroundGradient, symbolGradient }: IconPalette) {
+  return (
+    <>
+      <circle cx="28" cy="28.0001" r="27.5" fill="url(#paint0_linear_3327_28417)" stroke="white" />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M32.1595 14.8478C32.8243 15.0807 33.0464 15.9095 32.5871 16.4436L28.2649 21.4698C27.741 22.079 26.7488 21.8528 26.5408 21.0766L25.9824 18.9925C24.1732 19.4316 22.4592 20.3575 21.0461 21.7706C16.9456 25.8711 16.9456 32.5193 21.0461 36.6198C25.1466 40.7204 31.7948 40.7204 35.8953 36.6198C37.513 35.0022 38.4908 32.9921 38.8328 30.8967C39.0993 29.2643 38.9794 27.5814 38.4742 25.9963C38.2226 25.207 38.6585 24.3632 39.4478 24.1116C40.2371 23.86 41.0809 24.2959 41.3325 25.0852C41.9823 27.1238 42.1357 29.2845 41.7937 31.3799C41.3538 34.0752 40.0934 36.6644 38.0166 38.7412C32.7446 44.0132 24.1968 44.0132 18.9248 38.7412C13.6527 33.4691 13.6527 24.9214 18.9248 19.6493C20.7232 17.8509 22.9045 16.6656 25.2058 16.0942L24.6068 13.8587C24.3988 13.0825 25.1449 12.3904 25.9033 12.6561L32.1595 14.8478Z"
+        fill="url(#paint1_linear_3327_28417)"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_3327_28417"
+          x1="9.3986"
+          y1="7.83223"
+          x2="48.951"
+          y2="46.9931"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(backgroundGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint1_linear_3327_28417"
+          x1="18.8576"
+          y1="15.796"
+          x2="37.949"
+          y2="38.632"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+      </defs>
+    </>
+  )
+}

--- a/features/marketing-layouts/icons/loop.tsx
+++ b/features/marketing-layouts/icons/loop.tsx
@@ -1,5 +1,6 @@
 import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
 import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
+import React from 'react'
 
 export function loop({ backgroundGradient, symbolGradient }: MarketingLayoutIconPalette) {
   return (

--- a/features/marketing-layouts/icons/loop.tsx
+++ b/features/marketing-layouts/icons/loop.tsx
@@ -1,7 +1,7 @@
 import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
-import type { IconPalette } from 'features/marketing-layouts/types'
+import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
 
-export function loop({ backgroundGradient, symbolGradient }: IconPalette) {
+export function loop({ backgroundGradient, symbolGradient }: MarketingLayoutIconPalette) {
   return (
     <>
       <circle cx="28" cy="28.0001" r="27.5" fill="url(#paint0_linear_3327_28417)" stroke="white" />

--- a/features/marketing-layouts/icons/sleep.tsx
+++ b/features/marketing-layouts/icons/sleep.tsx
@@ -1,11 +1,11 @@
 import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
-import type { IconPalette } from 'features/marketing-layouts/types'
+import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
 
 export function sleep({
   backgroundGradient,
   foregroundGradient,
   symbolGradient,
-}: IconPalette) {
+}: MarketingLayoutIconPalette) {
   return (
     <>
       <circle cx="40" cy="40" r="33.5" fill="url(#paint1_linear_4087_1130)" />

--- a/features/marketing-layouts/icons/sleep.tsx
+++ b/features/marketing-layouts/icons/sleep.tsx
@@ -1,0 +1,143 @@
+import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
+import type { IconPalette } from 'features/marketing-layouts/types'
+
+export function sleep({
+  backgroundGradient,
+  foregroundGradient,
+  symbolGradient,
+}: IconPalette) {
+  return (
+    <>
+      <circle cx="40" cy="40" r="33.5" fill="url(#paint1_linear_4087_1130)" />
+      <circle cx="40" cy="40" r="33.5" stroke="white" />
+      <g filter="url(#filter0_d_4087_1130)">
+        <circle cx="40" cy="40" r="24" fill="url(#paint2_linear_4087_1130)" />
+        <circle cx="40" cy="40" r="23.5" stroke="white" />
+      </g>
+      <g filter="url(#filter1_d_4087_1130)">
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M47.2833 48.2382C47.1891 48.2406 47.0947 48.2418 47 48.2418C40.9249 48.2418 36 43.3169 36 37.2418C36 34.4702 37.025 31.938 38.7167 30.0037C32.7725 30.1539 28 35.0197 28 41.0001C28 47.0752 32.9249 52.0001 39 52.0001C42.3035 52.0001 45.2669 50.5438 47.2833 48.2382Z"
+          fill="url(#paint3_linear_4087_1130)"
+        />
+      </g>
+      <path
+        d="M51.6491 28.6417C51.8008 28.3643 52.1992 28.3643 52.3509 28.6417L53.0044 29.8366C53.0412 29.9037 53.0963 29.9588 53.1634 29.9956L54.3583 30.6491C54.6357 30.8008 54.6357 31.1992 54.3583 31.3509L53.1634 32.0044C53.0963 32.0412 53.0412 32.0963 53.0044 32.1634L52.3509 33.3583C52.1992 33.6357 51.8008 33.6357 51.6491 33.3583L50.9956 32.1634C50.9588 32.0963 50.9037 32.0412 50.8366 32.0044L49.6417 31.3509C49.3643 31.1992 49.3643 30.8008 49.6417 30.6491L50.8366 29.9956C50.9037 29.9588 50.9588 29.9037 50.9956 29.8366L51.6491 28.6417Z"
+        fill="url(#paint4_linear_4087_1130)"
+      />
+      <path
+        d="M47.6491 35.6417C47.8008 35.3643 48.1992 35.3643 48.3509 35.6417L49.358 37.483C49.3947 37.5501 49.4499 37.6053 49.517 37.642L51.3583 38.6491C51.6357 38.8008 51.6357 39.1992 51.3583 39.3509L49.517 40.358C49.4499 40.3947 49.3947 40.4499 49.358 40.517L48.3509 42.3583C48.1992 42.6357 47.8008 42.6357 47.6491 42.3583L46.642 40.517C46.6053 40.4499 46.5501 40.3947 46.483 40.358L44.6417 39.3509C44.3643 39.1992 44.3643 38.8008 44.6417 38.6491L46.483 37.642C46.5501 37.6053 46.6053 37.5501 46.642 37.483L47.6491 35.6417Z"
+        fill="url(#paint5_linear_4087_1130)"
+      />
+      <defs>
+        <filter
+          id="filter0_d_4087_1130"
+          x="0"
+          y="0"
+          width="80"
+          height="80"
+          filterUnits="userSpaceOnUse"
+          color-interpolation-filters="sRGB"
+        >
+          <feFlood flood-opacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="8" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4087_1130" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_4087_1130"
+            result="shape"
+          />
+        </filter>
+        <filter
+          id="filter1_d_4087_1130"
+          x="12"
+          y="14.0037"
+          width="51.2832"
+          height="53.9963"
+          filterUnits="userSpaceOnUse"
+          color-interpolation-filters="sRGB"
+        >
+          <feFlood flood-opacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="8" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4087_1130" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_4087_1130"
+            result="shape"
+          />
+        </filter>
+        <linearGradient
+          id="paint1_linear_4087_1130"
+          x1="17.4126"
+          y1="15.5105"
+          x2="65.4406"
+          y2="63.0629"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(backgroundGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint2_linear_4087_1130"
+          x1="24.0559"
+          y1="22.7133"
+          x2="57.958"
+          y2="56.2797"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(foregroundGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint3_linear_4087_1130"
+          x1="30.776"
+          y1="32.3408"
+          x2="44.7825"
+          y2="48.7126"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint4_linear_4087_1130"
+          x1="49.8637"
+          y1="28.6375"
+          x2="53.5762"
+          y2="33.5875"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint5_linear_4087_1130"
+          x1="45.1517"
+          y1="35.85"
+          x2="50.1017"
+          y2="42.45"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+      </defs>
+    </>
+  )
+}

--- a/features/marketing-layouts/icons/sleep.tsx
+++ b/features/marketing-layouts/icons/sleep.tsx
@@ -1,5 +1,6 @@
 import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
 import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
+import React from 'react'
 
 export function sleep({
   backgroundGradient,

--- a/features/marketing-layouts/icons/stack.tsx
+++ b/features/marketing-layouts/icons/stack.tsx
@@ -1,5 +1,6 @@
 import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
 import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
+import React from 'react'
 
 export function stack({
   backgroundGradient,

--- a/features/marketing-layouts/icons/stack.tsx
+++ b/features/marketing-layouts/icons/stack.tsx
@@ -1,0 +1,130 @@
+import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
+import type { IconPalette } from 'features/marketing-layouts/types'
+
+export function stack({
+  backgroundGradient,
+  foregroundGradient,
+  symbolGradient,
+}: IconPalette) {
+  return (
+    <>
+      <circle cx="36" cy="36" r="33.5" fill="url(#paint1_linear_3327_31414)" />
+      <circle cx="36" cy="36" r="33.5" stroke="white" />
+      <g filter="url(#filter0_dd_3327_31414)">
+        <rect x="16" y="16" width="40" height="40" rx="8" fill="url(#paint2_linear_3327_31414)" />
+        <rect x="16.5" y="16.5" width="39" height="39" rx="7.5" stroke="white" />
+      </g>
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M27.9946 39.5084L34.7561 44.2208C35.4432 44.6997 36.356 44.6997 37.0432 44.2208L43.8037 39.5091L44.621 40.0787C45.192 40.4767 45.192 41.3216 44.621 41.7195L36.4704 47.4001C36.1268 47.6396 35.6704 47.6396 35.3268 47.4001L27.1763 41.7195C26.6053 41.3216 26.6053 40.4767 27.1763 40.0787L27.9946 39.5084Z"
+        fill="url(#paint3_linear_3327_31414)"
+      />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M28.713 35.0089L34.7565 39.2209C35.4436 39.6998 36.3564 39.6998 37.0436 39.2209L43.0866 35.0092L44.622 36.0792C45.1929 36.4772 45.1929 37.3221 44.622 37.7201L36.4714 43.4006C36.1278 43.6401 35.6714 43.6401 35.3278 43.4006L27.1772 37.7201C26.6063 37.3221 26.6063 36.4772 27.1772 36.0792L28.713 35.0089Z"
+        fill="url(#paint4_linear_3327_31414)"
+      />
+      <path
+        d="M35.3276 25.3985C35.6712 25.159 36.1276 25.159 36.4712 25.3985L44.6218 31.0791C45.1927 31.477 45.1927 32.322 44.6218 32.7199L36.4712 38.4005C36.1276 38.6399 35.6712 38.6399 35.3276 38.4005L27.177 32.7199C26.6061 32.322 26.6061 31.477 27.177 31.0791L35.3276 25.3985Z"
+        fill="url(#paint5_linear_3327_31414)"
+      />
+      <defs>
+        <filter
+          id="filter0_dd_3327_31414"
+          x="0"
+          y="0"
+          width="72"
+          height="72"
+          filterUnits="userSpaceOnUse"
+          color-interpolation-filters="sRGB"
+        >
+          <feFlood flood-opacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="8" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_3327_31414" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="8" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0" />
+          <feBlend
+            mode="normal"
+            in2="effect1_dropShadow_3327_31414"
+            result="effect2_dropShadow_3327_31414"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect2_dropShadow_3327_31414"
+            result="shape"
+          />
+        </filter>
+        <linearGradient
+          id="paint1_linear_3327_31414"
+          x1="13.4126"
+          y1="11.5105"
+          x2="61.4406"
+          y2="59.0629"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(backgroundGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint2_linear_3327_31414"
+          x1="22.7133"
+          y1="21.5944"
+          x2="50.965"
+          y2="49.5664"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(foregroundGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint3_linear_3327_31414"
+          x1="29.3826"
+          y1="39.8213"
+          x2="32.9163"
+          y2="49.7543"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint4_linear_3327_31414"
+          x1="29.3836"
+          y1="35.3749"
+          x2="33.2841"
+          y2="45.742"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+        <linearGradient
+          id="paint5_linear_3327_31414"
+          x1="36.2727"
+          y1="24.4769"
+          x2="34.2309"
+          y2="38.7693"
+          gradientUnits="userSpaceOnUse"
+        >
+          {renderLinearGradientStops(symbolGradient)}
+        </linearGradient>
+      </defs>
+    </>
+  )
+}

--- a/features/marketing-layouts/icons/stack.tsx
+++ b/features/marketing-layouts/icons/stack.tsx
@@ -1,11 +1,11 @@
 import { renderLinearGradientStops } from 'features/marketing-layouts/helpers'
-import type { IconPalette } from 'features/marketing-layouts/types'
+import type { MarketingLayoutIconPalette } from 'features/marketing-layouts/types'
 
 export function stack({
   backgroundGradient,
   foregroundGradient,
   symbolGradient,
-}: IconPalette) {
+}: MarketingLayoutIconPalette) {
   return (
     <>
       <circle cx="36" cy="36" r="33.5" fill="url(#paint1_linear_3327_31414)" />

--- a/features/marketing-layouts/types.ts
+++ b/features/marketing-layouts/types.ts
@@ -1,0 +1,5 @@
+export interface IconPalette {
+  backgroundGradient: string[]
+  foregroundGradient: string[]
+  symbolGradient: string[]
+}

--- a/features/marketing-layouts/types.ts
+++ b/features/marketing-layouts/types.ts
@@ -1,5 +1,10 @@
-export interface IconPalette {
+export interface MarketingLayoutIconPalette {
   backgroundGradient: string[]
   foregroundGradient: string[]
   symbolGradient: string[]
+}
+
+export interface MarketingLayoutPalette {
+  mainGradient: string[]
+  icon: MarketingLayoutIconPalette
 }

--- a/pages/better-on-summer/test-page.tsx
+++ b/pages/better-on-summer/test-page.tsx
@@ -1,19 +1,26 @@
 import { AppLayout } from 'components/layouts/AppLayout'
 import { IconWithPalette } from 'features/marketing-layouts/components'
 import { sleep, stack } from 'features/marketing-layouts/icons'
+import type { MarketingLayoutPalette } from 'features/marketing-layouts/types'
 import React from 'react'
 import { Box } from 'theme-ui'
 
 function BetterOnSummerPage() {
-  const compoundPalette = {
-    backgroundGradient: ['#c7e6dd', '#e6f7e6', '#c4edeb'],
-    foregroundGradient: ['#a8ddcd', '#efffef', '#ffece2'],
-    symbolGradient: ['#0b9f74', '#64dfbb'],
+  const compoundPalette: MarketingLayoutPalette = {
+    mainGradient: ['#effff7', '#f9faf9'],
+    icon: {
+      backgroundGradient: ['#c7e6dd', '#e6f7e6', '#c4edeb'],
+      foregroundGradient: ['#a8ddcd', '#efffef', '#ffece2'],
+      symbolGradient: ['#0b9f74', '#64dfbb'],
+    },
   }
-  const sparkPalette = {
-    backgroundGradient: ['#ffdfbe', '#f2e7c0'],
-    foregroundGradient: ['#fbd8b2', '#ffffef', '#f3e9c4'],
-    symbolGradient: ['#f58013', '#f19d19'],
+  const sparkPalette: MarketingLayoutPalette = {
+    mainGradient: ['#ffeddb', '#fffefc'],
+    icon: {
+      backgroundGradient: ['#ffdfbe', '#f2e7c0'],
+      foregroundGradient: ['#fbd8b2', '#ffffef', '#f3e9c4'],
+      symbolGradient: ['#f58013', '#f19d19'],
+    },
   }
 
   return (
@@ -21,10 +28,10 @@ function BetterOnSummerPage() {
       <Box>
         Test
         <Box>
-          <IconWithPalette size={80} contents={sleep} {...compoundPalette} />
+          <IconWithPalette size={80} contents={sleep} {...compoundPalette.icon} />
         </Box>
         <Box>
-          <IconWithPalette size={72} contents={stack} {...sparkPalette} />
+          <IconWithPalette size={72} contents={stack} {...sparkPalette.icon} />
         </Box>
       </Box>
     </AppLayout>

--- a/pages/better-on-summer/test-page.tsx
+++ b/pages/better-on-summer/test-page.tsx
@@ -1,8 +1,34 @@
 import { AppLayout } from 'components/layouts/AppLayout'
+import { IconWithPalette } from 'features/marketing-layouts/components'
+import { sleep, stack } from 'features/marketing-layouts/icons'
 import React from 'react'
+import { Box } from 'theme-ui'
 
 function BetterOnSummerPage() {
-  return <AppLayout>Test</AppLayout>
+  const compoundPalette = {
+    backgroundGradient: ['#c7e6dd', '#e6f7e6', '#c4edeb'],
+    foregroundGradient: ['#a8ddcd', '#efffef', '#ffece2'],
+    symbolGradient: ['#0b9f74', '#64dfbb'],
+  }
+  const sparkPalette = {
+    backgroundGradient: ['#ffdfbe', '#f2e7c0'],
+    foregroundGradient: ['#fbd8b2', '#ffffef', '#f3e9c4'],
+    symbolGradient: ['#f58013', '#f19d19'],
+  }
+
+  return (
+    <AppLayout>
+      <Box>
+        Test
+        <Box>
+          <IconWithPalette size={80} contents={sleep} {...compoundPalette} />
+        </Box>
+        <Box>
+          <IconWithPalette size={72} contents={stack} {...sparkPalette} />
+        </Box>
+      </Box>
+    </AppLayout>
+  )
 }
 
 export default BetterOnSummerPage

--- a/pages/better-on-summer/test-page.tsx
+++ b/pages/better-on-summer/test-page.tsx
@@ -1,0 +1,8 @@
+import { AppLayout } from 'components/layouts/AppLayout'
+import React from 'react'
+
+function BetterOnSummerPage() {
+  return <AppLayout>Test</AppLayout>
+}
+
+export default BetterOnSummerPage


### PR DESCRIPTION
# [Icons with configurable main color](https://app.shortcut.com/oazo-apps/story/13976/icons-with-configurable-main-color)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/866e29c2-0f27-4362-97e9-1e98b15e47e1)
  
## Changes 👷‍♀️

- Created set of set of components and settings allowing to display icon with extendable palette.
- Created temporary page `/better-on-summer/test-page` for a playground.

So far the icons themselves are broken in figma, so I did not exported them all. Those included in this PR are examples that could be used during development until desing team delivers fixed svgs.