### PR TITLE
Landing page layout

### DIFF
--- a/components/layouts/MarketingLayout.tsx
+++ b/components/layouts/MarketingLayout.tsx
@@ -1,4 +1,5 @@
 import { Footer } from 'components/Footer'
+import { renderCssGradient } from 'features/marketing-layouts/helpers'
 import { NavigationController } from 'features/navigation/controls/NavigationController'
 import React from 'react'
 
@@ -7,9 +8,10 @@ import { BasicLayout } from './BasicLayout'
 import type { MarketingLayoutProps } from './MarketingLayout.types'
 
 export function MarketingLayout({
+  backgroundGradient,
   children,
-  variant,
   topBackground = 'default',
+  variant,
 }: MarketingLayoutProps) {
   return (
     <>
@@ -17,7 +19,14 @@ export function MarketingLayout({
         header={<NavigationController />}
         footer={<Footer />}
         variant={variant || 'marketingContainer'}
-        sx={{ position: 'relative' }}
+        sx={{
+          position: 'relative',
+          ...(backgroundGradient && {
+            background: renderCssGradient('180deg', backgroundGradient),
+            backgroundSize: '100% 850px',
+            backgroundRepeat: 'no-repeat',
+          }),
+        }}
         bg={marketingBackgrounds[topBackground]}
       >
         {children}

--- a/components/layouts/MarketingLayout.types.tsx
+++ b/components/layouts/MarketingLayout.types.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from 'react'
 import type { marketingBackgrounds } from './backgrounds'
 
 export interface MarketingLayoutProps extends PropsWithChildren<{}> {
-  variant?: string
+  backgroundGradient?: string[]
   topBackground?: keyof typeof marketingBackgrounds
+  variant?: string
 }

--- a/features/marketing-layouts/helpers/index.ts
+++ b/features/marketing-layouts/helpers/index.ts
@@ -1,1 +1,2 @@
+export * from './renderCssGradient'
 export * from './renderLinearGradientStops'

--- a/features/marketing-layouts/helpers/renderCssGradient.ts
+++ b/features/marketing-layouts/helpers/renderCssGradient.ts
@@ -1,5 +1,5 @@
 export function renderCssGradient(angle: string, gradient: string[]) {
-  const stops = gradient.map((item, i) => `${item} ${((1 / (gradient.length - 1)) * i) * 100}%`)
+  const stops = gradient.map((item, i) => `${item} ${(1 / (gradient.length - 1)) * i * 100}%`)
 
   return `linear-gradient(${angle}, ${stops.join(', ')})`
 }

--- a/features/marketing-layouts/helpers/renderCssGradient.ts
+++ b/features/marketing-layouts/helpers/renderCssGradient.ts
@@ -1,0 +1,5 @@
+export function renderCssGradient(angle: string, gradient: string[]) {
+  const stops = gradient.map((item, i) => `${item} ${((1 / (gradient.length - 1)) * i) * 100}%`)
+
+  return `linear-gradient(${angle}, ${stops.join(', ')})`
+}

--- a/features/marketing-layouts/types.ts
+++ b/features/marketing-layouts/types.ts
@@ -8,3 +8,7 @@ export interface MarketingLayoutPalette {
   mainGradient: string[]
   icon: MarketingLayoutIconPalette
 }
+
+export interface MarketingLayoutPageProps {
+  palette: MarketingLayoutPalette
+}

--- a/pages/better-on-summer/test-page.tsx
+++ b/pages/better-on-summer/test-page.tsx
@@ -1,38 +1,23 @@
-import { AppLayout } from 'components/layouts/AppLayout'
+import { MarketingLayout } from 'components/layouts/MarketingLayout'
 import { SimpleCarousel } from 'components/SimpleCarousel'
 import { IconWithPalette } from 'features/marketing-layouts/components'
-import { sleep, stack } from 'features/marketing-layouts/icons'
-import type { MarketingLayoutPalette } from 'features/marketing-layouts/types'
+import { sleep } from 'features/marketing-layouts/icons'
+import type {
+  MarketingLayoutPageProps,
+  MarketingLayoutPalette,
+} from 'features/marketing-layouts/types'
+import type { GetServerSidePropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
 import { Box, Heading, Text } from 'theme-ui'
 
-function BetterOnSummerPage() {
-  const compoundPalette: MarketingLayoutPalette = {
-    mainGradient: ['#effff7', '#f9faf9'],
-    icon: {
-      backgroundGradient: ['#c7e6dd', '#e6f7e6', '#c4edeb'],
-      foregroundGradient: ['#a8ddcd', '#efffef', '#ffece2'],
-      symbolGradient: ['#0b9f74', '#64dfbb'],
-    },
-  }
-  const sparkPalette: MarketingLayoutPalette = {
-    mainGradient: ['#ffeddb', '#fffefc'],
-    icon: {
-      backgroundGradient: ['#ffdfbe', '#f2e7c0'],
-      foregroundGradient: ['#fbd8b2', '#ffffef', '#f3e9c4'],
-      symbolGradient: ['#f58013', '#f19d19'],
-    },
-  }
-
+function BetterOnSummerPage({ palette }: MarketingLayoutPageProps) {
   return (
-    <AppLayout>
+    <MarketingLayout topBackground="none" backgroundGradient={palette.mainGradient}>
       <Box sx={{ width: '100%' }}>
         Test
         <Box>
-          <IconWithPalette size={80} contents={sleep} {...compoundPalette.icon} />
-        </Box>
-        <Box>
-          <IconWithPalette size={72} contents={stack} {...sparkPalette.icon} />
+          <IconWithPalette size={80} contents={sleep} {...palette.icon} />
         </Box>
         <SimpleCarousel
           header={
@@ -52,8 +37,27 @@ function BetterOnSummerPage() {
           ]}
         />
       </Box>
-    </AppLayout>
+    </MarketingLayout>
   )
 }
 
 export default BetterOnSummerPage
+
+export async function getServerSideProps({ locale }: GetServerSidePropsContext) {
+  // TODO - to be replaced with API call
+  const palette: MarketingLayoutPalette = {
+    mainGradient: ['#effff7', '#f9faf9'],
+    icon: {
+      backgroundGradient: ['#c7e6dd', '#e6f7e6', '#c4edeb'],
+      foregroundGradient: ['#a8ddcd', '#efffef', '#ffece2'],
+      symbolGradient: ['#0b9f74', '#64dfbb'],
+    },
+  }
+
+  return {
+    props: {
+      ...(await serverSideTranslations(locale || 'en', ['common'])),
+      palette,
+    },
+  }
+}


### PR DESCRIPTION
# [Landing page layout](https://app.shortcut.com/oazo-apps/story/13973/landing-page-layout)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/9595eb4a-4e4f-4240-9795-7ae8537fe62f)
  
## Changes 👷‍♀️

- Added `backgroundGradient` prop to `MarketingLayout` component that allows displaying gradient in the background based on array of colors.
- Created `renderCssGradient` function that transforms an array of colors to css gradient format.