### PR TITLE
Add additional Morpho Blue markets

### DIFF
--- a/features/omni-kit/protocols/morpho-blue/settings.ts
+++ b/features/omni-kit/protocols/morpho-blue/settings.ts
@@ -33,11 +33,8 @@ export const morphoMarkets: NetworkIdsWithValues<{ [key: string]: string }> = {
   [NetworkIds.MAINNET]: {
     'WSTETH-ETH': '0xc54d7acf14de29e0e5527cabd7a576506870346a78a11a6762e2cca66322ec41',
     'WSTETH-USDC': '0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc',
-  },
-  [NetworkIds.GOERLI]: {
-    'DAI-ETH': '0x3098a46de09dd8d9a8c6fa1ab7b3f943b6f13e5ea72a4e475d9e48f222bfd5a0',
-    'ETH-USDC': '0x98ee9f294c961a5dbb9073c0fd2c2a6a66468f911e49baa935c0eab364499dbd',
-    'USDC-ETH': '0x900d90c624f9bd1e1143059c14610bde45ff7d1746c52bf6c094d3568285b661',
-    'WSTETH-ETH': '0x44f9ccdefcee6c2b8dc7bce454ea3a9dfc48ed3be1ef79ce4bc9696932b56ddd',
+    'ETH-USDC': '0xf9acc677910cc17f650416a22e2a14d5da7ccb9626db18f1bf94efe64f92b372',
+    'WBTC-USDC': '0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49',
+    'SDAI-USDC': '0x06f2842602373d247c4934f7656e513955ccc4c377f0febc0d9ca2c3bcc191b1',
   },
 }


### PR DESCRIPTION
# [Add additional Morpho Blue markets](https://app.shortcut.com/oazo-apps/story/14054/add-missing-morpho-blue-markets)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/7d01f4f6-4b73-42da-b3c4-f3cc87ac6689)
  
## Changes 👷‍♀️

- Added: `ETH-USDC`, `WBTC-USDC` and `SDAI-USDC`.