### PR TITLE
Changed price source for Aave/Spark in portfolio, add debug option

### DIFF
--- a/features/aave/components/AaveMultiplyManageComponent.tsx
+++ b/features/aave/components/AaveMultiplyManageComponent.tsx
@@ -18,7 +18,6 @@ export type AaveManageComponentProps = {
   nextPosition?: IPosition
   strategyConfig: IStrategyConfig
   collateralPrice?: BigNumber
-  tokenPrice?: BigNumber
   debtPrice?: BigNumber
   dpmProxy?: string
   cumulatives?: AaveCumulativeData

--- a/features/aave/manage/containers/AaveManageTabBar.tsx
+++ b/features/aave/manage/containers/AaveManageTabBar.tsx
@@ -116,9 +116,8 @@ export function AaveManageTabBar({
                 aaveReserveDataDebtToken={aaveReserveDataDebtToken}
                 strategyConfig={strategyConfig}
                 currentPosition={state.context.currentPosition!}
-                collateralPrice={state.context.collateralPrice}
-                tokenPrice={state.context.tokenPrice}
-                debtPrice={state.context.debtPrice}
+                collateralPrice={state.context.balance?.collateral.price}
+                debtPrice={state.context.balance?.debt.price}
                 nextPosition={nextPosition}
                 cumulatives={state.context.cumulatives}
                 dpmProxy={state.context.effectiveProxyAddress}

--- a/features/aave/open/containers/AaveOpenView.tsx
+++ b/features/aave/open/containers/AaveOpenView.tsx
@@ -41,9 +41,8 @@ function SimulateSectionComponent({ config }: { config: IStrategyConfig }) {
       isOpenView
       strategyConfig={config}
       currentPosition={state.context.currentPosition}
-      collateralPrice={state.context.collateralPrice}
-      tokenPrice={state.context.tokenPrice}
-      debtPrice={state.context.debtPrice}
+      collateralPrice={state.context.balance?.collateral.price}
+      debtPrice={state.context.balance?.debt.price}
       nextPosition={
         hasUserInteracted(state) ? state.context.transition?.simulation.position : undefined
       }

--- a/features/aave/types/base-aave-context.ts
+++ b/features/aave/types/base-aave-context.ts
@@ -84,10 +84,6 @@ export interface BaseAaveContext {
   allowance?: StrategyTokenAllowance
   balance?: StrategyTokenBalance
   /**
-   * @deprecated no idea what token it is 🤦‍. use **balance.{}.price** instead
-   */
-  tokenPrice?: BigNumber
-  /**
    * @deprecated use **balance.collateral.price** instead
    */
   collateralPrice?: BigNumber

--- a/features/automation/contexts/AaveAutomationContext.tsx
+++ b/features/automation/contexts/AaveAutomationContext.tsx
@@ -33,7 +33,7 @@ export function AaveAutomationContext({
   const commonData = useMemo(
     () => ({
       controller: aaveManageVault.address,
-      nextCollateralPrice: aaveManageVault.context.collateralPrice || zero,
+      nextCollateralPrice: aaveManageVault.context.balance?.collateral.price || zero,
       token: aaveManageVault.context.tokens.collateral,
     }),
     [aaveManageVault],

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -152,7 +152,6 @@ export const commonDataMapper = ({
 export const aaveLikeProtocolNames = {
   [LendingProtocol.AaveV3]: 'AAVE_V3',
   [LendingProtocol.SparkV3]: 'Spark',
-  [LendingProtocol.AaveV2]: ['AAVE', 'AaveV2'],
 }
 
 export const uniqueTokensReducer = (

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -7,6 +7,7 @@ import type { SparkV3SupportedNetwork } from 'blockchain/spark-v3'
 import { getSparkV3ReserveConfigurationData, getSparkV3ReserveData } from 'blockchain/spark-v3'
 import type { OmniProductBorrowishType } from 'features/omni-kit/types'
 import { OmniProductType } from 'features/omni-kit/types'
+import type { AaveLikeOraclePriceData } from 'handlers/portfolio/positions/handlers/aave-like/types'
 import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
 import {
   getBorrowishPositionType,
@@ -63,6 +64,8 @@ interface CommonDataMapperParams {
   positionIdAsString?: boolean
   prices: TokensPricesList
   apiVaults?: Vault[]
+  allOraclePrices?: AaveLikeOraclePriceData
+  debug?: boolean
 }
 
 export const commonDataMapper = ({
@@ -71,9 +74,21 @@ export const commonDataMapper = ({
   positionIdAsString,
   prices,
   apiVaults,
+  allOraclePrices,
+  debug,
 }: CommonDataMapperParams) => {
   const primaryToken = getTokenName(dpm.networkId, dpm.collateralToken)
   const secondaryToken = getTokenName(dpm.networkId, dpm.debtToken)
+  // these token prices are separated for debugging purposes
+  const primaryTokenOraclePrice = allOraclePrices?.find(
+    (oraclePrice) => oraclePrice?.tokenSymbol.toLowerCase() === primaryToken.toLowerCase(),
+  )?.price
+  const primaryTokenTickerPrice = new BigNumber(prices[primaryToken])
+  const secondaryTokenOraclePrice = allOraclePrices?.find(
+    (oraclePrice) => oraclePrice?.tokenSymbol.toLowerCase() === secondaryToken.toLowerCase(),
+  )?.price
+  const secondaryTokenTickerPrice = new BigNumber(prices[secondaryToken])
+
   const protocol = {
     AAVE_V3: LendingProtocol.AaveV3,
     Spark: LendingProtocol.SparkV3,
@@ -121,7 +136,49 @@ export const commonDataMapper = ({
           }),
       },
     },
-    primaryTokenPrice: new BigNumber(prices[primaryToken]),
-    secondaryTokenPrice: new BigNumber(prices[secondaryToken]),
+    primaryTokenPrice: primaryTokenOraclePrice || primaryTokenTickerPrice,
+    secondaryTokenPrice: secondaryTokenOraclePrice || secondaryTokenTickerPrice,
+    ...(debug && {
+      primaryTokenOraclePrice,
+      primaryTokenTickerPrice,
+      secondaryTokenOraclePrice,
+      secondaryTokenTickerPrice,
+      primaryTokenOraclePriceMissing: !primaryTokenOraclePrice,
+      secondaryTokenOraclePriceMissing: !secondaryTokenOraclePrice,
+    }),
   }
 }
+
+export const aaveLikeProtocolNames = {
+  [LendingProtocol.AaveV3]: 'AAVE_V3',
+  [LendingProtocol.SparkV3]: 'Spark',
+  [LendingProtocol.AaveV2]: ['AAVE', 'AaveV2'],
+}
+
+export const uniqueTokensReducer = (
+  acc: Record<NetworkIds, string[]>,
+  {
+    networkId,
+    debtToken,
+    collateralToken,
+  }: { networkId: NetworkIds; debtToken: string; collateralToken: string },
+) => {
+  if (!acc[networkId]) {
+    acc[networkId] = []
+  }
+  if (!acc[networkId].includes(debtToken)) {
+    acc[networkId].push(debtToken)
+  }
+  if (!acc[networkId].includes(collateralToken)) {
+    acc[networkId].push(collateralToken)
+  }
+  return acc
+}
+
+export const formatBigNumberDebugData = (data: Record<string, BigNumber>) =>
+  Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      BigNumber.isBigNumber(value) ? value.toString() : value,
+    ]),
+  )

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -10,14 +10,18 @@ import { OmniProductType } from 'features/omni-kit/types'
 import { GraphQLClient } from 'graphql-request'
 import { notAvailable } from 'handlers/portfolio/constants'
 import {
+  aaveLikeProtocolNames,
   commonDataMapper,
   filterAutomation,
+  formatBigNumberDebugData,
   getReserveConfigurationDataCall,
   getReserveDataCall,
+  uniqueTokensReducer,
 } from 'handlers/portfolio/positions/handlers/aave-like/helpers'
 import type { GetAaveLikePositionHandlerType } from 'handlers/portfolio/positions/handlers/aave-like/types'
 import { getAutomationData } from 'handlers/portfolio/positions/helpers/getAutomationData'
 import { getHistoryData } from 'handlers/portfolio/positions/helpers/getHistoryData'
+import { getOraclePriceData } from 'handlers/portfolio/positions/helpers/getOraclePriceData'
 import type { PortfolioPositionsHandler, PositionDetail } from 'handlers/portfolio/types'
 import {
   formatCryptoBalance,
@@ -25,21 +29,25 @@ import {
   formatUsdValue,
 } from 'helpers/formatters/format'
 import { zero } from 'helpers/zero'
+import { LendingProtocol } from 'lendingProtocols'
 import { getAaveWstEthYield } from 'lendingProtocols/aave-v3/calculations/wstEthYield'
 
-const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
+const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async ({
   dpm,
   prices,
-  _history,
   allPositionsAutomations,
+  allOraclePrices,
   apiVaults,
-) => {
+  debug,
+}) => {
   const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
-  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({
+  const { commonData, primaryTokenPrice, secondaryTokenPrice, ...commonRest } = commonDataMapper({
     automations: positionAutomations,
     dpm,
     prices,
     apiVaults,
+    allOraclePrices,
+    debug,
   })
   const [primaryTokenReserveData, secondaryTokenReserveData, onChainPositionData] =
     await Promise.all([
@@ -100,22 +108,31 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async (
       },
     ],
     netValue: calculations.netValue.toNumber(),
+    debuggingData: debug
+      ? {
+          ...formatBigNumberDebugData(commonRest),
+        }
+      : undefined,
   }
 }
 
-const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
+const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async ({
   dpm,
   prices,
   allPositionsHistory,
   allPositionsAutomations,
+  allOraclePrices,
   apiVaults,
-) => {
+  debug,
+}) => {
   const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
-  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({
+  const { commonData, primaryTokenPrice, secondaryTokenPrice, ...commonRest } = commonDataMapper({
     automations: positionAutomations,
     dpm,
     prices,
     apiVaults,
+    allOraclePrices,
+    debug,
   })
   const [
     primaryTokenReserveConfiguration,
@@ -215,15 +232,23 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async (
       },
     ],
     netValue: calculations.netValue.toNumber(),
+    debuggingData: debug ? { ...formatBigNumberDebugData(commonRest) } : undefined,
   }
 }
 
-const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
+const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async ({
   dpm,
   prices,
   allPositionsHistory,
-) => {
-  const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({ dpm, prices })
+  allOraclePrices,
+  debug,
+}) => {
+  const { commonData, primaryTokenPrice, secondaryTokenPrice, ...commonRest } = commonDataMapper({
+    dpm,
+    prices,
+    allOraclePrices,
+    debug,
+  })
   const [onChainPositionData, primaryTokenReserveData, secondaryTokenReserveData] =
     await Promise.all([
       getOnChainPosition({
@@ -310,6 +335,7 @@ const getAaveLikeEarnPosition: GetAaveLikePositionHandlerType = async (
       },
     ].filter(Boolean) as PositionDetail[],
     netValue: netValuePnlModalData.netValue.inToken.toNumber(),
+    debuggingData: debug ? { ...formatBigNumberDebugData(commonRest) } : undefined,
   }
 }
 
@@ -318,15 +344,24 @@ export const aaveLikePositionsHandler: PortfolioPositionsHandler = async ({
   prices,
   apiVaults,
   positionsCount,
+  debug,
 }) => {
-  const aaveLikeDpmList = dpmList.filter(({ protocol }) => ['AAVE_V3', 'Spark'].includes(protocol))
+  const aaveLikeDpmList = dpmList.filter(({ protocol }) =>
+    [aaveLikeProtocolNames.aavev3, aaveLikeProtocolNames.sparkv3].includes(protocol),
+  )
   if (positionsCount) {
     return {
       positions: aaveLikeDpmList.map(({ vaultId }) => ({ positionId: vaultId })),
     }
   }
+  const aaveUniqueTokens = aaveLikeDpmList
+    .filter(({ protocol }) => protocol === aaveLikeProtocolNames.aavev3)
+    .reduce(uniqueTokensReducer, {} as Record<NetworkIds, string[]>)
+  const sparkUniqueTokens = aaveLikeDpmList
+    .filter(({ protocol }) => protocol === aaveLikeProtocolNames.sparkv3)
+    .reduce(uniqueTokensReducer, {} as Record<NetworkIds, string[]>)
   const uniqueDpmNetworks = Array.from(new Set(aaveLikeDpmList.map(({ networkId }) => networkId)))
-  const [allPositionsHistory, allPositionsAutomations] = await Promise.all([
+  const [allPositionsHistory, allPositionsAutomations, allOraclePrices] = await Promise.all([
     Promise.all(
       uniqueDpmNetworks.map((networkId) =>
         getHistoryData({
@@ -343,35 +378,46 @@ export const aaveLikePositionsHandler: PortfolioPositionsHandler = async ({
         .map(({ id }) => id),
       network: NetworkIds.MAINNET,
     }),
+    Promise.all([
+      ...uniqueDpmNetworks
+        .map((networkId) =>
+          getOraclePriceData({
+            network: networkId,
+            tokens: aaveUniqueTokens[networkId],
+            protocol: LendingProtocol.AaveV3,
+          }),
+        )
+        .flat(),
+      ...uniqueDpmNetworks
+        .map((networkId) =>
+          getOraclePriceData({
+            network: networkId,
+            tokens: sparkUniqueTokens[networkId],
+            protocol: LendingProtocol.SparkV3,
+          }),
+        )
+        .flat(),
+    ]).then((data) => data.flat()),
   ])
 
   const positions = await Promise.all(
     aaveLikeDpmList.map(async (dpm) => {
+      const payload = {
+        dpm,
+        prices,
+        allPositionsHistory,
+        allPositionsAutomations,
+        allOraclePrices,
+        apiVaults,
+        debug,
+      }
       switch (dpm.positionType.toLowerCase()) {
         case OmniProductType.Multiply:
-          return getAaveLikeMultiplyPosition(
-            dpm,
-            prices,
-            allPositionsHistory,
-            allPositionsAutomations,
-            apiVaults,
-          )
+          return getAaveLikeMultiplyPosition(payload)
         case OmniProductType.Borrow:
-          return getAaveLikeBorrowPosition(
-            dpm,
-            prices,
-            allPositionsHistory,
-            allPositionsAutomations,
-            apiVaults,
-          )
+          return getAaveLikeBorrowPosition(payload)
         case OmniProductType.Earn:
-          return getAaveLikeEarnPosition(
-            dpm,
-            prices,
-            allPositionsHistory,
-            allPositionsAutomations,
-            apiVaults,
-          )
+          return getAaveLikeEarnPosition(payload)
         default:
           throw new Error(`Unsupported position type ${dpm.positionType}`)
       }

--- a/handlers/portfolio/positions/handlers/aave-like/types.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/types.ts
@@ -1,14 +1,36 @@
 import type { Vault } from '@prisma/client'
+import type BigNumber from 'bignumber.js'
 import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
 import type { DpmSubgraphData } from 'handlers/portfolio/positions/helpers/getAllDpmsForWallet'
 import type { AutomationResponse } from 'handlers/portfolio/positions/helpers/getAutomationData'
 import type { HistoryResponse } from 'handlers/portfolio/positions/helpers/getHistoryData'
 import type { PortfolioPosition } from 'handlers/portfolio/types'
+import type { LendingProtocol } from 'lendingProtocols'
 
-export type GetAaveLikePositionHandlerType = (
-  dpm: DpmSubgraphData,
-  prices: TokensPricesList,
-  allPositionsHistory: HistoryResponse,
-  allPositionsAutomation: AutomationResponse,
-  apiVaults?: Vault[],
-) => Promise<PortfolioPosition>
+export type AaveLikeOraclePriceData = (
+  | {
+      protocol: LendingProtocol.SparkV3 | LendingProtocol.AaveV2 | LendingProtocol.AaveV3
+      price: BigNumber
+      tokenSymbol: string
+      tokenAddress: string
+    }
+  | undefined
+)[]
+
+export type GetAaveLikePositionHandlerType = ({
+  dpm,
+  prices,
+  allPositionsHistory,
+  allPositionsAutomations,
+  allOraclePrices,
+  apiVaults,
+  debug,
+}: {
+  dpm: DpmSubgraphData
+  prices: TokensPricesList
+  allPositionsHistory: HistoryResponse
+  allPositionsAutomations: AutomationResponse
+  allOraclePrices: AaveLikeOraclePriceData
+  apiVaults?: Vault[]
+  debug?: boolean
+}) => Promise<PortfolioPosition>

--- a/handlers/portfolio/positions/handlers/aave-v2/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/index.ts
@@ -19,11 +19,11 @@ import {
 } from 'helpers/formatters/format'
 import { zero } from 'helpers/zero'
 
-const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async (
+const getAaveV2MultiplyPosition: GetAaveLikePositionHandlerType = async ({
   dpm,
   prices,
   allPositionsHistory,
-) => {
+}) => {
   const { commonData, primaryTokenPrice, secondaryTokenPrice } = commonDataMapper({ dpm, prices })
   const [
     primaryTokenReserveConfiguration,
@@ -145,7 +145,13 @@ export const aaveV2PositionHandler: PortfolioPositionsHandler = async ({
   ])
   const positions = await Promise.all(
     aaveV2DpmList.map(async (dpm) =>
-      getAaveV2MultiplyPosition(dpm, prices, allPositionsHistory, []),
+      getAaveV2MultiplyPosition({
+        dpm,
+        prices,
+        allPositionsHistory,
+        allPositionsAutomations: [], // not needed here
+        allOraclePrices: [], // not needed here
+      }),
     ),
   )
   return {

--- a/handlers/portfolio/positions/helpers/getOraclePriceData.ts
+++ b/handlers/portfolio/positions/helpers/getOraclePriceData.ts
@@ -1,0 +1,62 @@
+import { captureException } from '@sentry/nextjs'
+import { ensureIsSupportedAaveV3NetworkId, getAaveV3OracleAssetPrice } from 'blockchain/aave-v3'
+import type { NetworkIds } from 'blockchain/networks'
+import { ensureIsSupportedSparkV3NetworkId, getSparkV3OracleAssetPrice } from 'blockchain/spark-v3'
+import { getTokenSymbolBasedOnAddress } from 'blockchain/tokensMetadata'
+import { LendingProtocol } from 'lendingProtocols'
+
+import { eth2weth } from '@oasisdex/utils/lib/src/utils'
+
+export const getOraclePriceData = ({
+  tokens,
+  protocol,
+  network,
+}: {
+  tokens: string[]
+  protocol: LendingProtocol.AaveV3 | LendingProtocol.SparkV3
+  network: NetworkIds
+}) => {
+  try {
+    if (!tokens) {
+      return []
+    }
+    if (protocol === LendingProtocol.AaveV3) {
+      ensureIsSupportedAaveV3NetworkId(network)
+      return tokens.map(async (tokenAddress) => {
+        const tokenSymbol = eth2weth(getTokenSymbolBasedOnAddress(network, tokenAddress))
+        return await getAaveV3OracleAssetPrice({ token: tokenSymbol, networkId: network }).then(
+          (price) => ({
+            protocol,
+            price,
+            tokenSymbol,
+            tokenAddress,
+          }),
+        )
+      })
+    }
+    if (protocol === LendingProtocol.SparkV3) {
+      ensureIsSupportedSparkV3NetworkId(network)
+      return tokens.map(async (tokenAddress) => {
+        const tokenSymbol = eth2weth(getTokenSymbolBasedOnAddress(network, tokenAddress))
+        return await getSparkV3OracleAssetPrice({ token: tokenSymbol, networkId: network }).then(
+          (price) => ({
+            protocol,
+            price,
+            tokenSymbol,
+            tokenAddress,
+          }),
+        )
+      })
+    }
+    return []
+  } catch (error) {
+    captureException({
+      region: 'getOraclePriceData',
+      tokens,
+      protocol,
+      network,
+      error,
+    })
+    return []
+  }
+}

--- a/handlers/portfolio/positions/index.ts
+++ b/handlers/portfolio/positions/index.ts
@@ -53,6 +53,7 @@ export const portfolioPositionsHandler = async ({
       apiVaults,
       prices: prices.data.tokens,
       positionsCount,
+      debug,
     }
 
     const positionsReply = await Promise.all([

--- a/handlers/portfolio/types.ts
+++ b/handlers/portfolio/types.ts
@@ -40,6 +40,7 @@ export type PortfolioPosition = {
   secondaryToken: string
   type: OmniProductType
   url: string
+  debuggingData?: any
 }
 interface PortfolioPositionsCommonReply {
   error?: boolean | string
@@ -62,6 +63,7 @@ export type PortfolioPositionsHandler = ({
   dpmList,
   prices,
   positionsCount,
+  debug,
 }: {
   address: string
   apiVaults?: Vault[]
@@ -69,6 +71,7 @@ export type PortfolioPositionsHandler = ({
   prices: TokensPricesList
   positionsCount?: boolean
   allPositionsHistory?: HistoryResponse
+  debug?: boolean
 }) => Promise<PortfolioPositionsReply | PortfolioPositionsCountReply>
 
 type DetailsTypeCommon =


### PR DESCRIPTION
- Changed price source for Aave/Spark in portfolio, from price tickers to oracle prices
- Added debug option (shows ticker and oracle price, info if any is missing and uses ticker as failsafe)