### PR TITLE
Filter out Ajna events from Aave.

### DIFF
--- a/features/aave/services/get-aave-history-events.ts
+++ b/features/aave/services/get-aave-history-events.ts
@@ -83,6 +83,10 @@ export async function getAaveHistoryEvents(
             trigger: event.trigger ?? undefined,
           }),
         )
+        // Ajna & Morpho have additional mapping later (mapLendingEvents.ts), so there is no issue with
+        // overlapping events from different protocols. Aave & Spark doesn't so this one-liner will do the job
+        // until we will rewrite it to omni-kit
+        .filter((item) => !item.kind.includes('Ajna'))
         .sort((a, b) => b.timestamp - a.timestamp),
       positionCumulatives: positions[0]
         ? {


### PR DESCRIPTION
# [Filter out Ajna events from Aave](https://app.shortcut.com/oazo-apps/story/13988/bug-history-ajna-related-events-displayed-in-aave-position-s-history)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- filtered out Ajna events from Aave.
  
## How to test 🧪
  <Please explain how to test your changes>

- `/ethereum/aave/v3/84#history` following position should contain only Aave events
