### PR TITLE
Filter Ajna Pool Finder banner in Product Finder 

### DIFF
--- a/features/productHub/controls/ProductHubContentController.tsx
+++ b/features/productHub/controls/ProductHubContentController.tsx
@@ -55,6 +55,7 @@ export const ProductHubContentController: FC<ProductHubContentControllerProps> =
   )
 
   const banner = useProductHubBanner({
+    filters: selectedFilters,
     product: selectedProduct,
   })
 

--- a/features/productHub/hooks/useProductHubBanner.tsx
+++ b/features/productHub/hooks/useProductHubBanner.tsx
@@ -1,24 +1,35 @@
 import type { ActionBannerProps } from 'components/ActionBanner'
+import type { ProductHubFilters } from 'features/productHub/types'
 import { ProductHubProductType } from 'features/productHub/types'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAppConfig } from 'helpers/config'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
+import { LendingProtocol } from 'lendingProtocols'
 import { startCase } from 'lodash'
 import { useTranslation } from 'next-i18next'
 import poolFinderIcon from 'public/static/img/product_hub_banners/pool-finder.svg'
 
 interface ProductHubBannerProps {
+  filters: ProductHubFilters
   product: ProductHubProductType
 }
 
 export const useProductHubBanner = ({
+  filters: {
+    and: { protocol },
+  },
   product,
 }: ProductHubBannerProps): ActionBannerProps | undefined => {
   const { AjnaSafetySwitch: ajnaSafetySwitchOn, AjnaPoolFinder: ajnaPoolFinderEnabled } =
     useAppConfig('features')
   const { t } = useTranslation()
 
-  if (!ajnaSafetySwitchOn && ajnaPoolFinderEnabled && product !== ProductHubProductType.Multiply) {
+  if (
+    !ajnaSafetySwitchOn &&
+    ajnaPoolFinderEnabled &&
+    product !== ProductHubProductType.Multiply &&
+    (protocol === undefined || protocol?.includes(LendingProtocol.Ajna))
+  ) {
     return {
       title: t('product-hub.banners.pool-finder.title'),
       children: t('product-hub.banners.pool-finder.description', {


### PR DESCRIPTION
# [Filter Ajna Pool Finder banner in Product Finder ](https://app.shortcut.com/oazo-apps/story/14058/ajna-custom-pool-selector-appears-on-any-protocol)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- Added additional filters to Product Finder banners so Ajna Pool Finder shows when no protocol is selected or Ajna is one of selected protocols.
