### PR TITLE
Add Product Finder to Marketing Template

### DIFF
--- a/features/marketing-layouts/types.ts
+++ b/features/marketing-layouts/types.ts
@@ -1,5 +1,9 @@
 import type { marketingTemplatesIcons } from 'features/marketing-layouts/icons'
-import type { ProductFinderPromoCardFilters, ProductHubProductType, ProductHubSupportedNetworks } from 'features/productHub/types'
+import type {
+  ProductFinderPromoCardFilters,
+  ProductHubProductType,
+  ProductHubSupportedNetworks,
+} from 'features/productHub/types'
 import type { LendingProtocol } from 'lendingProtocols'
 import type { ReactNode } from 'react'
 

--- a/features/marketing-layouts/types.ts
+++ b/features/marketing-layouts/types.ts
@@ -1,17 +1,18 @@
 import type { marketingTemplatesIcons } from 'features/marketing-layouts/icons'
+import type { ProductFinderPromoCardFilters, ProductHubProductType, ProductHubSupportedNetworks } from 'features/productHub/types'
 import type { LendingProtocol } from 'lendingProtocols'
 import type { ReactNode } from 'react'
 
 export type IconWithPaletteContents = (params: MarketingTemplateIconPalette) => ReactNode
 
 export interface MarketingTemplateIconPalette {
-  backgroundGradient: string[]
-  foregroundGradient: string[]
-  symbolGradient: string[]
+  backgroundGradient: [string, string, ...string[]]
+  foregroundGradient: [string, string, ...string[]]
+  symbolGradient: [string, string, ...string[]]
 }
 
 export interface MarketingTemplatePalette {
-  mainGradient: string[]
+  mainGradient: [string, string, ...string[]]
   icon: MarketingTemplateIconPalette
 }
 
@@ -56,6 +57,17 @@ export interface MarketingTemplatePageProps {
   benefitsTitle: string
   hero: MarketingTemplateHeroProps
   palette: MarketingTemplatePalette
+  productFinder: {
+    initialNetwork?: ProductHubSupportedNetworks[]
+    initialProtocol?: LendingProtocol[]
+    product: ProductHubProductType
+    token?: string
+    promoCards: [
+      ProductFinderPromoCardFilters,
+      ProductFinderPromoCardFilters,
+      ProductFinderPromoCardFilters,
+    ]
+  }
   products: MarketingTemplateProductsProps[]
   productsTitle: string
 }

--- a/features/productHub/components/ProductHubPromoCardsList.tsx
+++ b/features/productHub/components/ProductHubPromoCardsList.tsx
@@ -8,9 +8,7 @@ interface ProductHubPromoCardsListProps {
   promoCards: PromoCardProps[]
 }
 
-export const ProductHubPromoCardsList: FC<ProductHubPromoCardsListProps> = ({
-  promoCards,
-}) => {
+export const ProductHubPromoCardsList: FC<ProductHubPromoCardsListProps> = ({ promoCards }) => {
   return (
     <Grid columns={[1, null, 2, 3]} gap={3} sx={{ my: 4 }}>
       {promoCards.map((promoCard, i) => (

--- a/features/productHub/components/ProductHubPromoCardsList.tsx
+++ b/features/productHub/components/ProductHubPromoCardsList.tsx
@@ -1,0 +1,21 @@
+import { PromoCard } from 'components/PromoCard'
+import type { PromoCardProps } from 'components/PromoCard.types'
+import type { FC } from 'react'
+import React from 'react'
+import { Grid } from 'theme-ui'
+
+interface ProductHubPromoCardsListProps {
+  promoCards: PromoCardProps[]
+}
+
+export const ProductHubPromoCardsList: FC<ProductHubPromoCardsListProps> = ({
+  promoCards,
+}) => {
+  return (
+    <Grid columns={[1, null, 2, 3]} gap={3} sx={{ my: 4 }}>
+      {promoCards.map((promoCard, i) => (
+        <PromoCard key={`${promoCard.title}-${i}`} {...promoCard} />
+      ))}
+    </Grid>
+  )
+}

--- a/features/productHub/controls/ProductHubPromoCardsController.tsx
+++ b/features/productHub/controls/ProductHubPromoCardsController.tsx
@@ -1,8 +1,7 @@
-import { PromoCard } from 'components/PromoCard'
+import { ProductHubPromoCardsList } from 'features/productHub/components/ProductHubPromoCardsList'
 import type { ProductHubProductType, ProductHubPromoCards } from 'features/productHub/types'
 import type { FC } from 'react'
 import React, { useMemo } from 'react'
-import { Grid } from 'theme-ui'
 
 interface ProductHubPromoCardsControllerProps {
   promoCardsData: ProductHubPromoCards
@@ -23,15 +22,5 @@ export const ProductHubPromoCardsController: FC<ProductHubPromoCardsControllerPr
     [promoCardsData, selectedProduct, selectedToken],
   )
 
-  return (
-    <>
-      {promoCards.length > 0 && (
-        <Grid columns={[1, null, 2, 3]} gap={3} sx={{ mb: 4 }}>
-          {promoCards.map((promoCard, i) => (
-            <PromoCard key={`${selectedProduct}-${i}`} {...promoCard} />
-          ))}
-        </Grid>
-      )}
-    </>
-  )
+  return <>{promoCards.length > 0 && <ProductHubPromoCardsList promoCards={promoCards} />}</>
 }

--- a/features/productHub/types.ts
+++ b/features/productHub/types.ts
@@ -109,3 +109,11 @@ export interface ProductHubQueryString {
   secondaryToken?: ProductHubTokenType[]
   strategy?: ProductHubMultiplyStrategyType[]
 }
+
+export interface ProductFinderPromoCardFilters {
+  network: ProductHubSupportedNetworks
+  primaryToken: string
+  product: ProductHubProductType
+  protocol: LendingProtocol
+  secondaryToken: ProductHubTokenType
+}

--- a/features/productHub/views/ProductHubView.tsx
+++ b/features/productHub/views/ProductHubView.tsx
@@ -39,6 +39,7 @@ interface ProductHubViewProps {
   intro?: (selectedProduct: ProductHubProductType, selectedToken: string) => ReactNode
   headerGradient?: [string, string, ...string[]]
   product: ProductHubProductType
+  promoCardsPosition?: 'top' | 'bottom' | 'none'
   promoCardsCollection: PromoCardsCollection
   token?: string
   url?: string
@@ -51,6 +52,7 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
   headerGradient = ['#007DA3', '#E7A77F', '#E97047'],
   product,
   promoCardsCollection,
+  promoCardsPosition = 'top',
   intro,
   token,
   url,
@@ -146,11 +148,13 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
       >
         {() => (
           <>
-            <ProductHubPromoCardsController
-              promoCardsData={PROMO_CARD_COLLECTIONS_PARSERS[promoCardsCollection](data.table)}
-              selectedProduct={selectedProduct}
-              selectedToken={selectedToken}
-            />
+            {promoCardsPosition === 'top' && (
+              <ProductHubPromoCardsController
+                promoCardsData={PROMO_CARD_COLLECTIONS_PARSERS[promoCardsCollection](data.table)}
+                selectedProduct={selectedProduct}
+                selectedToken={selectedToken}
+              />
+            )}
             <ProductHubContentController
               initialNetwork={resolvedInitialNetwork}
               initialProtocol={initialProtocol}
@@ -189,6 +193,13 @@ export const ProductHubView: FC<ProductHubViewProps> = ({
                   </WithArrow>
                 </AppLink>
               </Flex>
+            )}
+            {promoCardsPosition === 'bottom' && (
+              <ProductHubPromoCardsController
+                promoCardsData={PROMO_CARD_COLLECTIONS_PARSERS[promoCardsCollection](data.table)}
+                selectedProduct={selectedProduct}
+                selectedToken={selectedToken}
+              />
             )}
           </>
         )}

--- a/pages/better-on-summer/test-page.tsx
+++ b/pages/better-on-summer/test-page.tsx
@@ -1,3 +1,5 @@
+import { NetworkNames } from 'blockchain/networks'
+import { usePreloadAppDataContext } from 'components/context/PreloadAppDataContextProvider'
 import { MarketingLayout } from 'components/layouts/MarketingLayout'
 import { SimpleCarousel } from 'components/SimpleCarousel'
 import {
@@ -7,6 +9,10 @@ import {
 } from 'features/marketing-layouts/components'
 import { getGridTemplateAreas } from 'features/marketing-layouts/helpers'
 import type { MarketingTemplatePageProps } from 'features/marketing-layouts/types'
+import { ProductHubPromoCardsList } from 'features/productHub/components/ProductHubPromoCardsList'
+import { getGenericPromoCard } from 'features/productHub/helpers'
+import { ProductHubProductType } from 'features/productHub/types'
+import { ProductHubView } from 'features/productHub/views'
 import { getGradientColor, summerBrandGradient } from 'helpers/getGradientColor'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { LendingProtocol } from 'lendingProtocols'
@@ -21,13 +27,41 @@ function BetterOnSummerPage({
   benefitsTitle,
   hero,
   palette,
+  productFinder,
   products,
   productsTitle,
 }: MarketingTemplatePageProps) {
+  const {
+    productHub: { table },
+  } = usePreloadAppDataContext()
+
+  const promoCards = table
+    .filter((product) =>
+      productFinder.promoCards.some(
+        (filters) =>
+          product.network === filters.network &&
+          product.protocol === filters.protocol &&
+          product.product.includes(filters.product) &&
+          product.primaryToken === filters.primaryToken &&
+          product.secondaryToken === filters.secondaryToken,
+      ),
+    )
+    .map((product) => getGenericPromoCard({ product }))
+
   return (
     <MarketingLayout topBackground="none" backgroundGradient={palette.mainGradient}>
       <Box sx={{ width: '100%' }}>
         <MarketingTemplateHero {...hero} />
+        <Box sx={{ mt: 7 }}>
+          <ProductHubView
+            headerGradient={palette.icon.symbolGradient}
+            promoCardsCollection="Home"
+            promoCardsPosition="none"
+            limitRows={10}
+            {...productFinder}
+          />
+          <ProductHubPromoCardsList promoCards={promoCards} />
+        </Box>
         <Heading as="h2" variant="header2" sx={{ mb: 5, textAlign: 'center' }}>
           {productsTitle}
         </Heading>
@@ -84,6 +118,34 @@ export async function getServerSideProps({ locale }: GetServerSidePropsContext) 
       "Earn interest, Borrow Assets and Multiply Exposure with DeFi's leading liquidity protocol. Made even better with Summer.fi's Superpowers of one click actions, advanced automations and unified frontend gateway to the best of DeFi.",
     link: { label: 'Open a position', url: '/' },
     image: staticFilesRuntimeUrl('/static/img/marketing-layout/temp-hero.png'),
+  }
+
+  const productFinder: MarketingTemplatePageProps['productFinder'] = {
+    product: ProductHubProductType.Multiply,
+    initialProtocol: [LendingProtocol.AaveV2, LendingProtocol.AaveV3],
+    promoCards: [
+      {
+        network: NetworkNames.ethereumMainnet,
+        primaryToken: 'WSTETH',
+        secondaryToken: 'ETH',
+        product: ProductHubProductType.Borrow,
+        protocol: LendingProtocol.AaveV3,
+      },
+      {
+        network: NetworkNames.optimismMainnet,
+        primaryToken: 'WBTC',
+        secondaryToken: 'USDC',
+        product: ProductHubProductType.Multiply,
+        protocol: LendingProtocol.AaveV3,
+      },
+      {
+        network: NetworkNames.baseMainnet,
+        primaryToken: 'CBETH',
+        secondaryToken: 'ETH',
+        product: ProductHubProductType.Earn,
+        protocol: LendingProtocol.AaveV3,
+      },
+    ],
   }
 
   const productsTitle = 'The simplest way Borrow stables and Multiply your crypto'
@@ -182,6 +244,7 @@ export async function getServerSideProps({ locale }: GetServerSidePropsContext) 
     benefits,
     benefitsSubtitle,
     benefitsTitle,
+    productFinder,
     products,
     productsTitle,
     hero,

--- a/pages/better-on-summer/test-page.tsx
+++ b/pages/better-on-summer/test-page.tsx
@@ -42,8 +42,8 @@ function BetterOnSummerPage({
           product.network === filters.network &&
           product.protocol === filters.protocol &&
           product.product.includes(filters.product) &&
-          product.primaryToken === filters.primaryToken &&
-          product.secondaryToken === filters.secondaryToken,
+          product.primaryToken.toLowerCase() === filters.primaryToken.toLowerCase() &&
+          product.secondaryToken.toLowerCase() === filters.secondaryToken.toLowerCase(),
       ),
     )
     .map((product) => getGenericPromoCard({ product }))


### PR DESCRIPTION
# [Add Product Finder to Marketing Template](https://app.shortcut.com/oazo-apps/story/14091/ui-integration-add-product-finder-to-template)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/87da83ec-f704-44e7-9d49-785ec810a40b)
  
## Changes 👷‍♀️

- Added Product Finder to Marketing Template interface and view.
- Extracted `ProductHubPromoCardsList` from Product Finder as separated component so the list can be generated independently from Product Finder settings.

## Additional notes 🗒️

- Product Finder design wasn't adjusted to the new layouts as this is not a part of current epic; for more info see here: https://discord.com/channels/837076147694207067/1199024181447237652/1200138180746301480