### PR TITLE
UI component: MarketingTemplateBanner

### DIFF
--- a/components/layouts/MarketingLayout.tsx
+++ b/components/layouts/MarketingLayout.tsx
@@ -22,7 +22,12 @@ export function MarketingLayout({
         sx={{
           position: 'relative',
           ...(backgroundGradient && {
-            background: renderCssGradient('180deg', [...backgroundGradient, '#fff']),
+            background: renderCssGradient('180deg', [
+              ...backgroundGradient,
+              ...(!['#fff', '#ffffff'].includes(backgroundGradient[backgroundGradient.length - 1])
+                ? ['#fff']
+                : []),
+            ]),
             backgroundSize: '100% 1024px',
             backgroundRepeat: 'no-repeat',
           }),

--- a/features/marketing-layouts/components/MarketingTemplateBanner.tsx
+++ b/features/marketing-layouts/components/MarketingTemplateBanner.tsx
@@ -31,7 +31,7 @@ export const MarketingTemplateBanner: FC<
         <Heading variant="header4">{title}</Heading>
         {description && <MarketingTemplateMarkdown content={description} />}
       </Flex>
-      <AppLink variant="primary" href={url} sx={{ flexShrink: '0', px: 4 }}>
+      <AppLink variant="primary" href={url} sx={{ flexShrink: 0, px: 4 }}>
         {label} →
       </AppLink>
     </Flex>

--- a/features/marketing-layouts/components/MarketingTemplateBanner.tsx
+++ b/features/marketing-layouts/components/MarketingTemplateBanner.tsx
@@ -1,0 +1,39 @@
+import { AppLink } from 'components/Links'
+import { MarketingTemplateMarkdown } from 'features/marketing-layouts/components/MarketingTemplateMarkdown'
+import { renderCssGradient } from 'features/marketing-layouts/helpers'
+import type {
+  MarketingTemplateBannerProps,
+  MarketingTemplatePalette,
+} from 'features/marketing-layouts/types'
+import React, { type FC } from 'react'
+import { Flex, Heading } from 'theme-ui'
+
+export const MarketingTemplateBanner: FC<
+  MarketingTemplateBannerProps & { palette: MarketingTemplatePalette }
+> = ({ cta: { label, url }, description, palette: { background }, title }) => {
+  return (
+    <Flex
+      sx={{
+        flexDirection: ['column', 'row'],
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        rowGap: '24px',
+        columnGap: 5,
+        px: [4, 5],
+        py: 5,
+        border: '1px solid',
+        borderColor: 'neutral20',
+        borderRadius: 'rounder',
+        background: renderCssGradient('90deg', background),
+      }}
+    >
+      <Flex sx={{ flexDirection: 'column', rowGap: 2 }}>
+        <Heading variant="header4">{title}</Heading>
+        {description && <MarketingTemplateMarkdown content={description} />}
+      </Flex>
+      <AppLink variant="primary" href={url} sx={{ flexShrink: '0', px: 4 }}>
+        {label} →
+      </AppLink>
+    </Flex>
+  )
+}

--- a/features/marketing-layouts/components/MarketingTemplateProductBox.tsx
+++ b/features/marketing-layouts/components/MarketingTemplateProductBox.tsx
@@ -2,14 +2,27 @@ import { AppLink } from 'components/Links'
 import { WithArrow } from 'components/WithArrow'
 import { MarketingTemplateMarkdown } from 'features/marketing-layouts/components'
 import { renderCssGradient } from 'features/marketing-layouts/helpers'
-import type { MarketingTemplateProductBoxProps } from 'features/marketing-layouts/types'
+import type {
+  MarketingTemplatePalette,
+  MarketingTemplateProductBoxProps,
+} from 'features/marketing-layouts/types'
 import React, { type FC } from 'react'
 import { useOnMobile } from 'theme/useBreakpointIndex'
 import { Box, Flex, Heading, Image, Text } from 'theme-ui'
 
 export const MarketingTemplateProductBox: FC<
-  MarketingTemplateProductBoxProps & { background: [string, string, ...string[]]; index: number }
-> = ({ actionsList, background, composition, description, index, image, link, title, type }) => {
+  MarketingTemplateProductBoxProps & { index: number; palette: MarketingTemplatePalette }
+> = ({
+  actionsList,
+  composition,
+  description,
+  image,
+  index,
+  link,
+  palette: { background },
+  title,
+  type,
+}) => {
   const isMobile = useOnMobile()
   const isNarrow = composition === 'narrow' || isMobile
 

--- a/features/marketing-layouts/components/index.ts
+++ b/features/marketing-layouts/components/index.ts
@@ -1,3 +1,4 @@
+export * from './MarketingTemplateBanner'
 export * from './MarketingTemplateBenefitBox'
 export * from './MarketingTemplateHeading'
 export * from './MarketingTemplateHero'

--- a/features/marketing-layouts/types.ts
+++ b/features/marketing-layouts/types.ts
@@ -14,8 +14,8 @@ export interface MarketingTemplateHeroProps {
   description: string
   image: string
   link: {
-    url: string
     label: string
+    url: string
   }
   protocol?: LendingProtocol | LendingProtocol[]
   title: string
@@ -49,8 +49,8 @@ export interface MarketingTemplateInfoBoxProps {
   description: string
   image: string
   link?: {
-    url: string
     label: string
+    url: string
   }
   title: string
   tokens?: string[]
@@ -71,8 +71,8 @@ export interface MarketingTemplateProductBoxProps {
   description: string
   image?: string
   link?: {
-    url: string
     label: string
+    url: string
   }
   title: string
   type: string
@@ -94,7 +94,22 @@ interface MarketingTemplateBeneftBoxBlock extends MarketingTemplateBlock {
   content: MarketingTemplateBenefitBoxProps[]
 }
 
+export interface MarketingTemplateBannerProps {
+  cta: {
+    label: string
+    url: string
+  }
+  description?: string
+  title: string
+}
+
+interface MarketingTemplateBannerBlock extends MarketingTemplateBlock {
+  type: 'banner'
+  content: MarketingTemplateBannerProps
+}
+
 export type MarketingTemplateProductFinderBlocks =
+  | MarketingTemplateBannerBlock
   | MarketingTemplateBeneftBoxBlock
   | MarketingTemplateInfoBoxBlock
   | MarketingTemplateProductBoxBlock

--- a/features/marketing-layouts/views/MarketingTemplateBlockView.tsx
+++ b/features/marketing-layouts/views/MarketingTemplateBlockView.tsx
@@ -1,6 +1,7 @@
 import { usePreloadAppDataContext } from 'components/context/PreloadAppDataContextProvider'
 import { SimpleCarousel } from 'components/SimpleCarousel'
 import {
+  MarketingTemplateBanner,
   MarketingTemplateBenefitBox,
   MarketingTemplateHeading,
   MarketingTemplateInfoBox,
@@ -34,9 +35,11 @@ export const MarketingTemplateBlockView: FC<MarketingTemplateBlockViewProps> = (
     productHub: { table },
   } = usePreloadAppDataContext()
 
-  const { background, foreground } = palette
+  const { foreground } = palette
 
   switch (type) {
+    case 'banner':
+      return <MarketingTemplateBanner palette={palette} {...content} />
     case 'benefit-box':
       return (
         <SimpleCarousel
@@ -76,12 +79,7 @@ export const MarketingTemplateBlockView: FC<MarketingTemplateBlockViewProps> = (
           }}
         >
           {content.map((productBox, i) => (
-            <MarketingTemplateProductBox
-              key={i}
-              background={background}
-              index={i}
-              {...productBox}
-            />
+            <MarketingTemplateProductBox key={i} index={i} palette={palette} {...productBox} />
           ))}
         </Grid>
       )

--- a/features/marketing-layouts/views/MarketingTemplateView.tsx
+++ b/features/marketing-layouts/views/MarketingTemplateView.tsx
@@ -20,7 +20,7 @@ export const MarketingTemplateView: FC<MarketingTemplateViewProps> = ({
       {blocks.map((block, i) => (
         <Box key={i} sx={{ mt: 7 }}>
           {block.type !== 'benefit-box' && (
-            <Box sx={{ mb: 5, px: 6, textAlign: 'center' }}>
+            <Box sx={{ mb: 5, px: [0, null, 5, 6], textAlign: ['left', 'center'] }}>
               <MarketingTemplateHeading
                 palette={palette}
                 description={block.description}

--- a/pages/better-on-summer/[...slug].tsx
+++ b/pages/better-on-summer/[...slug].tsx
@@ -28,7 +28,7 @@ export default MarketingTemplatePage
 export async function getServerSideProps({ locale }: GetServerSidePropsContext) {
   const marketingTemplatePageProps: MarketingTemplateFreeform = {
     palette: {
-      background: ['#f8eaff', '#edf8ff'],
+      background: ['#f8eaff', '#edf8ff', '#fff'],
       foreground: ['#2ebac6', '#b6509e'],
     },
     hero: {
@@ -188,6 +188,16 @@ export async function getServerSideProps({ locale }: GetServerSidePropsContext) 
               '- Unlock the superpowers of other protocols\n- View all your positions and assets at glance\n- Discover new curated DeFi opportunities\n- Swap and Bridge',
           },
         ],
+      },
+      {
+        type: 'banner',
+        content: {
+          title: 'Ready to get started?',
+          cta: {
+            label: 'Open a position',
+            url: '/',
+          },
+        },
       },
     ],
   }


### PR DESCRIPTION
# [UI component: MarketingTemplateBanner](https://app.shortcut.com/oazo-apps/story/14122/ui-integration-add-actionbanner-to-template)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/20600df7-1db4-40c5-b77b-39eaab1b4ee7)
  
## Changes 👷‍♀️

- Created `MarketingTemplateBanner` component.
- Various mobile fixes.