### PR TITLE
Add Aave trigger types to getPositionsAutomationsParams

### DIFF
--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -9,8 +9,13 @@ interface getPositionsAutomationsParams {
 }
 
 const triggerTypesMap = {
-  autoBuy: [TriggerType.BasicBuy, TriggerType.MakerBasicBuyV2],
-  autoSell: [TriggerType.BasicSell, TriggerType.MakerBasicSellV2, TriggerType.SimpleAAVESell],
+  autoBuy: [TriggerType.BasicBuy, TriggerType.MakerBasicBuyV2, TriggerType.AaveBasicBuyV2],
+  autoSell: [
+    TriggerType.BasicSell,
+    TriggerType.MakerBasicSellV2,
+    TriggerType.SimpleAAVESell,
+    TriggerType.AaveBasicSellV2,
+  ],
   stopLoss: [
     TriggerType.AaveStopLossToCollateral,
     TriggerType.AaveStopLossToCollateralV2,


### PR DESCRIPTION
This pull request adds the Aave trigger types to the getPositionsAutomationsParams interface. Previously, the autoBuy and autoSell trigger types were missing the AaveBasicBuyV2 and AaveBasicSellV2 options. This update ensures that these options are included, allowing for more comprehensive automation of Aave positions.