### PR TITLE
Simple Carousel mobile UI

### DIFF
--- a/components/SimpleCarousel.tsx
+++ b/components/SimpleCarousel.tsx
@@ -57,24 +57,30 @@ export const SimpleCarousel: FC<SimpleCarouselProps> = ({
         }}
       >
         {header}
-        <Flex sx={{ columnGap: '12px', flexShrink: 0 }}>
-          <Button
-            variant="action"
-            sx={{ p: '12px' }}
-            onClick={() => emblaApi?.scrollPrev()}
-            disabled={!canScrollPrev}
-          >
-            <Icon icon={arrow_left} size="16px" sx={{ position: 'relative', display: 'block' }} />
-          </Button>
-          <Button
-            variant="action"
-            sx={{ p: '12px' }}
-            onClick={() => emblaApi?.scrollNext()}
-            disabled={!canScrollNext}
-          >
-            <Icon icon={arrow_right} size="16px" sx={{ position: 'relative', display: 'block' }} />
-          </Button>
-        </Flex>
+        {!isMobile && (
+          <Flex sx={{ columnGap: '12px', flexShrink: 0 }}>
+            <Button
+              variant="action"
+              sx={{ p: '12px' }}
+              onClick={() => emblaApi?.scrollPrev()}
+              disabled={!canScrollPrev}
+            >
+              <Icon icon={arrow_left} size="16px" sx={{ position: 'relative', display: 'block' }} />
+            </Button>
+            <Button
+              variant="action"
+              sx={{ p: '12px' }}
+              onClick={() => emblaApi?.scrollNext()}
+              disabled={!canScrollNext}
+            >
+              <Icon
+                icon={arrow_right}
+                size="16px"
+                sx={{ position: 'relative', display: 'block' }}
+              />
+            </Button>
+          </Flex>
+        )}
       </Flex>
       <Box ref={emblaRef} sx={{ overflow }}>
         <Flex
@@ -91,30 +97,32 @@ export const SimpleCarousel: FC<SimpleCarouselProps> = ({
           ))}
         </Flex>
       </Box>
-      <Flex
-        as="ul"
-        sx={{ justifyContent: 'center', columnGap: 2, m: 0, mt: 4, p: 0, listStyle: 'none' }}
-      >
-        {slides.map((_, i) => (
-          <Box key={i} as="li">
-            <Button
-              variant="unStyled"
-              onClick={() => emblaApi?.scrollTo(i)}
-              sx={{
-                display: 'block',
-                width: 2,
-                height: 2,
-                borderRadius: 'ellipse',
-                bg: currentSlide === i ? 'primary100' : 'primary30',
-                transition: 'background-color 200ms',
-                '&:hover': {
-                  bg: currentSlide === i ? 'primary100' : 'neutral80',
-                },
-              }}
-            />
-          </Box>
-        ))}
-      </Flex>
+      {isMobile && (
+        <Flex
+          as="ul"
+          sx={{ justifyContent: 'center', columnGap: 2, m: 0, mt: 4, p: 0, listStyle: 'none' }}
+        >
+          {slides.map((_, i) => (
+            <Box key={i} as="li">
+              <Button
+                variant="unStyled"
+                onClick={() => emblaApi?.scrollTo(i)}
+                sx={{
+                  display: 'block',
+                  width: 2,
+                  height: 2,
+                  borderRadius: 'ellipse',
+                  bg: currentSlide === i ? 'primary100' : 'primary30',
+                  transition: 'background-color 200ms',
+                  '&:hover': {
+                    bg: currentSlide === i ? 'primary100' : 'neutral80',
+                  },
+                }}
+              />
+            </Box>
+          ))}
+        </Flex>
+      )}
     </Box>
   )
 }

--- a/components/SimpleCarousel.tsx
+++ b/components/SimpleCarousel.tsx
@@ -32,6 +32,7 @@ export const SimpleCarousel: FC<SimpleCarouselProps> = ({
     slidesToScroll: resolvedSlidesToScroll,
   })
 
+  const [currentSlide, setCurrentSlide] = useState<number>(1)
   const [canScrollPrev, setCanScrollPrev] = useState<boolean>(false)
   const [canScrollNext, setCanScrollNext] = useState<boolean>(true)
 
@@ -40,6 +41,7 @@ export const SimpleCarousel: FC<SimpleCarouselProps> = ({
 
   function updateSliderUI() {
     if (emblaApi) {
+      setCurrentSlide(emblaApi.selectedScrollSnap())
       setCanScrollPrev(emblaApi.canScrollPrev())
       setCanScrollNext(emblaApi.canScrollNext())
     }
@@ -89,6 +91,30 @@ export const SimpleCarousel: FC<SimpleCarouselProps> = ({
           ))}
         </Flex>
       </Box>
+      <Flex
+        as="ul"
+        sx={{ justifyContent: 'center', columnGap: 2, m: 0, mt: 4, p: 0, listStyle: 'none' }}
+      >
+        {slides.map((_, i) => (
+          <Box key={i} as="li">
+            <Button
+              variant="unStyled"
+              onClick={() => emblaApi?.scrollTo(i)}
+              sx={{
+                display: 'block',
+                width: 2,
+                height: 2,
+                borderRadius: 'ellipse',
+                bg: currentSlide === i ? 'primary100' : 'primary30',
+                transition: 'background-color 200ms',
+                '&:hover': {
+                  bg: currentSlide === i ? 'primary100' : 'neutral80',
+                },
+              }}
+            />
+          </Box>
+        ))}
+      </Flex>
     </Box>
   )
 }


### PR DESCRIPTION
# Simple Carousel mobile UI

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/d9d4e65e-0fa2-43e4-8446-31432a62711d)
  
## Changes 👷‍♀️

- Changed UI of `SimpleCarousel` on mobile - according to the design, instead of prev/next arrows there should be a list of dots below slider.