### PR TITLE
Update currency denomination in sidebars and details view

### DIFF
--- a/features/aave/components/BasicAutomationDetailsView.tsx
+++ b/features/aave/components/BasicAutomationDetailsView.tsx
@@ -6,6 +6,7 @@ import {
   DetailsSectionContentCardWrapper,
 } from 'components/DetailsSectionContentCard'
 import type { ExecutionPrice } from 'features/aave/manage/services/calculations'
+import { getDenomination } from 'features/aave/manage/services/calculations'
 import type { PositionLike } from 'features/aave/manage/state'
 import { AutomationFeatures } from 'features/automation/common/types'
 import { formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
@@ -144,7 +145,7 @@ function ContentCardTriggerTargetLTV({
         : 'auto-buy.continual-buy-threshold-v2'
     contentCardSettings.footnote = t(key, {
       amount: formatted.threshold,
-      denomination,
+      denomination: denomination,
     })
   }
 
@@ -184,7 +185,7 @@ export function BasicAutomationDetailsView({
               currentExecutionLTV={currentTrigger?.executionLTV}
               afterTxExecutionLTV={afterTxTrigger?.executionLTV}
               nextPrice={nextPrice?.price}
-              denomination={nextPrice?.denomination || ''}
+              denomination={nextPrice?.denomination || getDenomination(position)}
             />
             <ContentCardTriggerTargetLTV
               automationFeature={automationFeature}
@@ -192,7 +193,7 @@ export function BasicAutomationDetailsView({
               currentTargetLTV={currentTrigger?.targetLTV}
               afterTxTargetLTV={afterTxTrigger?.targetLTV}
               thresholdPrice={thresholdPrice}
-              denomination={nextPrice?.denomination || ''}
+              denomination={nextPrice?.denomination || getDenomination(position)}
             />
           </DetailsSectionContentCardWrapper>
         </>

--- a/features/aave/manage/containers/OptimizationControl.tsx
+++ b/features/aave/manage/containers/OptimizationControl.tsx
@@ -31,7 +31,7 @@ function getAutoBuyDetailsLayoutProps(
 
   const nextPrice = getTriggerExecutionPrice({
     position: context.position,
-    executionTriggerLTV: currentTrigger?.executionLTV.times(100).toNumber(),
+    executionTriggerLTV: currentTrigger?.executionLTV.toNumber(),
   })
   const thresholdPrice = context.usePriceInput
     ? context.usePrice

--- a/features/aave/manage/services/calculations/get-trigger-execution-price.ts
+++ b/features/aave/manage/services/calculations/get-trigger-execution-price.ts
@@ -1,10 +1,16 @@
 import type BigNumber from 'bignumber.js'
-import type { AutoBuyTriggerAaveContext } from 'features/aave/manage/state'
+import type { AutoBuyTriggerAaveContext, PositionLike } from 'features/aave/manage/state'
 import { one } from 'helpers/zero'
 
 export interface ExecutionPrice {
   price: BigNumber
   denomination: string
+}
+
+export const getDenomination = (position: PositionLike) => {
+  return position.pricesDenomination === 'debt'
+    ? `${position.debt.token.symbol}/${position.collateral.token.symbol}`
+    : `${position.collateral.token.symbol}/${position.debt.token.symbol}`
 }
 
 export const getTriggerExecutionPrice = ({
@@ -22,12 +28,12 @@ export const getTriggerExecutionPrice = ({
   if (position.pricesDenomination === 'debt') {
     return {
       price: one.div(debtToCollateralRatio),
-      denomination: `${position.debt.token.symbol}/${position.collateral.token.symbol}`,
+      denomination: getDenomination(position),
     }
   }
 
   return {
     price: debtToCollateralRatio,
-    denomination: `${position.collateral.token.symbol}/${position.debt.token.symbol}`,
+    denomination: getDenomination(position),
   }
 }

--- a/features/aave/manage/sidebars/AutoBuySidebarAaveVault.tsx
+++ b/features/aave/manage/sidebars/AutoBuySidebarAaveVault.tsx
@@ -15,7 +15,10 @@ import { RemoveTriggerInfoSection } from 'features/aave/components'
 import type { BuyInfoSectionProps } from 'features/aave/components/AutoBuyInfoSection'
 import { AutoBuyInfoSection } from 'features/aave/components/AutoBuyInfoSection'
 import { mapErrorsToErrorVaults, mapWarningsToWarningVaults } from 'features/aave/helpers'
-import { getTriggerExecutionPrice } from 'features/aave/manage/services/calculations'
+import {
+  getDenomination,
+  getTriggerExecutionPrice,
+} from 'features/aave/manage/services/calculations'
 import type {
   AutoBuyTriggerAaveContext,
   AutoBuyTriggerAaveEvent,
@@ -204,7 +207,7 @@ function AutoBuySidebarAaveVaultEditingState({
             amount={state.price}
             hasAuxiliary={false}
             hasError={false}
-            currencyCode={'USD'}
+            currencyCode={getDenomination(state.position)}
             onChange={handleNumericInput((price) => {
               updateState({ type: 'SET_PRICE', price: price })
             })}

--- a/features/aave/manage/sidebars/AutoSellSidebarAaveVault.tsx
+++ b/features/aave/manage/sidebars/AutoSellSidebarAaveVault.tsx
@@ -14,7 +14,10 @@ import { RemoveTriggerInfoSection, type RemoveTriggerSectionProps } from 'featur
 import type { AutoSellInfoSectionProps } from 'features/aave/components/AutoSellInfoSection'
 import { AutoSellInfoSection } from 'features/aave/components/AutoSellInfoSection'
 import { mapErrorsToErrorVaults, mapWarningsToWarningVaults } from 'features/aave/helpers'
-import { getTriggerExecutionPrice } from 'features/aave/manage/services/calculations'
+import {
+  getDenomination,
+  getTriggerExecutionPrice,
+} from 'features/aave/manage/services/calculations'
 import type {
   AutoSellTriggerAaveContext,
   AutoSellTriggerAaveEvent,
@@ -202,7 +205,7 @@ function AutoSellSidebarAaveVaultEditingState({
             amount={state.price}
             hasAuxiliary={false}
             hasError={false}
-            currencyCode={'USD'}
+            currencyCode={getDenomination(state.position)}
             onChange={handleNumericInput((price) => {
               updateState({ type: 'SET_PRICE', price: price })
             })}


### PR DESCRIPTION
The update involves using a newly created function, getDenomination, from the calculations service. This function is used to set the currency code in both the AutoSellSidebarAaveVault and AutoBuySidebarAaveVault sidebars. It's also introduced in BasicAutomationDetailsView to show the correct denomination in the views. A minor adjustment in OptimizationControl's nextPrice calculation is dually covered.
