### PR TITLE
Proposed error handling for missing tickers

### DIFF
--- a/blockchain/prices.ts
+++ b/blockchain/prices.ts
@@ -61,7 +61,11 @@ export function createGasPriceOnNetwork$(
   )
 }
 
-function getPrice(tickers: Tickers, tickerServiceLabels: Array<string | undefined>) {
+function getPrice(
+  tickers: Tickers,
+  tickerServiceLabels: Array<string | undefined>,
+  errorLocation?: string,
+) {
   const errorsArray = []
   for (const label of tickerServiceLabels) {
     if (label && tickers[label]) {
@@ -70,7 +74,9 @@ function getPrice(tickers: Tickers, tickerServiceLabels: Array<string | undefine
     errorsArray.push({ label, tickerServiceLabels })
   }
 
-  throw new Error(`No price data for given token - ${JSON.stringify(errorsArray)}`)
+  throw new Error(
+    `No price data for given token - ${JSON.stringify(errorsArray)} in ${errorLocation}`,
+  )
 }
 
 export function getTokenPriceSources(token: string) {
@@ -91,10 +97,9 @@ export function getTokenPriceSources(token: string) {
   ]
 }
 
-export function getTokenPrice(token: string, tickers: Tickers) {
+export function getTokenPrice(token: string, tickers: Tickers, errorLocation?: string) {
   const priceSources = getTokenPriceSources(token)
-
-  return getPrice(tickers, priceSources)
+  return getPrice(tickers, priceSources, errorLocation)
 }
 
 export function createTokenPriceInUSD$(
@@ -107,7 +112,7 @@ export function createTokenPriceInUSD$(
       forkJoin(
         tokens.map((token) => {
           try {
-            const tokenPrice = getTokenPrice(token, tickers)
+            const tokenPrice = getTokenPrice(token, tickers, 'createTokenPriceInUSD$')
 
             return of({
               [token]: new BigNumber(tokenPrice),

--- a/handlers/portfolio/positions/helpers/getTokensPrices.ts
+++ b/handlers/portfolio/positions/helpers/getTokensPrices.ts
@@ -29,13 +29,20 @@ export async function getTokensPrices(retries: number = 0): Promise<TokensPrices
     return {
       tokens: Object.keys(tokensBySymbol)
         .filter((key) => getTokenPriceSources(key).filter((item) => item !== undefined).length)
-        .reduce<{ [key: string]: number }>(
-          (result, current) => ({
+        .reduce<{ [key: string]: number }>((result, current) => {
+          let value = new BigNumber(0)
+          try {
+            value = getTokenPrice(current, tickers, 'getTokensPrices')
+          } catch (e) {
+            // When ticker value is not found we will log error and fallback to 0
+            console.error('Error getTokenPrice for token: ' + current)
+          }
+
+          return {
             ...result,
-            [current]: getTokenPrice(current, tickers).toNumber(),
-          }),
-          {},
-        ),
+            [current]: value.toNumber(),
+          }
+        }, {}),
     }
   } catch (e) {
     console.info('Error loading one of the prices')

--- a/handlers/product-hub/update-handlers/aaveV2/aaveV2Handler.ts
+++ b/handlers/product-hub/update-handlers/aaveV2/aaveV2Handler.ts
@@ -22,7 +22,7 @@ import { aaveV2ProductHubProducts } from './aaveV2Products'
 export default async function (tickers: Tickers): ProductHubHandlerResponse {
   // Multiply: max multiple, liq available, variable fee
   // Earn: 7 day net APY, liq available
-  const usdcPrice = new BigNumber(getTokenPrice('USDC', tickers))
+  const usdcPrice = new BigNumber(getTokenPrice('USDC', tickers, 'aaveV2Handler'))
   const primaryTokensList = [
     ...new Set(
       flatten(

--- a/handlers/product-hub/update-handlers/aaveV3/aaveV3Handler.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aaveV3Handler.ts
@@ -56,7 +56,7 @@ const getAaveV3TokensData = async (networkName: AaveV3Networks, tickers: Tickers
   // reserveData -> liq available and variable fee
   const tokensReserveDataPromises = secondaryTokensList.map(async (token) => {
     const reserveData = await getAaveV3ReserveData({ token, networkId })
-    const debtTokenPrice = new BigNumber(getTokenPrice(token, tickers))
+    const debtTokenPrice = new BigNumber(getTokenPrice(token, tickers, 'aaveV3Handler'))
     return {
       [token]: {
         liquidity: reserveData.totalAToken

--- a/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
+++ b/handlers/product-hub/update-handlers/ajna/ajnaHandler.ts
@@ -49,7 +49,10 @@ async function getAjnaPoolData(
   const prices = uniq(
     Object.keys(getNetworkContracts(networkId).ajnaPoolPairs).flatMap((pair) => pair.split('-')),
   ).reduce<Tickers>(
-    (v, token) => ({ ...v, [token]: new BigNumber(getTokenPrice(token, tickers)) }),
+    (v, token) => ({
+      ...v,
+      [token]: new BigNumber(getTokenPrice(token, tickers, 'ajnaHandler')),
+    }),
     {},
   )
 

--- a/handlers/product-hub/update-handlers/maker/makerHandler.ts
+++ b/handlers/product-hub/update-handlers/maker/makerHandler.ts
@@ -50,7 +50,7 @@ async function getMakerData(
   const SpotContract = SpotFactory.connect(SpotContractAddress, rpcProvider)
   const PotContractAddress = getNetworkContracts(networkId).mcdPot.address
   const PotContract = PotFactory.connect(PotContractAddress, rpcProvider)
-  const daiPrice = new BigNumber(getTokenPrice('DAI', tickers))
+  const daiPrice = new BigNumber(getTokenPrice('DAI', tickers, 'makerHandler'))
 
   const ilksListWithHexValues = makerProductHubProducts.reduce((acc, product) => {
     const ilk = getIlk(product.label)


### PR DESCRIPTION
When ticker value is not found will log error on the server and fallback to 0 price for that token instead of crashing entire page data response.

Also extended logs in getTokenPrice to easier track the error source in the future.