### PR TITLE
Switch to borrow or multiply label

### DIFF
--- a/features/omni-kit/helpers/getOmniPrimaryButtonLabelKey.ts
+++ b/features/omni-kit/helpers/getOmniPrimaryButtonLabelKey.ts
@@ -6,6 +6,7 @@ interface GetPrimaryButtonLabelKeyParams {
   hasAllowance: boolean
   hasDpmAddress: boolean
   isOpening: boolean
+  isTransitionInProgress: boolean
   isTxError: boolean
   isTxSuccess: boolean
   shouldSwitchNetwork: boolean
@@ -18,6 +19,7 @@ export function getOmniPrimaryButtonLabelKey({
   hasAllowance,
   hasDpmAddress,
   isOpening,
+  isTransitionInProgress,
   isTxError,
   isTxSuccess,
   shouldSwitchNetwork,
@@ -33,7 +35,8 @@ export function getOmniPrimaryButtonLabelKey({
       else if (isTxError) return 'retry'
       else return 'confirm'
     case OmniSidebarStep.Transition:
-      return 'borrow-to-multiply.button-progress'
+      if (isTransitionInProgress) return 'borrow-to-multiply.button-progress'
+      else return 'confirm'
     default:
       if (walletAddress && shouldSwitchNetwork) return 'switch-network'
       else if (

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -176,6 +176,7 @@ export function OmniFormView({
     hasAllowance: flowState.isAllowanceReady,
     hasDpmAddress: flowState.isProxyReady,
     isOpening,
+    isTransitionInProgress,
     isTxError,
     isTxSuccess,
     shouldSwitchNetwork,


### PR DESCRIPTION
# [Switch to borrow or multiply label](https://app.shortcut.com/oazo-apps/story/14209/switch-to-borrow-multiply-button-says-transition-in-progress-before-clicking)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed condition which was previously broken by mistake
  
## How to test 🧪
  <Please explain how to test your changes>

- while switching to borrow or multiply position type, button should have correct labels
