### PR TITLE
Limit max on morpho multiply slider

### DIFF
--- a/features/omni-kit/components/sidebars/OmniAdjustSlider.tsx
+++ b/features/omni-kit/components/sidebars/OmniAdjustSlider.tsx
@@ -41,7 +41,7 @@ export function OmniAdjustSlider({ disabled = false }: OmniAdjustSliderProps) {
       isSimulationLoading,
     },
     dynamicMetadata: {
-      values: { changeVariant },
+      values: { changeVariant, maxSliderAsMaxLtv },
     },
   } = useOmniProductContext(productType)
 
@@ -62,8 +62,11 @@ export function OmniAdjustSlider({ disabled = false }: OmniAdjustSliderProps) {
   }, [depositAmount?.toString()])
 
   const resolvedValue = loanToValue || position.riskRatio.loanToValue
+  const resolvedMax = maxSliderAsMaxLtv
+    ? position.maxRiskRatio.loanToValue.decimalPlaces(2, BigNumber.ROUND_DOWN)
+    : max
 
-  const percentage = resolvedValue.minus(min).div(max.minus(min)).times(100)
+  const percentage = resolvedValue.minus(min).div(resolvedMax.minus(min)).times(100)
   const ltv = position.riskRatio.loanToValue
   const liquidationPrice = simulation?.liquidationPrice || position.liquidationPrice
 
@@ -111,7 +114,7 @@ export function OmniAdjustSlider({ disabled = false }: OmniAdjustSliderProps) {
       )}
       onChange={(value) => dispatch({ type: 'update-loan-to-value', loanToValue: value })}
       minBoundry={min}
-      maxBoundry={max}
+      maxBoundry={resolvedMax}
       lastValue={resolvedValue}
       disabled={disabled}
       step={0.01}

--- a/features/omni-kit/contexts/OmniProductContext.tsx
+++ b/features/omni-kit/contexts/OmniProductContext.tsx
@@ -79,6 +79,7 @@ export type LendingMetadata = CommonMetadata & {
     debtMin: BigNumber
     paybackMax: BigNumber
     shouldShowDynamicLtv: ShouldShowDynamicLtvMetadata
+    maxSliderAsMaxLtv?: boolean
   }
   elements: CommonMetadataElements & {
     highlighterOrderInformation: ReactNode

--- a/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
+++ b/features/omni-kit/protocols/morpho-blue/metadata/useMorphoMetadata.tsx
@@ -118,6 +118,7 @@ export const useMorphoMetadata: GetOmniMetadata = (productContext) => {
             productType,
           }),
           footerColumns: 2,
+          maxSliderAsMaxLtv: true,
         },
         elements: {
           faq: productType === OmniProductType.Borrow ? faqBorrow : faqMultiply,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.38",
     "@oasisdex/automation": "1.6.0-alpha.9",
-    "@oasisdex/dma-library": "0.6.15",
+    "@oasisdex/dma-library": "0.6.16",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.15":
-  version "0.6.15"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.15.tgz#2faccab9ec1095027c864a77df8e22cfe8e4f780"
-  integrity sha512-u0ePHZ5uFYvJ8ub2KZN30ZHIpz02EXZyZFWjucAGhxT2NDb8FIFRXEDFPVMfz6G8ljQXeICtrEdYNU0oNukWMg==
+"@oasisdex/dma-library@0.6.16":
+  version "0.6.16"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.16.tgz#57821ad08acd04b1f4006c8defeb57ca1c8f7435"
+  integrity sha512-zlAEFMDPSLue2n8KHMBHovjwCYg8WJP0wRu8K0QMju5TUz35rp1nKkNC8AKR2Xt9QdezFwHo0FJfMmCE0kvPvA==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
# [Limit max on morpho multiply slider](https://app.shortcut.com/oazo-apps/story/14214/slider-goes-to-99-while-it-should-only-go-up-to-the-highest-value-the-market-offers)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- limited slider max value to max ltv rounded down
- bumped library version with fix for payback action
  
## How to test 🧪
  <Please explain how to test your changes>

- max on slider limited to max ltv
- working payback action