### PR TITLE
Landing Page Product Finder missing config 

### DIFF
--- a/contentful/mappers/mapLandingProductFinderBlock.ts
+++ b/contentful/mappers/mapLandingProductFinderBlock.ts
@@ -5,6 +5,7 @@ import type {
   MarketingTemplateProductFinderBlock,
 } from 'features/marketing-layouts/types'
 import { MarketingTemplateBlocks } from 'features/marketing-layouts/types'
+import { uniq } from 'lodash'
 
 export const mapLandingProductFinderBlock = (
   blockItem: ProductFinder,
@@ -13,7 +14,9 @@ export const mapLandingProductFinderBlock = (
   type: MarketingTemplateBlocks.PRODUCT_FINDER,
   content: blockItem.collection.map((item) => ({
     product: item.product.slug,
-    initialProtocol: item.initialProtocolCollection.items.map((protocolItem) => protocolItem.slug),
+    token: item.token,
+    initialNetwork: uniq(item.initialNetworkCollection.items.map(({ slug }) => slug)),
+    initialProtocol: uniq(item.initialProtocolCollection.items.map(({ slug }) => slug)),
     promoCards: item.promoCardsCollection.items.map((promoCard) => ({
       network: promoCard.network.slug,
       primaryToken: promoCard.primaryToken,

--- a/contentful/types/rawResponses.ts
+++ b/contentful/types/rawResponses.ts
@@ -5,8 +5,9 @@ import {
   MarketingTemplatePalette,
 } from 'features/marketing-layouts/types'
 import { LandingPageRawBlocks } from 'contentful/types'
-import { ProductHubProductType } from 'features/productHub/types'
+import { ProductHubProductType, ProductHubSupportedNetworks } from 'features/productHub/types'
 import { type Document as ContentfulDocument } from '@contentful/rich-text-types'
+import { NetworkLabelType } from 'blockchain/networks'
 
 export interface LandingPageRawBlocksItems {
   sys: {
@@ -153,8 +154,8 @@ export interface ProductFinderRawResponse {
   }
   initialNetworkCollection: {
     items: {
-      slug: string
-      name: string
+      slug: ProductHubSupportedNetworks
+      name: NetworkLabelType
     }[]
   }
   promoCardsCollection: {


### PR DESCRIPTION
# Landing Page Product Finder missing config 
  
## Changes 👷‍♀️

- Add support for `token` and `initialNetwork`.