### PR TITLE
Add `yvCurve-USDM-sDAI-f/DAI` to PF as oracless pool

### DIFF
--- a/blockchain/contracts/arbitrum.ts
+++ b/blockchain/contracts/arbitrum.ts
@@ -180,8 +180,7 @@ export const arbitrumContracts: MainnetContractsWithOptional = {
     'AJNA-DAI': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_AJNADAI),
   },
   ajnaOraclessPoolPairs: {
-    'YIELDBTC-WBTC': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_YIELDBTCWBTC),
-    'YIELDETH-ETH': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_YIELDETHETH),
+    'YVCURVEUSDMSDAIF-DAI': contractDesc(ajnaPool, arbitrum.ajna.AjnaPoolPairs_YVCURVEUSDMSDAIFDAI),
   },
   ajnaERC20PoolFactory: contractDesc(ajnaERC20PoolFactory, arbitrum.ajna.ERC20PoolFactory),
   ajnaRedeemer: contractDesc(ajnaReedemer, arbitrum.ajna.AjnaRewardsReedemer),

--- a/blockchain/contracts/base.ts
+++ b/blockchain/contracts/base.ts
@@ -175,8 +175,7 @@ export const baseContracts: MainnetContractsWithOptional = {
     'AJNA-DAI': contractDesc(ajnaPool, base.ajna.AjnaPoolPairs_AJNADAI),
   },
   ajnaOraclessPoolPairs: {
-    'YIELDBTC-WBTC': contractDesc(ajnaPool, base.ajna.AjnaPoolPairs_YIELDBTCWBTC),
-    'YIELDETH-ETH': contractDesc(ajnaPool, base.ajna.AjnaPoolPairs_YIELDETHETH),
+    'YVCURVEUSDMSDAIF-DAI': contractDesc(ajnaPool, base.ajna.AjnaPoolPairs_YVCURVEUSDMSDAIFDAI),
   },
   ajnaERC20PoolFactory: contractDesc(ajnaERC20PoolFactory, base.ajna.ERC20PoolFactory),
   ajnaRedeemer: contractDesc(ajnaReedemer, base.ajna.AjnaRewardsReedemer),

--- a/blockchain/contracts/goerli.ts
+++ b/blockchain/contracts/goerli.ts
@@ -197,8 +197,7 @@ export const goerliContracts: MainnetContractsWithOptional = {
     'AJNA-DAI': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_AJNADAI),
   },
   ajnaOraclessPoolPairs: {
-    'YIELDBTC-WBTC': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_YIELDBTCWBTC),
-    'YIELDETH-ETH': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_YIELDETHETH),
+    'YVCURVEUSDMSDAIF-DAI': contractDesc(ajnaPool, goerli.ajna.AjnaPoolPairs_YVCURVEUSDMSDAIFDAI),
   },
   ajnaERC20PoolFactory: contractDesc(ajnaERC20PoolFactory, goerli.ajna.ERC20PoolFactory),
   ajnaRedeemer: contractDesc(ajnaReedemer, goerli.ajna.AjnaRewardsReedemer),

--- a/blockchain/contracts/mainnet.ts
+++ b/blockchain/contracts/mainnet.ts
@@ -209,8 +209,7 @@ export const mainnetContracts = {
     'AJNA-DAI': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_AJNADAI),
   },
   ajnaOraclessPoolPairs: {
-    'YIELDBTC-WBTC': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_YIELDBTCWBTC),
-    'YIELDETH-ETH': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_YIELDETHETH),
+    'YVCURVEUSDMSDAIF-DAI': contractDesc(ajnaPool, mainnet.ajna.AjnaPoolPairs_YVCURVEUSDMSDAIFDAI),
   },
   ajnaERC20PoolFactory: contractDesc(ajnaERC20PoolFactory, mainnet.ajna.ERC20PoolFactory),
   ajnaRedeemer: contractDesc(ajnaReedemer, mainnet.ajna.AjnaRewardsReedemer),

--- a/blockchain/contracts/optimism.ts
+++ b/blockchain/contracts/optimism.ts
@@ -202,8 +202,7 @@ export const optimismContracts: OptimismContracts = {
     'AJNA-DAI': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_AJNADAI),
   },
   ajnaOraclessPoolPairs: {
-    'YIELDBTC-WBTC': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_YIELDBTCWBTC),
-    'YIELDETH-ETH': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_YIELDETHETH),
+    'YVCURVEUSDMSDAIF-DAI': contractDesc(ajnaPool, optimism.ajna.AjnaPoolPairs_YVCURVEUSDMSDAIFDAI),
   },
   ajnaERC20PoolFactory: contractDesc(ajnaERC20PoolFactory, optimism.ajna.ERC20PoolFactory),
   ajnaRedeemer: contractDesc(ajnaReedemer, optimism.ajna.AjnaRewardsReedemer),

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@lifi/wallet-management": "^2.3.4",
     "@lifi/widget": "2.4.6",
     "@metamask/eth-sig-util": "^5.0.2",
-    "@oasisdex/addresses": "0.1.38",
+    "@oasisdex/addresses": "0.1.40",
     "@oasisdex/automation": "1.6.0-alpha.9",
     "@oasisdex/dma-library": "0.6.16",
     "@oasisdex/multiply": "^0.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,10 +2385,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oasisdex/addresses@0.1.38":
-  version "0.1.38"
-  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.1.38.tgz#ff0583f42c0dd26279cd1493d680fdc462597132"
-  integrity sha512-SOONyX9fJJGhGcvNaR95s3MglEHNeUoRBKBi3AVmwFLaOWrJ+pSEYmzTQPtU1tw3fNn2z6hV4bg91NWW3Xe28g==
+"@oasisdex/addresses@0.1.40":
+  version "0.1.40"
+  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.1.40.tgz#de71729c09352cf7a2aa9aad2bc21e4380ac038f"
+  integrity sha512-xqoUqc5sqIg/n8OkkE9fA8exNi4qWNPPSuBTXbXKhnabWhMYa2nSyeIuw+GzsWY+GeWJZt6hAbeDxFkwtHzB6g==
 
 "@oasisdex/automation@1.6.0-alpha.9":
   version "1.6.0-alpha.9"


### PR DESCRIPTION
# [Add `yvCurve-USDM-sDAI-f/DAI` to PF as oracless pool](https://app.shortcut.com/oazo-apps/story/14182/add-curve-usdm-sdai-pool-to-main-table-in-oracleless-mode)
  
## Changes 👷‍♀️

- Added `yvCurve-USDM-sDAI-f/DAI` to config.
- Removed `YIELDBTC-WBTC` and `YIELDETH-ETH` as they are no longer in use.