### PR TITLE
Add empty automations, triggerType and remove unused code

### DIFF
--- a/handlers/portfolio/constants.ts
+++ b/handlers/portfolio/constants.ts
@@ -1,1 +1,7 @@
 export const notAvailable = 'n/a'
+export const emptyAutomations = {
+  autoBuy: { enabled: false },
+  autoSell: { enabled: false },
+  stopLoss: { enabled: false },
+  takeProfit: { enabled: false },
+}

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -8,6 +8,7 @@ import type { SparkV3SupportedNetwork } from 'blockchain/spark-v3'
 import { getSparkV3ReserveConfigurationData, getSparkV3ReserveData } from 'blockchain/spark-v3'
 import type { OmniProductBorrowishType } from 'features/omni-kit/types'
 import { OmniProductType } from 'features/omni-kit/types'
+import { emptyAutomations } from 'handlers/portfolio/constants'
 import type { AaveLikeOraclePriceData } from 'handlers/portfolio/positions/handlers/aave-like/types'
 import type { TokensPricesList } from 'handlers/portfolio/positions/helpers'
 import {
@@ -126,12 +127,13 @@ export const commonDataMapper = ({
         }[dpm.protocol]
       }/${dpm.vaultId}`,
       automations: {
-        ...(dpm.positionType !== OmniProductType.Earn &&
-          automations && {
-            ...getPositionsAutomations({
-              triggers: [automations.triggers],
-            }),
-          }),
+        ...(dpm.positionType !== OmniProductType.Earn && automations
+          ? {
+              ...getPositionsAutomations({
+                triggers: [automations.triggers],
+              }),
+            }
+          : emptyAutomations),
       },
     },
     primaryTokenPrice: primaryTokenOraclePrice || primaryTokenTickerPrice,

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -104,7 +104,6 @@ export const commonDataMapper = ({
         defaultType: dpm.positionType as OmniProductBorrowishType,
       })
     : dpm.positionType
-
   return {
     commonData: {
       positionId: positionIdAsString ? dpm.vaultId : Number(dpm.vaultId),
@@ -129,9 +128,7 @@ export const commonDataMapper = ({
       automations: {
         ...(dpm.positionType !== OmniProductType.Earn &&
           automations && {
-            stopLoss: { enabled: false },
             ...getPositionsAutomations({
-              networkId: dpm.networkId,
               triggers: [automations.triggers],
             }),
           }),

--- a/handlers/portfolio/positions/handlers/maker/index.ts
+++ b/handlers/portfolio/positions/handlers/maker/index.ts
@@ -69,7 +69,7 @@ export const makerPositionsHandler: PortfolioPositionsHandler = async ({
               autoSell: { enabled: false },
               stopLoss: { enabled: false },
               takeProfit: { enabled: false },
-              ...getPositionsAutomations({ networkId: NetworkIds.MAINNET, triggers }),
+              ...getPositionsAutomations({ triggers }),
             }),
           },
           details: getMakerPositionDetails({

--- a/handlers/portfolio/positions/handlers/maker/types.ts
+++ b/handlers/portfolio/positions/handlers/maker/types.ts
@@ -14,6 +14,7 @@ export interface MakerDiscoverPositionsTrigger {
   executedBlock: string
   removedBlock: string
   triggerData: string
+  triggerType: string
 }
 
 export interface MakerDiscoverPositionsResponse {

--- a/handlers/portfolio/positions/helpers/getAutomationData.ts
+++ b/handlers/portfolio/positions/helpers/getAutomationData.ts
@@ -25,6 +25,7 @@ type AutomationQueryResponse = {
     executedBlock: string
     removedBlock: string
     triggerData: string
+    triggerType: string
     owner: string
   }[]
 }
@@ -43,6 +44,7 @@ export type AutomationResponse = {
     executedBlock: string
     removedBlock: string
     triggerData: string
+    triggerType: string
     owner: string
   }
 }[]


### PR DESCRIPTION
This pull request adds an emptyAutomations constant to the Aave-like helpers and removes unused code. It adds triggerType to the automation subgraph query and uses it for filtering, without decodeTriggerDataAsJson.