### PR TITLE
Refactor automation handling in portfolio positions

### DIFF
--- a/handlers/portfolio/constants.ts
+++ b/handlers/portfolio/constants.ts
@@ -3,5 +3,4 @@ export const emptyAutomations = {
   autoBuy: { enabled: false },
   autoSell: { enabled: false },
   stopLoss: { enabled: false },
-  takeProfit: { enabled: false },
 }

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -127,13 +127,14 @@ export const commonDataMapper = ({
         }[dpm.protocol]
       }/${dpm.vaultId}`,
       automations: {
-        ...(dpm.positionType !== OmniProductType.Earn && automations
+        ...(dpm.positionType !== OmniProductType.Earn
           ? {
               ...getPositionsAutomations({
-                triggers: [automations.triggers],
+                triggers: automations ? [automations.triggers] : [],
+                defaultList: dpm.protocol !== 'AAVE' ? emptyAutomations : {},
               }),
             }
-          : emptyAutomations),
+          : {}),
       },
     },
     primaryTokenPrice: primaryTokenOraclePrice || primaryTokenTickerPrice,

--- a/handlers/portfolio/positions/helpers/getAutomationData.ts
+++ b/handlers/portfolio/positions/helpers/getAutomationData.ts
@@ -12,6 +12,7 @@ const automationQuery = gql`
       executedBlock
       removedBlock
       triggerData
+      triggerType
       owner
     }
   }

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -1,10 +1,10 @@
 import { TriggerType } from '@oasisdex/automation'
-import { emptyAutomations } from 'handlers/portfolio/constants'
 import type { MakerDiscoverPositionsTrigger } from 'handlers/portfolio/positions/handlers/maker/types'
 import type { PortfolioPositionAutomations } from 'handlers/portfolio/types'
 
-interface getPositionsAutomationsParams {
+interface GetPositionsAutomationsParams {
   triggers: MakerDiscoverPositionsTrigger[]
+  defaultList?: Record<string, boolean> | {}
 }
 
 const triggerTypesMap = {
@@ -41,7 +41,8 @@ const triggerTypesMap = {
 
 export function getPositionsAutomations({
   triggers,
-}: getPositionsAutomationsParams): PortfolioPositionAutomations {
+  defaultList = {},
+}: GetPositionsAutomationsParams): PortfolioPositionAutomations {
   return triggers
     .filter(({ executedBlock, removedBlock }) => executedBlock === null && removedBlock === null)
     .reduce((automations, { triggerType }) => {
@@ -59,5 +60,5 @@ export function getPositionsAutomations({
           {},
         ),
       }
-    }, emptyAutomations)
+    }, defaultList)
 }


### PR DESCRIPTION
This pull request refactors the automation handling in the portfolio positions code. It includes changes to the `commonDataMapper` function, the `automationQuery` GraphQL query, and the `getPositionsAutomations` function. The changes ensure that automations are correctly retrieved and processed based on the position type and trigger type.