### PR TITLE
chore: add missing label

### DIFF
--- a/features/positionHistory/getHistoryEventLabel.ts
+++ b/features/positionHistory/getHistoryEventLabel.ts
@@ -26,6 +26,7 @@ export const getHistoryEventLabel = ({
     case 'AjnaSupplyQuote':
       return isOpen ? t('position-history.open-position') : t('position-history.deposit')
     case 'AjnaDepositBorrow':
+    case 'AAVEDepositBorrow':
     case 'MorphoBlueDepositBorrow':
       return isOpen ? t('position-history.open-position') : t('position-history.deposit-generate')
     case 'MorphoBlueOpenPosition':


### PR DESCRIPTION
# [Title](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- add missing `AAVEDepositBorrow` event
  
## How to test 🧪
check locally : localhost:3000/base/aave/v3/244#history