### PR TITLE
Aave remove redirect or reload after successful tx when clicking on btn

### DIFF
--- a/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
+++ b/features/aave/manage/sidebars/SidebarManageAaveVault.tsx
@@ -24,10 +24,8 @@ import { AllowanceView } from 'features/stateMachines/allowance'
 import { allDefined } from 'helpers/allDefined'
 import { getLocalAppConfig } from 'helpers/config'
 import { formatCryptoBalance } from 'helpers/formatters/format'
-import { getAaveLikeOpenStrategyUrl } from 'helpers/getAaveLikeStrategyUrl'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { zero } from 'helpers/zero'
-import { LendingProtocol } from 'lendingProtocols'
 import { useTranslation } from 'next-i18next'
 import React, { useEffect } from 'react'
 import { OpenVaultAnimation } from 'theme/animations'
@@ -366,7 +364,11 @@ function ManageAaveSuccessAdjustPositionStateView({ state, send }: ManageAaveSta
     ),
     primaryButton: {
       label: t('manage-earn.aave.vault-form.position-adjusted-btn'),
-      action: () => location && location.reload(),
+      action: () => {
+        send({
+          type: 'BACK_TO_EDITING',
+        })
+      },
     },
   }
 
@@ -395,14 +397,11 @@ function ManageAaveSuccessClosePositionStateView({ state, send }: ManageAaveStat
     ),
     primaryButton: {
       label: t('manage-earn.aave.vault-form.position-adjusted-btn'),
-      url: getAaveLikeOpenStrategyUrl({
-        aaveLikeProduct:
-          state.context.strategyConfig.protocol === LendingProtocol.SparkV3 ? 'spark' : 'aave',
-        protocol: state.context.strategyConfig.protocol,
-        slug: state.context.strategyConfig.urlSlug,
-        strategyType: state.context.strategyConfig.type,
-        network: state.context.strategyConfig.network,
-      }),
+      action: () => {
+        send({
+          type: 'BACK_TO_EDITING',
+        })
+      },
     },
   }
 


### PR DESCRIPTION
# [Aave remove redirect or reload after successful tx when clicking on b…](https://app.shortcut.com/oazo-apps/story/11893/nice-to-have-bug-aave-v3-multiply-closing-a-position-is-redirecting-to-new-position-simulation-page-instead-of-to-old-position)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed redirect to simulation after position closed
- removed forced page reload after adjusting position
  
## How to test 🧪
  <Please explain how to test your changes>

- after closing aave position or adjusting, when user will click on button form state should change back to editing state
