### PR TITLE
Refactor og:image meta tags in HeadTags.tsx

### DIFF
--- a/components/HeadTags.tsx
+++ b/components/HeadTags.tsx
@@ -78,15 +78,19 @@ export function PageSEOTags({
 
       <meta
         property="og:image"
-        content={staticFilesRuntimeUrl(
-          `/static/img/og_images/${OGImages.ogImage}?${getRandomString()}`,
-        )}
+        key="og:image"
+        content={
+          ogImage ??
+          staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.ogImage}?${getRandomString()}`)
+        }
       />
       <meta
         property="og:image:secure_url"
-        content={staticFilesRuntimeUrl(
-          `/static/img/og_images/${OGImages.ogImage}?${getRandomString()}`,
-        )}
+        key="og:image:secure_url"
+        content={
+          ogImage ??
+          staticFilesRuntimeUrl(`/static/img/og_images/${OGImages.ogImage}?${getRandomString()}`)
+        }
       />
       <meta
         name="twitter:image"


### PR DESCRIPTION
This pull request refactors the og:image meta tags in the HeadTags.tsx file. The changes include adding a key attribute to the og:image and og:image:secure_url meta tags and updating the content attribute to use the ogImage variable if it exists.