### PR TITLE
Update AaveV3 naming in trigger configuration

### DIFF
--- a/helpers/triggers/setup-triggers/get-setup-trigger-config.ts
+++ b/helpers/triggers/setup-triggers/get-setup-trigger-config.ts
@@ -25,7 +25,7 @@ export const getSetupTriggerConfig = (params: GetSetupTriggerConfigParams) => {
   return {
     url: `/api/triggers/${params.networkId}/${
       {
-        [LendingProtocol.AaveV3]: 'aavev3',
+        [LendingProtocol.AaveV3]: 'aave3',
         [LendingProtocol.SparkV3]: 'spark',
       }[params.protocol]
     }/${params.path}`,


### PR DESCRIPTION
Renamed the naming convention for AaveV3 to 'aave3' within the trigger configuration setup. This modification aligns the key used to identify this protocol in the setup process with the expected keys, thus ensuring accurate trigger configuration.
