### PR TITLE
Add fitContents prop to GenericMultiselect component

### DIFF
--- a/components/GenericMultiselect.tsx
+++ b/components/GenericMultiselect.tsx
@@ -31,6 +31,7 @@ export interface GenericMultiselectProps {
   options: GenericMultiselectOption[]
   onChange: (value: string[]) => void
   sx?: ThemeUIStyleObject
+  fitContents?: boolean
 }
 
 function GenericMultiselectIcon({
@@ -159,6 +160,7 @@ export function GenericMultiselect({
   options,
   onChange,
   sx,
+  fitContents = false,
 }: GenericMultiselectProps) {
   const { t } = useTranslation()
 
@@ -284,7 +286,7 @@ export function GenericMultiselect({
           sx={{
             flexDirection: 'column',
             rowGap: 2,
-            maxHeight: '342px',
+            maxHeight: fitContents ? 'auto' : '342px',
             pl: 0,
             pr:
               scrollRef.current && scrollRef.current.scrollHeight > scrollRef.current.offsetHeight

--- a/features/productHub/controls/ProductHubFiltersController.tsx
+++ b/features/productHub/controls/ProductHubFiltersController.tsx
@@ -155,7 +155,6 @@ export const ProductHubFiltersController: FC<ProductHubFiltersControllerProps> =
           options={productHubStrategyFilter}
           onChange={(value) => {
             const multiplyStrategyType = value as ProductHubMultiplyStrategyType[]
-
             onChange(
               {
                 or: selectedFilters.or,
@@ -202,9 +201,9 @@ export const ProductHubFiltersController: FC<ProductHubFiltersControllerProps> =
         initialValues={queryString.protocol || initialProtocol}
         label={t('product-hub.filters.protocols')}
         options={productHubProtocolFilter}
+        fitContents
         onChange={(value) => {
           const protocol = value as LendingProtocol[]
-
           onChange(
             {
               or: selectedFilters.or,


### PR DESCRIPTION
This pull request adds a new prop called `fitContents` to the `GenericMultiselect` component. When set to `true`, the component's height will adjust to fit its contents. This allows for more flexibility in displaying options within the component.