### PR TITLE
Update defaultList in emptySutomations commonDataMapper

### DIFF
--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -131,7 +131,7 @@ export const commonDataMapper = ({
           ? {
               ...getPositionsAutomations({
                 triggers: automations ? [automations.triggers] : [],
-                defaultList: dpm.protocol !== 'AAVE' ? emptyAutomations : {},
+                defaultList: !['AAVE', 'Spark'].includes(dpm.protocol) ? emptyAutomations : {},
               }),
             }
           : {}),


### PR DESCRIPTION
This pull request updates the defaultList in the emptySutomations commonDataMapper. The change ensures that the defaultList is updated based on the protocol, excluding 'AAVE' and 'Spark'. This improves the functionality and accuracy of the automations.