### PR TITLE
Show not empty oracless positions in portfolio as default

### DIFF
--- a/components/portfolio/positions/PortfolioPositionsView.tsx
+++ b/components/portfolio/positions/PortfolioPositionsView.tsx
@@ -42,8 +42,9 @@ type PortfolioPositionsViewFiltersType = {
 
 const filterEmptyPosition =
   (isFilterOn: boolean = false) =>
-  ({ netValue }: PortfolioPosition) =>
-    isFilterOn || netValue >= 0.01
+  ({ netValue, isOraclessAndNotEmpty }: PortfolioPosition) => {
+    return isFilterOn || netValue >= 0.01 || isOraclessAndNotEmpty
+  }
 
 export const PortfolioPositionsView = ({
   address,

--- a/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaIsOraclessAndNotEmpty.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/getAjnaIsOraclessAndNotEmpty.ts
@@ -1,0 +1,32 @@
+import type { AjnaEarnPosition, AjnaPosition } from '@oasisdex/dma-library'
+import type { AjnaGenericPosition } from 'features/omni-kit/protocols/ajna/types'
+import { OmniProductType } from 'features/omni-kit/types'
+import { zero } from 'helpers/zero'
+
+interface GetAjnaPositionNetValueParams {
+  isOracless: boolean
+  position: AjnaGenericPosition
+  type: OmniProductType
+}
+
+export function getAjnaIsOraclessAndNotEmpty({
+  isOracless,
+  position,
+  type,
+}: GetAjnaPositionNetValueParams): boolean {
+  if (!isOracless) {
+    return false
+  }
+
+  switch (type) {
+    case OmniProductType.Borrow:
+    case OmniProductType.Multiply:
+      const { collateralAmount } = position as AjnaPosition
+
+      return collateralAmount.gt(zero)
+    case OmniProductType.Earn:
+      const { quoteTokenAmount } = position as AjnaEarnPosition
+
+      return quoteTokenAmount.gt(zero)
+  }
+}

--- a/handlers/portfolio/positions/handlers/ajna/helpers/index.ts
+++ b/handlers/portfolio/positions/handlers/ajna/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './getAjnaPositionDetails'
 export * from './getAjnaPositionInfo'
 export * from './getAjnaPositionNetValue'
+export * from './getAjnaIsOraclessAndNotEmpty'

--- a/handlers/portfolio/positions/handlers/ajna/index.ts
+++ b/handlers/portfolio/positions/handlers/ajna/index.ts
@@ -11,6 +11,7 @@ import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
 import type { SubgraphsResponses } from 'features/subgraphLoader/types'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
 import {
+  getAjnaIsOraclessAndNotEmpty,
   getAjnaPositionDetails,
   getAjnaPositionInfo,
   getAjnaPositionNetValue,
@@ -134,6 +135,11 @@ async function getAjnaPositions({
               position,
               quotePrice,
               type,
+            }),
+            isOraclessAndNotEmpty: getAjnaIsOraclessAndNotEmpty({
+              position,
+              type,
+              isOracless,
             }),
             openDate: Number(protocolEvents[0].timestamp),
             positionId: Number(positionId),

--- a/handlers/portfolio/types.ts
+++ b/handlers/portfolio/types.ts
@@ -33,6 +33,7 @@ export type PortfolioPosition = {
   lendingType?: 'active' | 'passive' | 'loop' | 'staking' | 'pool' // are these all types?
   network: NetworkNames
   netValue: number
+  isOraclessAndNotEmpty?: boolean
   openDate?: number // epoch based on block height timestamp
   positionId: number | string
   primaryToken: string


### PR DESCRIPTION
# Show not empty oracless positions in portfolio as default

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added `isOraclessAndNotEmpty` in handler interface so it's possible to determine whether position is oracless and is not empty to show it later in portfolio as not empty position
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory, test it using not empty ajna oracless position
