### PR TITLE
Adjust ajna slider handling when lup is below htp

### DIFF
--- a/features/omni-kit/protocols/ajna/helpers/getAjnaMinMaxAndRange.tsx
+++ b/features/omni-kit/protocols/ajna/helpers/getAjnaMinMaxAndRange.tsx
@@ -55,7 +55,10 @@ export const getAjnaMinMaxAndRange = ({
   }
 
   // Generate ranges from lup to max
-  const lupToMaxRange = [lowestUtilizedPrice]
+  const lupToMaxRange = [
+    // Condition to handle special case since LUP can be potentially lower than HTP for a while
+    lowestUtilizedPrice.gt(highestThresholdPrice) ? lowestUtilizedPrice : highestThresholdPrice,
+  ]
 
   while (lupToMaxRange[lupToMaxRange.length - 1].lt(lupToMaxRange[0].times(one.plus(lupOffset)))) {
     lupToMaxRange.push(lupToMaxRange[lupToMaxRange.length - 1].times(1.005))

--- a/features/omni-kit/protocols/ajna/metadata/AjnaEarnSlider.tsx
+++ b/features/omni-kit/protocols/ajna/metadata/AjnaEarnSlider.tsx
@@ -20,6 +20,29 @@ import type { FC } from 'react'
 import React, { useEffect, useMemo } from 'react'
 import { Box } from 'theme-ui'
 
+const resolveColorfulRanges = ({
+  htpPercentage,
+  lupPercentage,
+  lowestUtilizedPrice,
+  highestThresholdPrice,
+}: {
+  htpPercentage: number
+  lupPercentage: number
+  lowestUtilizedPrice: BigNumber
+  highestThresholdPrice: BigNumber
+}) => {
+  if (lowestUtilizedPrice.gte(highestThresholdPrice)) {
+    return `linear-gradient(to right,
+        ${omniLendingPriceColors[0]} 0 ${htpPercentage}%,
+        ${omniLendingPriceColors[1]} ${htpPercentage}% ${lupPercentage}%,
+        ${omniLendingPriceColors[2]} ${lupPercentage}% 100%)`
+  }
+
+  return `linear-gradient(to right,
+        ${omniLendingPriceColors[0]} 0 ${lupPercentage}%,
+        ${omniLendingPriceColors[2]} ${lupPercentage}% 100%`
+}
+
 interface AjnaEarnSliderProps {
   isFormFrozen: boolean
   isDisabled?: boolean
@@ -127,10 +150,12 @@ export const AjnaEarnSlider: FC<AjnaEarnSliderProps> = ({
           }
           leftBottomLabel={t('safer')}
           rightBottomLabel={t('riskier')}
-          colorfulRanges={`linear-gradient(to right,
-        ${omniLendingPriceColors[0]} 0 ${htpPercentage}%,
-        ${omniLendingPriceColors[1]} ${htpPercentage}% ${lupPercentage}%,
-        ${omniLendingPriceColors[2]} ${lupPercentage}% 100%)`}
+          colorfulRanges={resolveColorfulRanges({
+            htpPercentage,
+            lupPercentage,
+            lowestUtilizedPrice,
+            highestThresholdPrice,
+          })}
           useRcSlider
         />
       )}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.43",
     "@oasisdex/automation": "1.6.0-alpha.9",
-    "@oasisdex/dma-library": "0.6.23",
+    "@oasisdex/dma-library": "0.6.24",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.23":
-  version "0.6.23"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.23.tgz#b34fb8b7ecfae019270f2fd357cd79f1c312e74b"
-  integrity sha512-4WpMoJ9BpBIc3rouJpp2bmG0d+yKpQU+ZvolBDIeLR09G7NtbOt52U46T5Uw8dadnb4DXkRfKELGJ/It5xr3Dg==
+"@oasisdex/dma-library@0.6.24":
+  version "0.6.24"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.24.tgz#babd569a0b89bd449c1d1fa9f7cef5007302c2f4"
+  integrity sha512-47OkEMFYg8CbpNEWF6C/vCuvAYVNvcyTI/3tPVTE2TRwLQ7grWwsTA2A6mpTFwBVqnRSO0qZWF+CmNFDhHp9ew==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
# [Adjust ajna slider handling when lup is below htp](https://app.shortcut.com/oazo-apps/story/14337/when-lup-is-below-htp-warning-stops-users-from-depositing)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- bumped lib version with ajna earn validation adjustments when LUP below HTP
- adjusted ajna earn slider handling when LUP below HTP
  
## How to test 🧪
  <Please explain how to test your changes>

- when LUP below HTP it should be possible to deposit to current bucket or move lending price to higher ranges
