### PR TITLE
Shorten tokens symbol in pool finder if necessary

### DIFF
--- a/features/ajna/pool-finder/helpers/parsePoolResponse.ts
+++ b/features/ajna/pool-finder/helpers/parsePoolResponse.ts
@@ -14,7 +14,7 @@ import {
   productHubEmptyPoolWeeklyApyTooltip,
   productHubOraclessLtvTooltip,
 } from 'features/productHub/content'
-import { formatCryptoBalance } from 'helpers/formatters/format'
+import { formatCryptoBalance, shortenTokenSymbol } from 'helpers/formatters/format'
 import { one } from 'helpers/zero'
 
 export function parsePoolResponse(
@@ -61,6 +61,9 @@ export function parsePoolResponse(
         const fee = interestRate.toString()
         const weeklyNetApy = lendApr.toString()
 
+        const resolvedCollateralToken = shortenTokenSymbol({ token: collateralToken })
+        const resolvedQuoteToken = shortenTokenSymbol({ token: collateralToken })
+
         return {
           ...(isPoolNotEmpty &&
             !isOracless && {
@@ -71,7 +74,7 @@ export function parsePoolResponse(
           }),
           liquidity,
           earnStrategy: EarnStrategies.liquidity_provision,
-          earnStrategyDescription: `${collateralToken}/${quoteToken} LP`,
+          earnStrategyDescription: `${resolvedCollateralToken}/${resolvedQuoteToken} LP`,
           fee,
           managementType: 'active',
           networkId,

--- a/features/ajna/pool-finder/helpers/parsePoolResponse.ts
+++ b/features/ajna/pool-finder/helpers/parsePoolResponse.ts
@@ -62,7 +62,7 @@ export function parsePoolResponse(
         const weeklyNetApy = lendApr.toString()
 
         const resolvedCollateralToken = shortenTokenSymbol({ token: collateralToken })
-        const resolvedQuoteToken = shortenTokenSymbol({ token: collateralToken })
+        const resolvedQuoteToken = shortenTokenSymbol({ token: quoteToken })
 
         return {
           ...(isPoolNotEmpty &&

--- a/helpers/formatters/format.ts
+++ b/helpers/formatters/format.ts
@@ -150,6 +150,20 @@ export function formatAddress(address: string, first: number = 4, last: number =
   return `${address.slice(0, first)}...${address.slice(-last)}`
 }
 
+export function shortenTokenSymbol({
+  token,
+  length = 15,
+  first = 3,
+  last = 3,
+}: {
+  token: string
+  length?: number
+  first?: number
+  last?: number
+}) {
+  return token.length > length ? `${token.slice(0, first)}...${token.slice(-last)}` : token
+}
+
 export function formatBigNumber(amount: BigNumber, digits: number) {
   return amount.dp(digits, BigNumber.ROUND_DOWN).toString()
 }


### PR DESCRIPTION
# Shorten tokens symbol in pool finder if necessary

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- in pool finder we have 2x columns with displays collateral and quote token, if tokens symbols are very long it breaks styles. Added method to shorten it in strategy column
  
## How to test 🧪
  <Please explain how to test your changes>

- shortened token symbols in pool finder strategy column
