### PR TITLE
New stop loss UI fixes

### DIFF
--- a/features/aave/components/AaveBorrowPositionData.tsx
+++ b/features/aave/components/AaveBorrowPositionData.tsx
@@ -1,5 +1,6 @@
 import type { IPosition } from '@oasisdex/dma-library'
 import { amountFromWei } from '@oasisdex/utils'
+import { useActor } from '@xstate/react'
 import { getCurrentPositionLibCallData } from 'actions/aave-like/helpers'
 import type BigNumber from 'bignumber.js'
 import { useAutomationContext } from 'components/context/AutomationContextProvider'
@@ -11,6 +12,8 @@ import { ContentCardLtv } from 'components/vault/detailsSection/ContentCardLtv'
 import { CostToBorrowContentCardModal } from 'features/aave/components/CostToBorrowContentCard'
 import { SparkTokensBannerController } from 'features/aave/components/SparkTokensBannerController'
 import { checkElligibleSparkPosition } from 'features/aave/helpers/eligible-spark-position'
+import { useTriggersAaveStateMachineContext } from 'features/aave/manage/contexts'
+import { mapStopLossFromLambda } from 'features/aave/manage/helpers/map-stop-loss-from-lambda'
 import { calculateViewValuesForPosition } from 'features/aave/services'
 import { StrategyType } from 'features/aave/types'
 import { StopLossTriggeredBanner } from 'features/automation/protection/stopLoss/controls/StopLossTriggeredBanner'
@@ -79,6 +82,9 @@ export function AaveBorrowPositionData({
     },
     automationTriggersData: { isAutomationDataLoaded },
   } = useAutomationContext()
+  const triggersStateMachine = useTriggersAaveStateMachineContext()
+  const [triggersState] = useActor(triggersStateMachine)
+  const stopLossLambdaData = mapStopLossFromLambda(triggersState.context.currentTriggers.triggers)
   const currentPositionThings = calculateViewValuesForPosition(
     currentPosition,
     collateralTokenPrice,
@@ -283,10 +289,11 @@ export function AaveBorrowPositionData({
               afterLoanToValue={nextPosition?.riskRatio.loanToValue}
               maxLoanToValue={nextPosition?.category.maxLoanToValue}
               automation={{
-                isAutomationAvailable,
+                isAutomationAvailable:
+                  !!stopLossLambdaData.stopLossTriggerName ?? isAutomationAvailable,
+                stopLossLevel: stopLossLambdaData.stopLossLevel?.div(10 ** 2) || stopLossLevel, // still needs to be divided by 100
+                isStopLossEnabled: !!stopLossLambdaData.stopLossTriggerName ?? isStopLossEnabled,
                 isAutomationDataLoaded,
-                isStopLossEnabled,
-                stopLossLevel,
               }}
             />
             <OmniContentCard

--- a/features/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/aave/components/AaveMultiplyPositionData.tsx
@@ -1,4 +1,5 @@
 import type { IPosition } from '@oasisdex/dma-library'
+import { useActor } from '@xstate/react'
 import { getCurrentPositionLibCallData } from 'actions/aave-like/helpers'
 import type BigNumber from 'bignumber.js'
 import { useAutomationContext } from 'components/context/AutomationContextProvider'
@@ -9,6 +10,8 @@ import { DetailsSectionFooterItemWrapper } from 'components/DetailsSectionFooter
 import { ContentCardLtv } from 'components/vault/detailsSection/ContentCardLtv'
 import { SparkTokensBannerController } from 'features/aave/components/SparkTokensBannerController'
 import { checkElligibleSparkPosition } from 'features/aave/helpers/eligible-spark-position'
+import { useTriggersAaveStateMachineContext } from 'features/aave/manage/contexts'
+import { mapStopLossFromLambda } from 'features/aave/manage/helpers/map-stop-loss-from-lambda'
 import { calculateViewValuesForPosition } from 'features/aave/services'
 import { ProductType, StrategyType } from 'features/aave/types'
 import { StopLossTriggeredBanner } from 'features/automation/protection/stopLoss/controls/StopLossTriggeredBanner'
@@ -81,6 +84,9 @@ export function AaveMultiplyPositionData({
     },
     automationTriggersData: { isAutomationDataLoaded },
   } = useAutomationContext()
+  const triggersStateMachine = useTriggersAaveStateMachineContext()
+  const [triggersState] = useActor(triggersStateMachine)
+  const stopLossLambdaData = mapStopLossFromLambda(triggersState.context.currentTriggers.triggers)
   const currentPositionThings = calculateViewValuesForPosition(
     currentPosition,
     collateralTokenPrice,
@@ -252,6 +258,13 @@ export function AaveMultiplyPositionData({
 
   const netValueContentCardAaveData = useAaveCardDataNetValueLending(netValuePnlModalData)
 
+  console.log('asd123qwe', {
+    isAutomationAvailable,
+    stopLossLevel,
+    isStopLossEnabled,
+    isAutomationDataLoaded,
+  })
+
   return (
     <Grid>
       {stopLossTriggered && (
@@ -271,9 +284,10 @@ export function AaveMultiplyPositionData({
               afterLoanToValue={nextPosition?.riskRatio.loanToValue}
               maxLoanToValue={nextPosition?.category.maxLoanToValue}
               automation={{
-                isAutomationAvailable,
-                stopLossLevel,
-                isStopLossEnabled,
+                isAutomationAvailable:
+                  !!stopLossLambdaData.stopLossTriggerName ?? isAutomationAvailable,
+                stopLossLevel: stopLossLambdaData.stopLossLevel?.div(10 ** 2) || stopLossLevel, // still needs to be divided by 100
+                isStopLossEnabled: !!stopLossLambdaData.stopLossTriggerName ?? isStopLossEnabled,
                 isAutomationDataLoaded,
               }}
             />

--- a/features/aave/components/AaveMultiplyPositionData.tsx
+++ b/features/aave/components/AaveMultiplyPositionData.tsx
@@ -258,13 +258,6 @@ export function AaveMultiplyPositionData({
 
   const netValueContentCardAaveData = useAaveCardDataNetValueLending(netValuePnlModalData)
 
-  console.log('asd123qwe', {
-    isAutomationAvailable,
-    stopLossLevel,
-    isStopLossEnabled,
-    isAutomationDataLoaded,
-  })
-
   return (
     <Grid>
       {stopLossTriggered && (

--- a/features/aave/components/order-information/OpenAaveStopLossInformationLambda.tsx
+++ b/features/aave/components/order-information/OpenAaveStopLossInformationLambda.tsx
@@ -47,7 +47,9 @@ export function OpenAaveStopLossInformationLambda({
   const collateralDuringLiquidation = getCollateralDuringLiquidation({
     lockedCollateral,
     debt,
-    liquidationPrice: stopLossParams.liquidationPrice,
+    liquidationPrice: stopLossParams.liquidationPrice.eq(zero)
+      ? one
+      : stopLossParams.liquidationPrice,
     liquidationPenalty: strategyInfo.liquidationBonus,
   })
 

--- a/features/aave/manage/helpers/map-stop-loss-from-lambda.ts
+++ b/features/aave/manage/helpers/map-stop-loss-from-lambda.ts
@@ -33,6 +33,7 @@ export const mapStopLossFromLambda = (triggers?: StopLossTriggers) => {
         ? ('debt' as const)
         : ('collateral' as const),
       stopLossData: trigger,
+      triggerId: trigger.triggerId,
       stopLossTriggerName,
     }
   }

--- a/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
@@ -55,7 +55,7 @@ type StopLossSidebarStates =
   | 'removeInProgress'
   | 'finished'
 
-const refreshDataTime = 5 * 1000
+const refreshDataTime = 10 * 1000
 
 export function AaveManagePositionStopLossLambdaSidebar({
   state,
@@ -151,9 +151,9 @@ export function AaveManagePositionStopLossLambdaSidebar({
 
   useEffect(() => {
     if (refreshingTriggerData) {
-      setRefreshingTriggerData(false)
-      onTxFinished()
       setTimeout(() => {
+        setRefreshingTriggerData(false)
+        onTxFinished()
         if (stopLossLambdaData.triggerId !== triggerId) {
           setTriggerId(stopLossLambdaData.triggerId ?? '0')
           setRefreshingTriggerData(false)
@@ -393,7 +393,7 @@ export function AaveManagePositionStopLossLambdaSidebar({
     void executeCall()
       .then(() => {
         setTransactionStep('finished')
-        setRefreshingTriggerData(true)
+        action !== TriggerAction.Remove && setRefreshingTriggerData(true)
       })
       .catch((error) => {
         console.error('error', error)
@@ -501,7 +501,7 @@ export function AaveManagePositionStopLossLambdaSidebar({
       finished: sidebarFinishedContent,
     }[transactionStep],
     primaryButton: {
-      isLoading: isGettingStopLossTx,
+      isLoading: isGettingStopLossTx || refreshingTriggerData,
       disabled: isDisabled,
       label: primaryButtonLabel(),
       action: primaryButtonAction,

--- a/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
@@ -449,13 +449,17 @@ export function AaveManagePositionStopLossLambdaSidebar({
 
   const showSecondaryButton =
     (transactionStep === 'prepare' && isStopLossEnabled && action !== TriggerAction.Remove) ||
-    (action === TriggerAction.Remove && transactionStep !== 'finished')
+    (action === TriggerAction.Remove && transactionStep !== 'finished') ||
+    ['preparedAdd', 'preparedUpdate', 'preparedRemove'].includes(transactionStep)
 
   const secondaryButtonLabel = () => {
     if (transactionStep === 'prepare' && isStopLossEnabled) {
       return t('system.remove-trigger')
     }
-    if (action === TriggerAction.Remove) {
+    if (
+      action === TriggerAction.Remove ||
+      ['preparedAdd', 'preparedUpdate', 'preparedRemove'].includes(transactionStep)
+    ) {
       return t('go-back')
     }
     return ''
@@ -464,7 +468,7 @@ export function AaveManagePositionStopLossLambdaSidebar({
     if (transactionStep === 'prepare' && isStopLossEnabled) {
       setTransactionStep('preparedRemove')
     }
-    if (transactionStep === 'preparedRemove') {
+    if (['preparedAdd', 'preparedUpdate', 'preparedRemove'].includes(transactionStep)) {
       setTransactionStep('prepare')
     }
   }

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -61,7 +61,7 @@ export const getReserveConfigurationDataCall = (dpm: DpmSubgraphData, token: str
 }
 
 interface CommonDataMapperParams {
-  automations?: AutomationResponse[number]
+  automations?: AutomationResponse[number]['triggers'][]
   dpm: DpmSubgraphData
   positionIdAsString?: boolean
   prices: TokensPricesList
@@ -130,7 +130,7 @@ export const commonDataMapper = ({
         ...(dpm.positionType !== OmniProductType.Earn
           ? {
               ...getPositionsAutomations({
-                triggers: automations ? [automations.triggers] : [],
+                triggers: automations ?? [],
                 defaultList: !['AAVE', 'Spark'].includes(dpm.protocol) ? emptyAutomations : {},
               }),
             }

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -40,7 +40,9 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async ({
   apiVaults,
   debug,
 }) => {
-  const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
+  const positionAutomations = allPositionsAutomations
+    .filter(filterAutomation(dpm))
+    .map((automation) => automation.triggers)
   const { commonData, primaryTokenPrice, secondaryTokenPrice, ...commonRest } = commonDataMapper({
     automations: positionAutomations,
     dpm,
@@ -125,7 +127,9 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async ({
   apiVaults,
   debug,
 }) => {
-  const positionAutomations = allPositionsAutomations.find(filterAutomation(dpm))
+  const positionAutomations = allPositionsAutomations
+    .filter(filterAutomation(dpm))
+    .map((automation) => automation.triggers)
   const { commonData, primaryTokenPrice, secondaryTokenPrice, ...commonRest } = commonDataMapper({
     automations: positionAutomations,
     dpm,

--- a/handlers/portfolio/positions/handlers/maker/index.ts
+++ b/handlers/portfolio/positions/handlers/maker/index.ts
@@ -1,3 +1,4 @@
+import { decodeTriggerDataAsJson } from '@oasisdex/automation'
 import BigNumber from 'bignumber.js'
 import { NetworkIds, NetworkNames } from 'blockchain/networks'
 import { OmniProductType } from 'features/omni-kit/types'
@@ -70,8 +71,15 @@ export const makerPositionsHandler: PortfolioPositionsHandler = async ({
               autoSell: { enabled: false },
               stopLoss: { enabled: false },
               takeProfit: { enabled: false },
-              ...getPositionsAutomations({ triggers } as {
-                triggers: AutomationResponse[number]['triggers'][]
+              ...getPositionsAutomations({
+                triggers: triggers.map((trigger) => ({
+                  ...trigger,
+                  ...decodeTriggerDataAsJson(
+                    trigger.commandAddress,
+                    NetworkIds.MAINNET,
+                    trigger.triggerData,
+                  ),
+                })) as unknown as AutomationResponse[number]['triggers'][],
               }),
             }),
           },

--- a/handlers/portfolio/positions/handlers/maker/index.ts
+++ b/handlers/portfolio/positions/handlers/maker/index.ts
@@ -8,6 +8,7 @@ import {
   getMakerPositionInfo,
 } from 'handlers/portfolio/positions/handlers/maker/helpers'
 import { getPositionsAutomations } from 'handlers/portfolio/positions/helpers'
+import type { AutomationResponse } from 'handlers/portfolio/positions/helpers/getAutomationData'
 import type { PortfolioPosition, PortfolioPositionsHandler } from 'handlers/portfolio/types'
 import { LendingProtocol } from 'lendingProtocols'
 
@@ -69,7 +70,9 @@ export const makerPositionsHandler: PortfolioPositionsHandler = async ({
               autoSell: { enabled: false },
               stopLoss: { enabled: false },
               takeProfit: { enabled: false },
-              ...getPositionsAutomations({ triggers }),
+              ...getPositionsAutomations({ triggers } as {
+                triggers: AutomationResponse[number]['triggers'][]
+              }),
             }),
           },
           details: getMakerPositionDetails({

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -1,9 +1,9 @@
 import { TriggerType } from '@oasisdex/automation'
-import type { MakerDiscoverPositionsTrigger } from 'handlers/portfolio/positions/handlers/maker/types'
+import type { AutomationResponse } from 'handlers/portfolio/positions/helpers/getAutomationData'
 import type { PortfolioPositionAutomations } from 'handlers/portfolio/types'
 
 interface GetPositionsAutomationsParams {
-  triggers: MakerDiscoverPositionsTrigger[]
+  triggers: AutomationResponse[number]['triggers'][]
   defaultList?: Record<string, boolean> | {}
 }
 


### PR DESCRIPTION
New stop loss UI fixes:


[[BUG] - New Stop-Loss - After Setting up or updating stop-loss a message reads that vault will update in 30 seconds but screen never updates](https://app.shortcut.com/oazo-apps/story/14334/bug-new-stop-loss-after-setting-up-or-updating-stop-loss-a-message-reads-that-vault-will-update-in-30-seconds-but-screen)

[[BUG] - New Stop-Loss - When LTV is equal to 0 'NaN' is displayed for 'Saving compared to liquidation'](https://app.shortcut.com/oazo-apps/story/14356/bug-new-stop-loss-when-ltv-is-equal-to-0-nan-is-displayed-for-saving-compared-to-liquidation)

[[BUG] - Overview - LTV tooltip reads 'Stop-Loss not set' even when it's ON](https://app.shortcut.com/oazo-apps/story/14345/bug-overview-ltv-tooltip-reads-stop-loss-not-set-even-when-it-s-on)

[[BUG] - Portfolio's automation icons don't switch on for stop-loss](https://app.shortcut.com/oazo-apps/story/14336/bug-portfolio-s-automation-icons-don-t-switch-on-for-stop-loss)

[[BUG] - Stop-Loss - No 'Back to edit' option](https://app.shortcut.com/oazo-apps/story/14343/bug-stop-loss-no-back-to-edit-option)

[[BUG] - Stop-Loss - Optimism - Cannot update or remove stop-loss automation](https://app.shortcut.com/oazo-apps/story/14338/bug-stop-loss-optimism-cannot-update-or-remove-stop-loss-automation)