### PR TITLE
Add Gas Estimations For Stop Loss Transactions

### DIFF
--- a/blockchain/better-calls/dpm-account.ts
+++ b/blockchain/better-calls/dpm-account.ts
@@ -153,7 +153,7 @@ export async function createExecuteOperationExecutorTransaction({
 
 export interface DpmOperationParams {
   networkId: NetworkIds
-  proxyAddress: string
+  proxyAddress?: string
   signer: ethers.Signer
   value?: BigNumber
   data: string
@@ -168,7 +168,7 @@ export async function estimateGas({
   value,
   to,
 }: DpmOperationParams) {
-  await validateParameters({ signer, networkId, proxyAddress })
+  await validateParameters({ signer, networkId, proxyAddress: proxyAddress ?? to })
 
   try {
     const result = await signer.estimateGas({
@@ -180,7 +180,9 @@ export async function estimateGas({
 
     return new BigNumber(result.toString()).multipliedBy(GasMultiplier).toFixed(0)
   } catch (e) {
-    const message = `Error estimating gas. Action: ${data} on proxy: ${proxyAddress}. Network: ${networkId}`
+    const message = `Error estimating gas. Action: ${data} on proxy: ${
+      proxyAddress ?? to
+    }. Network: ${networkId}`
     console.error(message, e)
     throw new Error(message, {
       cause: e,
@@ -196,7 +198,7 @@ export async function executeTransaction({
   value,
   to,
 }: DpmOperationParams) {
-  await validateParameters({ signer, networkId, proxyAddress })
+  await validateParameters({ signer, networkId, proxyAddress: proxyAddress ?? to })
 
   const dangerTransactionEnabled = isDangerTransactionEnabled()
 

--- a/features/aave/hooks/useGasEstimation.tsx
+++ b/features/aave/hooks/useGasEstimation.tsx
@@ -1,0 +1,58 @@
+import BigNumber from 'bignumber.js'
+import { estimateGas } from 'blockchain/better-calls/dpm-account'
+import type { NetworkIds } from 'blockchain/networks'
+import { getTransactionFee } from 'blockchain/transaction-fee'
+import type { ethers } from 'ethers'
+import type { TriggerTransaction } from 'helpers/triggers'
+import type { HasGasEstimation } from 'helpers/types/HasGasEstimation.types'
+import { GasEstimationStatus } from 'helpers/types/HasGasEstimation.types'
+import { useEffect, useState } from 'react'
+
+export interface GasEstimationParams {
+  signer?: ethers.Signer
+  networkId: NetworkIds
+  transaction?: TriggerTransaction
+}
+
+export function useGasEstimation({
+  signer,
+  transaction,
+  networkId,
+}: GasEstimationParams): HasGasEstimation {
+  const [resultState, setResultState] = useState<HasGasEstimation>({
+    gasEstimationStatus: GasEstimationStatus.unset,
+  })
+
+  useEffect(() => {
+    if (signer && transaction) {
+      setResultState({ gasEstimationStatus: GasEstimationStatus.calculating })
+      estimateGas({
+        ...transaction,
+        signer,
+        networkId,
+      })
+        .then(async (_gas) => {
+          const fee = await getTransactionFee({ estimatedGas: _gas, networkId })
+          return { fee, gas: _gas }
+        })
+        .then(({ fee, gas: _gas }) => {
+          if (!fee) {
+            setResultState({ gasEstimationStatus: GasEstimationStatus.error })
+            return
+          }
+          setResultState({
+            gasEstimationStatus: GasEstimationStatus.calculated,
+            gasEstimationEth: new BigNumber(fee.fee),
+            gasEstimation: parseInt(_gas),
+            gasEstimationUsd: new BigNumber(fee.feeUsd),
+          })
+        })
+        .catch((error) => {
+          setResultState({ gasEstimationStatus: GasEstimationStatus.error })
+          console.error('Error estimating gas', error)
+        })
+    }
+  }, [transaction, signer, networkId])
+
+  return resultState
+}

--- a/features/aave/hooks/useTransactionCostWithLoading.tsx
+++ b/features/aave/hooks/useTransactionCostWithLoading.tsx
@@ -1,0 +1,18 @@
+import { InfoSectionLoadingState } from 'components/infoSection/Item'
+import { getEstimatedGasFeeTextOld } from 'components/vault/VaultChangesInformation'
+import { GasEstimationStatus, type HasGasEstimation } from 'helpers/types/HasGasEstimation.types'
+import React from 'react'
+
+export function useTransactionCostWithLoading({
+  transactionCost = { gasEstimationStatus: GasEstimationStatus.calculating },
+  isLoading = false,
+}: {
+  transactionCost?: HasGasEstimation
+  isLoading?: boolean
+}) {
+  return isLoading || transactionCost.gasEstimationStatus === GasEstimationStatus.calculating ? (
+    <InfoSectionLoadingState />
+  ) : (
+    getEstimatedGasFeeTextOld(transactionCost, false)
+  )
+}

--- a/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
@@ -441,8 +441,16 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
     if (transactionStep === 'finished') {
       return false
     }
+    if (trailingStopLossTxDataLambda === undefined) {
+      return true
+    }
     return !trailingStopLossConfigChanged
-  }, [isGettingTrailingStopLossTx, trailingStopLossConfigChanged, transactionStep])
+  }, [
+    isGettingTrailingStopLossTx,
+    trailingStopLossConfigChanged,
+    transactionStep,
+    trailingStopLossTxDataLambda,
+  ])
 
   const primaryButtonAction = () => {
     if (transactionStep === 'prepare') {

--- a/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
@@ -1,8 +1,5 @@
-import BigNumber from 'bignumber.js'
-import { estimateGas } from 'blockchain/better-calls/dpm-account'
-import { getOverrides } from 'blockchain/better-calls/utils/get-overrides'
-import { ensureContractsExist, getNetworkContracts } from 'blockchain/contracts'
-import type { ContextConnected } from 'blockchain/network.types'
+import type BigNumber from 'bignumber.js'
+import { executeTransaction } from 'blockchain/better-calls/dpm-account'
 import { ActionPills } from 'components/ActionPills'
 import { DimmedList } from 'components/DImmedList'
 import { SliderValuePicker } from 'components/dumb/SliderValuePicker'
@@ -16,9 +13,9 @@ import {
   VaultChangesInformationItem,
 } from 'components/vault/VaultChangesInformation'
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
-import { ethers } from 'ethers'
 import { ConnectedSidebarSection } from 'features/aave/components'
-// import { OpenAaveStopLossInformationLambda } from 'features/aave/components/order-information/OpenAaveStopLossInformationLambda'
+import { useGasEstimation } from 'features/aave/hooks/useGasEstimation'
+import { useTransactionCostWithLoading } from 'features/aave/hooks/useTransactionCostWithLoading'
 import type { mapStopLossFromLambda } from 'features/aave/manage/helpers/map-stop-loss-from-lambda'
 import type { mapTrailingStopLossFromLambda } from 'features/aave/manage/helpers/map-trailing-stop-loss-from-lambda'
 import type { ManageAaveStateProps } from 'features/aave/manage/sidebars/SidebarManageAaveVault'
@@ -29,6 +26,7 @@ import {
   sidebarAutomationFeatureCopyMap,
   sidebarAutomationLinkMap,
 } from 'features/automation/common/consts'
+import { useWalletManagement } from 'features/web3OnBoard/useConnection'
 import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
@@ -72,11 +70,23 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
 }) {
   const { t } = useTranslation()
   const [refreshingTriggerData, setRefreshingTriggerData] = useState(false)
+  const { signer } = useWalletManagement()
+
   const [triggerId, setTriggerId] = useState<string>(trailingStopLossLambdaData.triggerId ?? '0')
   const [transactionStep, setTransactionStep] = useState<TrailingStopLossSidebarStates>('prepare')
   const isRegularStopLossEnabled = stopLossLambdaData.stopLossLevel !== undefined
   const isTrailingStopLossEnabled = trailingStopLossLambdaData.trailingDistance !== undefined
-  const { strategyConfig, strategyInfo, trailingStopLossTxDataLambda, web3Context } = state.context
+  const { strategyConfig, strategyInfo, trailingStopLossTxDataLambda } = state.context
+  const gasEstimation = useGasEstimation({
+    transaction: trailingStopLossTxDataLambda,
+    networkId: strategyConfig.networkId,
+    signer,
+  })
+  const TransactionCost = useTransactionCostWithLoading({
+    transactionCost: gasEstimation,
+    isLoading: refreshingTriggerData,
+  })
+
   const {
     trailingDistance,
     trailingDistanceValue,
@@ -168,29 +178,12 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
   }
 
   const executeCall = async () => {
-    if (trailingStopLossTxDataLambda) {
-      const proxyAddress = trailingStopLossTxDataLambda.to
-      const networkId = strategyConfig.networkId
-      const contracts = getNetworkContracts(networkId, web3Context?.chainId)
-      ensureContractsExist(networkId, contracts, ['automationBotV2'])
-      const signer = (web3Context as ContextConnected)?.transactionProvider
-      const bnValue = new BigNumber(0)
-      const data = trailingStopLossTxDataLambda.data
-      const value = ethers.utils.parseEther(bnValue.toString()).toHexString()
-      const gasLimit = await estimateGas({
-        networkId,
-        proxyAddress,
-        signer,
-        value: bnValue,
-        to: proxyAddress,
-        data,
-      })
-      return signer.sendTransaction({
-        ...(await getOverrides(signer)),
-        to: proxyAddress,
-        data,
-        value,
-        gasLimit: gasLimit ?? undefined,
+    if (trailingStopLossTxDataLambda && signer) {
+      return await executeTransaction({
+        data: trailingStopLossTxDataLambda.data,
+        to: trailingStopLossTxDataLambda.to,
+        signer: signer,
+        networkId: strategyConfig.networkId,
       })
     }
     return null
@@ -226,8 +219,7 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
         label={`${t('protection.estimated-fees-on-trigger', {
           token: selectedTokenLabel,
         })}`}
-        value={<Flex>${'estimatedFeesWhenSlTriggered'}</Flex>}
-        tooltip={<Box>{t('protection.sl-triggered-gas-estimation')}</Box>}
+        value={TransactionCost}
       />
     </DimmedList>
   )

--- a/features/aave/open/helpers/get-aave-like-stop-loss-params.ts
+++ b/features/aave/open/helpers/get-aave-like-stop-loss-params.ts
@@ -45,6 +45,10 @@ export const getAaveLikeStopLossParams = {
       liquidationRatio: one.div(liquidationRatio),
       stopLossLevel: one.div(stopLossLevel.div(100)).times(100),
     })
+
+    const stopLossTxData = state.context.stopLossTxDataLambda
+    const strategy = state.context.strategyConfig
+
     return {
       stopLossLevel,
       positionRatio,
@@ -56,6 +60,8 @@ export const getAaveLikeStopLossParams = {
       liquidationPrice,
       sliderPercentageFill,
       dynamicStopLossPrice,
+      stopLossTxData,
+      strategy,
     }
   }),
   manage: memoize(({ state }: Pick<ManageAaveStateProps, 'state'>) => {
@@ -87,6 +93,10 @@ export const getAaveLikeStopLossParams = {
       liquidationRatio: one.div(liquidationRatio),
       stopLossLevel: one.div(stopLossLevel.div(100)).times(100),
     })
+
+    const stopLossTxData = state.context.stopLossTxDataLambda
+    const strategy = state.context.strategyConfig
+
     return {
       stopLossLevel,
       positionRatio,
@@ -98,6 +108,8 @@ export const getAaveLikeStopLossParams = {
       liquidationPrice,
       sliderPercentageFill,
       dynamicStopLossPrice,
+      stopLossTxData,
+      strategy,
     }
   }),
 }

--- a/features/aave/open/helpers/use-lambda-debounced-stop-loss.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-stop-loss.ts
@@ -80,7 +80,7 @@ export const useLambdaDebouncedStopLoss = ({
           if (
             res.transaction &&
             res.encodedTriggerData &&
-            res.transaction.triggerTxData &&
+            res.transaction &&
             context.effectiveProxyAddress
           ) {
             send({
@@ -88,8 +88,6 @@ export const useLambdaDebouncedStopLoss = ({
               stopLossTxDataLambda: {
                 to: res.transaction.to,
                 data: res.transaction.data,
-                triggerTxData: res.transaction.triggerTxData,
-                encodedTriggerData: res.encodedTriggerData,
               },
             })
           }

--- a/features/aave/open/helpers/use-lambda-debounced-trailing-stop-loss.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-trailing-stop-loss.ts
@@ -74,19 +74,12 @@ export const useLambdaDebouncedTrailingStopLoss = ({
       setTrailingStopLossTxCancelablePromise(trailingStopLossTxDataPromise)
       trailingStopLossTxDataPromise
         .then((res) => {
-          if (
-            res.transaction &&
-            res.encodedTriggerData &&
-            res.transaction.triggerTxData &&
-            context.effectiveProxyAddress
-          ) {
+          if (res.transaction) {
             send({
               type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA',
               trailingStopLossTxDataLambda: {
                 to: res.transaction.to,
                 data: res.transaction.data,
-                triggerTxData: res.transaction.triggerTxData,
-                encodedTriggerData: res.encodedTriggerData,
               },
             })
           }

--- a/features/aave/open/sidebars/components/AaveOpenPositionStopLossLambdaSidebar.tsx
+++ b/features/aave/open/sidebars/components/AaveOpenPositionStopLossLambdaSidebar.tsx
@@ -1,6 +1,5 @@
 import type BigNumber from 'bignumber.js'
 import { ActionPills } from 'components/ActionPills'
-import { useProductContext } from 'components/context/ProductContextProvider'
 import { SliderValuePicker } from 'components/dumb/SliderValuePicker'
 import { AppLink } from 'components/Links'
 import type { SidebarSectionProps } from 'components/sidebar/SidebarSection'
@@ -10,11 +9,9 @@ import { getAaveLikeStopLossParams } from 'features/aave/open/helpers'
 import { useLambdaDebouncedStopLoss } from 'features/aave/open/helpers/use-lambda-debounced-stop-loss'
 import type { OpenAaveStateProps } from 'features/aave/open/sidebars/sidebar.types'
 import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
-import { WithErrorHandler } from 'helpers/errorHandlers/WithErrorHandler'
 import { formatAmount, formatPercent } from 'helpers/formatters/format'
-import { useObservable } from 'helpers/observableHook'
 import { TriggerAction } from 'helpers/triggers'
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Grid, Text } from 'theme-ui'
 
@@ -33,16 +30,6 @@ export function AaveOpenPositionStopLossLambdaSidebar({
   const [stopLossToken, setStopLossToken] = useState<'debt' | 'collateral'>('debt')
   const { strategyConfig } = state.context
   const stopLossParams = getAaveLikeStopLossParams.open({ state })
-  const { tokenPriceUSD$ } = useProductContext()
-  const _tokenPriceUSD$ = useMemo(
-    () =>
-      tokenPriceUSD$([
-        'ETH',
-        stopLossToken === 'debt' ? strategyConfig.tokens.debt : strategyConfig.tokens.collateral,
-      ]),
-    [stopLossToken, strategyConfig.tokens.collateral, strategyConfig.tokens.debt, tokenPriceUSD$],
-  )
-  const [tokensPriceData, tokensPriceDataError] = useObservable(_tokenPriceUSD$)
   const { stopLossLevel, dynamicStopLossPrice, sliderMin, sliderMax, sliderPercentageFill } =
     stopLossParams
   const { stopLossTxCancelablePromise, isGettingStopLossTx } = useLambdaDebouncedStopLoss({
@@ -111,7 +98,6 @@ export function AaveOpenPositionStopLossLambdaSidebar({
         {!!state.context.strategyInfo && (
           <OpenAaveStopLossInformationLambda
             stopLossParams={stopLossParams}
-            tokensPriceData={tokensPriceData}
             strategyInfo={state.context.strategyInfo}
             collateralActive={stopLossToken === 'collateral'}
           />
@@ -132,15 +118,13 @@ export function AaveOpenPositionStopLossLambdaSidebar({
   }
 
   return (
-    <WithErrorHandler error={[tokensPriceDataError]}>
-      <ConnectedSidebarSection
-        {...sidebarSectionProps}
-        textButton={{
-          label: t('open-earn.aave.vault-form.back-to-editing'),
-          action: () => send('BACK_TO_EDITING'),
-        }}
-        context={state.context}
-      />
-    </WithErrorHandler>
+    <ConnectedSidebarSection
+      {...sidebarSectionProps}
+      textButton={{
+        label: t('open-earn.aave.vault-form.back-to-editing'),
+        action: () => send('BACK_TO_EDITING'),
+      }}
+      context={state.context}
+    />
   )
 }

--- a/features/aave/types/base-aave-context.ts
+++ b/features/aave/types/base-aave-context.ts
@@ -8,7 +8,7 @@ import { UserDpmAccount } from 'blockchain/userDpmProxies.types'
 import { ManageCollateralActionsEnum, ManageDebtActionsEnum } from 'features/aave'
 import { getTxTokenAndAmount } from 'features/aave/helpers/getTxTokenAndAmount'
 import { IStrategyConfig } from './strategy-config'
-import { AutomationAddTriggerData, AutomationAddTriggerLambda } from 'features/automation/common/txDefinitions.types'
+import { AutomationAddTriggerData } from 'features/automation/common/txDefinitions.types'
 import { UserSettingsState } from 'features/userSettings/userSettings.types'
 import { HasGasEstimation } from 'helpers/types/HasGasEstimation.types'
 import { AllowanceStateMachine } from 'features/stateMachines/allowance'
@@ -17,6 +17,7 @@ import { zero } from 'helpers/zero'
 import { ActorRefFrom, EventObject, Sender } from 'xstate'
 import { AaveLikeReserveData } from 'lendingProtocols/aave-like-common'
 import { AaveCumulativeData } from 'features/omni-kit/protocols/aave/history/types'
+import { TriggerTransaction } from "../../../helpers/triggers";
 
 export type UserInput = {
   riskRatio?: IRiskRatio
@@ -110,8 +111,8 @@ export interface BaseAaveContext {
   trailingDistance?: BigNumber
   collateralActive?: boolean
   stopLossTxData?: AutomationAddTriggerData
-  stopLossTxDataLambda?: AutomationAddTriggerLambda
-  trailingStopLossTxDataLambda?: AutomationAddTriggerLambda
+  stopLossTxDataLambda?: TriggerTransaction
+  trailingStopLossTxDataLambda?: TriggerTransaction
   stopLossSkipped?: boolean
   getSlippageFrom: 'userSettings' | 'strategyConfig'
   reserveData?: ReserveData

--- a/features/aave/types/base-aave-event.ts
+++ b/features/aave/types/base-aave-event.ts
@@ -11,18 +11,19 @@ import {
   StrategyTokenAllowance,
   StrategyTokenBalance,
 } from './base-aave-context'
-import { AutomationAddTriggerData, AutomationAddTriggerLambda } from 'features/automation/common/txDefinitions.types'
+import { AutomationAddTriggerData } from 'features/automation/common/txDefinitions.types'
 import { UserSettingsState } from 'features/userSettings/userSettings.types'
 import { ManageDebtActionsEnum } from './manage-debt-actions-enum'
 import { ManageCollateralActionsEnum } from './manage-collateral-actions-enum'
+import { TriggerTransaction } from "../../../helpers/triggers";
 
 type AaveOpenPositionWithStopLossEvents =
   | { type: 'SET_STOP_LOSS_LEVEL'; stopLossLevel: BigNumber }
   | { type: 'SET_TRAILING_STOP_LOSS_LEVEL'; trailingDistance: BigNumber }
   | { type: 'SET_COLLATERAL_ACTIVE'; collateralActive: boolean }
   | { type: 'SET_STOP_LOSS_TX_DATA'; stopLossTxData: AutomationAddTriggerData }
-  | { type: 'SET_STOP_LOSS_TX_DATA_LAMBDA'; stopLossTxDataLambda: AutomationAddTriggerLambda }
-  | { type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA'; trailingStopLossTxDataLambda: AutomationAddTriggerLambda }
+  | { type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA'; trailingStopLossTxDataLambda: TriggerTransaction }
+  | { type: 'SET_STOP_LOSS_TX_DATA_LAMBDA'; stopLossTxDataLambda: TriggerTransaction }
   | { type: 'SET_STOP_LOSS_SKIPPED'; stopLossSkipped: boolean }
 
 

--- a/features/automation/common/txDefinitions.types.ts
+++ b/features/automation/common/txDefinitions.types.ts
@@ -14,13 +14,6 @@ export type AutomationAddTriggerData =
   | AutomationBotAddAggregatorTriggerData
   | AutomationBotV2AddTriggerData
 
-export type AutomationAddTriggerLambda = {
-  data: string
-  to: string
-  encodedTriggerData: string
-  triggerTxData: string
-}
-
 export type AutomationAddTriggerTxDef =
   | TransactionDef<AutomationBotAddTriggerData>
   | TransactionDef<AutomationBotAddAggregatorTriggerData>

--- a/features/web3OnBoard/useConnection.tsx
+++ b/features/web3OnBoard/useConnection.tsx
@@ -1,5 +1,6 @@
 import type { NetworkConfigHexId, NetworkIds } from 'blockchain/networks'
 import { ethers } from 'ethers'
+import { useMemo } from 'react'
 
 import { useWeb3OnBoardConnectorContext } from './web3-on-board-connector-provider'
 
@@ -42,19 +43,25 @@ export interface WalletManagementState {
 }
 export function useWalletManagement(): WalletManagementState {
   const { state, disconnect } = useWeb3OnBoardConnectorContext()
-  return {
-    disconnect,
-    connecting: state.status === 'connecting',
-    chainId: state.networkConnectorNetworkId,
-    wallet: state.connector
+  const signer = useMemo(() => {
+    return state.connector
+      ? new ethers.providers.Web3Provider(state.connector.connectorInformation.provider).getSigner()
+      : undefined
+  }, [state.connector])
+  const wallet = useMemo(() => {
+    return state.connector
       ? {
           address: state.connector.connectedAccount,
           chainHexId: state.connector.hexChainId,
           chainId: state.connector.chainId,
         }
-      : undefined,
-    signer: state.connector
-      ? new ethers.providers.Web3Provider(state.connector.connectorInformation.provider).getSigner()
-      : undefined,
+      : undefined
+  }, [state.connector])
+  return {
+    disconnect,
+    connecting: state.status === 'connecting',
+    chainId: state.networkConnectorNetworkId,
+    wallet: wallet,
+    signer: signer,
   }
 }

--- a/helpers/triggers/get-triggers/get-triggers-types.ts
+++ b/helpers/triggers/get-triggers/get-triggers-types.ts
@@ -1,21 +1,6 @@
 import type { NetworkIds } from 'blockchain/networks'
 import type { UserDpmAccount } from 'blockchain/userDpmProxies.types'
 
-export const AaveStopLossToCollateralV2ID = 111n as const
-export const AaveStopLossToDebtV2ID = 112n as const
-export const SparkStopLossToCollateralV2ID = 117n as const
-export const SparkStopLossToDebtV2ID = 118n as const
-
-export const DmaAaveStopLossToCollateralV2ID = 123n as const
-export const DmaAaveStopLossToDebtV2ID = 124n as const
-export const DmaSparkStopLossToCollateralV2ID = 125n as const
-export const DmaSparkStopLossToDebtV2ID = 126n as const
-
-export const DmaAaveBasicBuyV2ID = 121n as const
-export const DmaAaveBasicSellV2ID = 122n as const
-
-export const DmaAaveTrailingStopLossID = 10005n as const
-
 export interface GetTriggersParams {
   networkId: NetworkIds
   dpm: UserDpmAccount
@@ -23,7 +8,7 @@ export interface GetTriggersParams {
 
 export type AaveStopLossToCollateral = {
   triggerTypeName: 'AaveStopLossToCollateralV2'
-  triggerType: typeof AaveStopLossToCollateralV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -38,7 +23,7 @@ export type AaveStopLossToCollateral = {
 }
 export type AaveStopLossToDebt = {
   triggerTypeName: 'AaveStopLossToDebtV2'
-  triggerType: typeof AaveStopLossToDebtV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -53,7 +38,7 @@ export type AaveStopLossToDebt = {
 }
 export type SparkStopLossToCollateral = {
   triggerTypeName: 'SparkStopLossToCollateralV2'
-  triggerType: typeof SparkStopLossToCollateralV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -68,7 +53,7 @@ export type SparkStopLossToCollateral = {
 }
 export type SparkStopLossToDebt = {
   triggerTypeName: 'SparkStopLossToDebtV2'
-  triggerType: typeof SparkStopLossToDebtV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -83,7 +68,7 @@ export type SparkStopLossToDebt = {
 }
 export type AaveStopLossToCollateralDMA = {
   triggerTypeName: 'DmaAaveStopLossToCollateralV2'
-  triggerType: typeof DmaAaveStopLossToCollateralV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -99,7 +84,7 @@ export type AaveStopLossToCollateralDMA = {
 
 export type AaveStopLossToDebtDMA = {
   triggerTypeName: 'DmaAaveStopLossToDebtV2'
-  triggerType: typeof DmaAaveStopLossToDebtV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -114,7 +99,7 @@ export type AaveStopLossToDebtDMA = {
 }
 export type SparkStopLossToCollateralDMA = {
   triggerTypeName: 'DmaSparkStopLossToCollateralV2'
-  triggerType: typeof DmaSparkStopLossToCollateralV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -129,7 +114,7 @@ export type SparkStopLossToCollateralDMA = {
 }
 export type SparkStopLossToDebtDMA = {
   triggerTypeName: 'DmaSparkStopLossToDebtV2'
-  triggerType: typeof DmaSparkStopLossToDebtV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -145,7 +130,7 @@ export type SparkStopLossToDebtDMA = {
 
 export type DmaAaveBasicBuy = {
   triggerTypeName: 'DmaAaveBasicBuyV2'
-  triggerType: typeof DmaAaveBasicBuyV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -164,7 +149,7 @@ export type DmaAaveBasicBuy = {
 }
 export type DmaAaveBasicSell = {
   triggerTypeName: 'DmaAaveBasicSellV2'
-  triggerType: typeof DmaAaveBasicSellV2ID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {
@@ -184,7 +169,7 @@ export type DmaAaveBasicSell = {
 
 export type DmaAaveTrailingStopLoss = {
   triggerTypeName: 'DmaAaveTrailingStopLoss'
-  triggerType: typeof DmaAaveTrailingStopLossID
+  triggerType: bigint
   triggerId: string
   triggerData: string
   decodedParams: {

--- a/helpers/triggers/setup-triggers/setup-aave-stop-loss.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-stop-loss.ts
@@ -1,12 +1,3 @@
-import type { SupportedLambdaProtocols } from 'helpers/triggers/common'
-import {
-  DmaAaveStopLossToCollateralV2ID,
-  DmaAaveStopLossToDebtV2ID,
-  DmaSparkStopLossToCollateralV2ID,
-  DmaSparkStopLossToDebtV2ID,
-} from 'helpers/triggers/get-triggers'
-import { LendingProtocol } from 'lendingProtocols'
-
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type {
   SetupAaveStopLossParams,
@@ -20,24 +11,9 @@ export const setupAaveLikeStopLoss = async (
 ): Promise<SetupBasicStopLossResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'dma-stop-loss' })
 
-  const triggerTypeMap = {
-    [LendingProtocol.AaveV3]: {
-      collateral: DmaAaveStopLossToCollateralV2ID.toString(),
-      debt: DmaAaveStopLossToDebtV2ID.toString(),
-    },
-    [LendingProtocol.SparkV3]: {
-      collateral: DmaSparkStopLossToCollateralV2ID.toString(),
-      debt: DmaSparkStopLossToDebtV2ID.toString(),
-    },
-  }
-
-  const triggerTypePicker: keyof (typeof triggerTypeMap)[SupportedLambdaProtocols] =
-    params.executionToken === params.strategy.collateralAddress ? 'collateral' : 'debt'
-
   const body = JSON.stringify({
     dpm: params.dpm,
     triggerData: {
-      type: triggerTypeMap[params.protocol][triggerTypePicker],
       executionLTV: params.executionLTV
         .times(10 ** 2)
         .integerValue()

--- a/helpers/triggers/setup-triggers/setup-aave-trailing-stop-loss.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-trailing-stop-loss.ts
@@ -1,6 +1,4 @@
 import { trailingStopLossDenomination } from 'features/aave/constants'
-import { DmaAaveTrailingStopLossID } from 'helpers/triggers/get-triggers'
-import { LendingProtocol } from 'lendingProtocols'
 
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type {
@@ -14,14 +12,9 @@ export const setupAaveLikeTrailingStopLoss = async (
 ): Promise<SetupTrailingStopLossResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'dma-trailing-stop-loss' })
 
-  const triggerTypeMap = {
-    [LendingProtocol.AaveV3]: DmaAaveTrailingStopLossID.toString(),
-  }
-
   const body = JSON.stringify({
     dpm: params.dpm,
     triggerData: {
-      type: triggerTypeMap[params.protocol as keyof typeof triggerTypeMap],
       trailingDistance: params.trailingDistance
         .times(trailingStopLossDenomination)
         .integerValue()

--- a/helpers/triggers/setup-triggers/setup-triggers-types.ts
+++ b/helpers/triggers/setup-triggers/setup-triggers-types.ts
@@ -76,6 +76,11 @@ export enum TriggerAction {
   Update = 'update',
 }
 
+export type TriggerTransaction = {
+  data: string
+  to: string
+}
+
 export interface SetupAaveBasicAutomationParams {
   price: BigNumber | undefined
   executionLTV: BigNumber
@@ -102,11 +107,7 @@ export type SetupBasicAutoResponse = {
     targetLTVWithDeviation: [string, string]
     targetMultiple: string
   }
-  transaction?: {
-    data: string
-    to: string
-    triggerTxData?: string
-  }
+  transaction?: TriggerTransaction
 }
 
 export type SetupBasicStopLossResponse = {
@@ -121,11 +122,7 @@ export type SetupBasicStopLossResponse = {
     targetLTVWithDeviation: [string, string]
     targetMultiple: string
   }
-  transaction?: {
-    data: string
-    to: string
-    triggerTxData?: string
-  }
+  transaction?: TriggerTransaction
 }
 
 export interface SetupAaveStopLossParams {
@@ -214,7 +211,7 @@ export type SetupTrailingStopLossResponse = {
 }
 
 export type SetupBasicAutoResponseWithRequiredTransaction = SetupBasicAutoResponse & {
-  transaction: { data: string; to: string }
+  transaction: TriggerTransaction
 }
 
 export const hasTransaction = (

--- a/helpers/triggers/setup-triggers/setup-triggers-types.ts
+++ b/helpers/triggers/setup-triggers/setup-triggers-types.ts
@@ -1,14 +1,6 @@
 import type BigNumber from 'bignumber.js'
 import type { SupportedLambdaProtocols } from 'helpers/triggers/common'
 
-export enum AutoBuyTriggerCustomErrorCodes {}
-
-export enum AutoBuyTriggerCustomWarningCodes {}
-
-export enum AutoSellTriggerCustomErrorCodes {}
-
-export enum AutoSellTriggerCustomWarningCodes {}
-
 export enum TriggersApiErrorCode {
   MinSellPriceIsNotSet = 'min-sell-price-is-not-set',
   MaxBuyPriceIsNotSet = 'max-buy-price-is-not-set',
@@ -150,64 +142,8 @@ export type SetupTrailingStopLossResponse = {
   errors?: TriggersApiError[]
   warnings?: TriggersApiWarning[]
   encodedTriggerData?: string
-  simulation?: {
-    latestPrice?: {
-      tokenRoundId: string
-      denominationRoundId: string
-      token: {
-        id: string
-        symbol: string
-        oraclesToken: [
-          {
-            address: string
-          },
-        ]
-      }
-      denomination: {
-        id: string
-        symbol: string
-        oraclesToken: [
-          {
-            address: string
-          },
-        ]
-      }
-      derivedPrice: string
-    }
-    position?: {
-      hasStablecoinDebt: boolean
-      ltv: string
-      collateral: {
-        balance: string
-        token: {
-          decimals: number
-          symbol: string
-          address: string
-        }
-      }
-      debt: {
-        balance: string
-        token: {
-          decimals: number
-          symbol: string
-          address: string
-        }
-      }
-      address: string
-      prices: {
-        collateralPrice: string
-        debtPrice: string
-      }
-      netValueUSD: string
-      debtValueUSD: string
-      collateralValueUSD: string
-    }
-  }
-  transaction?: {
-    data: string
-    to: string
-    triggerTxData?: string
-  }
+  simulation?: unknown
+  transaction?: TriggerTransaction
 }
 
 export type SetupBasicAutoResponseWithRequiredTransaction = SetupBasicAutoResponse & {


### PR DESCRIPTION
- Real gas estimation for Aave Stop Loss & Trailing Stop Loss
- Removed not used code from triggers
- Removed a new trigger types. Frontend doesn't need to know what are current types.
- Added a hook for Gas Estimations
- Performance update for the  `WalletManagement` hook.