### PR TITLE
Add aaveTrailingStopLossDMA trigger to hasActiveProtection function

### DIFF
--- a/features/aave/manage/state/triggersAaveStateMachine.ts
+++ b/features/aave/manage/state/triggersAaveStateMachine.ts
@@ -115,6 +115,7 @@ export const hasActiveProtection = ({
     sparkStopLossToDebt,
     aaveStopLossToDebt,
     aaveBasicSell,
+    aaveTrailingStopLossDMA,
   } = context.currentTriggers.triggers
   switch (protocol) {
     case LendingProtocol.AaveV3:
@@ -124,6 +125,7 @@ export const hasActiveProtection = ({
         aaveBasicSell,
         aaveStopLossToCollateralDMA,
         aaveStopLossToDebtDMA,
+        aaveTrailingStopLossDMA,
       )
     case LendingProtocol.SparkV3:
       return isAnyValueDefined(


### PR DESCRIPTION
This pull request adds the aaveTrailingStopLossDMA trigger to the hasActiveProtection function in order to include it in the list of active protection triggers for the AaveV3 lending protocol.