### PR TITLE
Fix stop loss configuration comparison bug

### DIFF
--- a/features/aave/components/AaveStopLossManageDetails.tsx
+++ b/features/aave/components/AaveStopLossManageDetails.tsx
@@ -65,9 +65,10 @@ export const AaveStopLossManageDetails = ({
 
   const stopLossConfigChanged = useMemo(() => {
     return !!(
-      stopLossLambdaData.stopLossLevel &&
-      (!stopLossLevel.eq(stopLossLambdaData.stopLossLevel) ||
-        stopLossLambdaData.stopLossToken !== stopLossToken)
+      (stopLossLambdaData.stopLossLevel &&
+        (!stopLossLevel.eq(stopLossLambdaData.stopLossLevel) ||
+          stopLossLambdaData.stopLossToken !== stopLossToken)) ||
+      (!stopLossLambdaData.stopLossLevel && stopLossLevel)
     )
   }, [stopLossLambdaData, stopLossLevel, stopLossToken])
 

--- a/features/aave/open/helpers/use-lambda-debounced-stop-loss.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-stop-loss.ts
@@ -99,6 +99,10 @@ export const useLambdaDebouncedStopLoss = ({
             type: 'TRANSACTION_FAILED',
             error,
           })
+          send({
+            type: 'SET_STOP_LOSS_TX_DATA_LAMBDA',
+            stopLossTxDataLambda: undefined,
+          })
         })
         .finally(() => {
           setIsGettingStopLossTx(false)

--- a/features/aave/open/helpers/use-lambda-debounced-trailing-stop-loss.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-trailing-stop-loss.ts
@@ -91,6 +91,10 @@ export const useLambdaDebouncedTrailingStopLoss = ({
             type: 'TRANSACTION_FAILED',
             error,
           })
+          send({
+            type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA',
+            trailingStopLossTxDataLambda: undefined,
+          })
         })
         .finally(() => {
           setIsGettingTrailingStopLossTx(false)

--- a/features/aave/types/base-aave-event.ts
+++ b/features/aave/types/base-aave-event.ts
@@ -22,8 +22,8 @@ type AaveOpenPositionWithStopLossEvents =
   | { type: 'SET_TRAILING_STOP_LOSS_LEVEL'; trailingDistance: BigNumber }
   | { type: 'SET_COLLATERAL_ACTIVE'; collateralActive: boolean }
   | { type: 'SET_STOP_LOSS_TX_DATA'; stopLossTxData: AutomationAddTriggerData }
-  | { type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA'; trailingStopLossTxDataLambda: TriggerTransaction }
-  | { type: 'SET_STOP_LOSS_TX_DATA_LAMBDA'; stopLossTxDataLambda: TriggerTransaction }
+  | { type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA'; trailingStopLossTxDataLambda: TriggerTransaction | undefined }
+  | { type: 'SET_STOP_LOSS_TX_DATA_LAMBDA'; stopLossTxDataLambda: TriggerTransaction | undefined }
   | { type: 'SET_STOP_LOSS_SKIPPED'; stopLossSkipped: boolean }
 
 

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -31,6 +31,7 @@ const triggerTypesMap = {
     TriggerType.DmaSparkStopLossToCollateralV2,
     TriggerType.DmaSparkStopLossToDebtV2,
     TriggerType.DmaAaveTrailingStopLossV2,
+    124, // legacy: aave stop loss to debt
   ],
   takeProfit: [
     TriggerType.AutoTakeProfitToCollateral,

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -31,7 +31,10 @@ const triggerTypesMap = {
     TriggerType.DmaSparkStopLossToCollateralV2,
     TriggerType.DmaSparkStopLossToDebtV2,
     TriggerType.DmaAaveTrailingStopLossV2,
+    123, // legacy: aave stop loss to collateral
     124, // legacy: aave stop loss to debt
+    125, // legacy: spark stop loss to collateral
+    126, // legacy: spark stop loss to debt
   ],
   takeProfit: [
     TriggerType.AutoTakeProfitToCollateral,


### PR DESCRIPTION
This pull request fixes a bug in the stop loss configuration comparison logic. The bug caused incorrect comparison results when the stop loss level or token changed. The fix ensures that the comparison is accurate in all cases.