### PR TITLE
Fix position not loading and add not-found page constant

### DIFF
--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -5,6 +5,7 @@ import { loadStrategyFromTokens } from 'features/aave'
 import { aaveLikeProtocols } from 'features/aave/constants'
 import type { PositionCreated } from 'features/aave/services'
 import {
+  extractLendingProtocolFromPositionCreatedEvent,
   getPositionCreatedEventForProxyAddress,
   mapCreatedPositionEventToPositionCreated,
 } from 'features/aave/services'
@@ -140,8 +141,10 @@ export async function getAaveLikeStrategyConfig(
   const createdPositions = await getPositionCreatedEventForProxyAddress(networkId, dpmProxy.proxy)
 
   const lastCreatedPosition = createdPositions
+    .filter((event) =>
+      aaveLikeProtocols.includes(extractLendingProtocolFromPositionCreatedEvent(event)),
+    )
     .map((event) => mapCreatedPositionEventToPositionCreated(event, networkId))
-    .filter((position) => aaveLikeProtocols.includes(position.protocol))
     .pop()
 
   if (!lastCreatedPosition) {

--- a/features/omni-kit/server/getOmniServerSideProps.ts
+++ b/features/omni-kit/server/getOmniServerSideProps.ts
@@ -8,6 +8,7 @@ import type {
   OmniProductType,
   OmniSupportedProtocols,
 } from 'features/omni-kit/types'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import type { ParsedUrlQuery } from 'querystring'
 
@@ -34,7 +35,7 @@ export async function getOmniServerSideProps({
     return {
       redirect: {
         permanent: false,
-        destination: '/not-found',
+        destination: INTERNAL_LINKS.notFound,
       },
     }
   }
@@ -59,7 +60,7 @@ export async function getOmniServerSideProps({
     return {
       redirect: {
         permanent: false,
-        destination: '/not-found',
+        destination: INTERNAL_LINKS.notFound,
       },
     }
   }

--- a/pages/[...rest].tsx
+++ b/pages/[...rest].tsx
@@ -1,7 +1,8 @@
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import NotFound from 'pages/not-found'
 
 export const getServerSideProps: () => Promise<unknown> = async () => {
-  return { redirect: { destination: '/not-found', permanent: true } }
+  return { redirect: { destination: INTERNAL_LINKS.notFound, permanent: true } }
 }
 
 export default NotFound

--- a/pages/[networkOrProduct]/aave/[version]/[...strategy].tsx
+++ b/pages/[networkOrProduct]/aave/[version]/[...strategy].tsx
@@ -40,7 +40,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     redirect: {
       permanent: false,
-      destination: '/not-found',
+      destination: INTERNAL_LINKS.notFound,
     },
   }
 }

--- a/pages/[networkOrProduct]/aave/[version]/[vault].tsx
+++ b/pages/[networkOrProduct]/aave/[version]/[vault].tsx
@@ -44,7 +44,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     redirect: {
       permanent: false,
-      destination: '/not-found',
+      destination: INTERNAL_LINKS.notFound,
     },
   }
 }

--- a/pages/[networkOrProduct]/maker/[vault]/index.tsx
+++ b/pages/[networkOrProduct]/maker/[vault]/index.tsx
@@ -7,6 +7,7 @@ import { AppLayout } from 'components/layouts/AppLayout'
 import { GeneralManageControl } from 'components/vault/GeneralManageControl'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { WithWalletAssociatedRisk } from 'features/walletAssociatedRisk/WalletAssociatedRisk'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import type { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import NotFoundPage from 'pages/not-found'
@@ -25,7 +26,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     return {
       redirect: {
         permanent: false,
-        destination: '/not-found',
+        destination: INTERNAL_LINKS.notFound,
       },
     }
   }

--- a/pages/[networkOrProduct]/spark/[version]/[...strategy].tsx
+++ b/pages/[networkOrProduct]/spark/[version]/[...strategy].tsx
@@ -40,7 +40,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     redirect: {
       permanent: false,
-      destination: '/not-found',
+      destination: INTERNAL_LINKS.notFound,
     },
   }
 }

--- a/pages/[networkOrProduct]/spark/[version]/[vault].tsx
+++ b/pages/[networkOrProduct]/spark/[version]/[vault].tsx
@@ -44,7 +44,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     redirect: {
       permanent: false,
-      destination: '/not-found',
+      destination: INTERNAL_LINKS.notFound,
     },
   }
 }

--- a/pages/better-on-summer/[...slug].tsx
+++ b/pages/better-on-summer/[...slug].tsx
@@ -3,6 +3,7 @@ import { MarketingLayout } from 'components/layouts/MarketingLayout'
 import { getMarketingTemplatePageProps } from 'features/marketing-layouts/helpers'
 import type { MarketingTemplateFreeform } from 'features/marketing-layouts/types'
 import { MarketingTemplateView } from 'features/marketing-layouts/views'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import type { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
@@ -30,7 +31,7 @@ export async function getServerSideProps({
   locale,
   query: { slug: rawSlug },
 }: GetServerSidePropsContext<{ slug: [string] }>) {
-  if (!rawSlug) return { redirect: { permanent: false, destination: '/not-found' } }
+  if (!rawSlug) return { redirect: { permanent: false, destination: INTERNAL_LINKS.notFound } }
   const [slug, preview] = Array.isArray(rawSlug) ? rawSlug : [rawSlug]
 
   try {
@@ -48,6 +49,6 @@ export async function getServerSideProps({
   } catch (e) {
     console.error('Caught error on better-on-summer', e)
 
-    return { redirect: { permanent: false, destination: '/not-found' } }
+    return { redirect: { permanent: false, destination: INTERNAL_LINKS.notFound } }
   }
 }

--- a/pages/portfolio/[address].tsx
+++ b/pages/portfolio/[address].tsx
@@ -9,7 +9,7 @@ import { PortfolioWalletView } from 'components/portfolio/wallet/PortfolioWallet
 import { TabBar } from 'components/TabBar'
 import { MigrationsContext } from 'features/migrations/context'
 import type { PortfolioPosition } from 'handlers/portfolio/types'
-import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
+import { EXTERNAL_LINKS, INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { usePortfolioClientData } from 'helpers/clients/portfolio-client-data'
 import { useAppConfig } from 'helpers/config'
 import { useAccount } from 'helpers/useAccount'
@@ -45,7 +45,7 @@ export async function getServerSideProps(
     console.error(e)
     return {
       redirect: {
-        destination: '/not-found',
+        destination: INTERNAL_LINKS.notFound,
         permanent: false,
       },
     }


### PR DESCRIPTION
The position could not load because it was trying to read the tokens from events before filtering the protocol and the events had ajna-only tokens there (not mapped in the tokens config). Moved the filtering first.

Added INTERNAL_LINKS constant for not-found page.