### PR TITLE
Update Aave to accurately display trailing distance for short positions

### DIFF
--- a/features/aave/components/AaveTrailingStopLossManageDetails.tsx
+++ b/features/aave/components/AaveTrailingStopLossManageDetails.tsx
@@ -30,18 +30,18 @@ export const AaveTrailingStopLossManageDetails = ({
     dynamicStopPriceChange,
     estimatedTokenOnSLTrigger,
     estimatedTokenOnSLTriggerChange,
+    currentTrailingDistanceValue,
   } = getAaveLikeTrailingStopLossParams.manage({
     state,
     trailingStopLossLambdaData,
     trailingStopLossToken,
   })
-
   const isShort = strategyConfig.strategyType === StrategyType.Short
   const trailingDistanceToken = isShort
     ? strategyConfig.tokens.collateral
     : strategyConfig.tokens.debt
   const trailingDistanceDisplayValue = `${formatAmount(
-    trailingStopLossLambdaData.trailingDistance || zero,
+    currentTrailingDistanceValue,
     trailingDistanceToken,
   )} ${trailingDistanceToken}`
   const trailingDistanceChangeDisplayValue =


### PR DESCRIPTION
Modified the existing code to correctly display the trailing distance for short positions in Aave. This is achieved by introducing a new variable called 'currentTrailingDistanceValue'. The 'currentTrailingDistanceValue' represents the trailing distance for short positions and is used to calculate the 'dynamicStopPrice' and 'trailingDistanceLambdaValue'.

