### PR TITLE
Refactor token conversion in Aave strategies

### DIFF
--- a/features/aave/strategies/index.ts
+++ b/features/aave/strategies/index.ts
@@ -70,8 +70,8 @@ export function loadStrategyFromTokens(
   // Aave uses WETH gateway for ETH (we have ETH strategy specified)
   // so we have to convert that on the fly just to find the strategy
   // this is then converted back to WETH using wethToEthAddress
-  const actualCollateralToken = collateralToken === 'WETH' ? 'ETH' : collateralToken
-  const actualDebtToken = debtToken === 'WETH' ? 'ETH' : debtToken
+  const actualCollateralToken = collateralToken === 'WETH' ? 'ETH' : collateralToken.toUpperCase()
+  const actualDebtToken = debtToken === 'WETH' ? 'ETH' : debtToken.toUpperCase()
   const strategy = strategies.find((s) => {
     /* Enhances for strategies to be filtered by product type */
     const matchesVaultType =


### PR DESCRIPTION
Capitalized the variables "collateralToken" and "debtToken" outside of their condition checks to ensure uppercase consistency. This change is applied to the part where Aave strategy filters tokens by product type.
