### PR TITLE
Refactor position automations in portfolio Aave-like handlers

### DIFF
--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -105,6 +105,13 @@ export const commonDataMapper = ({
         defaultType: dpm.positionType as OmniProductBorrowishType,
       })
     : dpm.positionType
+  const emptyAutomationsList = {
+    AAVE: {},
+    Spark: {
+      stopLoss: emptyAutomations.stopLoss,
+    },
+    AAVE_V3: emptyAutomations,
+  }[dpm.protocol]
   return {
     commonData: {
       positionId: positionIdAsString ? dpm.vaultId : Number(dpm.vaultId),
@@ -131,7 +138,7 @@ export const commonDataMapper = ({
           ? {
               ...getPositionsAutomations({
                 triggers: automations ?? [],
-                defaultList: !['AAVE', 'Spark'].includes(dpm.protocol) ? emptyAutomations : {},
+                defaultList: emptyAutomationsList,
               }),
             }
           : {}),

--- a/handlers/portfolio/positions/handlers/aave-like/helpers.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/helpers.ts
@@ -22,9 +22,7 @@ import { getTokenDisplayName } from 'helpers/getTokenDisplayName'
 import { LendingProtocol } from 'lendingProtocols'
 
 export const filterAutomation = (dpm: DpmSubgraphData) => (position: AutomationResponse[number]) =>
-  position.triggers.account.toLowerCase() === dpm.id.toLowerCase() &&
-  !position.triggers.executedBlock &&
-  !position.triggers.removedBlock
+  position.triggers.account.toLowerCase() === dpm.id.toLowerCase()
 
 export const getReserveDataCall = (dpm: DpmSubgraphData, token: string) => {
   switch (dpm.protocol) {

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -111,9 +111,7 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async ({
     ],
     netValue: calculations.netValue.toNumber(),
     debuggingData: debug
-      ? {
-          ...formatBigNumberDebugData(commonRest),
-        }
+      ? { ...formatBigNumberDebugData({ ...commonRest, positionAutomations }) }
       : undefined,
   }
 }
@@ -236,7 +234,9 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async ({
       },
     ],
     netValue: calculations.netValue.toNumber(),
-    debuggingData: debug ? { ...formatBigNumberDebugData(commonRest) } : undefined,
+    debuggingData: debug
+      ? { ...formatBigNumberDebugData({ ...commonRest, positionAutomations }) }
+      : undefined,
   }
 }
 

--- a/handlers/portfolio/positions/handlers/aave-like/index.ts
+++ b/handlers/portfolio/positions/handlers/aave-like/index.ts
@@ -111,7 +111,7 @@ const getAaveLikeBorrowPosition: GetAaveLikePositionHandlerType = async ({
     ],
     netValue: calculations.netValue.toNumber(),
     debuggingData: debug
-      ? { ...formatBigNumberDebugData({ ...commonRest, positionAutomations }) }
+      ? { ...formatBigNumberDebugData({ ...commonRest, positionAutomations, dpm }) }
       : undefined,
   }
 }
@@ -235,7 +235,7 @@ const getAaveLikeMultiplyPosition: GetAaveLikePositionHandlerType = async ({
     ],
     netValue: calculations.netValue.toNumber(),
     debuggingData: debug
-      ? { ...formatBigNumberDebugData({ ...commonRest, positionAutomations }) }
+      ? { ...formatBigNumberDebugData({ ...commonRest, positionAutomations, dpm }) }
       : undefined,
   }
 }

--- a/handlers/portfolio/positions/helpers/getAutomationData.ts
+++ b/handlers/portfolio/positions/helpers/getAutomationData.ts
@@ -5,12 +5,10 @@ import { configCacheTime, getRemoteConfigWithCache } from 'helpers/config'
 
 const automationQuery = gql`
   query automationTriggers($proxyAddresses: [String]) {
-    triggers(where: { account_in: $proxyAddresses }) {
+    triggers(where: { account_in: $proxyAddresses, removedBlock: null, executedBlock: null }) {
       id
       account
       commandAddress
-      executedBlock
-      removedBlock
       triggerData
       triggerType
       owner
@@ -23,8 +21,6 @@ type AutomationQueryResponse = {
     id: string
     account: string
     commandAddress: string
-    executedBlock: string
-    removedBlock: string
     triggerData: string
     triggerType: string
     owner: string
@@ -42,8 +38,6 @@ export type AutomationResponse = {
     id: string
     account: string
     commandAddress: string
-    executedBlock: string
-    removedBlock: string
     triggerData: string
     triggerType: string
     owner: string
@@ -52,8 +46,8 @@ export type AutomationResponse = {
 
 const subgraphListDict = {
   [NetworkIds.MAINNET]: 'summer-automation',
-  // [NetworkIds.ARBITRUMMAINNET]: 'summer-automation-arbitrum',
-  // [NetworkIds.OPTIMISMMAINNET]: 'summer-automation-optimism',
+  [NetworkIds.ARBITRUMMAINNET]: 'summer-automation-arbitrum',
+  [NetworkIds.OPTIMISMMAINNET]: 'summer-automation-optimism',
   [NetworkIds.BASEMAINNET]: 'summer-automation-base',
 } as Record<Partial<NetworkIds>, string>
 

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -31,6 +31,8 @@ const triggerTypesMap = {
     TriggerType.DmaSparkStopLossToCollateralV2,
     TriggerType.DmaSparkStopLossToDebtV2,
     TriggerType.DmaAaveTrailingStopLossV2,
+    116, // legacy + unused: spark stop loss to debt
+    119, // legacy + unused: aave stop loss to debt
     123, // legacy: aave stop loss to collateral
     124, // legacy: aave stop loss to debt
     125, // legacy: spark stop loss to collateral

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -50,22 +50,20 @@ export function getPositionsAutomations({
   triggers,
   defaultList = {},
 }: GetPositionsAutomationsParams): PortfolioPositionAutomations {
-  return triggers
-    .filter(({ executedBlock, removedBlock }) => executedBlock === null && removedBlock === null)
-    .reduce((automations, { triggerType }) => {
-      return {
-        ...automations,
-        ...Object.keys(triggerTypesMap).reduce(
-          (result, key) => ({
-            ...result,
-            ...(triggerTypesMap[key as keyof typeof triggerTypesMap].includes(
-              Number(triggerType),
-            ) && {
-              [key]: { enabled: true },
-            }),
+  return triggers.reduce((automations, { triggerType }) => {
+    return {
+      ...automations,
+      ...Object.keys(triggerTypesMap).reduce(
+        (result, key) => ({
+          ...result,
+          ...(triggerTypesMap[key as keyof typeof triggerTypesMap].includes(
+            Number(triggerType),
+          ) && {
+            [key]: { enabled: true },
           }),
-          {},
-        ),
-      }
-    }, defaultList)
+        }),
+        {},
+      ),
+    }
+  }, defaultList)
 }


### PR DESCRIPTION
This pull request refactors the position automations in Aave-like handlers. It fixes a bug where part of the automation data retrieval was disabled. The changes include updating the `commonDataMapper` function and the `getAaveLikeBorrowPosition` and `getAaveLikeMultiplyPosition` functions. Additionally, the `getPositionsAutomations` function has been modified to not filter out executed and removed triggers (its done on the query level).