### PR TITLE
Add support for Spark new automations

### DIFF
--- a/features/aave/manage/contexts/triggers-aave-state-machine-context.tsx
+++ b/features/aave/manage/contexts/triggers-aave-state-machine-context.tsx
@@ -10,6 +10,7 @@ import type { IStrategyConfig } from 'features/aave/types'
 import { AUTOMATION_CHANGE_FEATURE } from 'features/automation/common/state/automationFeatureChange.constants'
 import type { AutomationChangeFeature } from 'features/automation/common/state/automationFeatureChange.types'
 import { AutomationFeatures } from 'features/automation/common/types'
+import type { SupportedLambdaProtocols } from 'helpers/triggers'
 import { uiChanges } from 'helpers/uiChanges'
 import { useUIChanges } from 'helpers/uiChangesHook'
 import { env } from 'process'
@@ -30,6 +31,7 @@ function useSetupTriggersStateContext(
     autoBuyTriggerAaveStateMachine.withContext({
       ...autoBuyContext,
       networkId: strategy.networkId,
+      protocol: strategy.protocol as SupportedLambdaProtocols,
       usePriceInput: shouldUsePriceInput(strategy),
     }),
     {
@@ -42,6 +44,7 @@ function useSetupTriggersStateContext(
     autoSellTriggerAaveStateMachine.withContext({
       ...autoSellContext,
       networkId: strategy.networkId,
+      protocol: strategy.protocol as SupportedLambdaProtocols,
       usePriceInput: shouldUsePriceInput(strategy),
     }),
     {

--- a/features/aave/manage/state/triggersAaveStateMachine.ts
+++ b/features/aave/manage/state/triggersAaveStateMachine.ts
@@ -249,6 +249,7 @@ function mapPositionToAutoBuyPosition({
       amount: amountFromWei(position.debt.amount, position.debt.precision),
     },
     dpm: dpm.proxy,
+    protocol: strategyConfig.protocol,
     pricesDenomination: strategyConfig.strategyType === StrategyType.Short ? 'debt' : 'collateral',
   }
 }

--- a/features/aave/manage/state/triggersCommon.ts
+++ b/features/aave/manage/state/triggersCommon.ts
@@ -1,4 +1,5 @@
 import type BigNumber from 'bignumber.js'
+import type { AaveLendingProtocol, SparkLendingProtocol } from 'lendingProtocols'
 
 export type PositionLike = {
   dpm: string
@@ -19,5 +20,6 @@ export type PositionLike = {
     }
     amount: BigNumber
   }
+  protocol: AaveLendingProtocol | SparkLendingProtocol
   pricesDenomination: 'collateral' | 'debt'
 }

--- a/features/aave/strategies/ethereum-spark-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-spark-v3-strategies.ts
@@ -271,6 +271,13 @@ const borrowStrategies: IStrategyConfig[] = availableTokenPairs
       executeTransactionWith: 'ethers' as const,
       strategyType: config.strategyType,
       isAutomationFeatureEnabled: (feature) => {
+        if (feature === AutomationFeatures.TRAILING_STOP_LOSS) {
+          return getLocalAppConfig('features')[FeaturesEnum.SparkTrailingStopLossLambdaEthereum]
+        }
+
+        if (feature === AutomationFeatures.AUTO_BUY || feature === AutomationFeatures.AUTO_SELL) {
+          return getLocalAppConfig('features')[FeaturesEnum.SparkOptimizationEthereum]
+        }
         return (
           config.strategyType === StrategyType.Long &&
           feature === AutomationFeatures.STOP_LOSS &&
@@ -325,6 +332,13 @@ const multiplyStategies: IStrategyConfig[] = availableTokenPairs
       strategyType: config.strategyType,
       featureToggle: config.productTypes.Multiply.featureToggle,
       isAutomationFeatureEnabled: (feature) => {
+        if (feature === AutomationFeatures.TRAILING_STOP_LOSS) {
+          return getLocalAppConfig('features')[FeaturesEnum.SparkTrailingStopLossLambdaEthereum]
+        }
+
+        if (feature === AutomationFeatures.AUTO_BUY || feature === AutomationFeatures.AUTO_SELL) {
+          return getLocalAppConfig('features')[FeaturesEnum.SparkOptimizationEthereum]
+        }
         return (
           config.strategyType === StrategyType.Long &&
           feature === AutomationFeatures.STOP_LOSS &&


### PR DESCRIPTION
This pull request adds support for Spark new automations, including the necessary changes to the `useSetupTriggersStateContext` and `getDefaults` functions. It also includes updates to the `getBasicAutomationAaveStateMachine` and `mapPositionToAutoBuyPosition` functions to handle the new automation features.