### PR TITLE
Refactor automation feature checks in spark strategy configurations

### DIFF
--- a/features/aave/strategies/ethereum-spark-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-spark-v3-strategies.ts
@@ -279,9 +279,11 @@ const borrowStrategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.SparkOptimizationEthereum]
         }
         return (
-          config.strategyType === StrategyType.Long &&
-          feature === AutomationFeatures.STOP_LOSS &&
-          isSupportedAaveAutomationTokenPair(config.collateral, config.debt)
+          (config.strategyType === StrategyType.Long &&
+            feature === AutomationFeatures.STOP_LOSS &&
+            isSupportedAaveAutomationTokenPair(config.collateral, config.debt)) ||
+          (feature === AutomationFeatures.STOP_LOSS &&
+            getLocalAppConfig('features')[FeaturesEnum.SparkProtectionLambdaEthereum])
         )
       },
     }
@@ -340,9 +342,11 @@ const multiplyStategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.SparkOptimizationEthereum]
         }
         return (
-          config.strategyType === StrategyType.Long &&
-          feature === AutomationFeatures.STOP_LOSS &&
-          isSupportedAaveAutomationTokenPair(config.collateral, config.debt)
+          (config.strategyType === StrategyType.Long &&
+            feature === AutomationFeatures.STOP_LOSS &&
+            isSupportedAaveAutomationTokenPair(config.collateral, config.debt)) ||
+          (feature === AutomationFeatures.STOP_LOSS &&
+            getLocalAppConfig('features')[FeaturesEnum.SparkProtectionLambdaEthereum])
         )
       },
     }
@@ -395,9 +399,11 @@ const earnStrategies: IStrategyConfig[] = availableTokenPairs
       featureToggle: config.productTypes.Earn.featureToggle,
       isAutomationFeatureEnabled: (feature) => {
         return (
-          config.strategyType === StrategyType.Long &&
-          feature === AutomationFeatures.STOP_LOSS &&
-          isSupportedAaveAutomationTokenPair(config.collateral, config.debt)
+          (config.strategyType === StrategyType.Long &&
+            feature === AutomationFeatures.STOP_LOSS &&
+            isSupportedAaveAutomationTokenPair(config.collateral, config.debt)) ||
+          (feature === AutomationFeatures.STOP_LOSS &&
+            getLocalAppConfig('features')[FeaturesEnum.SparkProtectionLambdaEthereum])
         )
       },
     }


### PR DESCRIPTION
This pull request refactors the automation feature checks in the spark strategy configurations to include the new feature "SparkProtectionLambdaEthereum". This ensures that the feature is properly enabled for the specified strategy types and token pairs.