### PR TITLE
Update Aave V3 strategies for partial take profit

### DIFF
--- a/features/aave/strategies/arbitrum-aave-v3-strategies.ts
+++ b/features/aave/strategies/arbitrum-aave-v3-strategies.ts
@@ -430,7 +430,7 @@ const borrowStrategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaArbitrum]
         }
         if (feature === AutomationFeatures.PARTIAL_TAKE_PROFIT) {
-          return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaArbitrum]
+          return getLocalAppConfig('features')[FeaturesEnum.AaveV3PartialTakeProfitLambdaArbitrum]
         }
         return false
       },
@@ -492,7 +492,7 @@ const multiplyStategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaArbitrum]
         }
         if (feature === AutomationFeatures.PARTIAL_TAKE_PROFIT) {
-          return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaArbitrum]
+          return getLocalAppConfig('features')[FeaturesEnum.AaveV3PartialTakeProfitLambdaArbitrum]
         }
         return false
       },
@@ -548,7 +548,7 @@ const earnStrategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.AaveV3OptimizationArbitrum]
         }
         if (feature === AutomationFeatures.PARTIAL_TAKE_PROFIT) {
-          return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaArbitrum]
+          return getLocalAppConfig('features')[FeaturesEnum.AaveV3PartialTakeProfitLambdaArbitrum]
         }
         return false
       },

--- a/features/aave/strategies/ethereum-aave-v3-strategies.ts
+++ b/features/aave/strategies/ethereum-aave-v3-strategies.ts
@@ -525,7 +525,7 @@ const borrowStrategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.AaveV3OptimizationEthereum]
         }
         if (feature === AutomationFeatures.PARTIAL_TAKE_PROFIT) {
-          return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaEthereum]
+          return getLocalAppConfig('features')[FeaturesEnum.AaveV3PartialTakeProfitLambdaEthereum]
         }
 
         return false
@@ -588,7 +588,7 @@ const multiplyStategies: IStrategyConfig[] = availableTokenPairs
           return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaEthereum]
         }
         if (feature === AutomationFeatures.PARTIAL_TAKE_PROFIT) {
-          return getLocalAppConfig('features')[FeaturesEnum.AaveV3TrailingStopLossLambdaEthereum]
+          return getLocalAppConfig('features')[FeaturesEnum.AaveV3PartialTakeProfitLambdaEthereum]
         }
 
         if (feature === AutomationFeatures.AUTO_BUY || feature === AutomationFeatures.AUTO_SELL) {


### PR DESCRIPTION
This pull request updates the Aave V3 strategies to include support for partial take profit. It modifies the `borrowStrategies`, `multiplyStrategies`, and `earnStrategies` arrays to use the `AaveV3PartialTakeProfitLambdaArbitrum` and `AaveV3PartialTakeProfitLambdaEthereum` features instead of the `AaveV3TrailingStopLossLambdaArbitrum` and `AaveV3TrailingStopLossLambdaEthereum` features. 