### PR TITLE
Basic configuration of ERC-4626 products in Omnikit

### DIFF
--- a/features/omni-kit/protocols/erc-4626/actions/earn.ts
+++ b/features/omni-kit/protocols/erc-4626/actions/earn.ts
@@ -1,0 +1,37 @@
+import type { SummerStrategy, SupplyPosition } from '@oasisdex/dma-library'
+import { ethers } from 'ethers'
+
+const mockResponse = {
+  simulation: {
+    errors: [],
+    notices: [],
+    position: {} as SupplyPosition,
+    targetPosition: {} as SupplyPosition,
+    successes: [],
+    swaps: [],
+    warnings: [],
+  },
+  tx: {
+    to: ethers.constants.AddressZero,
+    data: '',
+    value: '',
+  },
+}
+
+export const erc4626ActionOpenEarn = (): Promise<SummerStrategy<SupplyPosition>> => {
+  return new Promise((resolve) => {
+    resolve(mockResponse)
+  })
+}
+
+export const erc4626ActionDepositEarn = (): Promise<SummerStrategy<SupplyPosition>> => {
+  return new Promise((resolve) => {
+    resolve(mockResponse)
+  })
+}
+
+export const erc4626ActionWithdrawEarn = (): Promise<SummerStrategy<SupplyPosition>> => {
+  return new Promise((resolve) => {
+    resolve(mockResponse)
+  })
+}

--- a/features/omni-kit/protocols/erc-4626/actions/index.ts
+++ b/features/omni-kit/protocols/erc-4626/actions/index.ts
@@ -1,0 +1,1 @@
+export * from './earn'

--- a/features/omni-kit/protocols/erc-4626/constants.ts
+++ b/features/omni-kit/protocols/erc-4626/constants.ts
@@ -1,0 +1,4 @@
+export const erc4626SeoTags = {
+  productKey: `seo.erc-4626.title`,
+  descriptionKey: 'seo.erc-4626.description',
+}

--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626Parameters.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626Parameters.ts
@@ -1,0 +1,42 @@
+import type { SummerStrategy } from '@oasisdex/dma-library'
+import {
+  erc4626ActionDepositEarn,
+  erc4626ActionOpenEarn,
+  erc4626ActionWithdrawEarn,
+} from 'features/omni-kit/protocols/erc-4626/actions'
+import type { OmniFormState, OmniGenericPosition } from 'features/omni-kit/types'
+import { OmniEarnFormAction } from 'features/omni-kit/types'
+
+interface Erc4626TxHandlerInput {
+  isFormValid: boolean
+  state: OmniFormState
+  walletAddress?: string
+}
+
+export async function getErc4626Parameters({
+  isFormValid,
+  state,
+  walletAddress,
+}: Erc4626TxHandlerInput): Promise<SummerStrategy<OmniGenericPosition> | undefined> {
+  const defaultPromise = Promise.resolve(undefined)
+
+  const { action } = state
+
+  if (!isFormValid || !walletAddress) {
+    return defaultPromise
+  }
+
+  switch (action) {
+    case OmniEarnFormAction.OpenEarn: {
+      return erc4626ActionOpenEarn()
+    }
+    case OmniEarnFormAction.DepositEarn: {
+      return erc4626ActionDepositEarn()
+    }
+    case OmniEarnFormAction.WithdrawEarn: {
+      return erc4626ActionWithdrawEarn()
+    }
+    default:
+      return defaultPromise
+  }
+}

--- a/features/omni-kit/protocols/erc-4626/helpers/index.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './getErc4626Parameters'

--- a/features/omni-kit/protocols/erc-4626/hooks/index.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useErc4626Data'
+export * from './useErc4626TxHandler'

--- a/features/omni-kit/protocols/erc-4626/hooks/useErc4626Data.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/useErc4626Data.ts
@@ -1,0 +1,16 @@
+import type { SupplyPosition } from '@oasisdex/dma-library'
+import type { OmniProtocolHookProps } from 'features/omni-kit/types'
+
+export function useErc4626Data({ tokenPriceUSDData }: OmniProtocolHookProps) {
+  return {
+    data: {
+      aggregatedData: {
+        auction: {},
+        history: [],
+      },
+      positionData: {} as SupplyPosition,
+      protocolPricesData: tokenPriceUSDData,
+    },
+    errors: [] as string[],
+  }
+}

--- a/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
@@ -1,0 +1,28 @@
+import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
+import { useOmniTxHandler } from 'features/omni-kit/hooks'
+import { getErc4626Parameters } from 'features/omni-kit/protocols/erc-4626/helpers'
+import { useAccount } from 'helpers/useAccount'
+
+export function useErc4626TxHandler(): () => void {
+  const {
+    environment: {
+      productType,
+    },
+  } = useOmniGeneralContext()
+  const {
+    form: { state },
+    dynamicMetadata: {
+      validations: { isFormValid },
+    },
+  } = useOmniProductContext(productType)
+  const { walletAddress } = useAccount()
+
+  return useOmniTxHandler({
+    getOmniParameters: () =>
+      getErc4626Parameters({
+        isFormValid,
+        state,
+        walletAddress,
+      }),
+  })
+}

--- a/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
@@ -5,9 +5,7 @@ import { useAccount } from 'helpers/useAccount'
 
 export function useErc4626TxHandler(): () => void {
   const {
-    environment: {
-      productType,
-    },
+    environment: { productType },
   } = useOmniGeneralContext()
   const {
     form: { state },

--- a/features/omni-kit/protocols/erc-4626/metadata/index.ts
+++ b/features/omni-kit/protocols/erc-4626/metadata/index.ts
@@ -1,0 +1,1 @@
+export * from './useErc4626Metadata'

--- a/features/omni-kit/protocols/erc-4626/metadata/useErc4626Metadata.tsx
+++ b/features/omni-kit/protocols/erc-4626/metadata/useErc4626Metadata.tsx
@@ -1,0 +1,69 @@
+import type { DetailsSectionNotificationItem } from 'components/DetailsSectionNotification'
+import type { GetOmniMetadata, SupplyMetadata } from 'features/omni-kit/contexts'
+import { useOmniGeneralContext } from 'features/omni-kit/contexts'
+import { OmniProductType } from 'features/omni-kit/types'
+import { zero } from 'helpers/zero'
+import React from 'react'
+
+export const useErc4626Metadata: GetOmniMetadata = () => {
+  // TODO: get from feature flags
+  const safetySwitch = false
+  const suppressValidation = false
+
+  const {
+    environment: { productType, isOpening },
+  } = useOmniGeneralContext()
+
+  // TODO: replace with real validation
+  const validations = {
+    errors: [],
+    hasErrors: false,
+    isFormFrozen: false,
+    isFormValid: true,
+    notices: [],
+    successes: [],
+    warnings: [],
+  }
+
+  // TODO: replace with real notifications
+  const notifications: DetailsSectionNotificationItem[] = []
+
+  switch (productType) {
+    case OmniProductType.Earn:
+      return {
+        notifications,
+        validations,
+        handlers: {
+          txSuccessEarnHandler: () => {},
+        },
+        filters: {
+          flowStateFilter: () => false,
+        },
+        values: {
+          interestRate: zero,
+          isFormEmpty: false,
+          sidebarTitle: 'Sidebar',
+          footerColumns: isOpening ? 2 : 3,
+          headlineDetails: [],
+          extraDropdownItems: [],
+          earnWithdrawMax: zero,
+          earnAfterWithdrawMax: zero,
+        },
+        elements: {
+          faq: <>FAQ placeholder</>,
+          overviewContent: <>Overview content placeholder</>,
+          overviewFooter: <>Overview footer placeholder</>,
+          earnFormOrder: <>Form order placeholder</>,
+          earnFormOrderAsElement: () => <>Form order placeholder</>,
+        },
+        featureToggles: {
+          safetySwitch,
+          suppressValidation,
+        },
+      } as SupplyMetadata
+    case OmniProductType.Borrow:
+    case OmniProductType.Multiply:
+    default:
+      throw new Error('ERC-4626 supports only Earn')
+  }
+}

--- a/features/omni-kit/protocols/erc-4626/settings.ts
+++ b/features/omni-kit/protocols/erc-4626/settings.ts
@@ -1,0 +1,40 @@
+import { NetworkIds } from 'blockchain/networks'
+import { omniSidebarManageBorrowishSteps, omniSidebarSetupSteps } from 'features/omni-kit/constants'
+import type { Erc4626Config } from 'features/omni-kit/protocols/erc-4626/types'
+import type { OmniProtocolSettings } from 'features/omni-kit/types'
+import { OmniProductType } from 'features/omni-kit/types'
+import { LendingProtocol } from 'lendingProtocols'
+
+export const settings: OmniProtocolSettings = {
+  rawName: {
+    [NetworkIds.MAINNET]: 'erc-4626',
+  },
+  supportedNetworkIds: [NetworkIds.MAINNET],
+  supportedMainnetNetworkIds: [NetworkIds.MAINNET],
+  supportedProducts: [OmniProductType.Earn],
+  supportedMultiplyTokens: {
+    [NetworkIds.MAINNET]: [],
+  },
+  steps: {
+    borrow: {
+      setup: [],
+      manage: [],
+    },
+    earn: {
+      setup: omniSidebarSetupSteps,
+      manage: omniSidebarManageBorrowishSteps,
+    },
+    multiply: {
+      setup: [],
+      manage: [],
+    },
+  },
+}
+
+export const erc4626LabelsMap: { [key: string]: Erc4626Config } = {
+  'steakhouse-USDC': {
+    name: 'Steakhouse USDC',
+    protocol: LendingProtocol.MorphoBlue,
+    token: 'USDC',
+  },
+}

--- a/features/omni-kit/protocols/erc-4626/types.ts
+++ b/features/omni-kit/protocols/erc-4626/types.ts
@@ -1,0 +1,7 @@
+import type { OmniSupportedProtocols } from 'features/omni-kit/types'
+
+export interface Erc4626Config {
+  name: string
+  protocol: OmniSupportedProtocols
+  token: string
+}

--- a/features/omni-kit/server/getOmniServerSideProps.ts
+++ b/features/omni-kit/server/getOmniServerSideProps.ts
@@ -6,30 +6,47 @@ import { omniProtocolSettings } from 'features/omni-kit/settings'
 import type {
   OmniProductPage,
   OmniProductType,
+  OmniProtocolSettings,
   OmniSupportedProtocols,
 } from 'features/omni-kit/types'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import type { ParsedUrlQuery } from 'querystring'
 
-export async function getOmniServerSideProps({
-  isProductPageValid = () => true,
-  locale,
-  protocol,
-  query,
-}: {
+interface OmniServerSidePropsWithTokens {
+  collateralToken: string
+  quoteToken: string
+}
+
+interface OmniServerSidePropsWithoutTokens {
+  collateralToken?: never
+  quoteToken?: never
+}
+
+type OmniServerSideProps = (OmniServerSidePropsWithTokens | OmniServerSidePropsWithoutTokens) & {
   isProductPageValid?: (params: OmniProductPage) => boolean
   locale?: string
   protocol: OmniSupportedProtocols
   query: ParsedUrlQuery
-}) {
+  settings: OmniProtocolSettings
+}
+
+export async function getOmniServerSideProps({
+  collateralToken,
+  isProductPageValid = () => true,
+  locale,
+  protocol,
+  query,
+  quoteToken,
+  settings,
+}: OmniServerSideProps) {
   const networkId = getNetworkByName(query.networkOrProduct as unknown as NetworkNames).id
   const [productType, pair, positionId] = query.position as string[]
   const castedProductType = productType as OmniProductType
 
   if (
     !isOmniSupportedNetworkId(networkId, omniProtocolSettings[protocol].supportedNetworkIds) ||
-    !omniProtocolSettings[protocol].supportedProducts.includes(castedProductType) ||
+    !settings.supportedProducts.includes(castedProductType) ||
     !pair
   ) {
     return {
@@ -40,21 +57,22 @@ export async function getOmniServerSideProps({
     }
   }
 
-  const [collateralToken, quoteToken] = pair.split('-')
-  const caseSensitiveCollateralToken = isAddress(collateralToken)
-    ? collateralToken.toLowerCase()
-    : collateralToken.toUpperCase()
-  const caseSensitiveQuoteToken = isAddress(quoteToken)
-    ? quoteToken.toLowerCase()
-    : quoteToken.toUpperCase()
+  const [resolvedCollateralToken, resolvedQuoteToken] =
+    collateralToken && quoteToken ? [collateralToken, quoteToken] : pair.split('-')
+  const caseSensitiveCollateralToken = isAddress(resolvedCollateralToken)
+    ? resolvedCollateralToken.toLowerCase()
+    : resolvedCollateralToken.toUpperCase()
+  const caseSensitiveQuoteToken = isAddress(resolvedQuoteToken)
+    ? resolvedQuoteToken.toLowerCase()
+    : resolvedQuoteToken.toUpperCase()
 
   const omniProductPage = {
     collateralToken: caseSensitiveCollateralToken,
     networkId,
     positionId,
     productType: castedProductType,
-    quoteToken: caseSensitiveQuoteToken,
     protocol,
+    quoteToken: caseSensitiveQuoteToken,
   }
 
   if (!isProductPageValid(omniProductPage)) {

--- a/pages/[networkOrProduct]/ajna/[...position].tsx
+++ b/pages/[networkOrProduct]/ajna/[...position].tsx
@@ -68,5 +68,6 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
     locale,
     protocol: LendingProtocol.Ajna,
     query,
+    settings,
   })
 }

--- a/pages/[networkOrProduct]/erc-4626/[...position].tsx
+++ b/pages/[networkOrProduct]/erc-4626/[...position].tsx
@@ -1,6 +1,11 @@
+import type { SupplyPosition } from '@oasisdex/dma-library'
 import { ProductContextHandler } from 'components/context/ProductContextHandler'
 import { PageSEOTags } from 'components/HeadTags'
 import { AppLayout } from 'components/layouts/AppLayout'
+import { OmniProductController } from 'features/omni-kit/controllers'
+import { erc4626SeoTags } from 'features/omni-kit/protocols/erc-4626/constants'
+import { useErc4626Data, useErc4626TxHandler } from 'features/omni-kit/protocols/erc-4626/hooks'
+import { useErc4626Metadata } from 'features/omni-kit/protocols/erc-4626/metadata'
 import { erc4626LabelsMap, settings } from 'features/omni-kit/protocols/erc-4626/settings'
 import { getOmniServerSideProps } from 'features/omni-kit/server'
 import type { OmniProductPage } from 'features/omni-kit/types'
@@ -11,24 +16,21 @@ import React from 'react'
 type Erc4626PositionPageProps = OmniProductPage
 
 function Erc4626PositionPage(props: Erc4626PositionPageProps) {
-  console.log(props)
-
   return (
     <AppLayout>
       <ProductContextHandler>
-        {/* <OmniProductController<MorphoHistoryEvent, MorphoHistoryEvent[], MorphoBluePosition>
+        <OmniProductController<unknown, unknown[], SupplyPosition>
           {...props}
           customState={({ children }) =>
             children({
-              useDynamicMetadata: useMorphoMetadata,
-              useTxHandler: useMorphoTxHandler,
+              useDynamicMetadata: useErc4626Metadata,
+              useTxHandler: useErc4626TxHandler,
             })
           }
-          protocol={LendingProtocol.MorphoBlue}
-          protocolHook={useMorphoData}
-          seoTags={morphoSeoTags}
+          protocolHook={useErc4626Data}
+          seoTags={erc4626SeoTags}
           settings={settings}
-        /> */}
+        />
       </ProductContextHandler>
     </AppLayout>
   )

--- a/pages/[networkOrProduct]/erc-4626/[...position].tsx
+++ b/pages/[networkOrProduct]/erc-4626/[...position].tsx
@@ -1,0 +1,63 @@
+import { ProductContextHandler } from 'components/context/ProductContextHandler'
+import { PageSEOTags } from 'components/HeadTags'
+import { AppLayout } from 'components/layouts/AppLayout'
+import { erc4626LabelsMap, settings } from 'features/omni-kit/protocols/erc-4626/settings'
+import { getOmniServerSideProps } from 'features/omni-kit/server'
+import type { OmniProductPage } from 'features/omni-kit/types'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
+import type { GetServerSidePropsContext } from 'next'
+import React from 'react'
+
+type Erc4626PositionPageProps = OmniProductPage
+
+function Erc4626PositionPage(props: Erc4626PositionPageProps) {
+  console.log(props)
+
+  return (
+    <AppLayout>
+      <ProductContextHandler>
+        {/* <OmniProductController<MorphoHistoryEvent, MorphoHistoryEvent[], MorphoBluePosition>
+          {...props}
+          customState={({ children }) =>
+            children({
+              useDynamicMetadata: useMorphoMetadata,
+              useTxHandler: useMorphoTxHandler,
+            })
+          }
+          protocol={LendingProtocol.MorphoBlue}
+          protocolHook={useMorphoData}
+          seoTags={morphoSeoTags}
+          settings={settings}
+        /> */}
+      </ProductContextHandler>
+    </AppLayout>
+  )
+}
+
+Erc4626PositionPage.seoTags = (
+  <PageSEOTags title="seo.erc-4626.title" description="seo.erc-4626.description" />
+)
+
+export default Erc4626PositionPage
+
+export async function getServerSideProps({ locale, query }: GetServerSidePropsContext) {
+  const [, label] = query.position as string[]
+
+  if (!Object.keys(erc4626LabelsMap).includes(label)) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: INTERNAL_LINKS.notFound,
+      },
+    }
+  }
+
+  return getOmniServerSideProps({
+    collateralToken: erc4626LabelsMap[label].token,
+    locale,
+    protocol: erc4626LabelsMap[label].protocol,
+    query,
+    quoteToken: erc4626LabelsMap[label].token,
+    settings,
+  })
+}

--- a/pages/[networkOrProduct]/morphoblue/[...position].tsx
+++ b/pages/[networkOrProduct]/morphoblue/[...position].tsx
@@ -45,5 +45,5 @@ MorphoPositionPage.seoTags = morphoPageSeoTags
 export default MorphoPositionPage
 
 export async function getServerSideProps({ locale, query }: GetServerSidePropsContext) {
-  return getOmniServerSideProps({ locale, protocol: LendingProtocol.MorphoBlue, query })
+  return getOmniServerSideProps({ locale, protocol: LendingProtocol.MorphoBlue, query, settings })
 }

--- a/pages/[networkOrProduct]/omni/aave/[version]/[...position].tsx
+++ b/pages/[networkOrProduct]/omni/aave/[version]/[...position].tsx
@@ -79,5 +79,10 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
     }
   }
 
-  return getOmniServerSideProps({ locale, protocol, query })
+  return getOmniServerSideProps({
+    locale,
+    protocol,
+    query,
+    settings: omniProtocolSettings[protocol],
+  })
 }

--- a/pages/[networkOrProduct]/omni/spark/[...position].tsx
+++ b/pages/[networkOrProduct]/omni/spark/[...position].tsx
@@ -9,7 +9,7 @@ import { aaveSeoTags } from 'features/omni-kit/protocols/aave/constants'
 import type { AaveLikeHistoryEvent } from 'features/omni-kit/protocols/aave-like/history/types'
 import { useAaveLikeData, useAaveLikeTxHandler } from 'features/omni-kit/protocols/aave-like/hooks'
 import { useAaveLikeMetadata } from 'features/omni-kit/protocols/aave-like/metadata'
-import { settings as sparkSettings } from 'features/omni-kit/protocols/spark/settings'
+import { settings } from 'features/omni-kit/protocols/spark/settings'
 import { getOmniServerSideProps } from 'features/omni-kit/server'
 import type { OmniProductPage } from 'features/omni-kit/types'
 import { LendingProtocol } from 'lendingProtocols'
@@ -39,7 +39,7 @@ function SparkPositionPage(props: SparkPositionPageProps) {
               protocol={props.protocol}
               protocolHook={useAaveLikeData}
               seoTags={aaveSeoTags}
-              settings={sparkSettings}
+              settings={settings}
             />
           </DeferedContextProvider>
         </AaveContextProvider>
@@ -55,5 +55,5 @@ SparkPositionPage.seoTags = (
 export default SparkPositionPage
 
 export async function getServerSideProps({ locale, query }: GetServerSidePropsContext) {
-  return getOmniServerSideProps({ locale, protocol: LendingProtocol.SparkV3, query })
+  return getOmniServerSideProps({ locale, protocol: LendingProtocol.SparkV3, query, settings })
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1134,7 +1134,7 @@
     },
     "aave": {
       "title": "Summer.fi × Aave",
-      "description": "Borrow Assets and Multiply Exposure with DeFi’s leading liquidity protocol. On Summer you do it with one click actions and advanced automations. We are the unified gateway to the best of DeFi."
+      "description": "Borrow Assets and Multiply Exposure with DeFi's leading liquidity protocol. On Summer you do it with one click actions and advanced automations. We are the unified gateway to the best of DeFi."
     },
     "morpho": {
       "title": "Summer.fi × Morpho Blue",
@@ -1160,7 +1160,11 @@
     },
     "title-single-token": "{{token}} - {{product}}",
     "title-product-w-tokens": "{{token1}}/{{token2}} - {{protocol}} - {{product}}",
-    "title-dsr": "Dai Savings Rate Strategy - {{protocol}} - {{product}}"
+    "title-dsr": "Dai Savings Rate Strategy - {{protocol}} - {{product}}",
+    "erc-4626": {
+      "title": "ERC-4626 on Summer.fi",
+      "description": ""
+    }
   },
   "set-allowance-for": "Set Allowance for {{token}}",
   "setup-stop-loss": "Set up Stop-Loss",


### PR DESCRIPTION
# [Basic configuration of ERC-4626 products in Omnikit](https://app.shortcut.com/oazo-apps/story/14586/fe-config-for-erc-4626)

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- Created a whole bunch of empty functions and mocks required for basic Omnikit support that are going to replaced with actions from library.
- Created Omnikit configuration for semi-new type of product/protocol.
- Created empty page for said protocol.
- Modified `getOmniServerSideProps` method to allow overwriting tokens from URL to custom ones.
  
## How to test 🧪

`/ethereum/erc-4626/earn/steakhouse-USDC` address should load fine with empty UI and mocked data.