### PR TITLE
Partial take profit fixes [pt.2]

### DIFF
--- a/components/SidebarAccordion.tsx
+++ b/components/SidebarAccordion.tsx
@@ -45,19 +45,7 @@ export function SidebarAccordion({
       </Flex>
       {additionalDescriptionComponent}
 
-      {isOpen && (
-        <Box
-          sx={{
-            border: '1px solid',
-            borderColor: 'secondary60',
-            borderTop: 'none',
-            borderBottomLeftRadius: 'mediumLarge',
-            borderBottomRightRadius: 'mediumLarge',
-          }}
-        >
-          {children}
-        </Box>
-      )}
+      {isOpen && <Box>{children}</Box>}
     </Box>
   )
 }

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -2,7 +2,14 @@ import React from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
 import { Box, Grid } from 'theme-ui'
 
-type SkeletonColorTheme = 'default' | 'dark' | 'positive' | 'negative' | 'fancy' | 'ajna'
+type SkeletonColorTheme =
+  | 'default'
+  | 'dark'
+  | 'positive'
+  | 'negative'
+  | 'fancy'
+  | 'ajna'
+  | 'interactive'
 
 type SkeletonColorThemes = {
   [key in SkeletonColorTheme]: [string, string]
@@ -15,6 +22,7 @@ const skeletonColorTheme: SkeletonColorThemes = {
   positive: ['#e7fcfa', '#f7fefd'],
   fancy: ['#ccf1fc', '#fcece3'], // based on the two main summer colors: #007DA3 + #E7A77F
   ajna: ['#fcddf8', '#eadcfb'], // based on the ajna brand gradient colors: #f154db + #974eea
+  interactive: ['#D8D9FE', '#EDEDFF'], // interactive 30 & 10
 }
 
 interface SkeletonProps {

--- a/components/infoSection/InfoSectionTable.tsx
+++ b/components/infoSection/InfoSectionTable.tsx
@@ -112,6 +112,17 @@ export function InfoSectionTable({
           </Button>
         </Box>
       )}
+      {expandItemsButtonLabel && limitItems === 'all' && (
+        <Box as="li" sx={{ listStyle: 'none' }}>
+          <Button
+            variant="textual"
+            sx={{ fontSize: '12px', color: 'interactive100', cursor: 'pointer', width: '100%' }}
+            onClick={() => setLimitItems(defaultLimitItems)}
+          >
+            Collapse
+          </Button>
+        </Box>
+      )}
     </Grid>
   )
 }

--- a/components/infoSection/InfoSectionTable.tsx
+++ b/components/infoSection/InfoSectionTable.tsx
@@ -1,8 +1,8 @@
-import { AppSpinner } from 'helpers/AppSpinner'
+import { Skeleton } from 'components/Skeleton'
 import type { ReactNode } from 'react'
 import React, { useState } from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
-import { Box, Button, Flex, Grid, Text } from 'theme-ui'
+import { Box, Button, Grid, Text } from 'theme-ui'
 
 interface InfoSectionTableProps {
   title?: ReactNode
@@ -29,6 +29,7 @@ export function InfoSectionTable({
 }: InfoSectionTableProps) {
   const [limitItems, setLimitItems] =
     useState<InfoSectionTableProps['defaultLimitItems']>(defaultLimitItems)
+  const defaultLoadingItems = typeof defaultLimitItems === 'number' ? defaultLimitItems : 3
   return (
     <Grid
       as="ul"
@@ -42,13 +43,6 @@ export function InfoSectionTable({
         ...wrapperSx,
       }}
     >
-      {loading && (
-        <Flex
-          sx={{ position: 'absolute', width: '100%', height: '100%', justifyContent: 'center' }}
-        >
-          <AppSpinner size={30} />
-        </Flex>
-      )}
       {title && (
         <Box as="li" sx={{ listStyle: 'none' }}>
           <Text as="h3" variant="paragraph3" sx={{ fontWeight: 'semiBold', mb: 2 }}>
@@ -69,6 +63,23 @@ export function InfoSectionTable({
           ))}
         </Grid>
       )}
+      {loading &&
+        (!rows || rows.length === 0) &&
+        new Array(defaultLoadingItems).fill(0).map((_, index) => (
+          <Grid
+            as="li"
+            key={`InfoSectionTable_${title}_${index}`}
+            columns={headers?.length}
+            sx={{ listStyle: 'none' }}
+          >
+            {headers?.map((_, cellIndex) => (
+              <Skeleton
+                key={`InfoSectionTable_${title}_${index}_${cellIndex}`}
+                sx={{ width: '80%', height: '35px' }}
+              />
+            ))}
+          </Grid>
+        ))}
       {rows &&
         rows
           .filter((_, itemIndex) => {
@@ -101,7 +112,7 @@ export function InfoSectionTable({
               )}
             </Grid>
           ))}
-      {expandItemsButtonLabel && limitItems !== 'all' && (
+      {expandItemsButtonLabel && !loading && limitItems !== 'all' && (
         <Box as="li" sx={{ listStyle: 'none' }}>
           <Button
             variant="textual"
@@ -112,7 +123,7 @@ export function InfoSectionTable({
           </Button>
         </Box>
       )}
-      {expandItemsButtonLabel && limitItems === 'all' && (
+      {expandItemsButtonLabel && !loading && limitItems === 'all' && (
         <Box as="li" sx={{ listStyle: 'none' }}>
           <Button
             variant="textual"
@@ -121,6 +132,11 @@ export function InfoSectionTable({
           >
             Collapse
           </Button>
+        </Box>
+      )}
+      {expandItemsButtonLabel && loading && (
+        <Box as="li" sx={{ listStyle: 'none', mt: 3 }}>
+          <Skeleton color="interactive" sx={{ width: '50%', height: '15px', margin: '0 auto' }} />
         </Box>
       )}
     </Grid>

--- a/features/aave/components/AavePartialTakeProfitManageDetails.tsx
+++ b/features/aave/components/AavePartialTakeProfitManageDetails.tsx
@@ -1,3 +1,4 @@
+import type BigNumber from 'bignumber.js'
 import { ActionPills } from 'components/ActionPills'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
@@ -10,6 +11,10 @@ import { WithArrow } from 'components/WithArrow'
 import type { mapPartialTakeProfitFromLambda } from 'features/aave/manage/helpers/map-partial-take-profit-from-lambda'
 import type { AaveLikePartialTakeProfitParamsResult } from 'features/aave/open/helpers/get-aave-like-partial-take-profit-params'
 import { OmniContentCard } from 'features/omni-kit/components/details-section'
+import type { OmniNetValuePnlDataReturnType } from 'features/omni-kit/helpers'
+import type { AaveLikeHistoryEvent } from 'features/omni-kit/protocols/aave-like/history/types'
+import type { AjnaHistoryEvent } from 'features/omni-kit/protocols/ajna/history/types'
+import type { PositionHistoryEvent } from 'features/positionHistory/types'
 import {
   formatAmount,
   formatCryptoBalance,
@@ -17,17 +22,54 @@ import {
 } from 'helpers/formatters/format'
 import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { zero } from 'helpers/zero'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Box, Divider, Flex, Image, Text } from 'theme-ui'
+
+type AavePartialTakeProfitManageDetailsProps = {
+  aaveLikePartialTakeProfitParams: AaveLikePartialTakeProfitParamsResult
+  aaveLikePartialTakeProfitLambdaData: ReturnType<typeof mapPartialTakeProfitFromLambda>
+  netValuePnlCollateralData: OmniNetValuePnlDataReturnType
+  netValuePnlDebtData: OmniNetValuePnlDataReturnType
+  historyEvents:
+    | Partial<AjnaHistoryEvent>[]
+    | Partial<AaveLikeHistoryEvent>[]
+    | Partial<PositionHistoryEvent>[]
+}
+
+const reduceHistoryEvents = (events: AavePartialTakeProfitManageDetailsProps['historyEvents']) => {
+  return (
+    events
+      // example: "AutomationExecuted-DmaAavePartialTakeProfitV2"
+      .filter(({ kind }) => kind?.includes('PartialTakeProfit'))
+      .filter(({ kind }) => kind?.includes('AutomationExecuted'))
+      .reduce(
+        (acc, event) => {
+          return {
+            debtRealized: (acc.debtRealized || zero).plus(event.debtDelta?.abs() || zero),
+            collateralRealized: (acc.collateralRealized || zero).plus(
+              event.collateralDelta?.abs() || zero,
+            ),
+          }
+        },
+        {
+          debtRealized: zero,
+          collateralRealized: zero,
+        },
+      ) as {
+      debtRealized: BigNumber
+      collateralRealized: BigNumber
+    }
+  )
+}
 
 export const AavePartialTakeProfitManageDetails = ({
   aaveLikePartialTakeProfitParams,
   aaveLikePartialTakeProfitLambdaData,
-}: {
-  aaveLikePartialTakeProfitParams: AaveLikePartialTakeProfitParamsResult
-  aaveLikePartialTakeProfitLambdaData: ReturnType<typeof mapPartialTakeProfitFromLambda>
-}) => {
+  netValuePnlCollateralData,
+  netValuePnlDebtData,
+  historyEvents,
+}: AavePartialTakeProfitManageDetailsProps) => {
   const { t } = useTranslation()
   const [chartView, setChartView] = useState<'price' | 'ltv'>('price')
 
@@ -40,15 +82,117 @@ export const AavePartialTakeProfitManageDetails = ({
     priceDenominationToken,
     currentLtv,
     currentMultiple,
-    startingTakeProfitPrice,
     triggerLtv,
     partialTakeProfitProfits,
+    partialTakeProfitFirstProfit,
   } = aaveLikePartialTakeProfitParams
-  const { startingTakeProfitPrice: lambdaStartingTakeProfitPrice, triggerLtv: lambdaTriggerLtv } =
-    aaveLikePartialTakeProfitLambdaData
+  const { triggerLtv: lambdaTriggerLtv } = aaveLikePartialTakeProfitLambdaData
 
+  const realizedProfit = useMemo(() => {
+    return reduceHistoryEvents(historyEvents)
+  }, [historyEvents])
+
+  const realizedProfitValue = formatAmount(
+    partialTakeProfitToken === 'debt'
+      ? realizedProfit.debtRealized
+      : realizedProfit.collateralRealized,
+    partialTakeProfitTokenData.symbol,
+  )
+  const realizedProfitSecondValue = `${formatAmount(
+    partialTakeProfitToken === 'collateral'
+      ? realizedProfit.debtRealized
+      : realizedProfit.collateralRealized,
+    partialTakeProfitSecondTokenData.symbol,
+  )} ${partialTakeProfitSecondTokenData.symbol}`
   const nextTriggerProfit = partialTakeProfitProfits ? partialTakeProfitProfits[0] : undefined
+  const primaryPnlValue = useMemo(() => {
+    if (netValuePnlCollateralData.pnl?.pnlToken === partialTakeProfitTokenData.symbol) {
+      return netValuePnlCollateralData.pnl.inToken
+    }
+    if (netValuePnlDebtData.pnl?.pnlToken === partialTakeProfitTokenData.symbol) {
+      return netValuePnlDebtData.pnl.inToken
+    }
+    return zero
+  }, [
+    netValuePnlCollateralData.pnl?.inToken,
+    netValuePnlCollateralData.pnl?.pnlToken,
+    netValuePnlDebtData.pnl?.inToken,
+    netValuePnlDebtData.pnl?.pnlToken,
+    partialTakeProfitTokenData.symbol,
+  ])
+  const secondaryPnlValue = useMemo(() => {
+    if (netValuePnlCollateralData.pnl?.pnlToken === partialTakeProfitSecondTokenData.symbol) {
+      return netValuePnlCollateralData.pnl.inToken
+    }
+    if (netValuePnlDebtData.pnl?.pnlToken === partialTakeProfitSecondTokenData.symbol) {
+      return netValuePnlDebtData.pnl.inToken
+    }
+    return zero
+  }, [
+    netValuePnlCollateralData.pnl?.inToken,
+    netValuePnlCollateralData.pnl?.pnlToken,
+    netValuePnlDebtData.pnl?.inToken,
+    netValuePnlDebtData.pnl?.pnlToken,
+    partialTakeProfitSecondTokenData.symbol,
+  ])
 
+  const nextDynamicTriggerPriceValue = useMemo(() => {
+    return partialTakeProfitFirstProfit
+      ? formatCryptoBalance(partialTakeProfitFirstProfit.triggerPrice)
+      : '-'
+  }, [partialTakeProfitFirstProfit])
+  const nextDynamicTriggerPriceValueChange = useMemo(() => {
+    if (
+      !partialTakeProfitFirstProfit ||
+      !nextTriggerProfit ||
+      partialTakeProfitFirstProfit.triggerPrice.eq(nextTriggerProfit.triggerPrice)
+    ) {
+      return undefined
+    }
+    return [`${formatCryptoBalance(nextTriggerProfit.triggerPrice)} ${priceFormat}`]
+  }, [nextTriggerProfit, partialTakeProfitFirstProfit, priceFormat])
+
+  const realizedProfitInSelectedToken = useMemo(() => {
+    return partialTakeProfitToken === 'collateral'
+      ? partialTakeProfitFirstProfit?.realizedProfitInCollateral
+      : partialTakeProfitFirstProfit?.realizedProfitInDebt
+  }, [
+    partialTakeProfitFirstProfit?.realizedProfitInCollateral,
+    partialTakeProfitFirstProfit?.realizedProfitInDebt,
+    partialTakeProfitToken,
+  ])
+  const estimatedToReceiveNextTriggerValue = useMemo(() => {
+    if (!partialTakeProfitFirstProfit || !realizedProfitInSelectedToken) {
+      return '-'
+    }
+    return formatCryptoBalance(realizedProfitInSelectedToken.balance)
+  }, [partialTakeProfitFirstProfit, realizedProfitInSelectedToken])
+
+  const estimatedToReceiveNextTriggerValueChange = useMemo(() => {
+    if (!partialTakeProfitFirstProfit || !nextTriggerProfit || !realizedProfitInSelectedToken) {
+      return undefined
+    }
+    const realizedProfitChangeInSelectedToken =
+      partialTakeProfitToken === 'collateral'
+        ? nextTriggerProfit.realizedProfitInCollateral
+        : nextTriggerProfit.realizedProfitInDebt
+
+    if (realizedProfitChangeInSelectedToken.balance.eq(realizedProfitInSelectedToken.balance)) {
+      return undefined
+    }
+
+    return [
+      `${formatCryptoBalance(realizedProfitChangeInSelectedToken.balance)} ${
+        partialTakeProfitTokenData.symbol
+      }`,
+    ]
+  }, [
+    nextTriggerProfit,
+    partialTakeProfitFirstProfit,
+    partialTakeProfitToken,
+    partialTakeProfitTokenData.symbol,
+    realizedProfitInSelectedToken,
+  ])
   return (
     <>
       <DetailsSection
@@ -58,7 +202,7 @@ export const AavePartialTakeProfitManageDetails = ({
           <DetailsSectionContentCardWrapper>
             <OmniContentCard
               title={'Next Dynamic Trigger Price'}
-              value={nextTriggerProfit ? formatCryptoBalance(nextTriggerProfit.triggerPrice) : '-'}
+              value={nextDynamicTriggerPriceValue}
               unit={priceFormat}
               modal={
                 <Text>
@@ -68,16 +212,12 @@ export const AavePartialTakeProfitManageDetails = ({
                 </Text>
               }
               modalAsTooltip
-              isLoading={!nextTriggerProfit}
-              isValueLoading={!nextTriggerProfit}
-              change={
-                !startingTakeProfitPrice.eq(lambdaStartingTakeProfitPrice || zero)
-                  ? [`${formatCryptoBalance(startingTakeProfitPrice)} ${priceFormat} after`]
-                  : undefined
-              }
+              isLoading={!partialTakeProfitFirstProfit || !nextTriggerProfit}
+              isValueLoading={!partialTakeProfitFirstProfit}
+              change={nextDynamicTriggerPriceValueChange}
               changeVariant={
-                lambdaStartingTakeProfitPrice
-                  ? lambdaStartingTakeProfitPrice.gte(startingTakeProfitPrice)
+                partialTakeProfitFirstProfit && nextTriggerProfit
+                  ? nextTriggerProfit.triggerPrice.gte(partialTakeProfitFirstProfit.triggerPrice)
                     ? 'positive'
                     : 'negative'
                   : 'positive'
@@ -93,28 +233,23 @@ export const AavePartialTakeProfitManageDetails = ({
                 </Text>
               }
               modalAsTooltip
-              value={
-                nextTriggerProfit
-                  ? formatAmount(
-                      partialTakeProfitToken === 'debt'
-                        ? nextTriggerProfit.realizedProfitInDebt.balance
-                        : nextTriggerProfit.realizedProfitInCollateral.balance,
-                      partialTakeProfitTokenData.symbol,
-                    )
-                  : '-'
+              value={estimatedToReceiveNextTriggerValue}
+              isLoading={
+                !partialTakeProfitFirstProfit ||
+                !nextTriggerProfit ||
+                !realizedProfitInSelectedToken
               }
-              isLoading={!nextTriggerProfit}
-              isValueLoading={!nextTriggerProfit}
+              isValueLoading={!partialTakeProfitFirstProfit || !realizedProfitInSelectedToken}
               unit={partialTakeProfitTokenData.symbol}
-              change={[`??? ${partialTakeProfitTokenData.symbol}`]}
+              change={estimatedToReceiveNextTriggerValueChange}
               changeVariant="positive"
               footnote={
-                nextTriggerProfit
+                partialTakeProfitFirstProfit
                   ? [
                       `${formatAmount(
                         partialTakeProfitToken === 'collateral' // yes, this is the other way around
-                          ? nextTriggerProfit.realizedProfitInDebt.balance
-                          : nextTriggerProfit.realizedProfitInCollateral.balance,
+                          ? partialTakeProfitFirstProfit.realizedProfitInDebt.balance
+                          : partialTakeProfitFirstProfit.realizedProfitInCollateral.balance,
                         partialTakeProfitSecondTokenData.symbol,
                       )} ${partialTakeProfitSecondTokenData.symbol}`,
                     ]
@@ -123,7 +258,7 @@ export const AavePartialTakeProfitManageDetails = ({
             />
             <OmniContentCard
               title={'Current profit/loss'}
-              value={'-'}
+              value={formatAmount(primaryPnlValue, partialTakeProfitTokenData.symbol)}
               modal={
                 <Text>
                   The profit or loss of your position, denominated in collateral, including realized
@@ -133,11 +268,15 @@ export const AavePartialTakeProfitManageDetails = ({
               }
               modalAsTooltip
               unit={partialTakeProfitTokenData.symbol}
-              footnote={[`0 ${partialTakeProfitSecondTokenData.symbol}`]}
+              footnote={[
+                `${formatAmount(secondaryPnlValue, partialTakeProfitSecondTokenData.symbol)} ${
+                  partialTakeProfitSecondTokenData.symbol
+                }`,
+              ]}
             />
             <OmniContentCard
               title={'Profit realized to wallet'}
-              value={'-'}
+              value={realizedProfitValue}
               modal={
                 <Text>
                   The cumulative amount of collateral or debt that you have realized as profits to
@@ -146,7 +285,7 @@ export const AavePartialTakeProfitManageDetails = ({
               }
               modalAsTooltip
               unit={partialTakeProfitTokenData.symbol}
-              footnote={[`0 ${partialTakeProfitSecondTokenData.symbol}`]}
+              footnote={realizedProfit ? [realizedProfitSecondValue] : []}
             />
           </DetailsSectionContentCardWrapper>
         }

--- a/features/aave/manage/containers/AaveManageTabBar.tsx
+++ b/features/aave/manage/containers/AaveManageTabBar.tsx
@@ -154,6 +154,7 @@ export function AaveManageTabBar({
               sendTriggerEvent={sendTriggerEvent}
               netValuePnlCollateralData={netValuePnlCollateralData}
               netValuePnlDebtData={netValuePnlDebtData}
+              aaveReserveState={aaveReserveState}
             />
           ) : (
             <DisabledOptimizationControl minNetValue={minNetValue} />

--- a/features/aave/manage/containers/AaveManageView.tsx
+++ b/features/aave/manage/containers/AaveManageView.tsx
@@ -25,10 +25,12 @@ function AaveManageContainer({
   strategyConfig,
   aaveReserveState,
   aaveReserveDataDebtToken,
+  aaveReserveDataCollateralToken,
   address,
 }: {
   aaveReserveState: AaveLikeReserveConfigurationData
   aaveReserveDataDebtToken: AaveLikeReserveData
+  aaveReserveDataCollateralToken: AaveLikeReserveData
   strategyConfig: IStrategyConfig
   address: string
 }) {
@@ -62,6 +64,7 @@ function AaveManageContainer({
           strategyConfig={strategyConfig}
           aaveReserveState={aaveReserveState}
           aaveReserveDataDebtToken={aaveReserveDataDebtToken}
+          aaveReserveDataCollateralToken={aaveReserveDataCollateralToken}
         />
         <Survey for="earn" />
       </Container>
@@ -80,6 +83,9 @@ export function AaveManagePositionView({
   const [aaveReserveDataDebt, aaveReserveDataDebtError] = useObservable(
     getAaveLikeReserveData$({ token: strategyConfig.tokens.debt }),
   )
+  const [aaveReserveDataCollateral, aaveReserveDataCollateralError] = useObservable(
+    getAaveLikeReserveData$({ token: strategyConfig.tokens.collateral }),
+  )
   const [aaveReserveState, aaveReserveStateError] = useObservable(
     aaveLikeReserveConfigurationData$({
       collateralToken: strategyConfig.tokens.collateral,
@@ -87,17 +93,20 @@ export function AaveManagePositionView({
     }),
   )
   return (
-    <WithErrorHandler error={[aaveReserveStateError, aaveReserveDataDebtError]}>
+    <WithErrorHandler
+      error={[aaveReserveStateError, aaveReserveDataDebtError, aaveReserveDataCollateralError]}
+    >
       <WithLoadingIndicator
-        value={[aaveReserveState, aaveReserveDataDebt]}
+        value={[aaveReserveState, aaveReserveDataDebt, aaveReserveDataCollateral]}
         customLoader={<VaultContainerSpinner />}
       >
-        {([_aaveReserveState, _aaveReserveDataDebt]) => {
+        {([_aaveReserveState, _aaveReserveDataDebt, _aaveReserveDataCollateral]) => {
           return (
             <AaveManageContainer
               strategyConfig={strategyConfig}
               aaveReserveState={_aaveReserveState}
               aaveReserveDataDebtToken={_aaveReserveDataDebt}
+              aaveReserveDataCollateralToken={_aaveReserveDataCollateral}
               address={address}
             />
           )

--- a/features/aave/manage/containers/OptimizationControl.tsx
+++ b/features/aave/manage/containers/OptimizationControl.tsx
@@ -1,3 +1,4 @@
+import type { AaveLikeReserveConfigurationData } from '@oasisdex/dma-library'
 import { useActor, useSelector } from '@xstate/react'
 import BigNumber from 'bignumber.js'
 import { AavePartialTakeProfitManageDetails } from 'features/aave/components/AavePartialTakeProfitManageDetails'
@@ -75,11 +76,13 @@ export function OptimizationControl({
   sendTriggerEvent,
   netValuePnlCollateralData,
   netValuePnlDebtData,
+  aaveReserveState,
 }: {
   triggersState: StateFrom<typeof triggersAaveStateMachine>
   sendTriggerEvent: Sender<TriggersAaveEvent>
   netValuePnlCollateralData: OmniNetValuePnlDataReturnType
   netValuePnlDebtData: OmniNetValuePnlDataReturnType
+  aaveReserveState: AaveLikeReserveConfigurationData
 }) {
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state, send] = useActor(stateMachine)
@@ -98,6 +101,7 @@ export function OptimizationControl({
   const aaveLikePartialTakeProfitParams = getAaveLikePartialTakeProfitParams.manage({
     state,
     aaveLikePartialTakeProfitLambdaData,
+    aaveReserveState,
   })
 
   const autoBuyDetailsLayoutProps = getAutoBuyDetailsLayoutProps(

--- a/features/aave/manage/containers/OptimizationControl.tsx
+++ b/features/aave/manage/containers/OptimizationControl.tsx
@@ -17,6 +17,7 @@ import type {
   triggersAaveStateMachine,
 } from 'features/aave/manage/state'
 import { getAaveLikePartialTakeProfitParams } from 'features/aave/open/helpers/get-aave-like-partial-take-profit-params'
+import type { OmniNetValuePnlDataReturnType } from 'features/omni-kit/helpers'
 import { zero } from 'helpers/zero'
 import React, { useEffect } from 'react'
 import { Container, Grid } from 'theme-ui'
@@ -72,9 +73,13 @@ function getAutoBuyDetailsLayoutProps(
 export function OptimizationControl({
   triggersState,
   sendTriggerEvent,
+  netValuePnlCollateralData,
+  netValuePnlDebtData,
 }: {
   triggersState: StateFrom<typeof triggersAaveStateMachine>
   sendTriggerEvent: Sender<TriggersAaveEvent>
+  netValuePnlCollateralData: OmniNetValuePnlDataReturnType
+  netValuePnlDebtData: OmniNetValuePnlDataReturnType
 }) {
   const { stateMachine } = useManageAaveStateMachineContext()
   const [state, send] = useActor(stateMachine)
@@ -121,6 +126,9 @@ export function OptimizationControl({
             <AavePartialTakeProfitManageDetails
               aaveLikePartialTakeProfitParams={aaveLikePartialTakeProfitParams}
               aaveLikePartialTakeProfitLambdaData={aaveLikePartialTakeProfitLambdaData}
+              netValuePnlCollateralData={netValuePnlCollateralData}
+              netValuePnlDebtData={netValuePnlDebtData}
+              historyEvents={state.context.historyEvents}
             />
           )}
           {triggersState.context.showAutoBuyBanner && (

--- a/features/aave/manage/helpers/map-partial-take-profit-from-lambda.ts
+++ b/features/aave/manage/helpers/map-partial-take-profit-from-lambda.ts
@@ -60,6 +60,10 @@ export const mapPartialTakeProfitFromLambda = (
           lambdaPriceDenomination,
         )
       : undefined,
+    partialTakeProfitToken:
+      selectedTrigger?.decodedParams.withdrawToDebt === 'true'
+        ? ('debt' as const)
+        : ('collateral' as const),
     hasStopLoss: hasStopLoss || hasTrailingStopLoss,
     currentStopLossLevel,
     stopLossLevelLabel:

--- a/features/aave/manage/helpers/map-partial-take-profit-from-lambda.ts
+++ b/features/aave/manage/helpers/map-partial-take-profit-from-lambda.ts
@@ -11,6 +11,7 @@ import { StrategyType } from 'features/aave/types'
 import { formatPercent } from 'helpers/formatters/format'
 import { nbsp } from 'helpers/nbsp'
 import type { GetTriggersResponse } from 'helpers/triggers'
+import { useMemo } from 'react'
 
 export const mapPartialTakeProfitFromLambda = (
   strategyConfig: IStrategyConfig,
@@ -40,7 +41,9 @@ export const mapPartialTakeProfitFromLambda = (
     triggers,
     protocol: strategyConfig.protocol,
   })
-  const stopLossData = mapStopLossFromLambda(triggers)
+  const currentStopLossLevel = useMemo(() => {
+    return mapStopLossFromLambda(triggers).stopLossLevel
+  }, [triggers])
   const trailingStopLossData = mapTrailingStopLossFromLambda(triggers)
   const stopLossTokenLabel = isShort
     ? `${strategyConfig.tokens.debt}/${strategyConfig.tokens.collateral}`
@@ -58,10 +61,9 @@ export const mapPartialTakeProfitFromLambda = (
         )
       : undefined,
     hasStopLoss: hasStopLoss || hasTrailingStopLoss,
+    currentStopLossLevel,
     stopLossLevelLabel:
-      hasStopLoss && stopLossData.stopLossLevel
-        ? `${formatPercent(stopLossData.stopLossLevel)}`
-        : '',
+      hasStopLoss && currentStopLossLevel ? `${formatPercent(currentStopLossLevel)}` : '',
     trailingStopLossDistanceLabel: hasTrailingStopLoss
       ? `${trailingStopLossData.trailingDistance}${nbsp}${stopLossTokenLabel}`
       : '',

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -1,3 +1,4 @@
+import type { AaveLikeReserveConfigurationData } from '@oasisdex/dma-library'
 import { executeTransaction } from 'blockchain/better-calls/dpm-account'
 import { InfoSectionTable } from 'components/infoSection/InfoSectionTable'
 import { AppLink } from 'components/Links'
@@ -57,10 +58,12 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
   aaveLikePartialTakeProfitParams,
   aaveLikePartialTakeProfitLambdaData,
   onTxFinished,
+  aaveReserveState,
 }: ManageAaveStateProps & {
   dropdown: SidebarSectionHeaderDropdown
   aaveLikePartialTakeProfitParams: AaveLikePartialTakeProfitParamsResult
   aaveLikePartialTakeProfitLambdaData: ReturnType<typeof mapPartialTakeProfitFromLambda>
+  aaveReserveState: AaveLikeReserveConfigurationData
   onTxFinished: () => void
 }) {
   const { t } = useTranslation()

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -183,6 +183,9 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
   }
 
   const isDisabled = useMemo(() => {
+    if (!aaveLikePartialTakeProfitLambdaData.hasStopLoss) {
+      return true
+    }
     if (
       isGettingPartialTakeProfitTx ||
       ['addInProgress', 'updateInProgress', 'removeInProgress'].includes(transactionStep)
@@ -193,7 +196,11 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       return false
     }
     return false
-  }, [isGettingPartialTakeProfitTx, transactionStep])
+  }, [
+    isGettingPartialTakeProfitTx,
+    transactionStep,
+    aaveLikePartialTakeProfitLambdaData.hasStopLoss,
+  ])
 
   const primaryButtonAction = () => {
     if (['prepare', 'preparedRemove'].includes(transactionStep)) {

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -68,8 +68,9 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     priceFormat,
     withdrawalLtvSliderConfig,
     positionPriceRatio,
+    newStopLossLtv,
   } = aaveLikePartialTakeProfitParams
-  const { startingTakeProfitPrice: lambdaStartingTakeProfitPrice } =
+  const { startingTakeProfitPrice: lambdaStartingTakeProfitPrice, currentStopLossLevel } =
     aaveLikePartialTakeProfitLambdaData
   const action = useMemo(() => {
     const anyPartialTakeProfit = aaveLikePartialTakeProfitLambdaData.triggerLtv
@@ -92,6 +93,11 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       startingTakeProfitPrice,
       partialTakeProfitToken,
       action,
+      newStopLossLtv:
+        (currentStopLossLevel && !newStopLossLtv.eq(currentStopLossLevel)) || !currentStopLossLevel
+          ? newStopLossLtv
+          : undefined,
+      newStopLossAction: currentStopLossLevel ? TriggerAction.Update : TriggerAction.Add,
     })
 
   useEffect(() => {
@@ -107,6 +113,19 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     // but only after its been loaded from the lambda (and its there)
     // should be empty
   }, [])
+
+  useEffect(() => {
+    if (
+      aaveLikePartialTakeProfitLambdaData.currentStopLossLevel &&
+      !aaveLikePartialTakeProfitLambdaData.currentStopLossLevel.eq(newStopLossLtv)
+    ) {
+      aaveLikePartialTakeProfitParams.setNewStopLossLtv(
+        aaveLikePartialTakeProfitLambdaData.currentStopLossLevel,
+      )
+    }
+    // this handles only when the stop loss in lambda is loaded
+    // user can update SL level with the slider
+  }, [aaveLikePartialTakeProfitLambdaData.currentStopLossLevel])
 
   useEffect(() => {
     if (refreshingTriggerData) {

--- a/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
+++ b/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
@@ -19,11 +19,7 @@ import { BigNumberInput } from 'helpers/BigNumberInput'
 import { formatAmount, formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { handleNumericInput } from 'helpers/input'
 import { nbsp } from 'helpers/nbsp'
-import type {
-  ProfitsSimulationMapped,
-  TriggersApiError,
-  TriggersApiWarning,
-} from 'helpers/triggers'
+import type { TriggersApiError, TriggersApiWarning } from 'helpers/triggers'
 import { hundred } from 'helpers/zero'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { createNumberMask } from 'text-mask-addons'
@@ -36,7 +32,7 @@ type PreparingPartialTakeProfitSidebarContentProps = {
   aaveLikePartialTakeProfitLambdaData: ReturnType<typeof mapPartialTakeProfitFromLambda>
   errors?: TriggersApiError[]
   warnings?: TriggersApiWarning[]
-  profits?: ProfitsSimulationMapped[]
+  profits?: (string | JSX.Element)[][]
   isGettingPartialTakeProfitTx: boolean
 }
 
@@ -123,61 +119,6 @@ export const PreparingPartialTakeProfitSidebarContent = ({
     }
     return startingTakeProfitPrice.lt(positionPriceRatio)
   }, [positionPriceRatio, startingTakeProfitPrice, lambdaStartingTakeProfitPrice])
-  const parsedProfits = useMemo(() => {
-    return profits
-      ? profits.map((profit) => {
-          const isSelectedTokenDebt = partialTakeProfitToken === 'debt'
-          const selectedTokenSymbol = partialTakeProfitTokenData.symbol
-          const secondaryToSelectedToken =
-            strategyConfig.tokens[partialTakeProfitToken === 'debt' ? 'collateral' : 'debt']
-          const realizedProfitValue = isSelectedTokenDebt
-            ? profit.realizedProfitInDebt
-            : profit.realizedProfitInCollateral
-          const totalProfitValue = isSelectedTokenDebt
-            ? profit.totalProfitInDebt
-            : profit.totalProfitInCollateral
-          const totalProfitSecondValue = isSelectedTokenDebt
-            ? profit.totalProfitInCollateral
-            : profit.totalProfitInDebt
-          return [
-            // Trigger price
-            `${formatAmount(profit.triggerPrice, selectedTokenSymbol)} ${priceFormat}`,
-            // Realized profit
-            <Flex sx={{ flexDirection: 'column', textAlign: 'right' }}>
-              <Text variant="paragraph4" color="neutral80" sx={{ fontSize: '11px' }}>
-                {`${formatAmount(
-                  realizedProfitValue.balance,
-                  selectedTokenSymbol,
-                )} ${selectedTokenSymbol}`}
-              </Text>
-            </Flex>,
-            // Total profit
-            <Flex sx={{ flexDirection: 'column', textAlign: 'right' }}>
-              <Text variant="paragraph4" color="neutral100" sx={{ fontSize: '11px' }}>
-                {`${formatAmount(
-                  totalProfitValue.balance,
-                  selectedTokenSymbol,
-                )} ${selectedTokenSymbol}`}
-              </Text>
-              <Text variant="paragraph4" sx={{ fontSize: '11px', mt: '-5px' }} color="neutral80">
-                {`${formatAmount(
-                  totalProfitSecondValue.balance,
-                  secondaryToSelectedToken,
-                )} ${secondaryToSelectedToken}`}
-              </Text>
-            </Flex>,
-            // Stop loss
-            `${formatAmount(profit.stopLossDynamicPrice, selectedTokenSymbol)} ${priceFormat}`,
-          ]
-        })
-      : []
-  }, [
-    partialTakeProfitToken,
-    partialTakeProfitTokenData.symbol,
-    priceFormat,
-    profits,
-    strategyConfig.tokens,
-  ])
 
   return (
     <Grid
@@ -681,7 +622,7 @@ export const PreparingPartialTakeProfitSidebarContent = ({
           </>
         }
         headers={['Trigger Price', 'Realized profit', 'Total profit', 'Stop Loss']}
-        rows={parsedProfits}
+        rows={profits}
         loading={isGettingPartialTakeProfitTx}
         wrapperSx={{
           gridGap: 1,
@@ -689,9 +630,9 @@ export const PreparingPartialTakeProfitSidebarContent = ({
         }}
         defaultLimitItems={partialTakeProfitConfig.realizedProfitRangeVisible}
         expandItemsButtonLabel={
-          parsedProfits.length
+          profits && profits.length
             ? `See next ${
-                parsedProfits.length - partialTakeProfitConfig.realizedProfitRangeVisible
+                profits.length - partialTakeProfitConfig.realizedProfitRangeVisible
               } price triggers`
             : ''
         }

--- a/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
+++ b/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
@@ -608,6 +608,7 @@ export const PreparingPartialTakeProfitSidebarContent = ({
             Your previously configured stop loss LTV will remain unchanged, unless edited below.
           </Text>
         }
+        openByDefault={!hasStopLoss}
       >
         <SliderValuePicker
           disabled={!!hasStopLoss}

--- a/features/aave/manage/state/manageAaveStateMachine.ts
+++ b/features/aave/manage/state/manageAaveStateMachine.ts
@@ -654,6 +654,9 @@ export function createManageAaveStateMachine(
         SET_PARTIAL_TAKE_PROFIT_PROFITS_LAMBDA: {
           actions: 'updateContext',
         },
+        SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA: {
+          actions: 'updateContext',
+        },
         USE_SLIPPAGE: {
           target: ['background.debouncing'],
           actions: 'updateContext',

--- a/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
+++ b/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
@@ -71,6 +71,7 @@ export type AaveLikePartialTakeProfitParamsResult = {
   withdrawalLtvSliderConfig: PTPSliderConfig
   partialTakeProfitConfig: typeof partialTakeProfitConfig
   partialTakeProfitProfits: ProfitsSimulationMapped[] | undefined
+  partialTakeProfitFirstProfit: ProfitsSimulationMapped | undefined
 }
 
 const getTriggerLtvSliderConfig = ({
@@ -202,6 +203,7 @@ export const getAaveLikePartialTakeProfitParams = {
         maxMultiple: maxMultiple.times(hundred),
         triggerLtv,
       })
+      console.log('state.context', state.context)
       return {
         partialTakeProfitConfig,
         partialTakeProfitTokenData,
@@ -227,6 +229,7 @@ export const getAaveLikePartialTakeProfitParams = {
         setWithdrawalLtv,
         withdrawalLtvSliderConfig,
         partialTakeProfitProfits: state.context.partialTakeProfitProfits,
+        partialTakeProfitFirstProfit: state.context.partialTakeProfitFirstProfit,
       }
     },
   ),

--- a/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
+++ b/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
@@ -169,8 +169,9 @@ export const getAaveLikePartialTakeProfitParams = {
 
       const liquidationPrice = debt.div(lockedCollateral.times(liquidationRatio)) || zero
       // user inputs
-      const [partialTakeProfitToken, setPartialTakeProfitToken] =
-        useState<ProfitToTokenType>('debt')
+      const [partialTakeProfitToken, setPartialTakeProfitToken] = useState<ProfitToTokenType>(
+        aaveLikePartialTakeProfitLambdaData.partialTakeProfitToken || 'debt',
+      )
       const [startingTakeProfitPrice, setStartingTakeProfitPrice] = useState<BigNumber>(
         aaveLikePartialTakeProfitLambdaData.startingTakeProfitPrice || positionPriceRatio,
       )

--- a/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
+++ b/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
@@ -203,7 +203,6 @@ export const getAaveLikePartialTakeProfitParams = {
         maxMultiple: maxMultiple.times(hundred),
         triggerLtv,
       })
-      console.log('state.context', state.context)
       return {
         partialTakeProfitConfig,
         partialTakeProfitTokenData,

--- a/features/aave/open/helpers/get-aave-like-stop-loss-params.ts
+++ b/features/aave/open/helpers/get-aave-like-stop-loss-params.ts
@@ -76,9 +76,9 @@ export const getAaveLikeStopLossParams = {
     const positionRatio = state.context.currentPosition?.riskRatio.loanToValue || zero
     const liquidationRatio = state.context?.currentPosition?.category.liquidationThreshold || zero
     const sliderMin = new BigNumber(
-      positionRatio.plus(aaveOffsets.open.min).times(100).toFixed(0, BigNumber.ROUND_UP),
+      positionRatio.plus(aaveOffsets.manage.min).times(100).toFixed(0, BigNumber.ROUND_UP),
     )
-    const sliderMax = liquidationRatio.minus(aaveOffsets.open.max).times(100)
+    const sliderMax = liquidationRatio.minus(aaveOffsets.manage.max).times(100)
     const debt = amountFromWei(
       state.context.currentPosition?.debt.amount || zero,
       state.context.currentPosition?.debt.precision,

--- a/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
@@ -52,11 +52,13 @@ export const useLambdaDebouncedPartialTakeProfit = ({
   send,
   triggerLtv,
   withdrawalLtv,
+  stopLossLtv,
   startingTakeProfitPrice,
   partialTakeProfitToken,
   action,
 }: (OpenAaveStateProps | ManageAaveStateProps) & {
   triggerLtv: BigNumber
+  stopLossLtv?: BigNumber
   withdrawalLtv: BigNumber
   startingTakeProfitPrice: BigNumber
   partialTakeProfitToken: string
@@ -84,10 +86,6 @@ export const useLambdaDebouncedPartialTakeProfit = ({
     })
   }
   const setFirstProfit = (partialTakeProfitFirstProfit: ProfitsSimulationMapped | undefined) => {
-    console.log({
-      type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
-      partialTakeProfitFirstProfit,
-    })
     send({
       type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
       partialTakeProfitFirstProfit,
@@ -127,6 +125,7 @@ export const useLambdaDebouncedPartialTakeProfit = ({
             collateralAddress,
             debtAddress,
           },
+          stopLoss: stopLossLtv,
           action,
         }),
       )
@@ -147,9 +146,7 @@ export const useLambdaDebouncedPartialTakeProfit = ({
           if (res.simulation) {
             const profitsMapped = mapProfits(res.simulation)
             setProfits(profitsMapped)
-            console.log('test 1')
             if (state.context.partialTakeProfitFirstProfit === undefined) {
-              console.log('test 2', profitsMapped)
               setFirstProfit(profitsMapped[0])
             }
           }

--- a/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
@@ -114,7 +114,6 @@ export const useLambdaDebouncedPartialTakeProfit = ({
         setIsGettingPartialTakeProfitTx(true)
         clearWarningsAndErrors()
       }
-      console.log('newStopLossLtv', newStopLossLtv)
       const partialTakeProfitTxDataPromise = cancelable(
         setupAaveLikePartialTakeProfit({
           dpm: dpmAccount,

--- a/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
@@ -83,6 +83,16 @@ export const useLambdaDebouncedPartialTakeProfit = ({
       partialTakeProfitProfits,
     })
   }
+  const setFirstProfit = (partialTakeProfitFirstProfit: ProfitsSimulationMapped | undefined) => {
+    console.log({
+      type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
+      partialTakeProfitFirstProfit,
+    })
+    send({
+      type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
+      partialTakeProfitFirstProfit,
+    })
+  }
 
   useDebouncedEffect(
     () => {
@@ -135,7 +145,13 @@ export const useLambdaDebouncedPartialTakeProfit = ({
             })
           }
           if (res.simulation) {
-            setProfits(mapProfits(res.simulation))
+            const profitsMapped = mapProfits(res.simulation)
+            setProfits(profitsMapped)
+            console.log('test 1')
+            if (state.context.partialTakeProfitFirstProfit === undefined) {
+              console.log('test 2', profitsMapped)
+              setFirstProfit(profitsMapped[0])
+            }
           }
           res.warnings && setWarnings(res.warnings)
           res.errors && setErrors(res.errors)

--- a/features/aave/open/state/openAaveStateMachine.ts
+++ b/features/aave/open/state/openAaveStateMachine.ts
@@ -527,6 +527,9 @@ export function createOpenAaveStateMachine(
         SET_PARTIAL_TAKE_PROFIT_PROFITS_LAMBDA: {
           actions: 'updateContext',
         },
+        SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA: {
+          actions: 'updateContext',
+        },
         SET_STOP_LOSS_SKIPPED: {
           actions: 'updateContext',
         },

--- a/features/aave/types/base-aave-context.ts
+++ b/features/aave/types/base-aave-context.ts
@@ -119,6 +119,7 @@ export interface BaseAaveContext {
   trailingStopLossTxDataLambda?: TriggerTransaction
   partialTakeProfitTxDataLambda?: TriggerTransaction
   partialTakeProfitProfits?: ProfitsSimulationMapped[] | undefined
+  partialTakeProfitFirstProfit?: ProfitsSimulationMapped | undefined
   stopLossSkipped?: boolean
   getSlippageFrom: 'userSettings' | 'strategyConfig'
   reserveData?: ReserveData

--- a/features/aave/types/base-aave-event.ts
+++ b/features/aave/types/base-aave-event.ts
@@ -25,6 +25,7 @@ type AaveOpenPositionWithStopLossEvents =
   | { type: 'SET_TRAILING_STOP_LOSS_TX_DATA_LAMBDA'; trailingStopLossTxDataLambda: TriggerTransaction | undefined }
   | { type: 'SET_PARTIAL_TAKE_PROFIT_TX_DATA_LAMBDA'; partialTakeProfitTxDataLambda: TriggerTransaction | undefined }
   | { type: 'SET_PARTIAL_TAKE_PROFIT_PROFITS_LAMBDA'; partialTakeProfitProfits: ProfitsSimulationMapped[] | undefined }
+  | { type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA'; partialTakeProfitFirstProfit: ProfitsSimulationMapped | undefined }
   | { type: 'SET_STOP_LOSS_TX_DATA_LAMBDA'; stopLossTxDataLambda: TriggerTransaction | undefined }
   | { type: 'SET_STOP_LOSS_SKIPPED'; stopLossSkipped: boolean }
 

--- a/helpers/formatters/format.ts
+++ b/helpers/formatters/format.ts
@@ -139,12 +139,18 @@ export function formatPercent(
 
 export function formatDecimalAsPercent(
   number: BigNumber,
-  { precision = 2, plus = false, roundMode = BigNumber.ROUND_DOWN }: FormatPercentOptions = {},
+  {
+    precision = 2,
+    plus = false,
+    roundMode = BigNumber.ROUND_DOWN,
+    noPercentSign = false,
+  }: FormatPercentOptions = {},
 ) {
   return formatPercent(number.times(100), {
     precision,
     plus,
     roundMode,
+    noPercentSign,
   })
 }
 

--- a/helpers/triggers/get-triggers/get-triggers-types.ts
+++ b/helpers/triggers/get-triggers/get-triggers-types.ts
@@ -271,6 +271,7 @@ export type DmaAavePartialTakeProfit = {
     positionAddress: string
     targetLtv: string
     triggerType: string
+    withdrawToDebt: 'true' | 'false'
   }
 }
 
@@ -290,6 +291,7 @@ export type DmaSparkPartialTakeProfit = {
     executionPrice: string
     deviation: string
     closeToCollateral: string
+    withdrawToDebt: 'true' | 'false'
   }
 }
 

--- a/helpers/triggers/setup-triggers/setup-aave-partial-take-profit.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-partial-take-profit.ts
@@ -25,7 +25,18 @@ export const setupAaveLikePartialTakeProfit = async (
         .times(lambdaPriceDenomination)
         .integerValue()
         .toString(),
-      stopLoss: params.stopLoss?.times(lambdaPriceDenomination).integerValue().toString(),
+      stopLoss: params.stopLoss
+        ? {
+            triggerData: {
+              executionLTV: params.stopLoss.triggerData.executionLTV
+                .times(lambdaPercentageDenomination)
+                .integerValue()
+                .toString(),
+              token: params.stopLoss.triggerData.token,
+            },
+            action: params.stopLoss.action,
+          }
+        : undefined,
       // trailingStopLoss: params.trailingStopLoss, // possibly in the future
     },
     position: {

--- a/helpers/triggers/setup-triggers/setup-triggers-types.ts
+++ b/helpers/triggers/setup-triggers/setup-triggers-types.ts
@@ -150,7 +150,13 @@ export interface SetupAavePartialTakeProfitParams {
   triggerLtv: BigNumber
   withdrawalLtv: BigNumber
   startingTakeProfitPrice: BigNumber
-  stopLoss?: BigNumber
+  stopLoss?: {
+    triggerData: {
+      executionLTV: BigNumber
+      token: string
+    }
+    action: TriggerAction.Add | TriggerAction.Update
+  }
   trailingStopLoss?: BigNumber
   networkId: number
   strategy: StrategyLike


### PR DESCRIPTION
This pull request includes the following commits:

- Some component style fixes
- `Skeleton` interactive color
- `InfoSectionTable` has skeleton when loading
- Parse history events to display take profit realized transfers
- Added PnL value to the take profit details
- Modified how we handle value/value change in the details
- Handle adding/updating stop loss during add/manage take profit automation
- Some minor fixes