### PR TITLE
Remove modalAsTooltip prop from OmniContentCard and DetailsSectionContentCard

### DIFF
--- a/components/DetailsSectionContentCard.tsx
+++ b/components/DetailsSectionContentCard.tsx
@@ -47,7 +47,6 @@ export interface ContentCardProps {
   footnoteTooltip?: ReactNode
   link?: DetailsSectionContentCardLinkProps
   modal?: ReactNode
-  modalAsTooltip?: boolean
   title: string
   unit?: TranslateStringType
   value?: ReactNode
@@ -193,7 +192,6 @@ export function DetailsSectionContentCard({
   footnoteTooltip,
   link,
   modal,
-  modalAsTooltip,
   title,
   unit,
   value,
@@ -202,19 +200,18 @@ export function DetailsSectionContentCard({
   const openModal = useModal()
   const [isHighlighted, setIsHighlighted] = useState(false)
   const modalHandler = () => {
-    if (modal && !modalAsTooltip)
-      openModal(DetailsSectionContentCardModal, { children: <>{modal}</> })
+    if (modal) openModal(DetailsSectionContentCardModal, { children: <>{modal}</> })
   }
   const hightlightableItemEvents = {
     onMouseEnter: () => setIsHighlighted(true),
     onMouseLeave: () => setIsHighlighted(false),
     onClick: modalHandler,
   }
-  let cardBackgroundColor = modal && !modalAsTooltip && isHighlighted ? 'neutral30' : 'neutral10'
+  let cardBackgroundColor = modal && isHighlighted ? 'neutral30' : 'neutral10'
   if (customBackground) {
     cardBackgroundColor = customBackground
   }
-  const cursorStyle = { cursor: modal && !modalAsTooltip ? 'pointer' : 'auto' }
+  const cursorStyle = { cursor: modal ? 'pointer' : 'auto' }
   const footnoteArray = Array.isArray(footnote) ? footnote : [footnote]
 
   return (
@@ -242,7 +239,7 @@ export function DetailsSectionContentCard({
         {...hightlightableItemEvents}
       >
         {title}
-        {modal && !modalAsTooltip && (
+        {modal && (
           <Icon
             color={isHighlighted ? 'primary100' : 'neutral80'}
             icon={question_o}
@@ -251,23 +248,6 @@ export function DetailsSectionContentCard({
             height="14px"
             sx={{ position: 'relative', top: '2px', ml: 1, transition: 'color 200ms' }}
           />
-        )}
-        {modal && modalAsTooltip && (
-          <StatefulTooltip
-            tooltip={modal}
-            containerSx={{ display: 'inline' }}
-            inline
-            tooltipSx={{ maxWidth: '350px' }}
-          >
-            <Icon
-              color={isHighlighted ? 'primary100' : 'neutral80'}
-              icon={question_o}
-              size="auto"
-              width="14px"
-              height="14px"
-              sx={{ position: 'relative', top: '2px', ml: 1, transition: 'color 200ms' }}
-            />
-          </StatefulTooltip>
         )}
       </Text>
       <Text

--- a/components/infoSection/InfoSectionTable.tsx
+++ b/components/infoSection/InfoSectionTable.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from 'components/Skeleton'
 import type { ReactNode } from 'react'
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { ThemeUIStyleObject } from 'theme-ui'
 import { Box, Button, Grid, Text } from 'theme-ui'
 
@@ -27,6 +28,7 @@ export function InfoSectionTable({
   expandItemsButtonLabel,
   loading = false,
 }: InfoSectionTableProps) {
+  const { t } = useTranslation()
   const [limitItems, setLimitItems] =
     useState<InfoSectionTableProps['defaultLimitItems']>(defaultLimitItems)
   const defaultLoadingItems = typeof defaultLimitItems === 'number' ? defaultLimitItems : 3
@@ -80,6 +82,13 @@ export function InfoSectionTable({
             ))}
           </Grid>
         ))}
+      {!loading && rows && (rows.length === 0 || !rows) && (
+        <Grid as="li" columns={1} sx={{ listStyle: 'none', textAlign: 'center', mt: 4 }}>
+          <Text variant="paragraph3" color="neutral80">
+            {t('system.no-data-to-display')}
+          </Text>
+        </Grid>
+      )}
       {rows &&
         rows
           .filter((_, itemIndex) => {

--- a/features/aave/components/AavePartialTakeProfitManageDetails.tsx
+++ b/features/aave/components/AavePartialTakeProfitManageDetails.tsx
@@ -24,7 +24,7 @@ import { staticFilesRuntimeUrl } from 'helpers/staticPaths'
 import { zero } from 'helpers/zero'
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Box, Divider, Flex, Image, Text } from 'theme-ui'
+import { Box, Divider, Flex, Heading, Image, Text } from 'theme-ui'
 
 type AavePartialTakeProfitManageDetailsProps = {
   aaveLikePartialTakeProfitParams: AaveLikePartialTakeProfitParamsResult
@@ -213,13 +213,15 @@ export const AavePartialTakeProfitManageDetails = ({
               value={nextDynamicTriggerPriceValue}
               unit={priceFormat}
               modal={
-                <Text>
-                  The next price in which you will realize profits to your wallet. It is dynamic
-                  because position changes made prior to it triggering may make the trigger price
-                  increase.
-                </Text>
+                <>
+                  <Heading variant="header4">Next Dynamic Trigger Price</Heading>
+                  <Text as="p" variant="paragraph3">
+                    The next price in which you will realize profits to your wallet. It is dynamic
+                    because position changes made prior to it triggering may make the trigger price
+                    increase.
+                  </Text>
+                </>
               }
-              modalAsTooltip
               isLoading={!partialTakeProfitFirstProfit || !nextTriggerProfit}
               isValueLoading={!partialTakeProfitFirstProfit}
               change={nextDynamicTriggerPriceValueChange}
@@ -235,12 +237,14 @@ export const AavePartialTakeProfitManageDetails = ({
             <OmniContentCard
               title={'Est. to receive next trigger'}
               modal={
-                <Text>
-                  The amount of collateral or debt that will be withdrawn to your wallet upon
-                  trigger.
-                </Text>
+                <>
+                  <Heading variant="header4">Est. to receive next trigger</Heading>
+                  <Text as="p" variant="paragraph3">
+                    The amount of collateral or debt that will be withdrawn to your wallet upon
+                    trigger.
+                  </Text>
+                </>
               }
-              modalAsTooltip
               value={estimatedToReceiveNextTriggerValue}
               isLoading={
                 !partialTakeProfitFirstProfit ||
@@ -272,13 +276,15 @@ export const AavePartialTakeProfitManageDetails = ({
                   : '-'
               }
               modal={
-                <Text>
-                  The profit or loss of your position, denominated in collateral, including realized
-                  profits to wallet. Specifically, P&L = ((Net value + Cumulative withdrawals) -
-                  Cumulative deposits) / Cumulative deposits.
-                </Text>
+                <>
+                  <Heading variant="header4">Current profit/loss</Heading>
+                  <Text as="p" variant="paragraph3">
+                    The profit or loss of your position, denominated in collateral, including
+                    realized profits to wallet. Specifically, P&L = ((Net value + Cumulative
+                    withdrawals) - Cumulative deposits) / Cumulative deposits.
+                  </Text>
+                </>
               }
-              modalAsTooltip
               unit={partialTakeProfitTokenData.symbol}
               footnote={
                 hasLambdaTriggerLtv
@@ -295,12 +301,14 @@ export const AavePartialTakeProfitManageDetails = ({
               title={'Profit realized to wallet'}
               value={hasLambdaTriggerLtv ? realizedProfitValue : '-'}
               modal={
-                <Text>
-                  The cumulative amount of collateral or debt that you have realized as profits to
-                  your wallet.
-                </Text>
+                <>
+                  <Heading variant="header4">Profit realized to wallet</Heading>
+                  <Text as="p" variant="paragraph3">
+                    The cumulative amount of collateral or debt that you have realized as profits to
+                    your wallet.
+                  </Text>
+                </>
               }
-              modalAsTooltip
               unit={partialTakeProfitTokenData.symbol}
               footnote={realizedProfit && hasLambdaTriggerLtv ? [realizedProfitSecondValue] : []}
             />

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -271,7 +271,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
   ])
 
   const isDisabled = useMemo(() => {
-    if (frontendErrors.length) {
+    if (frontendErrors.length || errors.length) {
       return true
     }
     if (
@@ -284,7 +284,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       return false
     }
     return false
-  }, [frontendErrors.length, isGettingPartialTakeProfitTx, transactionStep])
+  }, [errors.length, frontendErrors.length, isGettingPartialTakeProfitTx, transactionStep])
 
   const primaryButtonAction = () => {
     if (['prepare', 'preparedRemove'].includes(transactionStep)) {
@@ -327,7 +327,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       return true
     }
     return false
-  }, [action, transactionStep, triggerLtv])
+  }, [action, lambdaTriggerLtv, transactionStep])
 
   const secondaryButtonLabel = () => {
     if (transactionStep === 'prepare') {

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -70,8 +70,11 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     positionPriceRatio,
     newStopLossLtv,
   } = aaveLikePartialTakeProfitParams
-  const { startingTakeProfitPrice: lambdaStartingTakeProfitPrice, currentStopLossLevel } =
-    aaveLikePartialTakeProfitLambdaData
+  const {
+    startingTakeProfitPrice: lambdaStartingTakeProfitPrice,
+    currentStopLossLevel,
+    triggerLtv: lambdaTriggerLtv,
+  } = aaveLikePartialTakeProfitLambdaData
   const action = useMemo(() => {
     const anyPartialTakeProfit = aaveLikePartialTakeProfitLambdaData.triggerLtv
     if (transactionStep === 'preparedRemove') {
@@ -313,10 +316,18 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     return primaryButtonMap[transactionStep]
   }
 
-  const showSecondaryButton =
-    (transactionStep === 'prepare' && action !== TriggerAction.Remove) ||
-    (action === TriggerAction.Remove && transactionStep !== 'finished') ||
-    ['preparedAdd', 'preparedUpdate', 'preparedRemove'].includes(transactionStep)
+  const showSecondaryButton = useMemo(() => {
+    if (transactionStep === 'prepare' && action !== TriggerAction.Remove && !!lambdaTriggerLtv) {
+      return true
+    }
+    if (action === TriggerAction.Remove && transactionStep !== 'finished') {
+      return true
+    }
+    if (['preparedAdd', 'preparedUpdate', 'preparedRemove'].includes(transactionStep)) {
+      return true
+    }
+    return false
+  }, [action, transactionStep, triggerLtv])
 
   const secondaryButtonLabel = () => {
     if (transactionStep === 'prepare') {

--- a/features/omni-kit/components/details-section/OmniContentCard.tsx
+++ b/features/omni-kit/components/details-section/OmniContentCard.tsx
@@ -41,7 +41,6 @@ export interface OmniContentCardExtra {
   isLoading?: boolean
   isValueLoading?: boolean
   modal?: ReactNode
-  modalAsTooltip?: boolean
   link?: DetailsSectionContentCardLinkProps
   tooltips?: {
     change?: ReactNode
@@ -78,7 +77,6 @@ export function OmniContentCard({
   iconPosition = 'before',
   isLoading,
   modal,
-  modalAsTooltip,
   title,
   tooltips: {
     change: changeTooltip,
@@ -166,7 +164,6 @@ export function OmniContentCard({
     link,
     extra,
     modal,
-    modalAsTooltip,
     asFooter,
   }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1352,7 +1352,8 @@
     "net-borrow-cost": "Cost to Borrow",
     "position-debt": "Position Debt",
     "current-token-price": "Current {{token}} Price",
-    "next-token-price": "Next {{token}} Price"
+    "next-token-price": "Next {{token}} Price",
+    "no-data-to-display": "No data to display"
   },
   "token-balance": "{{token}} balance",
   "token-depositing": "{{token}} depositing {{amount}}",


### PR DESCRIPTION
This pull request removes the modalAsTooltip prop from the OmniContentCard and DetailsSectionContentCard components. The prop is no longer needed and has been causing issues.