### PR TITLE
Batch of Partial Take profit fixes

### DIFF
--- a/features/aave/hooks/useOptimizationSidebarDropdown.tsx
+++ b/features/aave/hooks/useOptimizationSidebarDropdown.tsx
@@ -21,23 +21,11 @@ export function useOptimizationSidebarDropdown(
     state.context.currentTriggers.triggers.sparkPartialTakeProfit !== undefined
 
   const currentPanel = useMemo(() => {
-    if (hasAavePartialTakeProfitEnabled || hasSparkPartialTakeProfitEnabled) {
-      return AutomationFeatures.PARTIAL_TAKE_PROFIT
-    }
-    if (hasAaveAutoBuyEnabled || hasSparkAutoBuyEnabled) {
-      return AutomationFeatures.AUTO_BUY
-    }
     return {
       'auto-buy': AutomationFeatures.AUTO_BUY,
       'partial-take-profit': AutomationFeatures.PARTIAL_TAKE_PROFIT,
     }[state.context.optimizationCurrentView || 'partial-take-profit']
-  }, [
-    hasAaveAutoBuyEnabled,
-    hasAavePartialTakeProfitEnabled,
-    hasSparkAutoBuyEnabled,
-    hasSparkPartialTakeProfitEnabled,
-    state.context.optimizationCurrentView,
-  ])
+  }, [state.context.optimizationCurrentView])
 
   return {
     forcePanel: currentPanel,

--- a/features/aave/manage/helpers/map-partial-take-profit-from-lambda.ts
+++ b/features/aave/manage/helpers/map-partial-take-profit-from-lambda.ts
@@ -60,6 +60,12 @@ export const mapPartialTakeProfitFromLambda = (
           lambdaPriceDenomination,
         )
       : undefined,
+    withdrawalLtv:
+      selectedTrigger?.decodedParams.targetLtv && selectedTrigger?.decodedParams.executionLtv
+        ? new BigNumber(Number(selectedTrigger.decodedParams.targetLtv))
+            .minus(new BigNumber(Number(selectedTrigger?.decodedParams.executionLtv)))
+            .div(lambdaPercentageDenomination)
+        : undefined,
     partialTakeProfitToken:
       selectedTrigger?.decodedParams.withdrawToDebt === 'true'
         ? ('debt' as const)

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -110,6 +110,10 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
         aaveLikePartialTakeProfitParams.setStartingTakeProfitPrice(
           aaveLikePartialTakeProfitLambdaData.startingTakeProfitPrice,
         )
+      aaveLikePartialTakeProfitLambdaData.withdrawalLtv &&
+        aaveLikePartialTakeProfitParams.setWithdrawalLtv(
+          aaveLikePartialTakeProfitLambdaData.withdrawalLtv,
+        )
       aaveLikePartialTakeProfitParams.setCustomPriceRatioPercentage(undefined)
     }
     // updates the trigger ltv and withdrawal ltv, removes the custom price ratio percentage

--- a/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
+++ b/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
@@ -336,7 +336,7 @@ export const PreparingPartialTakeProfitSidebarContent = ({
           {...triggerLtvSliderConfig}
           customSliderProps={{
             marks: {
-              [currentLtv.times(lambdaPercentageDenomination).toNumber()]: (
+              [currentLtv.times(lambdaPercentageDenomination).toFixed()]: (
                 <Text
                   variant="boldParagraph3"
                   sx={{ fontSize: '10px', textTransform: 'uppercase' }}

--- a/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
+++ b/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
@@ -331,9 +331,7 @@ export const PreparingPartialTakeProfitSidebarContent = ({
           rightBoundryFormatter={() => null}
           lastValue={triggerLtv}
           leftBoundry={triggerLtv}
-          onChange={(x) => {
-            setTriggerLtv(x)
-          }}
+          onChange={setTriggerLtv}
           useRcSlider
           {...triggerLtvSliderConfig}
           customSliderProps={{

--- a/features/aave/manage/state/triggersAaveStateMachine.ts
+++ b/features/aave/manage/state/triggersAaveStateMachine.ts
@@ -77,10 +77,6 @@ export const getCurrentOptimizationView = ({
   if (triggers.aavePartialTakeProfit || triggers.sparkPartialTakeProfit) {
     return 'partial-take-profit'
   }
-  // TODO: add this logic, currently just for debugging
-  if (!triggers.aaveBasicBuy) {
-    return 'auto-buy'
-  }
   return undefined
 }
 


### PR DESCRIPTION
Fixes:
- Optimization tab wont automatically select `auto-buy` now
- Added validation for current LTV > trigger LTV
- Fixed sidebar dropdown not updating after view change when position had automation set
- Fixed loading the current trigger withdrawal LTV value (wasn't loaded at all)