### PR TITLE
Partial take profit fixes [pt.4]

### DIFF
--- a/components/vault/ProtectionControl.tsx
+++ b/components/vault/ProtectionControl.tsx
@@ -113,11 +113,11 @@ function getZeroDebtProtectionBannerProps({
     return {
       useTranslationKeys: false,
       showLink: false,
-      header: 'Stop loss protection is not yet available for these positions.',
+      header: 'Stop-Loss protection is not yet available for these positions.',
       description: (
         <>
-          Currently, the Summer.Fi Stop loss is not yet available for this position. Let the team
-          know if you would like to set-up a Stop loss for this position on{' '}
+          Currently, the Summer.Fi Stop-Loss is not yet available for this position. Let the team
+          know if you would like to set-up a Stop-Loss for this position on{' '}
           <AppLink href="mailto:support@summer.fi">support@summer.fi</AppLink> or our{' '}
           <AppLink href={EXTERNAL_LINKS.DISCORD}>Discord</AppLink>.
         </>

--- a/features/aave/manage/helpers/map-stop-loss-from-lambda.ts
+++ b/features/aave/manage/helpers/map-stop-loss-from-lambda.ts
@@ -22,7 +22,7 @@ export const mapStopLossFromLambda = (triggers?: StopLossTriggers) => {
     triggerName.includes('StopLoss'),
   )
   if (stopLossTriggersNames.length > 1) {
-    console.warn('Warning: more than one stop loss trigger found:', stopLossTriggersNames)
+    console.warn('Warning: more than one Stop-Loss trigger found:', stopLossTriggersNames)
   }
   const stopLossTriggerName = stopLossTriggersNames[0] as keyof StopLossTriggers
   const trigger = triggers[stopLossTriggerName]

--- a/features/aave/manage/helpers/map-trailing-stop-loss-from-lambda.ts
+++ b/features/aave/manage/helpers/map-trailing-stop-loss-from-lambda.ts
@@ -18,7 +18,7 @@ export const mapTrailingStopLossFromLambda = (triggers?: TrailingStopLossTrigger
   )
   if (trailingStopLossTriggersNames.length > 1) {
     console.warn(
-      'Warning: more than one trailing stop loss trigger found:',
+      'Warning: more than one trailing Stop-Loss trigger found:',
       trailingStopLossTriggersNames,
     )
   }

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -167,6 +167,21 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     }
   }, [refreshingTriggerData])
 
+  const resetXStateData = () => {
+    send({
+      type: 'SET_PARTIAL_TAKE_PROFIT_TX_DATA_LAMBDA',
+      partialTakeProfitTxDataLambda: undefined,
+    })
+    send({
+      type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
+      partialTakeProfitFirstProfit: undefined,
+    })
+    send({
+      type: 'SET_PARTIAL_TAKE_PROFIT_PROFITS_LAMBDA',
+      partialTakeProfitProfits: undefined,
+    })
+  }
+
   const executeCall = async () => {
     if (partialTakeProfitTxDataLambda && signer) {
       return await executeTransaction({
@@ -249,6 +264,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     }
     if (transactionStep === 'finished') {
       onTxFinished()
+      resetXStateData()
       setTransactionStep('prepare')
     }
   }

--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -168,18 +168,20 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
   }, [refreshingTriggerData])
 
   const resetXStateData = () => {
-    send({
-      type: 'SET_PARTIAL_TAKE_PROFIT_TX_DATA_LAMBDA',
-      partialTakeProfitTxDataLambda: undefined,
-    })
-    send({
-      type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
-      partialTakeProfitFirstProfit: undefined,
-    })
-    send({
-      type: 'SET_PARTIAL_TAKE_PROFIT_PROFITS_LAMBDA',
-      partialTakeProfitProfits: undefined,
-    })
+    if (action === TriggerAction.Remove) {
+      send({
+        type: 'SET_PARTIAL_TAKE_PROFIT_TX_DATA_LAMBDA',
+        partialTakeProfitTxDataLambda: undefined,
+      })
+      send({
+        type: 'SET_PARTIAL_TAKE_PROFIT_FIRST_PROFIT_LAMBDA',
+        partialTakeProfitFirstProfit: undefined,
+      })
+      send({
+        type: 'SET_PARTIAL_TAKE_PROFIT_PROFITS_LAMBDA',
+        partialTakeProfitProfits: undefined,
+      })
+    }
   }
 
   const executeCall = async () => {
@@ -198,7 +200,9 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     void executeCall()
       .then(() => {
         if (action === TriggerAction.Remove) {
-          setTransactionStep('finished')
+          setTimeout(() => {
+            setTransactionStep('finished')
+          }, refreshDataTime)
         } else {
           setRefreshingTriggerData(true)
           setTransactionStep('finished')
@@ -246,6 +250,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
     }
     if (
       isGettingPartialTakeProfitTx ||
+      refreshingTriggerData ||
       ['addInProgress', 'updateInProgress', 'removeInProgress'].includes(transactionStep)
     ) {
       return true
@@ -254,7 +259,13 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       return false
     }
     return false
-  }, [errors.length, frontendErrors.length, isGettingPartialTakeProfitTx, transactionStep])
+  }, [
+    errors.length,
+    frontendErrors.length,
+    isGettingPartialTakeProfitTx,
+    refreshingTriggerData,
+    transactionStep,
+  ])
 
   const primaryButtonAction = () => {
     if (['prepare', 'preparedRemove'].includes(transactionStep)) {
@@ -569,7 +580,10 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       ),
     }[transactionStep],
     primaryButton: {
-      isLoading: isGettingPartialTakeProfitTx || refreshingTriggerData,
+      isLoading:
+        isGettingPartialTakeProfitTx ||
+        refreshingTriggerData ||
+        transactionStep === 'removeInProgress',
       disabled: isDisabled,
       label: primaryButtonLabel(),
       action: primaryButtonAction,

--- a/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
@@ -57,6 +57,7 @@ export const useLambdaDebouncedPartialTakeProfit = ({
   startingTakeProfitPrice,
   partialTakeProfitToken,
   action,
+  transactionStep,
 }: (OpenAaveStateProps | ManageAaveStateProps) & {
   triggerLtv: BigNumber
   newStopLossLtv?: BigNumber
@@ -65,6 +66,13 @@ export const useLambdaDebouncedPartialTakeProfit = ({
   partialTakeProfitToken: string
   action: TriggerAction
   newStopLossAction: TriggerAction.Add | TriggerAction.Update
+  transactionStep:
+    | 'prepare'
+    | 'preparedRemove'
+    | 'addInProgress'
+    | 'updateInProgress'
+    | 'removeInProgress'
+    | 'finished'
 }) => {
   const [isGettingPartialTakeProfitTx, setIsGettingPartialTakeProfitTx] = useState(false)
   const [warnings, setWarnings] = useState<TriggersApiWarning[]>([])
@@ -99,6 +107,7 @@ export const useLambdaDebouncedPartialTakeProfit = ({
       const { context } = state
       const dpmAccount = context.effectiveProxyAddress
       if (
+        !['prepare', 'preparedRemove'].includes(transactionStep) ||
         !dpmAccount ||
         !collateralAddress ||
         !debtAddress ||

--- a/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
+++ b/features/aave/open/helpers/use-lambda-debounced-partial-take-profit.ts
@@ -165,7 +165,10 @@ export const useLambdaDebouncedPartialTakeProfit = ({
           if (res.simulation) {
             const profitsMapped = mapProfits(res.simulation)
             setProfits(profitsMapped)
-            if (state.context.partialTakeProfitFirstProfit === undefined) {
+            if (
+              state.context.partialTakeProfitFirstProfit === undefined ||
+              transactionStep === 'finished'
+            ) {
               setFirstProfit(profitsMapped[0])
             }
           }

--- a/handlers/portfolio/constants.ts
+++ b/handlers/portfolio/constants.ts
@@ -3,4 +3,5 @@ export const emptyAutomations = {
   autoBuy: { enabled: false },
   autoSell: { enabled: false },
   stopLoss: { enabled: false },
+  takeProfit: { enabled: false },
 }

--- a/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
+++ b/handlers/portfolio/positions/helpers/getPositionsAutomations.ts
@@ -50,6 +50,8 @@ const triggerTypesMap = {
     TriggerType.AutoTakeProfitToDai,
     TriggerType.MakerAutoTakeProfitToCollateralV2,
     TriggerType.MakerAutoTakeProfitToDaiV2,
+    TriggerType.DmaAavePartialTakeProfitV2,
+    TriggerType.DmaSparkPartialTakeProfitV2,
   ],
 }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1828,6 +1828,7 @@
     "stop-loss-triggered-desc": "Your Stop-Loss was triggered on your Vault",
     "stop-loss-triggered-content": "Your stop loss was triggered on your Vault. You can read the fully summary of the Stop-Loss event on the right.",
     "cancel-notice": "Cancelling your Stop-Loss means you will no longer have protection in place and you will need to actively monitor your {{ratioParam}}.",
+    "take-profit-cancel-notice": "This needs copy! Something sad about cancelling take profit :(",
     "find-more-about-setting-stop-loss": "Find out more about setting Stop-Loss →",
     "set-stop-loss-again": "Set up Stop-Loss again",
     "sl-triggered-gas-estimation": "This fee represents the expected Gas Cost based on the current price of ETH and an assumed Gas Price of 50 GWEI.",


### PR DESCRIPTION
- Brings back the starting TP price validation
- Fixes the update button loading status on various occasions
- Adds take profit icon to all aave/spark products (with trigger ID handling)

This pull request adds the functionality to set take profit automations and trigger types. It also updates the stop-loss and take-profit messages and warnings. Additionally, it refactors the resetXStateData function to handle actions conditionally.