### PR TITLE
Partial take profit fixes [pt.4]

### DIFF
--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -485,11 +485,14 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
 
   const sidebarRemoveTriggerContent: SidebarSectionProps['content'] = strategyInfo ? (
     <Grid gap={3}>
+      <Text as="p" variant="paragraph3" sx={{ color: 'neutral80' }}>
+        {t('automation.cancel-summary-description', { feature: t('partial-take-profit') })}
+      </Text>
       <InfoSection
-        title={t('constant-multiple.vault-changes.general-summary')}
+        title="Cancel Auto Take Profit order summary"
         items={[
           {
-            label: 'Next Stop-Loss trigger price',
+            label: 'Next Dynamic Trigger Price',
             value: parsedSummaryProfits.nextTriggerPrice ? (
               <Text>{parsedSummaryProfits.nextTriggerPrice}</Text>
             ) : (

--- a/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
@@ -442,7 +442,8 @@ export function AaveManagePositionStopLossLambdaSidebar({
   const isDisabled = useMemo(() => {
     if (
       isGettingStopLossTx ||
-      ['addInProgress', 'updateInProgress', 'removeInProgress'].includes(transactionStep)
+      ['addInProgress', 'updateInProgress', 'removeInProgress'].includes(transactionStep) ||
+      errors.length
     ) {
       return true
     }
@@ -450,7 +451,7 @@ export function AaveManagePositionStopLossLambdaSidebar({
       return false
     }
     return !stopLossConfigChanged
-  }, [isGettingStopLossTx, stopLossConfigChanged, transactionStep])
+  }, [isGettingStopLossTx, stopLossConfigChanged, transactionStep, errors.length])
 
   const primaryButtonAction = () => {
     if (transactionStep === 'prepare') {

--- a/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
@@ -462,7 +462,8 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
   const isDisabled = useMemo(() => {
     if (
       isGettingTrailingStopLossTx ||
-      ['addInProgress', 'updateInProgress', 'removeInProgress'].includes(transactionStep)
+      ['addInProgress', 'updateInProgress', 'removeInProgress'].includes(transactionStep) ||
+      errors.length
     ) {
       return true
     }
@@ -472,12 +473,13 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
     if (trailingStopLossTxDataLambda === undefined) {
       return true
     }
-    return !trailingStopLossConfigChanged
+    return !trailingStopLossConfigChanged && !errors.length
   }, [
     isGettingTrailingStopLossTx,
     trailingStopLossConfigChanged,
     transactionStep,
     trailingStopLossTxDataLambda,
+    errors.length,
   ])
 
   const primaryButtonAction = () => {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1828,7 +1828,7 @@
     "stop-loss-triggered-desc": "Your Stop-Loss was triggered on your Vault",
     "stop-loss-triggered-content": "Your stop loss was triggered on your Vault. You can read the fully summary of the Stop-Loss event on the right.",
     "cancel-notice": "Cancelling your Stop-Loss means you will no longer have protection in place and you will need to actively monitor your {{ratioParam}}.",
-    "take-profit-cancel-notice": "This needs copy! Something sad about cancelling take profit :(",
+    "take-profit-cancel-notice": "With this action you will no longer realize profits automatically. Your Stop Loss will remain active.",
     "find-more-about-setting-stop-loss": "Find out more about setting Stop-Loss →",
     "set-stop-loss-again": "Set up Stop-Loss again",
     "sl-triggered-gas-estimation": "This fee represents the expected Gas Cost based on the current price of ETH and an assumed Gas Price of 50 GWEI.",


### PR DESCRIPTION
- Adds a brief summary on the remove trigger view
- Fixes the label on remove trigger view
- Fixes "This needs copy" with a new copy :)
- Errors on SL/TSL now block the action button

This pull request updates the AaveManagePositionPartialTakeProfitLambdaSidebar.tsx and common.json files. It includes changes to the sidebar content, specifically the addition of a cancel summary description for the automation feature. Additionally, the take-profit-cancel-notice message has been updated to provide clearer information about the action's impact.