### PR TITLE
Partial take profit fixes [pt.8]

### DIFF
--- a/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
+++ b/features/aave/manage/sidebars/partial-take-profit-components/PreparingPartialTakeProfitSidebarContent.tsx
@@ -14,7 +14,7 @@ import { lambdaPercentageDenomination } from 'features/aave/constants'
 import { mapErrorsToErrorVaults, mapWarningsToWarningVaults } from 'features/aave/helpers'
 import type { mapPartialTakeProfitFromLambda } from 'features/aave/manage/helpers/map-partial-take-profit-from-lambda'
 import type { AaveLikePartialTakeProfitParamsResult } from 'features/aave/open/helpers/get-aave-like-partial-take-profit-params'
-import type { IStrategyConfig } from 'features/aave/types'
+import { type IStrategyConfig, StrategyType } from 'features/aave/types'
 import { BigNumberInput } from 'helpers/BigNumberInput'
 import { formatAmount, formatCryptoBalance, formatPercent } from 'helpers/formatters/format'
 import { handleNumericInput } from 'helpers/input'
@@ -75,6 +75,8 @@ export const PreparingPartialTakeProfitSidebarContent = ({
 
   const { hasStopLoss, stopLossLevelLabel, trailingStopLossDistanceLabel, currentStopLossLevel } =
     aaveLikePartialTakeProfitLambdaData
+
+  const isShort = strategyConfig.strategyType === StrategyType.Short
 
   const inputMask = useMemo(() => {
     return createNumberMask({
@@ -251,7 +253,10 @@ export const PreparingPartialTakeProfitSidebarContent = ({
         </Text>
       </Box>
       <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-        {partialTakeProfitConfig.takeProfitStartingPercentageOptions.map((percentage) => (
+        {(isShort
+          ? partialTakeProfitConfig.takeProfitStartingPercentageOptionsShort
+          : partialTakeProfitConfig.takeProfitStartingPercentageOptionsLong
+        ).map((percentage) => (
           <Button
             key={percentage.toString()}
             variant="bean"
@@ -276,7 +281,7 @@ export const PreparingPartialTakeProfitSidebarContent = ({
           >
             {percentage === 0
               ? 'current'
-              : `+${formatPercent(new BigNumber(percentage).times(100))}`}
+              : `${isShort ? '' : '+'}${formatPercent(new BigNumber(percentage).times(100))}`}
           </Button>
         ))}
       </Flex>
@@ -578,7 +583,7 @@ export const PreparingPartialTakeProfitSidebarContent = ({
               ? `You already have a Stop-Loss trigger set at${nbsp}${stopLossLevelLabel}. You can update the Stop-Loss LTV above and it all be handled within your Partial Take Profit transaction.`
               : '',
             hasStopLoss && trailingStopLossDistanceLabel
-              ? `You already have a Trailing Stop-Loss trigger set at${nbsp}${trailingStopLossDistanceLabel}.`
+              ? `You already have a Trailing Stop-Loss trigger set at${nbsp}${trailingStopLossDistanceLabel} distance.`
               : '',
             hasStopLoss && currentStopLossLevel && !currentStopLossLevel.eq(newStopLossLtv)
               ? `Your stop-Loss will be updated to a new value: ${formatPercent(newStopLossLtv, {

--- a/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
+++ b/features/aave/open/helpers/get-aave-like-partial-take-profit-params.ts
@@ -16,7 +16,8 @@ import { memoize } from 'lodash'
 import { useMemo, useState } from 'react'
 
 const partialTakeProfitConfig = {
-  takeProfitStartingPercentageOptions: [0, 0.1, 0.2, 0.3, 0.4, 0.5] as const,
+  takeProfitStartingPercentageOptionsLong: [0, 0.1, 0.2, 0.3, 0.4, 0.5] as const,
+  takeProfitStartingPercentageOptionsShort: [0, -0.1, -0.2, -0.3, -0.4, -0.5] as const,
   defaultTriggelLtvOffset: new BigNumber(5),
   defaultWithdrawalLtv: new BigNumber(5),
   ltvSliderStep: 0.1,
@@ -24,7 +25,9 @@ const partialTakeProfitConfig = {
   realizedProfitRangeVisible: 3,
 }
 
-type PercentageOptionsType = typeof partialTakeProfitConfig.takeProfitStartingPercentageOptions
+type PercentageOptionsType =
+  | typeof partialTakeProfitConfig.takeProfitStartingPercentageOptionsLong
+  | typeof partialTakeProfitConfig.takeProfitStartingPercentageOptionsShort
 type ProfitToTokenType = 'debt' | 'collateral'
 type PTPSliderConfig = {
   sliderPercentageFill: BigNumber

--- a/helpers/triggers/setup-triggers/setup-aave-partial-take-profit.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-partial-take-profit.ts
@@ -1,4 +1,4 @@
-import { lambdaPercentageDenomination, lambdaPriceDenomination } from 'features/aave/constants'
+import { lambdaPercentageDenomination } from 'features/aave/constants'
 
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type {
@@ -21,10 +21,7 @@ export const setupAaveLikePartialTakeProfit = async (
         .times(lambdaPercentageDenomination)
         .integerValue()
         .toString(),
-      executionPrice: params.startingTakeProfitPrice
-        .times(lambdaPriceDenomination)
-        .integerValue()
-        .toString(),
+      executionPrice: params.startingTakeProfitPrice.integerValue().toString(),
       stopLoss: params.stopLoss
         ? {
             triggerData: {


### PR DESCRIPTION
This pull request fixes the configuration of the partial take profit feature in the Aave management module. It addresses issues related to the starting take profit price and the percentage options for both long and short strategies. Additionally, it updates the stop-loss level and trailing distance labels.