### PR TITLE
Updating incorrect 'setup' noun to correct 'set up' verb

### DIFF
--- a/features/aave/hooks/useOptimizationSidebarDropdown.tsx
+++ b/features/aave/hooks/useOptimizationSidebarDropdown.tsx
@@ -23,7 +23,7 @@ export function useOptimizationSidebarDropdown(
     forcePanel: currentPanel,
     items: [
       {
-        label: `${hasAaveAutoBuyEnabled || hasSparkAutoBuyEnabled ? 'Manage' : 'Setup'} ${t(
+        label: `${hasAaveAutoBuyEnabled || hasSparkAutoBuyEnabled ? 'Manage' : 'Set up'} ${t(
           'system.basic-buy',
         )}`,
         shortLabel: t('system.basic-buy'),

--- a/features/aave/hooks/useProtectionSidebarDropdown.tsx
+++ b/features/aave/hooks/useProtectionSidebarDropdown.tsx
@@ -43,7 +43,7 @@ export function useProtectionSidebarDropdown(
   }
   if (isStopLossEnabledForStrategy) {
     items.push({
-      label: `${hasStopLoss || hasTrailingStopLoss ? 'Manage' : 'Setup'} ${t('system.stop-loss')}`,
+      label: `${hasStopLoss || hasTrailingStopLoss ? 'Manage' : 'Set up'} ${t('system.stop-loss')}`,
       shortLabel: t('system.stop-loss'),
       iconShrink: 2,
       icon: circle_exchange,
@@ -58,7 +58,7 @@ export function useProtectionSidebarDropdown(
   }
   if (isAutoSellEnabledForStrategy) {
     items.push({
-      label: `${hasActiveAutoSell(state) ? 'Manage' : 'Setup'} ${t('system.basic-sell')}`,
+      label: `${hasActiveAutoSell(state) ? 'Manage' : 'Set up'} ${t('system.basic-sell')}`,
       shortLabel: t('system.basic-sell'),
       iconShrink: 2,
       icon: circle_exchange,

--- a/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
+++ b/features/automation/common/sidebars/getAutoFeaturesSidebarDropdown.ts
@@ -26,7 +26,7 @@ function getAutoFeaturesSidebarDropdownItem({
   const { t } = useTranslation()
 
   return {
-    label: `${t(isFeatureEnabled ? 'manage' : 'setup')} ${t(translationKey)}`,
+    label: `${t(isFeatureEnabled ? 'manage' : 'set up')} ${t(translationKey)}`,
     shortLabel: t(translationKey),
     iconShrink: 2,
     icon: circle_exchange,

--- a/features/dsr/utils/helpers.ts
+++ b/features/dsr/utils/helpers.ts
@@ -34,7 +34,7 @@ export function createPrimaryButtonLabel({
   if (stage === 'proxySuccess') return 'Set Allowance'
   if (activeTab === 'withdraw') return 'Withdraw'
   if (activeTab === 'convert') return 'Convert'
-  if (depositInputValue && !proxyAddress && !isMintingSDai) return 'Setup Proxy'
+  if (depositInputValue && !proxyAddress && !isMintingSDai) return 'Set up Proxy'
   if (stage === 'allowanceSuccess') return 'Go to deposit'
   if (
     (depositInputValue &&

--- a/features/omni-kit/controllers/OmniLayoutController.tsx
+++ b/features/omni-kit/controllers/OmniLayoutController.tsx
@@ -94,7 +94,7 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
         sections={[
           {
             value: isOpening ? 'setup' : 'overview',
-            label: t(isOpening ? 'setup' : 'system.overview'),
+            label: t(isOpening ? 'set up' : 'system.overview'),
             content: (
               <Grid variant="vaultContainer">
                 <OmniOverviewController />


### PR DESCRIPTION
# ['Setup' noun incorrectly used instead of 'Set up' verb](https://app.shortcut.com/oazo-apps/story/14629/bug-setup-noun-incorrectly-used-instead-of-set-up-verb#activity-14754)

## Changes 👷‍♀️
![Screenshot 2024-03-11 at 09 50 51](https://github.com/OasisDEX/oasis-borrow/assets/139757623/7cefed6d-c0cc-438c-8e93-1bae33fd3ffd)
