### PR TITLE
Add getLocalAppConfig import and use it to set shouldSkipValidation header

### DIFF
--- a/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionPartialTakeProfitLambdaSidebar.tsx
@@ -214,6 +214,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
   }
 
   const frontendErrors = useMemo(() => {
+    const validationDisabled = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
     const currentLtvValue = currentLtv.times(lambdaPercentageDenomination)
     const triggerLtvTooHigh = triggerLtv.gt(currentLtvValue.plus(triggerLtvSliderConfig.step))
     const cumulativeLtvTooHight = triggerLtv
@@ -238,6 +239,7 @@ export function AaveManagePositionPartialTakeProfitLambdaSidebar({
       isShort &&
         startingTakeProfitPriceTooHigh &&
         'Starting take profit price should be lower or equal the current price.',
+      validationDisabled && 'Validation is disabled, you are proceeding on your own risk.',
     ].filter(Boolean) as string[]
   }, [
     currentLtv,

--- a/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionStopLossLambdaSidebar.tsx
@@ -194,6 +194,13 @@ export function AaveManagePositionStopLossLambdaSidebar({
   }
   const [leftFormatter, rightFormatter] = getFormatters(strategyConfig)
 
+  const frontendErrors = useMemo(() => {
+    const validationDisabled = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
+    return [
+      validationDisabled && 'Validation is disabled, you are proceeding on your own risk.',
+    ].filter(Boolean) as string[]
+  }, [])
+
   const sidebarPreparingContent: SidebarSectionProps['content'] = (
     <Grid gap={3}>
       <ActionPills
@@ -280,6 +287,11 @@ export function AaveManagePositionStopLossLambdaSidebar({
         />
       )}
       <>
+        <MessageCard
+          type="error"
+          messages={frontendErrors}
+          withBullet={frontendErrors.length > 1}
+        />
         <VaultErrors errorMessages={mapErrorsToErrorVaults(errors)} autoType="Stop-Loss" />
         <VaultWarnings warningMessages={mapWarningsToWarningVaults(warnings)} />
       </>

--- a/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
+++ b/features/aave/manage/sidebars/AaveManagePositionTrailingStopLossLambdaSidebar.tsx
@@ -216,6 +216,12 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
     }
     return null
   }
+  const frontendErrors = useMemo(() => {
+    const validationDisabled = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
+    return [
+      validationDisabled && 'Validation is disabled, you are proceeding on your own risk.',
+    ].filter(Boolean) as string[]
+  }, [])
 
   const stopLossInformationPanel = (
     <DimmedList>
@@ -305,6 +311,11 @@ export function AaveManagePositionTrailingStopLossLambdaSidebar({
         rightLabel={t('slider.set-stoploss.right-label')}
       />
       <>
+        <MessageCard
+          type="error"
+          messages={frontendErrors}
+          withBullet={frontendErrors.length > 1}
+        />
         <VaultErrors errorMessages={mapErrorsToErrorVaults(errors)} autoType="Stop-Loss" />
         <VaultWarnings warningMessages={mapWarningsToWarningVaults(warnings)} />
       </>

--- a/helpers/triggers/setup-triggers/setup-aave-auto-buy.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-auto-buy.ts
@@ -1,3 +1,5 @@
+import { getLocalAppConfig } from 'helpers/config'
+
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type { SetupAaveBasicAutomationParams, SetupBasicAutoResponse } from './setup-triggers-types'
 import { TriggersApiErrorCode } from './setup-triggers-types'
@@ -6,6 +8,7 @@ export const setupAaveAutoBuy = async (
   params: SetupAaveBasicAutomationParams,
 ): Promise<SetupBasicAutoResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'auto-buy' })
+  const shouldSkipValidation = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
 
   const body = JSON.stringify({
     dpm: params.dpm,
@@ -28,6 +31,11 @@ export const setupAaveAutoBuy = async (
   try {
     response = await fetch(url, {
       method: 'POST',
+      headers: shouldSkipValidation
+        ? {
+            'x-summer-skip-validation': '1',
+          }
+        : undefined,
       body: body,
     })
   } catch (error) {

--- a/helpers/triggers/setup-triggers/setup-aave-auto-sell.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-auto-sell.ts
@@ -1,3 +1,5 @@
+import { getLocalAppConfig } from 'helpers/config'
+
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type { SetupAaveBasicAutomationParams, SetupBasicAutoResponse } from './setup-triggers-types'
 import { TriggersApiErrorCode } from './setup-triggers-types'
@@ -6,6 +8,7 @@ export const setupAaveAutoSell = async (
   params: SetupAaveBasicAutomationParams,
 ): Promise<SetupBasicAutoResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'auto-sell' })
+  const shouldSkipValidation = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
 
   const body = JSON.stringify({
     dpm: params.dpm,
@@ -28,6 +31,11 @@ export const setupAaveAutoSell = async (
   try {
     response = await fetch(url, {
       method: 'POST',
+      headers: shouldSkipValidation
+        ? {
+            'x-summer-skip-validation': '1',
+          }
+        : undefined,
       body: body,
     })
   } catch (error) {

--- a/helpers/triggers/setup-triggers/setup-aave-partial-take-profit.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-partial-take-profit.ts
@@ -1,4 +1,5 @@
 import { lambdaPercentageDenomination } from 'features/aave/constants'
+import { getLocalAppConfig } from 'helpers/config'
 
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type {
@@ -11,6 +12,7 @@ export const setupAaveLikePartialTakeProfit = async (
   params: SetupAavePartialTakeProfitParams,
 ): Promise<SetupPartialTakeProfitResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'dma-partial-take-profit' })
+  const shouldSkipValidation = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
 
   const body = JSON.stringify({
     dpm: params.dpm,
@@ -48,6 +50,11 @@ export const setupAaveLikePartialTakeProfit = async (
   try {
     response = await fetch(url, {
       method: 'POST',
+      headers: shouldSkipValidation
+        ? {
+            'x-summer-skip-validation': '1',
+          }
+        : undefined,
       body: body,
     })
   } catch (error) {

--- a/helpers/triggers/setup-triggers/setup-aave-stop-loss.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-stop-loss.ts
@@ -1,4 +1,5 @@
 import { lambdaPercentageDenomination } from 'features/aave/constants'
+import { getLocalAppConfig } from 'helpers/config'
 
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type {
@@ -12,6 +13,7 @@ export const setupAaveLikeStopLoss = async (
   params: SetupAaveStopLossParams,
 ): Promise<SetupBasicStopLossResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'dma-stop-loss' })
+  const shouldSkipValidation = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
 
   const body = JSON.stringify({
     dpm: params.dpm,
@@ -34,6 +36,11 @@ export const setupAaveLikeStopLoss = async (
   try {
     response = await fetch(url, {
       method: 'POST',
+      headers: shouldSkipValidation
+        ? {
+            'x-summer-skip-validation': '1',
+          }
+        : undefined,
       body: body,
     })
   } catch (error) {

--- a/helpers/triggers/setup-triggers/setup-aave-trailing-stop-loss.ts
+++ b/helpers/triggers/setup-triggers/setup-aave-trailing-stop-loss.ts
@@ -1,4 +1,5 @@
 import { lambdaPriceDenomination } from 'features/aave/constants'
+import { getLocalAppConfig } from 'helpers/config'
 
 import { getSetupTriggerConfig } from './get-setup-trigger-config'
 import type {
@@ -11,6 +12,7 @@ export const setupAaveLikeTrailingStopLoss = async (
   params: SetupAaveTrailingStopLossParams,
 ): Promise<SetupTrailingStopLossResponse> => {
   const { url, customRpc } = getSetupTriggerConfig({ ...params, path: 'dma-trailing-stop-loss' })
+  const shouldSkipValidation = getLocalAppConfig('features').AaveV3LambdaSuppressValidation
 
   const body = JSON.stringify({
     dpm: params.dpm,
@@ -33,6 +35,11 @@ export const setupAaveLikeTrailingStopLoss = async (
   try {
     response = await fetch(url, {
       method: 'POST',
+      headers: shouldSkipValidation
+        ? {
+            'x-summer-skip-validation': '1',
+          }
+        : undefined,
       body: body,
     })
   } catch (error) {


### PR DESCRIPTION
This pull request adds an import for the `getLocalAppConfig` function and uses it to set the `shouldSkipValidation` header in the `setupAaveLikePartialTakeProfit` function. This allows for conditional skipping of validation based on the local app configuration.

If validation is suppressed there is an error informing that the user proceeds at its own risk.