### PR TITLE
Change realized profit to wallet mapping to include actual eth/weth tokens

### DIFF
--- a/features/aave/components/AavePartialTakeProfitManageDetails.tsx
+++ b/features/aave/components/AavePartialTakeProfitManageDetails.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { ethNullAddress } from 'blockchain/networks'
 import { ActionPills } from 'components/ActionPills'
 import { DetailsSection } from 'components/DetailsSection'
 import { DetailsSectionContentCardWrapper } from 'components/DetailsSectionContentCard'
@@ -40,40 +41,47 @@ type AavePartialTakeProfitManageDetailsProps = {
 }
 
 const reduceHistoryEvents = (events: AavePartialTakeProfitManageDetailsProps['historyEvents']) => {
+  const eventsDefault = {
+    collateralToken: zero,
+    debtToken: zero,
+  } as const
   return (
     events
       // example: "AutomationExecuted-DmaAavePartialTakeProfitV2"
       .filter(({ kind }) => kind?.includes('PartialTakeProfit'))
       .filter(({ kind }) => kind?.includes('AutomationExecuted'))
-      .reduce(
-        (acc, event) => {
-          if (!event.withdrawTransfers?.length) {
-            return acc
-          }
-          const newTransfersRealized = { ...acc }
-          event.withdrawTransfers?.forEach((transfer) => {
-            if (!transfer.amount.isZero()) {
-              const isCollateralTokenTransfer = transfer.token === event.collateralAddress
-              const isDebtTokenTransfer = transfer.token === event.debtAddress
-              if (isCollateralTokenTransfer) {
-                newTransfersRealized.collateralToken = newTransfersRealized.collateralToken.plus(
-                  new BigNumber(transfer.amount),
-                )
-              }
-              if (isDebtTokenTransfer) {
-                newTransfersRealized.debtToken = newTransfersRealized.debtToken.plus(
-                  new BigNumber(transfer.amount),
-                )
-              }
+      .reduce((acc, event) => {
+        if (!event.withdrawTransfers?.length) {
+          return acc
+        }
+        const newTransfersRealized = { ...acc }
+        event.withdrawTransfers?.forEach((transfer) => {
+          if (!transfer.amount.isZero() && event.collateralAddress && event.debtAddress) {
+            const collateralTokenAddress =
+              event.collateralToken === 'WETH'
+                ? ethNullAddress.toLocaleLowerCase()
+                : event.collateralAddress.toLocaleLowerCase()
+            const debtTokenAddress =
+              event.debtToken === 'WETH'
+                ? ethNullAddress.toLocaleLowerCase()
+                : event.debtAddress.toLocaleLowerCase()
+            const isCollateralTokenTransfer =
+              transfer.token.toLocaleLowerCase() === collateralTokenAddress
+            const isDebtTokenTransfer = transfer.token.toLocaleLowerCase() === debtTokenAddress
+            if (isCollateralTokenTransfer) {
+              newTransfersRealized.collateralToken = newTransfersRealized.collateralToken.plus(
+                new BigNumber(transfer.amount),
+              )
             }
-          })
-          return newTransfersRealized
-        },
-        {
-          collateralToken: zero,
-          debtToken: zero,
-        } as const,
-      ) as Record<'debtToken' | 'collateralToken', BigNumber>
+            if (isDebtTokenTransfer) {
+              newTransfersRealized.debtToken = newTransfersRealized.debtToken.plus(
+                new BigNumber(transfer.amount),
+              )
+            }
+          }
+        })
+        return newTransfersRealized
+      }, eventsDefault) as Record<'debtToken' | 'collateralToken', BigNumber>
   )
 }
 


### PR DESCRIPTION
This pull request updates the code to include actual eth/weth tokens in the mapping for the realized profit to wallet. It also refactors the reduceHistoryEvents function to handle different token addresses for collateral and debt tokens.