### PR TITLE
Automation step reset on tab and sidebar change

### DIFF
--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -156,8 +156,8 @@ export function TabBar({
               tag={section.tag}
               variant={variant}
               onClick={() => {
-                section.callback && section.callback()
                 setHash(section.value)
+                section.callback && section.callback()
               }}
             />
           ))}

--- a/features/omni-kit/automation/controllers/OmniAutomationFormController.tsx
+++ b/features/omni-kit/automation/controllers/OmniAutomationFormController.tsx
@@ -12,7 +12,8 @@ export function OmniAutomationFormController({ txHandler }: { txHandler: () => (
   const { t } = useTranslation()
   const {
     environment: { isOpening, productType },
-    automationSteps: { currentStep },
+    automationSteps: { currentStep, setStep },
+    tx: { isTxInProgress },
   } = useOmniGeneralContext()
   const {
     automation: { automationForm },
@@ -32,6 +33,7 @@ export function OmniAutomationFormController({ txHandler }: { txHandler: () => (
         iconShrink: 2,
         action: () => {
           automationForm.dispatch({ type: 'reset' })
+          !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
           automationForm.updateState(
             'uiDropdownOptimization',
             AutomationFeatures.PARTIAL_TAKE_PROFIT,
@@ -46,6 +48,7 @@ export function OmniAutomationFormController({ txHandler }: { txHandler: () => (
         iconShrink: 2,
         action: () => {
           automationForm.dispatch({ type: 'reset' })
+          !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
           automationForm.updateState('uiDropdownOptimization', AutomationFeatures.AUTO_BUY)
         },
       },
@@ -59,6 +62,7 @@ export function OmniAutomationFormController({ txHandler }: { txHandler: () => (
         iconShrink: 2,
         action: () => {
           automationForm.dispatch({ type: 'reset' })
+          !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
           automationForm.updateState('uiDropdownProtection', AutomationFeatures.TRAILING_STOP_LOSS)
         },
       },
@@ -70,6 +74,7 @@ export function OmniAutomationFormController({ txHandler }: { txHandler: () => (
         iconShrink: 2,
         action: () => {
           automationForm.dispatch({ type: 'reset' })
+          !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
           automationForm.updateState('uiDropdownProtection', AutomationFeatures.STOP_LOSS)
         },
       },
@@ -81,6 +86,7 @@ export function OmniAutomationFormController({ txHandler }: { txHandler: () => (
         iconShrink: 2,
         action: () => {
           automationForm.dispatch({ type: 'reset' })
+          !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
           automationForm.updateState('uiDropdownProtection', AutomationFeatures.AUTO_SELL)
         },
       },

--- a/features/omni-kit/controllers/OmniLayoutController.tsx
+++ b/features/omni-kit/controllers/OmniLayoutController.tsx
@@ -20,7 +20,7 @@ import { OmniEarnFormController } from 'features/omni-kit/controllers/earn'
 import { OmniMultiplyFormController } from 'features/omni-kit/controllers/multiply'
 import { getOmniHeadlineProps } from 'features/omni-kit/helpers'
 import { isPoolSupportingMultiply } from 'features/omni-kit/protocols/ajna/helpers'
-import { OmniProductType } from 'features/omni-kit/types'
+import { OmniProductType, OmniSidebarAutomationStep } from 'features/omni-kit/types'
 import { useAppConfig } from 'helpers/config'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { hasCommonElement } from 'helpers/hasCommonElement'
@@ -59,6 +59,8 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
       isYieldLoop,
       settings,
     },
+    tx: { isTxInProgress },
+    automationSteps,
   } = useOmniGeneralContext()
   const {
     position: {
@@ -171,6 +173,9 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
                   ? [
                       {
                         value: 'protection',
+                        callback: !isTxInProgress
+                          ? () => automationSteps.setStep(OmniSidebarAutomationStep.Manage)
+                          : undefined,
                         tag: {
                           include: true,
                           active: hasActiveProtection(positionTriggers, protocol),
@@ -191,6 +196,9 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
                   ? [
                       {
                         value: 'optimization',
+                        callback: !isTxInProgress
+                          ? () => automationSteps.setStep(OmniSidebarAutomationStep.Manage)
+                          : undefined,
                         tag: {
                           include: true,
                           active: hasActiveOptimization(positionTriggers, protocol),

--- a/features/omni-kit/controllers/OmniOptimizationOverviewController.tsx
+++ b/features/omni-kit/controllers/OmniOptimizationOverviewController.tsx
@@ -5,6 +5,7 @@ import {
   OmniPartialTakeProfitOverviewDetailsSection,
 } from 'features/omni-kit/automation/components'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
+import { OmniSidebarAutomationStep } from 'features/omni-kit/types'
 import type { FC } from 'react'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -12,6 +13,8 @@ import { Grid } from 'theme-ui'
 export const OmniOptimizationOverviewController: FC = () => {
   const {
     environment: { productType, settings, networkId },
+    automationSteps: { setStep },
+    tx: { isTxInProgress },
   } = useOmniGeneralContext()
   const {
     dynamicMetadata: {
@@ -49,16 +52,20 @@ export const OmniOptimizationOverviewController: FC = () => {
         state.uiDropdownOptimization !== AutomationFeatures.PARTIAL_TAKE_PROFIT &&
         !isPartialTakeProfitEnabled && (
           <PartialTakeProfitBanner
-            buttonClicked={() =>
+            buttonClicked={() => {
+              !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
               updateState('uiDropdownOptimization', AutomationFeatures.PARTIAL_TAKE_PROFIT)
-            }
+            }}
           />
         )}
       {availableAutomations?.includes(AutomationFeatures.AUTO_BUY) &&
         state.uiDropdownOptimization !== AutomationFeatures.AUTO_BUY &&
         !isAutoBuyEnabled && (
           <AutoBuyBanner
-            buttonClicked={() => updateState('uiDropdownOptimization', AutomationFeatures.AUTO_BUY)}
+            buttonClicked={() => {
+              !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
+              updateState('uiDropdownOptimization', AutomationFeatures.AUTO_BUY)
+            }}
           />
         )}
     </Grid>

--- a/features/omni-kit/controllers/OmniProtectionOverviewController.tsx
+++ b/features/omni-kit/controllers/OmniProtectionOverviewController.tsx
@@ -10,6 +10,7 @@ import {
   OmniTrailingStopLossOverviewDetailsSection,
 } from 'features/omni-kit/automation/components'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
+import { OmniSidebarAutomationStep } from 'features/omni-kit/types'
 import type { FC } from 'react'
 import React from 'react'
 import { Grid } from 'theme-ui'
@@ -17,6 +18,8 @@ import { Grid } from 'theme-ui'
 export const OmniProtectionOverviewController: FC = () => {
   const {
     environment: { productType, settings, networkId },
+    automationSteps: { setStep },
+    tx: { isTxInProgress },
   } = useOmniGeneralContext()
   const {
     dynamicMetadata: {
@@ -58,36 +61,32 @@ export const OmniProtectionOverviewController: FC = () => {
         state.uiDropdownProtection !== AutomationFeatures.AUTO_SELL &&
         !isAutoSellEnabled && (
           <AutoSellBanner
-            buttonClicked={() => updateState('uiDropdownProtection', AutomationFeatures.AUTO_SELL)}
+            buttonClicked={() => {
+              !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
+              updateState('uiDropdownProtection', AutomationFeatures.AUTO_SELL)
+            }}
           />
         )}
       {availableAutomations?.includes(AutomationFeatures.STOP_LOSS) &&
         state.uiDropdownProtection !== AutomationFeatures.STOP_LOSS &&
         !isStopLossEnabled && (
           <StopLossBanner
-            buttonClicked={() => updateState('uiDropdownProtection', AutomationFeatures.STOP_LOSS)}
+            buttonClicked={() => {
+              !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
+              updateState('uiDropdownProtection', AutomationFeatures.STOP_LOSS)
+            }}
           />
         )}
       {availableAutomations?.includes(AutomationFeatures.TRAILING_STOP_LOSS) &&
         state.uiDropdownProtection !== AutomationFeatures.TRAILING_STOP_LOSS &&
         !isTrailingStopLossEnabled && (
           <TrailingStopLossBanner
-            buttonClicked={() =>
+            buttonClicked={() => {
+              !isTxInProgress && setStep(OmniSidebarAutomationStep.Manage)
               updateState('uiDropdownProtection', AutomationFeatures.TRAILING_STOP_LOSS)
-            }
+            }}
           />
         )}
-      {/*{state.uiDropdown === AutomationFeatures.STOP_LOSS &&*/}
-      {/*  !protectionControlUI.trailingStopLoss.banner && (*/}
-      {/*    <StopLossBanner buttonClicked={goToView('stop-loss')} />*/}
-      {/*  )}*/}
-      {/*{state.uiDropdown === AutomationFeatures.TRAILING_STOP_LOSS &&*/}
-      {/*  !protectionControlUI.stopLoss.banner && (*/}
-      {/*    <TrailingStopLossBanner buttonClicked={goToView('trailing-stop-loss')} />*/}
-      {/*  )}*/}
-      {/*{state.uiDropdown === AutomationFeatures.STOP_LOSS && protectionControlUI.trailingStopLoss.banner && (*/}
-      {/*  <StopLossBanner buttonClicked={goToView('stop-loss-selector')} />*/}
-      {/*)}*/}
     </Grid>
   )
 }


### PR DESCRIPTION
# Automation step reset on tab and sidebar change

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- handle resetting from transaction to manage step if user switch automation sidebars or tabs when tx is not in progress
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
