### PR TITLE
feat: [sc-14820] [FE] Integrate Claims & Rewards functions

### DIFF
--- a/blockchain/prices.constants.ts
+++ b/blockchain/prices.constants.ts
@@ -1,21 +1,19 @@
 import type { Observable } from 'rxjs'
 import { timer } from 'rxjs'
-import { ajax } from 'rxjs/ajax'
-import { map, shareReplay, switchMap } from 'rxjs/operators'
+import { shareReplay, switchMap } from 'rxjs/operators'
 
 import type { Tickers } from './prices.types'
 
+export function tokenPrices(): Promise<Tickers> {
+  return fetch('/api/tokensPrices', {
+    headers: {
+      Accept: 'application/json',
+    },
+  }).then((response) => response.json())
+}
+
 export const tokenPrices$: Observable<Tickers> = timer(0, 1000 * 60).pipe(
-  switchMap(() =>
-    ajax({
-      url: `/api/tokensPrices`,
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-      },
-    }),
-  ),
-  map(({ response }) => response),
+  switchMap(() => tokenPrices()),
   shareReplay(1),
 )
 export const DSVALUE_APPROX_SIZE = 6000

--- a/features/omni-kit/protocols/erc-4626/components/Erc4626ApyTooltip.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/Erc4626ApyTooltip.tsx
@@ -63,7 +63,7 @@ export const Erc4626ApyTooltip: FC<Erc4626ApyTooltipProps> = ({ rewardsApy, vaul
           token={token}
           {...(per1kUsd && {
             footnote: t('erc-4626.position-page.common.per-1k-usd', {
-              amount: per1kUsd.dp(0, BigNumber.ROUND_HALF_EVEN),
+              amount: per1kUsd.dp(2, BigNumber.ROUND_HALF_EVEN),
               token,
             }),
           })}

--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626ApyParameters.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626ApyParameters.ts
@@ -6,25 +6,84 @@ type GetErc4626ApyParametersResponse = ReturnType<
   Parameters<typeof views.common.getErc4626Position>[1]['getVaultApyParameters']
 >
 
-export async function getErc4626ApyParameters(): GetErc4626ApyParametersResponse {
-  return new Promise((resolve) =>
-    resolve({
-      vault: {
-        apy: '0.0175',
-        curator: 'Steakhouse',
-        fee: '0.05',
-      },
-      apyFromRewards: [
-        {
-          token: 'WSTETH',
-          value: '0.0125',
-        },
-        {
-          token: 'MORPHO',
-          value: '0.025',
-          per1kUsd: '250',
-        },
-      ],
-    }),
+interface RewardToken {
+  address: string
+  symbol: string
+  decimals: number
+  amountWei: string
+  humanReadable: string
+  apy: number
+}
+
+interface RewardsByMarket {
+  market: {
+    marketId: string
+    collateral: {
+      address: string
+      symbol: string
+      decimals: number
+      priceUsd: number | undefined
+    }
+    suppliedAssets: string
+    suppliedAssetsHumanReadable: string
+    allocation: number
+    liquidationLtv: number
+  }
+  tokens: RewardToken[]
+}
+
+interface GetRewardsResponse {
+  metaMorpho: {
+    address: string
+    weeklyApy: number
+    monthlyApy: number
+    dailyApy: number
+    apy: number
+    fee: number
+    totalAssets: string
+  }
+  rewardsByMarket: RewardsByMarket[]
+  rewardsByToken: RewardToken[]
+}
+
+export async function getErc4626ApyParameters(
+  vaultAddress: string,
+): GetErc4626ApyParametersResponse {
+  // TODO: Pass proper prices
+  const response = await fetch(
+    `/api/morpho/meta-morpho?address=${vaultAddress}&morhoPrice=1&wsEthPrice=4500`,
   )
+
+  if (response.status !== 200) {
+    console.warn('Failed to fetch vault details', response)
+    return {
+      vault: {
+        apy: '0',
+        curator: 'Steakhouse',
+        fee: '0',
+      },
+      apyFromRewards: [],
+      allocations: [],
+    }
+  }
+  const data = (await response.json()) as GetRewardsResponse
+  return {
+    vault: {
+      apy: data.metaMorpho.apy.toString(),
+      curator: 'Steakhouse',
+      fee: data.metaMorpho.fee.toString(),
+    },
+    apyFromRewards: data.rewardsByToken.map((token) => {
+      return {
+        token: token.symbol.toUpperCase(),
+        value: token.apy.toString(),
+        per1kUsd: token.humanReadable.toString(),
+      }
+    }),
+    allocations: data.rewardsByMarket.map((market) => ({
+      token: market.market.collateral.symbol.toUpperCase(),
+      supply: market.market.suppliedAssetsHumanReadable,
+      riskRatio: market.market.liquidationLtv.toString(),
+    })),
+  }
 }

--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626ApyParameters.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626ApyParameters.ts
@@ -1,4 +1,5 @@
 import type { views } from '@oasisdex/dma-library'
+import { tokenPrices } from 'blockchain/prices.constants'
 
 // TODO: entire file is a mock
 
@@ -49,9 +50,11 @@ interface GetRewardsResponse {
 export async function getErc4626ApyParameters(
   vaultAddress: string,
 ): GetErc4626ApyParametersResponse {
-  // TODO: Pass proper prices
+  const prices = await tokenPrices()
+  const wstETHPrice = prices['wsteth']
+  // TODO: Pass Morhpo price
   const response = await fetch(
-    `/api/morpho/meta-morpho?address=${vaultAddress}&morhoPrice=1&wsEthPrice=4500`,
+    `/api/morpho/meta-morpho?address=${vaultAddress}&morhoPrice=1&wsEthPrice=${wstETHPrice}`,
   )
 
   if (response.status !== 200) {

--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626Claims.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626Claims.ts
@@ -1,0 +1,86 @@
+import type { MorphoCloseClaimRewardsPayload } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
+
+interface GetErc4626ClaimsParams {
+  account: string
+  user: string
+}
+
+interface Erc4626Claims {
+  actionPayload: MorphoCloseClaimRewardsPayload
+  claims: {
+    token: string
+    earned: BigNumber
+    claimable: BigNumber
+  }[]
+}
+
+export interface MorphoClaimedReward {
+  urd: string
+  reward: string
+  rewardSymbol: string
+  amount: bigint
+}
+
+export interface MorphoAggregatedClaims {
+  rewardToken: {
+    address: string
+    symbol: string
+    decimals: number
+  }
+  claimable: bigint
+  claimed: bigint
+  total: bigint
+}
+
+export interface MorphoClaims {
+  claimable: {
+    urd: string
+    reward: string
+    claimable: bigint
+    proof: string[]
+  }[]
+  claimed: MorphoClaimedReward[]
+  claimsAggregated: MorphoAggregatedClaims[]
+}
+
+export async function getErc4626Claims({
+  account,
+}: GetErc4626ClaimsParams): Promise<Erc4626Claims> {
+  const claimsResponse = await fetch(`/api/morpho/claims?account=${account}`)
+
+  if (claimsResponse.status !== 200) {
+    console.warn('Failed to fetch claims', claimsResponse)
+    return {
+      actionPayload: {
+        claimable: [],
+        proofs: [],
+        urds: [],
+        rewards: [],
+      },
+      claims: [],
+    }
+  }
+
+  const claims = (await claimsResponse.json()) as MorphoClaims
+
+  const actionPayload: MorphoCloseClaimRewardsPayload = {
+    claimable: claims.claimable.map((claim) => new BigNumber(claim.claimable.toString())),
+    proofs: claims.claimable.map((claim) => claim.proof),
+    urds: claims.claimable.map((claim) => claim.urd),
+    rewards: claims.claimed.map((claim) => claim.reward),
+  }
+
+  const displayClaims = claims.claimsAggregated.map((claim) => {
+    return {
+      token: claim.rewardToken.symbol.toUpperCase(),
+      earned: new BigNumber(claim.claimable.toString()).shiftedBy(-claim.rewardToken.decimals),
+      claimable: new BigNumber(claim.claimed.toString()).shiftedBy(-claim.rewardToken.decimals),
+    }
+  })
+
+  return {
+    actionPayload,
+    claims: displayClaims,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.49",
     "@oasisdex/automation": "1.6.4-alpha.2",
-    "@oasisdex/dma-library": "0.6.34",
+    "@oasisdex/dma-library": "0.6.35",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/server/rewrites.ts
+++ b/server/rewrites.ts
@@ -14,6 +14,10 @@ const rewriteRules = () => [
     source: '/api/migrations',
     destination: `${process.env.FUNCTIONS_API_URL}/api/migrations`,
   },
+  {
+    source: '/api/morpho/:path*',
+    destination: `${process.env.FUNCTIONS_API_URL}/api/morpho/:path*`,
+  },
   // ... other rules
 ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.34":
-  version "0.6.34"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.34.tgz#29ce8a186562713395066a455d32bfe0befa58ab"
-  integrity sha512-kAc5dr4kxVI2Yo5Tfm1wm32GuI/y/8zqGr86cbaLXCRBj1MNsZaFTBis3xDYHsewH5zjQuZM9aMFpjpO9BZekw==
+"@oasisdex/dma-library@0.6.35":
+  version "0.6.35"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.35.tgz#540dc9e38d3799c7ea5761f95566bc438e5648af"
+  integrity sha512-6kfxP6orUjvWKnctuOsmja9ixKx2rlEZWnI9OF5VlJdWUlPjraX1/IXbVa9F5b0kxJqMe7h10vWu5i0yLiWOUQ==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14820

The getErc4626ApyParameters function is refactored to incorporate new interfaces and fetch real-time data over hardcoded values. This refactoring enriches the response data handling various reward tokens and market situations. Alongside, a rewrite rule is added to the server configuration, redirecting '/api/morpho' requests to the correct API URL.

Updated the function fetching token prices in prices.constants.ts to use the Fetch API instead of ajax from rxjs. This also involves updating the "@oasisdex/dma-library" to version 0.6.35 and adjusting the getErc4626ApyParameters function to work with the real token prices data. Additionally, a new getErc4626Claims helper function was introduced for fetching claim details.
