### PR TITLE
fix: [sc-14861] [BUG] - Spark position returning 'Page not found'

### DIFF
--- a/features/aave/services/read-position-created-events.ts
+++ b/features/aave/services/read-position-created-events.ts
@@ -105,11 +105,12 @@ export function extractLendingProtocolFromPositionCreatedEvent(
     case 'MorphoBlue':
       return LendingProtocol.MorphoBlue
     default:
-      throw new Error(
+      console.warn(
         `Unrecognised protocol received from positionCreatedChainEvent ${JSON.stringify(
           positionCreatedChainEvent,
         )}`,
       )
+      return LendingProtocol.Unknown
   }
 }
 

--- a/lendingProtocols/LendingProtocol.ts
+++ b/lendingProtocols/LendingProtocol.ts
@@ -5,6 +5,7 @@ export enum LendingProtocol {
   Maker = 'maker',
   MorphoBlue = 'morphoblue',
   SparkV3 = 'sparkv3',
+  Unknown = 'unknown',
 }
 
 export enum LendingProtocolLabel {


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14861

In the event of an unrecognised lending protocol, the code will not throw an error but instead log a warning message. A new case 'Unknown' has been added to LendingProtocol to give a default value for this scenario.