### PR TITLE
ERC-4626 rewards tokens market cap config

### DIFF
--- a/features/omni-kit/protocols/erc-4626/components/Erc4626ApyTooltip.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/Erc4626ApyTooltip.tsx
@@ -1,8 +1,8 @@
-import BigNumber from 'bignumber.js'
+import type BigNumber from 'bignumber.js'
 import { Icon } from 'components/Icon'
 import { TokensGroup } from 'components/TokensGroup'
 import type { GetErc4626ApyParams } from 'features/omni-kit/protocols/erc-4626/helpers'
-import { formatDecimalAsPercent } from 'helpers/formatters/format'
+import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
 import { useTranslation } from 'next-i18next'
 import type { FC } from 'react'
 import React from 'react'
@@ -63,7 +63,7 @@ export const Erc4626ApyTooltip: FC<Erc4626ApyTooltipProps> = ({ rewardsApy, vaul
           token={token}
           {...(per1kUsd && {
             footnote: t('erc-4626.position-page.common.per-1k-usd', {
-              amount: per1kUsd.dp(2, BigNumber.ROUND_HALF_EVEN),
+              amount: formatCryptoBalance(per1kUsd),
               token,
             }),
           })}

--- a/features/omni-kit/protocols/erc-4626/components/details-section/Erc4626DetailsSectionContentEstimationLoader.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/details-section/Erc4626DetailsSectionContentEstimationLoader.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from 'components/Skeleton'
+import type { FC } from 'react'
+import React from 'react'
+import { Flex } from 'theme-ui'
+
+export const Erc4626DetailsSectionContentEstimationLoader: FC = () => {
+  return (
+    <Flex sx={{ justifyContent: 'flex-end' }}>
+      <Skeleton width="100px" sx={{ mt: '3px' }} />
+    </Flex>
+  )
+}

--- a/features/omni-kit/protocols/erc-4626/components/details-section/index.ts
+++ b/features/omni-kit/protocols/erc-4626/components/details-section/index.ts
@@ -1,4 +1,5 @@
 export * from './Erc4626DetailsSectionContent'
 export * from './Erc4626DetailsSectionContentAllocation'
 export * from './Erc4626DetailsSectionContentEstimatedEarnings'
+export * from './Erc4626DetailsSectionContentEstimationLoader'
 export * from './Erc4626DetailsSectionFooter'

--- a/features/omni-kit/protocols/erc-4626/components/sidebar/Erc4626EstimatedMarketCap.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/sidebar/Erc4626EstimatedMarketCap.tsx
@@ -1,29 +1,36 @@
+import BigNumber from 'bignumber.js'
 import type { ActionPillsItem } from 'components/ActionPills'
 import { ActionPills } from 'components/ActionPills'
 import { TokensGroup } from 'components/TokensGroup'
 import { useErc4626CustomState } from 'features/omni-kit/protocols/erc-4626/contexts'
-import { erc4626EstimatedMarketCaps } from 'features/omni-kit/protocols/erc-4626/settings'
+import type { Erc4626PricePicker } from 'features/omni-kit/protocols/erc-4626/types'
 import { formatUsdValue } from 'helpers/formatters/format'
 import { Trans } from 'next-i18next'
 import type { FC } from 'react'
 import React from 'react'
 import { Box, Text } from 'theme-ui'
 
-interface Erc4626EstimatedMarketCapProps {
-  token: string
+interface Erc4626EstimatedMarketPriceProps {
+  pricePicker: Erc4626PricePicker
 }
 
-export const Erc4626EstimatedMarketCap: FC<Erc4626EstimatedMarketCapProps> = ({ token }) => {
+export const Erc4626EstimatedMarketPrice: FC<Erc4626EstimatedMarketPriceProps> = ({
+  pricePicker: { marketCap, prices, token },
+}) => {
   const {
     dispatch,
-    state: { estimatedMarketCap },
+    state: { estimatedPrice },
   } = useErc4626CustomState()
 
   return (
     <Box sx={{ mb: 2, pb: '24px', borderBottom: '1px solid', borderBottomColor: 'neutral20' }}>
       <Text variant="paragraph4" as="div" sx={{ mb: 2 }}>
         <Trans
-          i18nKey="erc-4626.position-page.common.estimated-market-cap"
+          i18nKey={
+            marketCap
+              ? 'erc-4626.position-page.common.estimated-market-cap'
+              : 'erc-4626.position-page.common.estimated-price'
+          }
           components={{
             icon: (
               <TokensGroup
@@ -37,15 +44,18 @@ export const Erc4626EstimatedMarketCap: FC<Erc4626EstimatedMarketCapProps> = ({ 
         />
       </Text>
       <ActionPills
-        active={estimatedMarketCap.toString()}
-        items={erc4626EstimatedMarketCaps.reduce<ActionPillsItem[]>(
-          (list, cap) => [
+        active={estimatedPrice.toString()}
+        items={prices.reduce<ActionPillsItem[]>(
+          (list, price) => [
             ...list,
             {
-              id: cap.toString(),
-              label: formatUsdValue(cap),
+              id: price.toString(),
+              label: formatUsdValue(
+                new BigNumber(marketCap ? marketCap * price : price),
+                marketCap ? 0 : undefined,
+              ),
               action: () => {
-                dispatch({ type: 'estimated-market-cap-change', estimatedMarketCap: cap })
+                dispatch({ type: 'estimated-price-change', estimatedPrice: new BigNumber(price) })
               },
             },
           ],

--- a/features/omni-kit/protocols/erc-4626/contexts/Erc4626CustomStateContext.tsx
+++ b/features/omni-kit/protocols/erc-4626/contexts/Erc4626CustomStateContext.tsx
@@ -3,10 +3,10 @@ import type { Dispatch, FC } from 'react'
 import React, { createContext, useContext, useMemo, useReducer } from 'react'
 
 interface Erc4626CustomState {
-  estimatedMarketCap: BigNumber
+  estimatedPrice: BigNumber
 }
 
-type Erc4626CustomActions = { type: 'estimated-market-cap-change'; estimatedMarketCap: BigNumber }
+type Erc4626CustomActions = { type: 'estimated-price-change'; estimatedPrice: BigNumber }
 
 const erc4626CustomStateContext = createContext<
   { state: Erc4626CustomState; dispatch: Dispatch<Erc4626CustomActions> } | undefined
@@ -14,8 +14,8 @@ const erc4626CustomStateContext = createContext<
 
 const reducer = (state: Erc4626CustomState, action: Erc4626CustomActions): Erc4626CustomState => {
   switch (action.type) {
-    case 'estimated-market-cap-change':
-      return { estimatedMarketCap: action.estimatedMarketCap }
+    case 'estimated-price-change':
+      return { estimatedPrice: action.estimatedPrice }
     default:
       return state
   }
@@ -32,13 +32,13 @@ export const useErc4626CustomState = () => {
 
 export const Erc4626CustomStateContextProvider: FC<Erc4626CustomState> = ({
   children,
-  estimatedMarketCap,
+  estimatedPrice,
 }) => {
-  const [state, dispatch] = useReducer(reducer, { estimatedMarketCap })
+  const [state, dispatch] = useReducer(reducer, { estimatedPrice })
 
   useMemo(() => {
-    dispatch({ type: 'estimated-market-cap-change', estimatedMarketCap })
-  }, [estimatedMarketCap?.toString()])
+    dispatch({ type: 'estimated-price-change', estimatedPrice })
+  }, [estimatedPrice?.toString()])
 
   return (
     <erc4626CustomStateContext.Provider value={{ state, dispatch }}>

--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626PositionParameters.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626PositionParameters.ts
@@ -3,38 +3,46 @@ import type { SubgraphsResponses } from 'features/subgraphLoader/types'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
 
 export interface Erc4626PositionParametersResponse {
-  earnCumulativeDepositInQuoteToken: string
-  earnCumulativeDepositUSD: string
-  earnCumulativeFeesInQuoteToken: string
-  earnCumulativeFeesUSD: string
-  earnCumulativeWithdrawInQuoteToken: string
-  earnCumulativeWithdrawUSD: string
-  id: string
-  shares: string
-  vault: {
+  positions: {
+    earnCumulativeDepositInQuoteToken: string
+    earnCumulativeDepositUSD: string
+    earnCumulativeFeesInQuoteToken: string
+    earnCumulativeFeesUSD: string
+    earnCumulativeWithdrawInQuoteToken: string
+    earnCumulativeWithdrawUSD: string
+    id: string
+    shares: string
+  }[]
+  vaults: {
     interestRates: {
       timestamp: string
       rate: string
     }[]
     totalAssets: string
     totalShares: string
-  }
+  }[]
 }
 
 const emptyErc4626PositionParametersResponse: Erc4626PositionParametersResponse = {
-  earnCumulativeDepositInQuoteToken: '0',
-  earnCumulativeDepositUSD: '0',
-  earnCumulativeFeesInQuoteToken: '0',
-  earnCumulativeFeesUSD: '0',
-  earnCumulativeWithdrawInQuoteToken: '0',
-  earnCumulativeWithdrawUSD: '0',
-  id: '',
-  shares: '0',
-  vault: {
-    interestRates: [],
-    totalAssets: '0',
-    totalShares: '0',
-  },
+  positions: [
+    {
+      earnCumulativeDepositInQuoteToken: '0',
+      earnCumulativeDepositUSD: '0',
+      earnCumulativeFeesInQuoteToken: '0',
+      earnCumulativeFeesUSD: '0',
+      earnCumulativeWithdrawInQuoteToken: '0',
+      earnCumulativeWithdrawUSD: '0',
+      id: '',
+      shares: '0',
+    },
+  ],
+  vaults: [
+    {
+      interestRates: [],
+      totalAssets: '0',
+      totalShares: '0',
+    },
+  ],
 }
 
 export function getErc4626PositionParameters(networkId: OmniSupportedNetworkIds) {
@@ -44,6 +52,15 @@ export function getErc4626PositionParameters(networkId: OmniSupportedNetworkIds)
       vault: vaultAddress.toLowerCase(),
     })) as SubgraphsResponses['Erc4626']['getErc4626PositionParameters']
 
-    return response[0] ?? emptyErc4626PositionParametersResponse
+    return {
+      positions:
+        response.positions.length > 0
+          ? response.positions
+          : emptyErc4626PositionParametersResponse.positions,
+      vaults:
+        response.vaults.length > 0
+          ? response.vaults
+          : emptyErc4626PositionParametersResponse.vaults,
+    }
   }
 }

--- a/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
@@ -1,7 +1,6 @@
 import { getRpcProvider } from 'blockchain/networks'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { useOmniTxHandler } from 'features/omni-kit/hooks'
-import { useErc4626CustomState } from 'features/omni-kit/protocols/erc-4626/contexts'
 import { getErc4626Parameters } from 'features/omni-kit/protocols/erc-4626/helpers'
 import { erc4626VaultsByName } from 'features/omni-kit/protocols/erc-4626/settings'
 import { useAccount } from 'helpers/useAccount'
@@ -25,7 +24,6 @@ export function useErc4626TxHandler(): () => void {
       validations: { isFormValid },
     },
   } = useOmniProductContext(productType)
-  const { state: customState } = useErc4626CustomState()
 
   // it is safe to assume that in erc-4626 context label is always availabe string
   const { address } = erc4626VaultsByName[label as string]
@@ -47,6 +45,5 @@ export function useErc4626TxHandler(): () => void {
         vaultAddress: address,
         walletAddress,
       }),
-    customState,
   })
 }

--- a/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/useErc4626TxHandler.ts
@@ -1,6 +1,7 @@
 import { getRpcProvider } from 'blockchain/networks'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { useOmniTxHandler } from 'features/omni-kit/hooks'
+import { useErc4626CustomState } from 'features/omni-kit/protocols/erc-4626/contexts'
 import { getErc4626Parameters } from 'features/omni-kit/protocols/erc-4626/helpers'
 import { erc4626VaultsByName } from 'features/omni-kit/protocols/erc-4626/settings'
 import { useAccount } from 'helpers/useAccount'
@@ -24,6 +25,7 @@ export function useErc4626TxHandler(): () => void {
       validations: { isFormValid },
     },
   } = useOmniProductContext(productType)
+  const { state: customState } = useErc4626CustomState()
 
   // it is safe to assume that in erc-4626 context label is always availabe string
   const { address } = erc4626VaultsByName[label as string]
@@ -45,5 +47,6 @@ export function useErc4626TxHandler(): () => void {
         vaultAddress: address,
         walletAddress,
       }),
+    customState,
   })
 }

--- a/features/omni-kit/protocols/erc-4626/metadata/useErc4626Metadata.tsx
+++ b/features/omni-kit/protocols/erc-4626/metadata/useErc4626Metadata.tsx
@@ -24,7 +24,6 @@ import {
 } from 'features/omni-kit/protocols/erc-4626/helpers'
 import { erc4626VaultsByName } from 'features/omni-kit/protocols/erc-4626/settings'
 import { OmniProductType } from 'features/omni-kit/types'
-import { notAvailable } from 'handlers/portfolio/constants'
 import { useAppConfig } from 'helpers/config'
 import { formatDecimalAsPercent, formatUsdValue } from 'helpers/formatters/format'
 import { zero } from 'helpers/zero'
@@ -121,7 +120,7 @@ export const useErc4626Metadata: GetOmniMetadata = (productContext) => {
             // TODO replace with real values
             {
               label: t('omni-kit.headline.details.30-days-avg-apy'),
-              value: notAvailable,
+              value: formatDecimalAsPercent(position.historicalApy.thirtyDayAverage),
             },
             {
               label: t('omni-kit.headline.details.tvl'),

--- a/features/omni-kit/protocols/erc-4626/metadata/useErc4626Metadata.tsx
+++ b/features/omni-kit/protocols/erc-4626/metadata/useErc4626Metadata.tsx
@@ -14,7 +14,7 @@ import {
   Erc4626DetailsSectionFooter,
 } from 'features/omni-kit/protocols/erc-4626/components/details-section'
 import {
-  Erc4626EstimatedMarketCap,
+  Erc4626EstimatedMarketPrice,
   Erc4626FormOrder,
 } from 'features/omni-kit/protocols/erc-4626/components/sidebar'
 import {
@@ -56,7 +56,7 @@ export const useErc4626Metadata: GetOmniMetadata = (productContext) => {
   } = useOmniGeneralContext()
 
   // it is safe to assume that in erc-4626 context label is always availabe string
-  const { address: vaultAddress } = erc4626VaultsByName[label as string]
+  const { address: vaultAddress, pricePicker } = erc4626VaultsByName[label as string]
 
   const validations = productContext.position.simulationCommon.getValidations({
     earnIsFormValid: getErc4626EarnIsFormValid({
@@ -142,8 +142,7 @@ export const useErc4626Metadata: GetOmniMetadata = (productContext) => {
             </>
           ),
           overviewWithSimulation: true,
-          // TODO: show only when rewards are available in vault
-          sidebarContent: <Erc4626EstimatedMarketCap token="MORPHO" />,
+          sidebarContent: pricePicker && <Erc4626EstimatedMarketPrice pricePicker={pricePicker} />,
           earnFormOrder: <Erc4626FormOrder />,
           earnFormOrderAsElement: Erc4626FormOrder,
         },

--- a/features/omni-kit/protocols/erc-4626/settings.ts
+++ b/features/omni-kit/protocols/erc-4626/settings.ts
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import { NetworkIds } from 'blockchain/networks'
 import { getToken } from 'blockchain/tokensMetadata'
@@ -45,12 +44,16 @@ export const erc4626Vaults: Erc4626Config[] = [
     id: 'steakhouse-USDC',
     name: 'Steakhouse USDC',
     networkId: NetworkIds.MAINNET,
+    pricePicker: {
+      marketCap: 1000000000,
+      prices: [0.5, 0.75, 1, 2],
+      token: 'MORPHO',
+    },
     protocol: LendingProtocol.MorphoBlue,
     rewards: [
       {
         token: 'MORPHO',
         label: 'Morpho token rewards',
-        withPricePicker: true,
       },
       {
         token: 'WSTETH',
@@ -68,10 +71,3 @@ export const erc4626Vaults: Erc4626Config[] = [
 
 export const erc4626VaultsById = keyBy(erc4626Vaults, 'id')
 export const erc4626VaultsByName = keyBy(erc4626Vaults, 'name')
-
-export const erc4626EstimatedMarketCaps = [
-  new BigNumber(500000000),
-  new BigNumber(750000000),
-  new BigNumber(1000000000),
-  new BigNumber(2000000000),
-]

--- a/features/omni-kit/protocols/erc-4626/state/Erc4626CustomStateProvider.tsx
+++ b/features/omni-kit/protocols/erc-4626/state/Erc4626CustomStateProvider.tsx
@@ -1,9 +1,10 @@
 import type { Erc4626Position } from '@oasisdex/dma-library'
+import BigNumber from 'bignumber.js'
 import type { OmniCustomStateParams } from 'features/omni-kit/controllers'
 import { Erc4626CustomStateContextProvider } from 'features/omni-kit/protocols/erc-4626/contexts'
 import { useErc4626TxHandler } from 'features/omni-kit/protocols/erc-4626/hooks'
 import { useErc4626Metadata } from 'features/omni-kit/protocols/erc-4626/metadata'
-import { erc4626EstimatedMarketCaps } from 'features/omni-kit/protocols/erc-4626/settings'
+import { erc4626Vaults } from 'features/omni-kit/protocols/erc-4626/settings'
 import { OmniEarnFormAction, OmniSidebarEarnPanel } from 'features/omni-kit/types'
 import type { FC } from 'react'
 import React from 'react'
@@ -14,6 +15,7 @@ type Erc4626CustomStateProviderProps = OmniCustomStateParams<unknown, unknown[],
 export const Erc4626CustomStateProvider: FC<Erc4626CustomStateProviderProps> = ({
   children,
   isOpening,
+  positionData,
 }) => {
   const formDefaults = {
     borrow: {},
@@ -24,8 +26,14 @@ export const Erc4626CustomStateProvider: FC<Erc4626CustomStateProviderProps> = (
     multiply: {},
   }
 
+  const defaultEstimatedPrice = new BigNumber(
+    erc4626Vaults.find(
+      ({ address }) => address.toLowerCase() === positionData.vault.address.toLowerCase(),
+    )?.pricePicker?.prices[0] ?? 0,
+  )
+
   return (
-    <Erc4626CustomStateContextProvider estimatedMarketCap={erc4626EstimatedMarketCaps[0]}>
+    <Erc4626CustomStateContextProvider estimatedPrice={defaultEstimatedPrice}>
       {children({
         formDefaults,
         useDynamicMetadata: useErc4626Metadata,

--- a/features/omni-kit/protocols/erc-4626/types.ts
+++ b/features/omni-kit/protocols/erc-4626/types.ts
@@ -1,5 +1,11 @@
 import type { OmniSupportedNetworkIds, OmniSupportedProtocols } from 'features/omni-kit/types'
 
+export interface Erc4626PricePicker {
+  marketCap?: number
+  prices: number[]
+  token: string
+}
+
 export interface Erc4626Token {
   address: string
   precision: number
@@ -15,11 +21,11 @@ export interface Erc4626Config {
   id: string
   name: string
   networkId: OmniSupportedNetworkIds
+  pricePicker?: Erc4626PricePicker
   protocol: OmniSupportedProtocols
   rewards: {
     label?: string
     token: string
-    withPricePicker?: boolean
   }[]
   strategy: string
   token: Erc4626Token

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -655,7 +655,7 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
   `,
   getErc4626PositionParameters: gql`
     query getPositionParameters($vault: String!, $dpmProxyAddress: String!) {
-      positions(where: { vault: $vault, account: $dpmProxyAddress }) {
+      positions(where: { account: $dpmProxyAddress }) {
         id
         shares
         earnCumulativeFeesUSD
@@ -664,14 +664,14 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
         earnCumulativeFeesInQuoteToken
         earnCumulativeDepositInQuoteToken
         earnCumulativeWithdrawInQuoteToken
-        vault {
-          interestRates(orderBy: timestamp, orderDirection: desc, first: 30) {
-            timestamp
-            rate
-          }
-          totalAssets
-          totalShares
+      }
+      vaults(where: { id: $vault }) {
+        interestRates(orderBy: timestamp, orderDirection: desc, first: 30) {
+          timestamp
+          rate
         }
+        totalAssets
+        totalShares
       }
     }
   `,

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -147,7 +147,7 @@ export type SubgraphsResponses = {
     }>
   }
   Erc4626: {
-    getErc4626PositionParameters: SubgraphBaseResponse<Erc4626PositionParametersResponse[]>
+    getErc4626PositionParameters: SubgraphBaseResponse<Erc4626PositionParametersResponse>
     getErc4626InterestRates: SubgraphBaseResponse<Erc4626InterestRatesResponse>
   }
   Referral: {

--- a/helpers/formatters/format.ts
+++ b/helpers/formatters/format.ts
@@ -68,7 +68,7 @@ export function formatCryptoBalance(amount: BigNumber): string {
   return formatAsShorthandNumbers(amount, 2)
 }
 
-export function formatUsdValue(amount: BigNumber): string {
+export function formatUsdValue(amount: BigNumber, decimalPlaces = 2): string {
   const absoluteAmount = amount.absoluteValue()
 
   return amount.isZero()
@@ -76,8 +76,8 @@ export function formatUsdValue(amount: BigNumber): string {
     : absoluteAmount.lt(0.01)
     ? `$<${amount.isNegative() ? '-' : ''}0.01`
     : absoluteAmount.lt(million)
-    ? `$${amount.toFormat(2, BigNumber.ROUND_DOWN)}`
-    : `$${formatAsShorthandNumbers(amount, 2)}`
+    ? `$${amount.toFormat(decimalPlaces, BigNumber.ROUND_DOWN)}`
+    : `$${formatAsShorthandNumbers(amount, decimalPlaces)}`
 }
 
 export function formatFiatBalance(amount: BigNumber): string {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.49",
     "@oasisdex/automation": "1.6.4-alpha.2",
-    "@oasisdex/dma-library": "0.6.37",
+    "@oasisdex/dma-library": "0.6.38",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.49",
     "@oasisdex/automation": "1.6.4-alpha.2",
-    "@oasisdex/dma-library": "0.6.35",
+    "@oasisdex/dma-library": "0.6.37",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3279,6 +3279,7 @@
     },
     "position-page": {
       "common": {
+        "estimated-price": "Estimate <icon /> {{token}} price for better APY accuracy",
         "estimated-market-cap": "Estimate <icon /> {{token}} market cap for better APY accuracy",
         "market-apy": "Market APY",
         "per-1k-usd": "{{amount}} {{token}} per $1,000",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.35":
-  version "0.6.35"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.35.tgz#540dc9e38d3799c7ea5761f95566bc438e5648af"
-  integrity sha512-6kfxP6orUjvWKnctuOsmja9ixKx2rlEZWnI9OF5VlJdWUlPjraX1/IXbVa9F5b0kxJqMe7h10vWu5i0yLiWOUQ==
+"@oasisdex/dma-library@0.6.37":
+  version "0.6.37"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.37.tgz#ad80b22ebd84f0977b6755d045bd91d3c5d0230d"
+  integrity sha512-9OCDVFUB9BiAU9KFi9Y+qejAdR2Sh5RkYyGOhEkwPT6TFtdvSBvwdtfHiW2uK9VgvOSOZiaWLNhvKa6TCrABLw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.37":
-  version "0.6.37"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.37.tgz#ad80b22ebd84f0977b6755d045bd91d3c5d0230d"
-  integrity sha512-9OCDVFUB9BiAU9KFi9Y+qejAdR2Sh5RkYyGOhEkwPT6TFtdvSBvwdtfHiW2uK9VgvOSOZiaWLNhvKa6TCrABLw==
+"@oasisdex/dma-library@0.6.38":
+  version "0.6.38"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.38.tgz#57b8136c45ea4b8dcd2b6ea7beb2b57a5d1a30b7"
+  integrity sha512-uQhQr3vgramj3cUjttwnEPtxXQSBYaiGI1oOi0jSoNHm/ZkLSs3xt1pVgYtH7MXpiIrgwN/0mfber3sBecNruw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
# ERC-4626 rewards tokens market cap config

<please insert a shortcut link above>
  
## Changes 👷‍♀️

- Updated rewards settings ERC-4626 vaults.
- Updated ERC-4626 subgraph request and interface.
- Displayed missing values on position's headline.