### PR TITLE
feat: [sc-14862] [FE] History for ERC-4626

### DIFF
--- a/components/history/PositionHistory.tsx
+++ b/components/history/PositionHistory.tsx
@@ -5,6 +5,7 @@ import { DetailsSection } from 'components/DetailsSection'
 import { PositionHistoryItem } from 'components/history/PositionHistoryItem'
 import type { AaveLikeHistoryEvent } from 'features/omni-kit/protocols/aave-like/history/types'
 import type { AjnaHistoryEvent } from 'features/omni-kit/protocols/ajna/history/types'
+import type { Erc4626HistoryEvent } from 'features/omni-kit/protocols/erc-4626/history/types'
 import { filterAndGroupByTxHash } from 'features/positionHistory/filterAndGroupByTxHash'
 import type { PositionHistoryEvent } from 'features/positionHistory/types'
 import { useTranslation } from 'next-i18next'
@@ -17,6 +18,7 @@ interface PositionHistoryProps {
     | Partial<AjnaHistoryEvent>[]
     | Partial<AaveLikeHistoryEvent>[]
     | Partial<PositionHistoryEvent>[]
+    | Partial<Erc4626HistoryEvent>[]
   isOracless?: boolean
   isShort?: boolean
   priceFormat?: string

--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626PositionAggregatedData.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626PositionAggregatedData.ts
@@ -1,0 +1,76 @@
+import BigNumber from 'bignumber.js'
+import type { NetworkIds } from 'blockchain/networks'
+import { erc2626DefaultHistoryEvent } from 'features/omni-kit/protocols/erc-4626/history/erc2626DefaultHistoryEvent'
+import type {
+  Erc4626EarnEventResponse,
+  Erc4626HistoryEvent,
+} from 'features/omni-kit/protocols/erc-4626/history/types'
+import type { SubgraphsResponses } from 'features/subgraphLoader/types'
+import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+
+export interface Erc4626PositionAggregatedData {
+  history: Erc4626HistoryEvent[]
+}
+
+const mapEvent = (event: Erc4626EarnEventResponse) => {
+  return {
+    ...event,
+    blockNumber: new BigNumber(event.blockNumber),
+    kind: event.kind,
+    timestamp: Number(event.timestamp) * 1000,
+    txHash: event.txHash,
+    quoteToken: event.quoteToken.symbol.toUpperCase(),
+    quoteTokensPriceUSD: new BigNumber(event.quoteTokenPriceUSD),
+    quoteTokensAfter: new BigNumber(event.quoteAfter),
+    quoteTokensBefore: new BigNumber(event.quoteBefore),
+    quoteTokensDelta: new BigNumber(event.quoteDelta),
+    swapFromAmount: new BigNumber(event.swapFromAmount),
+    depositedUSD: new BigNumber(event.depositedUSD),
+    withdrawnUSD: new BigNumber(event.withdrawnUSD),
+    ethPrice: new BigNumber(event.ethPrice),
+    gasFeeUSD: new BigNumber(event.gasFeeUSD),
+    gasPrice: new BigNumber(event.gasPrice),
+    gasUsed: new BigNumber(event.gasUsed),
+    marketPrice: new BigNumber(event.marketPrice),
+    oasisFee: new BigNumber(event.oasisFee),
+    oasisFeeUSD: new BigNumber(event.oasisFeeUSD),
+    swapToAmount: new BigNumber(event.swapToAmount),
+    totalFee: new BigNumber(event.totalFee),
+    withdrawTransfers: event.withdrawTransfers.map((transfer) => ({
+      ...transfer,
+      amount: new BigNumber(transfer.amount),
+      amountUSD: new BigNumber(transfer.amountUSD),
+    })),
+  }
+}
+
+export async function getErc4626PositionAggregatedData(
+  networkId: NetworkIds,
+  vaultAddress: string,
+  dpmProxyAddress: string,
+): Promise<Erc4626PositionAggregatedData> {
+  const { response } = (await loadSubgraph(
+    'Erc4626',
+    'getErc4626PositionAggregatedData',
+    networkId,
+    {
+      dpmProxyAddress: dpmProxyAddress.toLowerCase(),
+      vault: vaultAddress.toLowerCase(),
+    },
+  )) as SubgraphsResponses['Erc4626']['getErc4626PositionAggregatedData']
+
+  if (response.summerEvents.length === 0) {
+    return {
+      history: [],
+    }
+  }
+
+  return {
+    history: response.summerEvents.map((event) => {
+      return {
+        ...erc2626DefaultHistoryEvent,
+        ...mapEvent(event),
+      }
+    }),
+  }
+}

--- a/features/omni-kit/protocols/erc-4626/history/erc2626DefaultHistoryEvent.ts
+++ b/features/omni-kit/protocols/erc-4626/history/erc2626DefaultHistoryEvent.ts
@@ -1,0 +1,5 @@
+import { unifiedDefaultHistoryItem } from 'features/positionHistory/consts'
+
+export const erc2626DefaultHistoryEvent = {
+  ...unifiedDefaultHistoryItem,
+}

--- a/features/omni-kit/protocols/erc-4626/history/mapErc4626Events.ts
+++ b/features/omni-kit/protocols/erc-4626/history/mapErc4626Events.ts
@@ -1,0 +1,21 @@
+import type { Erc4626HistoryEvent } from './types'
+
+export const mapErc4626Events = (events: Erc4626HistoryEvent[]): Partial<Erc4626HistoryEvent>[] => {
+  return events.map((event): Partial<Erc4626HistoryEvent> => {
+    return {
+      kind: event.kind,
+      txHash: event.txHash,
+      timestamp: event.timestamp,
+      quoteToken: event.quoteToken,
+      quoteTokensPriceUSD: event.quoteTokensPriceUSD,
+      quoteTokensAfter: event.quoteTokensAfter,
+      quoteTokensBefore: event.quoteTokensBefore,
+      quoteTokensDelta: event.quoteTokensDelta,
+      totalFee: event.totalFee,
+      swapToAmount: event.swapToAmount,
+      swapFromToken: event.swapFromToken,
+      swapFromAmount: event.swapFromAmount,
+      swapToToken: event.swapToToken,
+    }
+  })
+}

--- a/features/omni-kit/protocols/erc-4626/history/types.ts
+++ b/features/omni-kit/protocols/erc-4626/history/types.ts
@@ -1,0 +1,72 @@
+import type BigNumber from 'bignumber.js'
+import type { PositionHistoryEvent } from 'features/positionHistory/types'
+
+interface QuoteToken {
+  id: string
+  address: string
+  decimals: string
+  symbol: string
+}
+
+interface Transfer {
+  id: string
+  priceInUSD: string
+  token: string
+  from: string
+  to: string
+  amount: string
+  amountUSD: string
+  txHash: string
+}
+
+export interface Erc4626EarnEventResponse {
+  id: string
+  kind: string
+  quoteToken: QuoteToken
+  isOpen: boolean
+  depositedUSD: string
+  depositedInQuoteToken: string
+  depositTransfers: Transfer[]
+  withdrawnUSD: string
+  withdrawnInQuoteToken: string
+  withdrawTransfers: Transfer[]
+  quoteAddress: string
+  quoteBefore: string
+  quoteAfter: string
+  quoteDelta: string
+  quoteTokenPriceUSD: string
+  swapToToken: string
+  swapToAmount: string
+  swapFromToken: string
+  swapFromAmount: string
+  gasFeeInQuoteToken: string
+  marketPrice: string
+  oasisFeeToken: string
+  oasisFee: string
+  oasisFeeUSD: string
+  oasisFeeInQuoteToken: string
+  gasUsed: string
+  gasPrice: string
+  gasFeeUSD: string
+  totalFee: string
+  totalFeeUSD: string
+  totalFeeInQuoteToken: string
+  ethPrice: string
+  timestamp: string
+  blockNumber: string
+  txHash: string
+}
+
+export interface Erc4626SummerEventsResponse {
+  summerEvents: Erc4626EarnEventResponse[]
+}
+
+type Erc4626HistoryEventExtension = {
+  quoteTokensAfter: BigNumber
+  quoteTokensBefore: BigNumber
+  quoteTokensDelta: BigNumber
+  quoteTokensPriceUSD: BigNumber
+  quoteToken: string
+}
+
+export type Erc4626HistoryEvent = PositionHistoryEvent & Erc4626HistoryEventExtension

--- a/features/omni-kit/protocols/erc-4626/observables/getErc4626AggregatedData.ts
+++ b/features/omni-kit/protocols/erc-4626/observables/getErc4626AggregatedData.ts
@@ -1,0 +1,21 @@
+import type { DpmPositionData } from 'features/omni-kit/observables'
+import type { Erc4626PositionAggregatedData } from 'features/omni-kit/protocols/erc-4626/helpers/getErc4626PositionAggregatedData'
+import { getErc4626PositionAggregatedData } from 'features/omni-kit/protocols/erc-4626/helpers/getErc4626PositionAggregatedData'
+import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
+import type { Observable } from 'rxjs'
+import { from } from 'rxjs'
+import { shareReplay } from 'rxjs/operators'
+
+export const getErc4626PositionAggregatedData$ = ({
+  dpmPositionData,
+  networkId,
+  vault,
+}: {
+  dpmPositionData: DpmPositionData
+  networkId: OmniSupportedNetworkIds
+  vault: string
+}): Observable<Erc4626PositionAggregatedData> => {
+  return from(getErc4626PositionAggregatedData(networkId, vault, dpmPositionData.proxy)).pipe(
+    shareReplay(1),
+  )
+}

--- a/features/positionHistory/filterAndGroupByTxHash.ts
+++ b/features/positionHistory/filterAndGroupByTxHash.ts
@@ -1,5 +1,6 @@
 import type { AaveLikeHistoryEvent } from 'features/omni-kit/protocols/aave-like/history/types'
 import type { AjnaHistoryEvent } from 'features/omni-kit/protocols/ajna/history/types'
+import type { Erc4626HistoryEvent } from 'features/omni-kit/protocols/erc-4626/history/types'
 import { find, groupBy, map } from 'lodash'
 
 import type { PositionHistoryEvent } from './types'
@@ -15,8 +16,13 @@ export function filterAndGroupByTxHash(
   events:
     | Partial<AjnaHistoryEvent>[]
     | Partial<AaveLikeHistoryEvent>[]
-    | Partial<PositionHistoryEvent>[],
-): Partial<AjnaHistoryEvent>[] | Partial<AaveLikeHistoryEvent>[] | Partial<PositionHistoryEvent>[] {
+    | Partial<PositionHistoryEvent>[]
+    | Partial<Erc4626HistoryEvent>[],
+):
+  | Partial<AjnaHistoryEvent>[]
+  | Partial<AaveLikeHistoryEvent>[]
+  | Partial<PositionHistoryEvent>[]
+  | Partial<Erc4626HistoryEvent>[] {
   const groups = groupBy(events, 'txHash')
 
   return map(
@@ -26,4 +32,5 @@ export function filterAndGroupByTxHash(
     | Partial<AjnaHistoryEvent>[]
     | Partial<AaveLikeHistoryEvent>[]
     | Partial<PositionHistoryEvent>[]
+    | Partial<Erc4626HistoryEvent>[]
 }

--- a/features/positionHistory/getHistoryEventLabel.ts
+++ b/features/positionHistory/getHistoryEventLabel.ts
@@ -47,6 +47,7 @@ export const getHistoryEventLabel = ({
     case 'AjnaUnstakeNftAndWithdrawQuote':
     case 'MorphoBlueWithdraw':
     case 'AAVEV3Withdraw':
+    case 'ERC4626Withdraw':
       return t('position-history.withdraw')
     case 'AAVEV3WithdrawToDebt':
       return t('position-history.withdraw-to-debt')
@@ -100,7 +101,10 @@ export const getHistoryEventLabel = ({
     case 'AAVEDeposit':
     case 'AAVEV3Deposit':
     case 'SparkDeposit':
+    case 'ERC4626Deposit':
       return t('position-history.deposit')
+    case 'ERC4626Transfer':
+      return t('position-history.transfer-to')
     case 'AjnaUnstakeNftAndClaimCollateral':
       return t('position-history.claim-collateral')
     case 'SparkDepositBorrow':

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -675,6 +675,75 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
       }
     }
   `,
+  getErc4626PositionAggregatedData: gql`
+    query Erc4626AggregatedData($vault: String!, $dpmProxyAddress: String!) {
+      summerEvents(where: { account: $dpmProxyAddress, vault: $vault }) {
+        id
+        kind
+        quoteToken {
+          id
+          address
+        }
+        isOpen
+        depositedUSD
+        depositedInQuoteToken
+        depositTransfers {
+          id
+          priceInUSD
+          token
+          from
+          to
+          amount
+          amountUSD
+          txHash
+        }
+        withdrawnUSD
+        withdrawnInQuoteToken
+        withdrawTransfers {
+          id
+          priceInUSD
+          token
+          from
+          to
+          amount
+          amountUSD
+          txHash
+        }
+        quoteToken {
+          id
+          address
+          decimals
+          symbol
+        }
+        quoteAddress
+        quoteBefore
+        quoteAfter
+        quoteDelta
+        quoteTokenPriceUSD
+        swapToToken
+        swapToAmount
+        swapFromToken
+        swapFromAmount
+        gasFeeInQuoteToken
+        marketPrice
+        oasisFeeToken
+        oasisFee
+        oasisFeeUSD
+        oasisFeeInQuoteToken
+        gasUsed
+        gasPrice
+        gasFeeUSD
+        gasFeeInQuoteToken
+        totalFee
+        totalFeeUSD
+        totalFeeInQuoteToken
+        ethPrice
+        timestamp
+        blockNumber
+        txHash
+      }
+    }
+  `,
   getErc4626InterestRates: gql`
     query getInterestRates($vault: String!) {
       vaults(where: { id: $vault }) {

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -12,6 +12,7 @@ import type {
   AjnaHistoryResponse,
 } from 'features/omni-kit/protocols/ajna/history/types'
 import type { Erc4626PositionParametersResponse } from 'features/omni-kit/protocols/erc-4626/helpers'
+import type { Erc4626SummerEventsResponse } from 'features/omni-kit/protocols/erc-4626/history/types'
 import type { MorphoBorrowerEventsResponse } from 'features/omni-kit/protocols/morpho-blue/history/types'
 import type {
   AaveCumulativesResponse,
@@ -60,6 +61,7 @@ export type Subgraphs = {
   }
   Erc4626: {
     getErc4626PositionParameters: { vault: string; dpmProxyAddress: string }
+    getErc4626PositionAggregatedData: { vault: string; dpmProxyAddress: string }
     getErc4626InterestRates: { vault: string }
     getErc4626DpmPositions: { dpmProxyAddress: string[] }
   }
@@ -150,6 +152,7 @@ export type SubgraphsResponses = {
   }
   Erc4626: {
     getErc4626PositionParameters: SubgraphBaseResponse<Erc4626PositionParametersResponse>
+    getErc4626PositionAggregatedData: SubgraphBaseResponse<Erc4626SummerEventsResponse>
     getErc4626InterestRates: SubgraphBaseResponse<Erc4626InterestRatesResponse>
     getErc4626DpmPositions: SubgraphBaseResponse<Erc4626DpmPositionsResponse>
   }

--- a/pages/[networkOrProduct]/erc-4626/[...position].tsx
+++ b/pages/[networkOrProduct]/erc-4626/[...position].tsx
@@ -4,6 +4,7 @@ import { PageSEOTags } from 'components/HeadTags'
 import { AppLayout } from 'components/layouts/AppLayout'
 import { OmniProductController } from 'features/omni-kit/controllers'
 import { erc4626SeoTags } from 'features/omni-kit/protocols/erc-4626/constants'
+import type { Erc4626HistoryEvent } from 'features/omni-kit/protocols/erc-4626/history/types'
 import { useErc4626Data } from 'features/omni-kit/protocols/erc-4626/hooks'
 import { erc4626VaultsById, settings } from 'features/omni-kit/protocols/erc-4626/settings'
 import { Erc4626CustomStateProvider } from 'features/omni-kit/protocols/erc-4626/state'
@@ -20,7 +21,7 @@ function Erc4626PositionPage(props: Erc4626PositionPageProps) {
   return (
     <AppLayout>
       <ProductContextHandler>
-        <OmniProductController<unknown, unknown[], Erc4626Position>
+        <OmniProductController<unknown, Erc4626HistoryEvent[], Erc4626Position>
           {...props}
           pseudoProtocol={Erc4626PseudoProtocol}
           customState={Erc4626CustomStateProvider}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -477,6 +477,7 @@
     "collateral-deposit": "Collateral Deposit",
     "withdrawn": "Withdrawn",
     "repaid": "Repaid",
+    "transfer-to": "Transfer to",
     "debt-borrowed": "Debt Borrowed",
     "ltv": "Loan To Value",
     "liquidation-price": "Liquidation price",


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14862

This commit adds handling and mapping of ERC4626 history events. It includes adding methods for fetching aggregated data, mapping between different events types and updates in displaying event labels. With this update, the application now supports more complete and accurate tracking of transaction history for ERC4626 protocol.

![CleanShot 2024-03-19 at 12 40 20@2x](https://github.com/OasisDEX/oasis-borrow/assets/14370675/f4360058-378f-4b6f-bfcb-74125644c153)
