### PR TITLE
chore: [sc-14915] [BE] Small Improvements in the API

### DIFF
--- a/features/omni-kit/protocols/erc-4626/helpers/getErc4626ApyParameters.ts
+++ b/features/omni-kit/protocols/erc-4626/helpers/getErc4626ApyParameters.ts
@@ -57,7 +57,7 @@ export function getErc4626ApyParameters({
 
     const wstETHPrice = resolvedPrices['WSTETH']
     const response = await fetchFromFunctionsApi(
-      `/api/morpho/meta-morpho?address=${vaultAddress}&morhoPrice=${rewardTokenPrice}&wsEthPrice=${wstETHPrice}`,
+      `/api/morpho/meta-morpho?address=${vaultAddress}&price_MORPHO=${rewardTokenPrice}&price_WSTETH=${wstETHPrice}`,
     )
 
     if (response.status !== 200) {
@@ -77,7 +77,8 @@ export function getErc4626ApyParameters({
         return {
           token: token.symbol.toUpperCase(),
           value: token.apy.toString(),
-          per1kUsd: token.humanReadable.toString(),
+          per1kUsd:
+            token.symbol.toUpperCase() === 'MORPHO' ? token.humanReadable.toString() : undefined,
         }
       })
       .filter((token) => token.value !== '0')


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14915

This commit updates the naming of parameters in the fetchFromFunctionsApi function call to adhere to standard naming conventions. Additionally, the assignment of the 'per1kUsd' field is now conditional, resulting in undefined if the token symbol is not 'MORPHO'. This ensures better data consistency and correctness.