### PR TITLE
Fix ERC-4626 position portfolio link

### DIFF
--- a/handlers/portfolio/positions/handlers/erc-4626/index.ts
+++ b/handlers/portfolio/positions/handlers/erc-4626/index.ts
@@ -134,6 +134,7 @@ async function getErc4626Positions({
               collateralToken: quoteToken,
               label: vault.name,
               networkName,
+              positionId: vaultId,
               productType: OmniProductType.Earn,
               protocol: vault.protocol,
               pseudoProtocol: Erc4626PseudoProtocol,


### PR DESCRIPTION
# [Fix ERC-4626 position portfolio link](https://app.shortcut.com/oazo-apps/story/14887/bug-wrong-link-to-position-page)
  
## Changes 👷‍♀️

- Added missing `positionId` to method returning position URL.
