### PR TITLE
fix: fix history order in erc4626 vaults

### DIFF
--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -677,7 +677,11 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
   `,
   getErc4626PositionAggregatedData: gql`
     query Erc4626AggregatedData($vault: String!, $dpmProxyAddress: String!) {
-      summerEvents(where: { account: $dpmProxyAddress, vault: $vault }) {
+      summerEvents(
+        where: { account: $dpmProxyAddress, vault: $vault }
+        orderBy: timestamp
+        orderDirection: desc
+      ) {
         id
         kind
         quoteToken {


### PR DESCRIPTION
# [Title](https://shortcutLink)

![image](https://github.com/OasisDEX/oasis-borrow/assets/6533433/bfcb2226-d8f5-4219-90d9-176b8a1b3309)
  
## Changes 👷‍♀️
- change history sorting
  
## How to test 🧪
[  <Please explain how to test your changes>
- step 1 ...](http://localhost:3000/ethereum/erc-4626/earn/steakhouse-USDC/1467#history)
