### PR TITLE
feat: [sc-14928] [CI Task] Allow ConnectorTokens to be available through the 1inch API call

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.49",
     "@oasisdex/automation": "1.6.5",
-    "@oasisdex/dma-library": "0.6.41",
+    "@oasisdex/dma-library": "0.6.43",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/pages/api/exchange/[[...params]].tsx
+++ b/pages/api/exchange/[[...params]].tsx
@@ -35,7 +35,7 @@ const urlCreator = (
     // We are adding the connectorTokens query param only if it's not already present
     if (!connectorTokens) {
       const connectorsTokenParams: string[] = []
-      const keyToCheck = [toTokenAddress, fromTokenAddress]
+      const keyToCheck = [toTokenAddress?.toLowerCase(), fromTokenAddress?.toLowerCase()]
         .filter((key): key is string => key !== null && key !== undefined)
         .filter((key): key is keyof typeof connectorTokensMap => key in connectorTokensMap)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.41":
-  version "0.6.41"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.41.tgz#51b90a94900b471a919ee551a93d1737a6fd5e8b"
-  integrity sha512-Moco9hxKEGG3f1IMwYNHxZzOXoJCw+qyHvoATg6SGuyFjIcIuP9ewhcEZvk2blfE4Y09SSQCOJQbdatnX/Kfsg==
+"@oasisdex/dma-library@0.6.43":
+  version "0.6.43"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.43.tgz#f91ee9e34303957474cc348bd387931273e5359b"
+  integrity sha512-rgNahNO4aU5PN1K3/BWVa8OJjSmGme3VmkWW7Ga/+otvW1c4iM++0j8aflD4j51iSneQax2LOSmA1wF/epjE9w==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14928

The connector token check for 'toTokenAddress' and 'fromTokenAddress' key has been modified to consider token addresses in lowercase. This enhancement ensures a broader and inclusive match, considering token addresses, which might be in different letter cases.