### PR TITLE
Ensure that position is accessible when automation api throws error

### DIFF
--- a/helpers/triggers/get-triggers/get-triggers-request.ts
+++ b/helpers/triggers/get-triggers/get-triggers-request.ts
@@ -1,3 +1,5 @@
+import { omniPositionTriggersDataDefault } from 'features/omni-kit/constants'
+
 import { getTriggersConfig } from './get-triggers-config'
 import type { GetTriggersParams, GetTriggersResponse } from './get-triggers-types'
 
@@ -7,6 +9,12 @@ export const getTriggersRequest = async ({
 }: GetTriggersParams): Promise<GetTriggersResponse> => {
   const { url } = getTriggersConfig({ dpm, networkId })
 
-  const response = await fetch(url)
-  return (await response.json()) as GetTriggersResponse
+  try {
+    const response = await fetch(url)
+    return (await response.json()) as GetTriggersResponse
+  } catch (e) {
+    console.warn('Failed to read data about triggers from server')
+    // We are returning a default response to ensure that UI won't crash and user will have access to position
+    return omniPositionTriggersDataDefault
+  }
 }

--- a/helpers/triggers/get-triggers/get-triggers-request.ts
+++ b/helpers/triggers/get-triggers/get-triggers-request.ts
@@ -13,7 +13,7 @@ export const getTriggersRequest = async ({
     const response = await fetch(url)
     return (await response.json()) as GetTriggersResponse
   } catch (e) {
-    console.warn('Failed to read data about triggers from server')
+    console.error('Failed to read data about triggers from server')
     // We are returning a default response to ensure that UI won't crash and user will have access to position
     return omniPositionTriggersDataDefault
   }

--- a/helpers/triggers/get-triggers/get-triggers-request.ts
+++ b/helpers/triggers/get-triggers/get-triggers-request.ts
@@ -13,7 +13,7 @@ export const getTriggersRequest = async ({
     const response = await fetch(url)
     return (await response.json()) as GetTriggersResponse
   } catch (e) {
-    console.error('Failed to read data about triggers from server')
+    console.error('Failed to read data about triggers from server', e)
     // We are returning a default response to ensure that UI won't crash and user will have access to position
     return omniPositionTriggersDataDefault
   }


### PR DESCRIPTION
# [Ensure that position is accessible when automation api throws error](https://app.shortcut.com/oazo-apps/epic/14671/omni-automations)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- if automation triggers api fail, we return default response with 0 automations enabled
  
## How to test 🧪
  <Please explain how to test your changes>

- add error in request method so you will be able to simulate issue with api
