### PR TITLE
Minor APY issues on ERC-4626

### DIFF
--- a/features/omni-kit/components/sidebars/OmniInputSwap.tsx
+++ b/features/omni-kit/components/sidebars/OmniInputSwap.tsx
@@ -55,14 +55,16 @@ export const OmniInputSwap: FC<OmniInputSwapProps> = ({
           price: defaultTokenPrice,
           token: defaultToken,
         },
-        ...(settings[`${type}Tokens`]?.[networkId] ?? []).map((token) => ({
-          address: getNetworkContracts(networkId).tokens[token].address,
-          balance: extraTokensData[token].balance,
-          digits: getToken(token).digits,
-          precision: getToken(token).precision,
-          price: extraTokensData[token].price,
-          token,
-        })),
+        ...(settings[`${type}Tokens`]?.[networkId] ?? [])
+          .filter((token) => token !== defaultToken)
+          .map((token) => ({
+            address: getNetworkContracts(networkId).tokens[token].address,
+            balance: extraTokensData[token].balance,
+            digits: getToken(token).digits,
+            precision: getToken(token).precision,
+            price: extraTokensData[token].price,
+            token,
+          })),
       ]
         .filter(({ balance }) => !balance.isZero())
         .sort((a, b) => b.balance.times(b.price).minus(a.balance.times(a.price)).toNumber()),

--- a/features/omni-kit/protocols/erc-4626/components/Erc4626HeadlineApy.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/Erc4626HeadlineApy.tsx
@@ -36,26 +36,28 @@ export const Erc4626HeadlineApy: FC<Erc4626HeadlineApyProps> = ({ vaultAddress }
               }),
             )}
           </Text>
-          <StatefulTooltip
-            tooltip={
-              <Erc4626ApyTooltip
-                rewardsApy={apy.rewardsApy.per365d}
-                vaultApy={apy.vaultApy.per365d}
-              />
-            }
-            containerSx={{ ml: 1 }}
-            tooltipSx={{
-              top: '24px',
-              fontSize: 1,
-              border: 'none',
-              borderRadius: 'medium',
-              boxShadow: 'buttonMenu',
-              fontWeight: 'regular',
-              lineHeight: 'body',
-            }}
-          >
-            <Icon icon={sparks} size={16} color="interactive100" sx={{ ml: 1 }} />
-          </StatefulTooltip>
+          {apy.rewardsApy.per365d.length > 0 && (
+            <StatefulTooltip
+              tooltip={
+                <Erc4626ApyTooltip
+                  rewardsApy={apy.rewardsApy.per365d}
+                  vaultApy={apy.vaultApy.per365d}
+                />
+              }
+              containerSx={{ ml: 1 }}
+              tooltipSx={{
+                top: '24px',
+                fontSize: 1,
+                border: 'none',
+                borderRadius: 'medium',
+                boxShadow: 'buttonMenu',
+                fontWeight: 'regular',
+                lineHeight: 'body',
+              }}
+            >
+              <Icon icon={sparks} size={16} color="interactive100" sx={{ ml: 1 }} />
+            </StatefulTooltip>
+          )}
         </>
       ) : (
         <Box sx={{ ml: 2, mr: 1 }}>

--- a/features/omni-kit/protocols/erc-4626/components/details-section/Erc4626DetailsSectionContentOpen.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/details-section/Erc4626DetailsSectionContentOpen.tsx
@@ -51,10 +51,12 @@ export const Erc4626DetailsSectionContentOpen: FC = () => {
                   estimatedEarnings={earnings.per1d}
                   token={quoteToken}
                   tooltip={
-                    <Erc4626ApyTooltip
-                      rewardsApy={apy.rewardsApy.per1d}
-                      vaultApy={apy.vaultApy.per1d}
-                    />
+                    apy.rewardsApy.per1d.length > 0 && (
+                      <Erc4626ApyTooltip
+                        rewardsApy={apy.rewardsApy.per1d}
+                        vaultApy={apy.vaultApy.per1d}
+                      />
+                    )
                   }
                 />,
                 `${formatCryptoBalance(netValue.per1d)} ${quoteToken}`,
@@ -65,10 +67,12 @@ export const Erc4626DetailsSectionContentOpen: FC = () => {
                   estimatedEarnings={earnings.per30d}
                   token={quoteToken}
                   tooltip={
-                    <Erc4626ApyTooltip
-                      rewardsApy={apy.rewardsApy.per30d}
-                      vaultApy={apy.vaultApy.per30d}
-                    />
+                    apy.rewardsApy.per30d.length > 0 && (
+                      <Erc4626ApyTooltip
+                        rewardsApy={apy.rewardsApy.per30d}
+                        vaultApy={apy.vaultApy.per30d}
+                      />
+                    )
                   }
                 />,
                 `${formatCryptoBalance(netValue.per30d)} ${quoteToken}`,
@@ -79,10 +83,12 @@ export const Erc4626DetailsSectionContentOpen: FC = () => {
                   estimatedEarnings={earnings.per365d}
                   token={quoteToken}
                   tooltip={
-                    <Erc4626ApyTooltip
-                      rewardsApy={apy.rewardsApy.per365d}
-                      vaultApy={apy.vaultApy.per365d}
-                    />
+                    apy.rewardsApy.per365d.length > 0 && (
+                      <Erc4626ApyTooltip
+                        rewardsApy={apy.rewardsApy.per365d}
+                        vaultApy={apy.vaultApy.per365d}
+                      />
+                    )
                   }
                 />,
                 `${formatCryptoBalance(netValue.per365d)} ${quoteToken}`,

--- a/features/omni-kit/protocols/erc-4626/hooks/useErc4626ApySimulation.ts
+++ b/features/omni-kit/protocols/erc-4626/hooks/useErc4626ApySimulation.ts
@@ -90,50 +90,48 @@ export function useErc4626ApySimulation({
 
       setCancelablePromise(promise)
 
-      void promise.then(({ vault, apyFromRewards }) => {
-        if (apyFromRewards) {
-          const rewardsApy = apyFromRewards.map(({ per1kUsd, token, value }) => ({
-            token,
-            value: new BigNumber(value),
-            ...(per1kUsd && { per1kUsd: new BigNumber(per1kUsd) }),
-          }))
-          const vaultApy = new BigNumber(vault.apy)
-          const totalApy = getErc4626Apy({
-            rewardsApy,
-            vaultApy,
-          })
+      void promise.then(({ vault, apyFromRewards = [] }) => {
+        const rewardsApy = apyFromRewards.map(({ per1kUsd, token, value }) => ({
+          token,
+          value: new BigNumber(value),
+          ...(per1kUsd && { per1kUsd: new BigNumber(per1kUsd) }),
+        }))
+        const vaultApy = new BigNumber(vault.apy)
+        const totalApy = getErc4626Apy({
+          rewardsApy,
+          vaultApy,
+        })
 
-          setApy({
-            rewardsApy: {
-              per1d: rewardsApy.map(({ per1kUsd, token, value }) => ({
-                token,
-                value: value.div(365),
-                ...(per1kUsd && { per1kUsd: per1kUsd.div(365) }),
-              })),
-              per30d: rewardsApy.map(({ per1kUsd, token, value }) => ({
-                token,
-                value: value.div(12),
-                ...(per1kUsd && { per1kUsd: per1kUsd.div(12) }),
-              })),
-              per365d: rewardsApy,
-            },
-            vaultApy: {
-              per1d: vaultApy.div(365),
-              per30d: vaultApy.div(12),
-              per365d: vaultApy,
-            },
-          })
-          setEarnings({
-            per1d: resolvedQuoteTokenAmount.times(totalApy.div(365)),
-            per30d: resolvedQuoteTokenAmount.times(totalApy.div(12)),
-            per365d: resolvedQuoteTokenAmount.times(totalApy),
-          })
-          setNetValue({
-            per1d: resolvedQuoteTokenAmount.plus(resolvedQuoteTokenAmount.times(totalApy.div(365))),
-            per30d: resolvedQuoteTokenAmount.plus(resolvedQuoteTokenAmount.times(totalApy.div(12))),
-            per365d: resolvedQuoteTokenAmount.plus(resolvedQuoteTokenAmount.times(totalApy)),
-          })
-        }
+        setApy({
+          rewardsApy: {
+            per1d: rewardsApy.map(({ per1kUsd, token, value }) => ({
+              token,
+              value: value.div(365),
+              ...(per1kUsd && { per1kUsd: per1kUsd.div(365) }),
+            })),
+            per30d: rewardsApy.map(({ per1kUsd, token, value }) => ({
+              token,
+              value: value.div(12),
+              ...(per1kUsd && { per1kUsd: per1kUsd.div(12) }),
+            })),
+            per365d: rewardsApy,
+          },
+          vaultApy: {
+            per1d: vaultApy.div(365),
+            per30d: vaultApy.div(12),
+            per365d: vaultApy,
+          },
+        })
+        setEarnings({
+          per1d: resolvedQuoteTokenAmount.times(totalApy.div(365)),
+          per30d: resolvedQuoteTokenAmount.times(totalApy.div(12)),
+          per365d: resolvedQuoteTokenAmount.times(totalApy),
+        })
+        setNetValue({
+          per1d: resolvedQuoteTokenAmount.plus(resolvedQuoteTokenAmount.times(totalApy.div(365))),
+          per30d: resolvedQuoteTokenAmount.plus(resolvedQuoteTokenAmount.times(totalApy.div(12))),
+          per365d: resolvedQuoteTokenAmount.plus(resolvedQuoteTokenAmount.times(totalApy)),
+        })
 
         setIsLoading(false)
       })


### PR DESCRIPTION
# Minor APY issues on ERC-4626

Partialy covers https://app.shortcut.com/oazo-apps/story/14917/bug-steakhouse-wbtc-current-apy-estimating-earnings-net-value-and-vault-allocation-breakdown-are-not-loading
  
## Changes 👷‍♀️

- Fix issue with infinity loading of APY data when all values were equal to zero.
- Fix issue with showing ✨ next to the APY with empty tooltips when no rewards were available.
- Fix issue with duplicated tokens in swap input when default token was declared in the config.