### PR TITLE
Fix `vault` address in erc4626 position query

### DIFF
--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -658,7 +658,7 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
   `,
   getErc4626PositionParameters: gql`
     query getPositionParameters($vault: String!, $dpmProxyAddress: String!) {
-      positions(where: { account: $dpmProxyAddress }) {
+      positions(where: { account: $dpmProxyAddress, vault: $vault }) {
         id
         shares
         earnCumulativeFeesUSD


### PR DESCRIPTION
This pull request fixes the `vault` address in the erc4626 position query by adding it as a parameter in the `positions` query.

How to test: 
http://localhost:3000/ethereum/erc-4626/earn/steakhouse-USDT/1467#overview