### PR TITLE
ERC-4626 pre-release updates

### DIFF
--- a/features/navigation/panels/getNavProductsPanel.tsx
+++ b/features/navigation/panels/getNavProductsPanel.tsx
@@ -94,7 +94,9 @@ export const getNavProductsPanel = ({
                         }),
                   tags: [
                     [
-                      lendingProtocolsByName[item.protocol].label,
+                      item.earnStrategy === EarnStrategies.erc_4626
+                        ? [item.earnStrategyDescription]
+                        : [lendingProtocolsByName[item.protocol].label],
                       lendingProtocolsByName[item.protocol].gradient,
                     ],
                     [capitalize(item.network), networksByName[item.network].gradient],

--- a/features/navigation/panels/getNavProtocolsPanel.tsx
+++ b/features/navigation/panels/getNavProtocolsPanel.tsx
@@ -11,7 +11,11 @@ import React from 'react'
 import type { TranslationType } from 'ts_modules/i18next'
 import type { AppConfigType } from 'types/config'
 
-const { AjnaSafetySwitch, MorphoBlue: MorphoBlueEnabled } = getLocalAppConfig('features')
+const {
+  AjnaSafetySwitch,
+  Erc4626Vaults: erc4626VaultsEnabled,
+  MorphoBlue: MorphoBlueEnabled,
+} = getLocalAppConfig('features')
 
 export const getNavProtocolsPanel = ({
   t,
@@ -194,6 +198,16 @@ export const getNavProtocolsPanel = ({
                         url: `${INTERNAL_LINKS.multiply}`,
                         query: query.morphoBlue,
                       },
+                      ...(erc4626VaultsEnabled
+                        ? [
+                            {
+                              title: t('nav.earn'),
+                              description: navigation.protocols.morphoBlue.earn.description,
+                              url: `${INTERNAL_LINKS.earn}`,
+                              query: query.morphoBlue,
+                            },
+                          ]
+                        : []),
                       {
                         title: navigation.protocols.morphoBlue.extra.title,
                         promoted: true,

--- a/features/omni-kit/protocols/erc-4626/components/details-section/Erc4626DetailsSectionFooter.tsx
+++ b/features/omni-kit/protocols/erc-4626/components/details-section/Erc4626DetailsSectionFooter.tsx
@@ -43,7 +43,9 @@ export const Erc4626DetailsSectionFooter: FC = () => {
     modal: (
       <DetailsSectionContentSimpleModal
         title={t('omni-kit.content-card.vault-fee.title')}
-        description={t(`erc-4626.content-card.vault-fee-${id}.modal-description`)}
+        description={t(
+          `erc-4626.content-card.vault-fee-${id.replace(`-${quoteToken}`, '')}.modal-description`,
+        )}
         value={formatDecimalAsPercent(interestRate)}
       />
     ),

--- a/features/omni-kit/protocols/erc-4626/settings.ts
+++ b/features/omni-kit/protocols/erc-4626/settings.ts
@@ -146,38 +146,6 @@ export const erc4626Vaults: Erc4626Config[] = [
       symbol: 'USDT',
     },
   },
-  {
-    address: '0xBEEf050ecd6a16c4e7bfFbB52Ebba7846C4b8cD4',
-    curator: steakhouseCurator,
-    id: 'steakhouse-ETH',
-    name: 'Steakhouse ETH',
-    protocol: LendingProtocol.MorphoBlue,
-    networkId: NetworkIds.MAINNET,
-    pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
-    strategy: 'MetaMorpho Lending',
-    token: {
-      address: getNetworkContracts(NetworkIds.MAINNET).tokens.ETH.address,
-      precision: getToken('ETH').precision,
-      symbol: 'ETH',
-    },
-  },
-  {
-    address: '0xbeEf094333AEdD535c130958c204E84f681FD9FA',
-    curator: steakhouseCurator,
-    id: 'steakhouse-WBTC',
-    name: 'Steakhouse WBTC',
-    protocol: LendingProtocol.MorphoBlue,
-    networkId: NetworkIds.MAINNET,
-    pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
-    strategy: 'MetaMorpho Lending',
-    token: {
-      address: getNetworkContracts(NetworkIds.MAINNET).tokens.WBTC.address,
-      precision: getToken('WBTC').precision,
-      symbol: 'WBTC',
-    },
-  },
 ]
 
 export const erc4626VaultsById = keyBy(erc4626Vaults, 'id')

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.54",
     "@oasisdex/automation": "1.6.5",
-    "@oasisdex/dma-library": "0.6.47",
+    "@oasisdex/dma-library": "0.6.48",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3331,8 +3331,8 @@
   },
   "erc-4626": {
     "content-card": {
-      "vault-fee-steakhouse-USDC": {
-        "modal-description": "MetaMorpho Vaults have a fee charged by the curator of the Vault for performing the risk management and selection of Blue Markets."
+      "vault-fee-steakhouse": {
+        "modal-description": "MetaMorpho Vaults have a fee charged by the curator of the Vault for performing the risk management and selection of Blue Markets. This fee is charged out of the earnings you make on the pool. The APY shown is after the fee has been applied"
       },
       "earnings-to-date": {
         "footnote": "Not including token rewards"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,10 +2397,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.47":
-  version "0.6.47"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.47.tgz#24c88ee8fccde9d1c5f7e4a7052920776377fc85"
-  integrity sha512-AfuaGepkIjJ6G5HQGas11J3GqxK9c2nSILZI5Q4c4IGBCbVToHztNabh6PRw4ovwH6hR98Gs728YcGp8XTrvaQ==
+"@oasisdex/dma-library@0.6.48":
+  version "0.6.48"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.48.tgz#a0bd0604d87a46b8c94c2fd702f723999ea2e91f"
+  integrity sha512-QQVUum1rOFfdV55AayyyDvUL4KdnSPLi1OV7G2XXvDQzOdDqDYt9fDUY+TOflaOydQ8ixcKKHmoPW8s6E7SKZQ==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION
# ERC-4626 pre-release updates
  
## Changes 👷‍♀️

- Changed protocol label in navigation for ERC-4626 type of products in Products > Earn panel.
- Added "Earn" link to Protocols > Morpho Blue panel in navigation.
- Changed description of modal in "Vault Fee" in ERC-4626 position overview footer and made it shared between all MetaMorpho products.
- Removed ETH and WBTC vaults from config.