### PR TITLE
Bring back ETH and WBTC vaults in ERC-4626 settings

### DIFF
--- a/features/omni-kit/protocols/erc-4626/settings.ts
+++ b/features/omni-kit/protocols/erc-4626/settings.ts
@@ -146,6 +146,38 @@ export const erc4626Vaults: Erc4626Config[] = [
       symbol: 'USDT',
     },
   },
+  {
+    address: '0xBEEf050ecd6a16c4e7bfFbB52Ebba7846C4b8cD4',
+    curator: steakhouseCurator,
+    id: 'steakhouse-ETH',
+    name: 'Steakhouse ETH',
+    protocol: LendingProtocol.MorphoBlue,
+    networkId: NetworkIds.MAINNET,
+    pricePicker: morphoPricePicker,
+    rewards: [morphoRewards],
+    strategy: 'MetaMorpho Lending',
+    token: {
+      address: getNetworkContracts(NetworkIds.MAINNET).tokens.ETH.address,
+      precision: getToken('ETH').precision,
+      symbol: 'ETH',
+    },
+  },
+  {
+    address: '0xbeEf094333AEdD535c130958c204E84f681FD9FA',
+    curator: steakhouseCurator,
+    id: 'steakhouse-WBTC',
+    name: 'Steakhouse WBTC',
+    protocol: LendingProtocol.MorphoBlue,
+    networkId: NetworkIds.MAINNET,
+    pricePicker: morphoPricePicker,
+    rewards: [morphoRewards],
+    strategy: 'MetaMorpho Lending',
+    token: {
+      address: getNetworkContracts(NetworkIds.MAINNET).tokens.WBTC.address,
+      precision: getToken('WBTC').precision,
+      symbol: 'WBTC',
+    },
+  },
 ]
 
 export const erc4626VaultsById = keyBy(erc4626Vaults, 'id')


### PR DESCRIPTION
# Bring back ETH and WBTC vaults in ERC-4626 settings

As in title.
