### PR TITLE
Add CONFIG_URL environment variable to dev and prod cache workflows

### DIFF
--- a/.github/workflows/dev-cache.yaml
+++ b/.github/workflows/dev-cache.yaml
@@ -1,4 +1,6 @@
 name: Create modules cache (dev)
+env:
+  CONFIG_URL: ${{ secrets.CONFIG_URL }}
 
 on:
   push:

--- a/.github/workflows/prod-cache.yaml
+++ b/.github/workflows/prod-cache.yaml
@@ -1,4 +1,6 @@
 name: Create modules cache (main)
+env:
+  CONFIG_URL: ${{ secrets.CONFIG_URL }}
 
 on:
   push:


### PR DESCRIPTION
This pull request adds the CONFIG_URL environment variable to the dev and prod cache workflows. This variable is used to configure the cache and is sourced from the secrets.CONFIG_URL secret.