### PR TITLE
Update Node.js version in Dockerfile.staging

### DIFF
--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,4 +1,4 @@
-FROM node:18.18-alpine
+FROM node:18.19.1-alpine
 EXPOSE 3000
 COPY server/database /app/server/database
 WORKDIR /app/server/database


### PR DESCRIPTION
This PR updates the Node.js version in the Dockerfile.staging from node:18.18-alpine to node:18.19.1-alpine.