### PR TITLE
Add support for Spark triggers

### DIFF
--- a/features/omni-kit/protocols/aave-like/helpers/getAaveLikeAutomationMetadataValues.ts
+++ b/features/omni-kit/protocols/aave-like/helpers/getAaveLikeAutomationMetadataValues.ts
@@ -135,27 +135,53 @@ export const getAaveLikeAutomationMetadataCommonValues = ({
         positionTriggers.triggers.aaveStopLossToCollateral ||
         positionTriggers.triggers.aaveStopLossToCollateralDMA ||
         positionTriggers.triggers.aaveStopLossToDebt ||
-        positionTriggers.triggers.aaveStopLossToDebtDMA
+        positionTriggers.triggers.aaveStopLossToDebtDMA ||
+        positionTriggers.triggers.sparkStopLossToCollateral ||
+        positionTriggers.triggers.sparkStopLossToCollateralDMA ||
+        positionTriggers.triggers.sparkStopLossToDebt ||
+        positionTriggers.triggers.sparkStopLossToDebtDMA
       ),
-      isTrailingStopLossEnabled: !!positionTriggers.triggers.aaveTrailingStopLossDMA,
-      isAutoSellEnabled: positionTriggers.flags.isAaveBasicSellEnabled,
-      isAutoBuyEnabled: positionTriggers.flags.isAaveBasicBuyEnabled,
-      isPartialTakeProfitEnabled: positionTriggers.flags.isAavePartialTakeProfitEnabled,
+      isTrailingStopLossEnabled: !!(
+        positionTriggers.triggers.aaveTrailingStopLossDMA ||
+        positionTriggers.triggers.sparkTrailingStopLossDMA
+      ),
+      isAutoSellEnabled: !!(
+        positionTriggers.flags.isAaveBasicSellEnabled ||
+        positionTriggers.flags.isSparkBasicSellEnabled
+      ),
+      isAutoBuyEnabled: !!(
+        positionTriggers.flags.isAaveBasicBuyEnabled ||
+        positionTriggers.flags.isSparkBasicBuyEnabled
+      ),
+      isPartialTakeProfitEnabled: !!(
+        positionTriggers.flags.isAavePartialTakeProfitEnabled ||
+        positionTriggers.flags.isSparkPartialTakeProfitEnabled
+      ),
     },
     triggers: {
       stopLoss: mapStopLossTriggers(
         positionTriggers.triggers.aaveStopLossToCollateral ||
           positionTriggers.triggers.aaveStopLossToCollateralDMA ||
           positionTriggers.triggers.aaveStopLossToDebt ||
-          positionTriggers.triggers.aaveStopLossToDebtDMA,
+          positionTriggers.triggers.aaveStopLossToDebtDMA ||
+          positionTriggers.triggers.sparkStopLossToCollateral ||
+          positionTriggers.triggers.sparkStopLossToCollateralDMA ||
+          positionTriggers.triggers.sparkStopLossToDebt ||
+          positionTriggers.triggers.sparkStopLossToDebtDMA,
       ),
       trailingStopLoss: mapTrailingStopLossTriggers(
-        positionTriggers.triggers.aaveTrailingStopLossDMA,
+        positionTriggers.triggers.aaveTrailingStopLossDMA ||
+          positionTriggers.triggers.sparkTrailingStopLossDMA,
       ),
-      autoSell: mapAutoSellTriggers(positionTriggers.triggers.aaveBasicSell),
-      autoBuy: mapAutoBuyTriggers(positionTriggers.triggers.aaveBasicBuy),
+      autoSell: mapAutoSellTriggers(
+        positionTriggers.triggers.aaveBasicSell || positionTriggers.triggers.sparkBasicSell,
+      ),
+      autoBuy: mapAutoBuyTriggers(
+        positionTriggers.triggers.aaveBasicBuy || positionTriggers.triggers.sparkBasicBuy,
+      ),
       partialTakeProfit: mapPartialTakeProfitTriggers(
-        positionTriggers.triggers.aavePartialTakeProfit,
+        positionTriggers.triggers.aavePartialTakeProfit ||
+          positionTriggers.triggers.sparkPartialTakeProfit,
       ),
     },
     simulation: simulationResponse?.simulation,

--- a/helpers/triggers/get-triggers/get-triggers-types.ts
+++ b/helpers/triggers/get-triggers/get-triggers-types.ts
@@ -419,17 +419,25 @@ export type StopLossTriggers =
   | AaveStopLossToCollateralDMA
   | AaveStopLossToDebt
   | AaveStopLossToDebtDMA
+  | SparkStopLossToCollateral
+  | SparkStopLossToCollateralDMA
+  | SparkStopLossToDebt
+  | SparkStopLossToDebtDMA
 
-export type TrailingStopLossTriggers = DmaAaveTrailingStopLoss
-export type AutoSellTriggers = DmaAaveBasicSell
-export type AutoBuyTriggers = DmaAaveBasicBuy
-export type PartialTakeProfitTriggers = DmaAavePartialTakeProfit
+export type TrailingStopLossTriggers = DmaAaveTrailingStopLoss | DmaSparkTrailingStopLoss
+export type AutoSellTriggers = DmaAaveBasicSell | DmaSparkBasicSell
+export type AutoBuyTriggers = DmaAaveBasicBuy | DmaSparkBasicBuy
+export type PartialTakeProfitTriggers = DmaAavePartialTakeProfit | DmaSparkPartialTakeProfit
 
 export type StopLossTriggersWithDecodedParams = (
   | AaveStopLossToCollateral
   | AaveStopLossToCollateralDMA
   | AaveStopLossToDebt
   | AaveStopLossToDebtDMA
+  | SparkStopLossToCollateral
+  | SparkStopLossToCollateralDMA
+  | SparkStopLossToDebt
+  | SparkStopLossToDebtDMA
 ) &
   WithMappedStopLossDecodedParams
 export type AutoSellTriggersWithDecodedParams = AutoSellTriggers & WithMappedAutoSellDecodedParams


### PR DESCRIPTION
This pull request adds support for Spark triggers to the existing codebase. It includes changes to the `getAaveLikeAutomationMetadataCommonValues` function to handle Spark triggers for stop loss, trailing stop loss, auto sell, auto buy, and partial take profit. The necessary types and mappings have also been updated to accommodate Spark triggers.