### PR TITLE
Fix fee calculation in OmniMultiplyFormOrder

### DIFF
--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
@@ -137,8 +137,8 @@ export function OmniMultiplyFormOrder() {
   const oasisFee = swapData
     ? amountFromWei(
         swapData.tokenFee,
-        swapData.collectFeeFrom === 'targetToken' ? quotePrecision : collateralPrecision,
-      ).multipliedBy(swapData.collectFeeFrom === 'targetToken' ? quotePrice : collateralPrice)
+        swapData.collectFeeFrom === 'targetToken' ? collateralPrecision : quotePrecision,
+      ).multipliedBy(swapData.collectFeeFrom === 'targetToken' ? collateralPrice : quotePrice)
     : zero
 
   const isLoading = !isTxSuccess && isSimulationLoading


### PR DESCRIPTION
This pull request fixes the fee calculation in the OmniMultiplyFormOrder function. The calculation was incorrect due to a mistake in the precision and price values used. This PR corrects the precision and price values to ensure accurate fee calculation.