### PR TITLE
Update trigger and target LTV values in OmniAutoBSSidebarController

### DIFF
--- a/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
+++ b/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
@@ -42,13 +42,13 @@ export const OmniAutoBSSidebarController: FC<{ type: OmniAutoBSAutomationTypes }
   const defaultTriggerValues = useMemo(() => {
     if (type === AutomationFeatures.AUTO_BUY) {
       return {
-        triggerLtv: currentLtv.times(100).minus(5),
-        targetLtv: currentLtv.times(100),
+        triggerLtv: currentLtv.times(100),
+        targetLtv: currentLtv.times(100).plus(5),
       }
     }
     return {
-      targetLtv: currentLtv.times(100).minus(5),
-      triggerLtv: currentLtv.times(100),
+      targetLtv: currentLtv.times(100),
+      triggerLtv: currentLtv.times(100).plus(5),
     }
   }, [currentLtv])
 


### PR DESCRIPTION
This pull request updates the trigger and target LTV values in the OmniAutoBSSidebarController. The triggerLtv and targetLtv values have been adjusted to improve the functionality of the AUTO_BUY automation feature.