### PR TITLE
Fix Next Dynamic Trigger price value in omni take profit

### DIFF
--- a/features/omni-kit/automation/components/partial-take-profit/OmniPartialTakeProfitOverviewDetailsSection.tsx
+++ b/features/omni-kit/automation/components/partial-take-profit/OmniPartialTakeProfitOverviewDetailsSection.tsx
@@ -43,7 +43,7 @@ export const OmniPartialTakeProfitOverviewDetailsSection: FC<
       badge={isPartialTakeProfitEnabled}
       content={
         <DetailsSectionContentCardWrapper>
-          <OmniContentCard {...nextDynamicTriggerPriceCommonData} />
+          <OmniContentCard {...nextDynamicTriggerPriceCommonData} isLoading={isLoading} />
           <OmniContentCard {...estimatedToReceiveCommonData} isLoading={isLoading} />
           <OmniContentCard {...currentProfitAndLossCommonData} />
           <OmniContentCard {...realizedProfitCommonData} />

--- a/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
+++ b/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
@@ -2,6 +2,7 @@ import type { AaveLikePositionV2 } from '@oasisdex/dma-library'
 import BigNumber from 'bignumber.js'
 import { getToken } from 'blockchain/tokensMetadata'
 import { DetailsSectionContentSimpleModal } from 'components/DetailsSectionContentSimpleModal'
+import { lambdaPriceDenomination } from 'features/aave/constants'
 import {
   hasActiveStopLossFromTriggers,
   hasActiveTrailingStopLossFromTriggers,
@@ -320,10 +321,19 @@ export const useOmniPartialTakeProfitDataHandler = () => {
     ? startingTakeProfitPriceShort
     : startingTakeProfitPriceLong
 
+  const simulatedNextDynamicTriggerPrice =
+    simulationData?.simulation && 'profits' in simulationData?.simulation
+      ? simulationData?.simulation?.profits?.[0].triggerPrice
+      : undefined
+
+  const afterNextDynamicTriggerPrice = simulatedNextDynamicTriggerPrice
+    ? new BigNumber(simulatedNextDynamicTriggerPrice).div(lambdaPriceDenomination)
+    : undefined
+
   const nextDynamicTriggerPriceCommonData = useOmniCardDataNextDynamicTriggerPrice({
     priceFormat,
     nextDynamicTriggerPrice: startingTakeProfitPrice,
-    afterNextDynamicTriggerPrice: state.price,
+    afterNextDynamicTriggerPrice,
     triggerLtv: resolvedTriggerLtv,
     modal: (
       <DetailsSectionContentSimpleModal


### PR DESCRIPTION
This pull request fixes the issue with the Next Dynamic Trigger price value in the omni take profit feature. The `OmniPartialTakeProfitOverviewDetailsSection` component was updated to pass the `isLoading` prop to the `OmniContentCard` component. Additionally, the `useOmniPartialTakeProfitDataHandler` hook was updated to calculate the `afterNextDynamicTriggerPrice` based on the simulated next dynamic trigger price. This ensures that the correct value is displayed in the UI.