### PR TITLE
Add Aave-like omni automation notifications

### DIFF
--- a/features/omni-kit/protocols/aave-like/helpers/getAaveLikeNotifications.tsx
+++ b/features/omni-kit/protocols/aave-like/helpers/getAaveLikeNotifications.tsx
@@ -1,18 +1,53 @@
 import type { DetailsSectionNotificationItem } from 'components/DetailsSectionNotification'
+import { mapTrailingStopLossFromLambda } from 'features/aave/manage/helpers/map-trailing-stop-loss-from-lambda'
 import type { AaveLikeHistoryEvent } from 'features/omni-kit/protocols/aave-like/history/types'
 import { OmniProductType } from 'features/omni-kit/types'
+import { formatCryptoBalance } from 'helpers/formatters/format'
+import { nbsp } from 'helpers/nbsp'
+import type { GetTriggersResponse } from 'helpers/triggers'
+import { bell } from 'theme/icons'
 
 export function getAaveLikeNotifications({
   productType,
+  triggers,
+  priceFormat,
 }: {
   auction?: AaveLikeHistoryEvent
   productType: OmniProductType
+  triggers?: GetTriggersResponse
+  priceFormat: string
 }) {
   const notifications: DetailsSectionNotificationItem[] = []
 
   switch (productType) {
     case OmniProductType.Borrow:
     case OmniProductType.Multiply:
+      const mappedLambdaData = mapTrailingStopLossFromLambda(triggers?.triggers)
+      const executionPrice = mappedLambdaData?.dynamicParams?.executionPrice
+      const originalExecutionPrice = mappedLambdaData?.dynamicParams?.originalExecutionPrice
+      if (executionPrice && originalExecutionPrice && executionPrice.gt(originalExecutionPrice)) {
+        return [
+          {
+            title: {
+              translationKey: 'automation.trailing-stop-loss-execution-price-increased',
+              params: {
+                executionPriceAndToken: `${formatCryptoBalance(
+                  executionPrice,
+                )}${nbsp}${priceFormat}`,
+                originalExecutionPriceAndToken: `${formatCryptoBalance(
+                  originalExecutionPrice,
+                )}${nbsp}${priceFormat}`,
+                delta: `+${formatCryptoBalance(executionPrice.minus(originalExecutionPrice))}`,
+                token: priceFormat,
+              },
+            },
+            sessionStorageParam: formatCryptoBalance(executionPrice),
+            closable: true,
+            icon: bell,
+          },
+        ]
+      }
+      break
     case OmniProductType.Earn: {
       break
     }

--- a/features/omni-kit/protocols/aave-like/metadata/useAaveLikeMetadata.tsx
+++ b/features/omni-kit/protocols/aave-like/metadata/useAaveLikeMetadata.tsx
@@ -44,6 +44,7 @@ export const useAaveLikeMetadata: GetOmniMetadata = (productContext) => {
       quoteToken,
       isOwner,
       networkId,
+      priceFormat,
     },
     steps: { currentStep },
     tx: { txDetails },
@@ -61,6 +62,8 @@ export const useAaveLikeMetadata: GetOmniMetadata = (productContext) => {
   const notifications: DetailsSectionNotificationItem[] = getAaveLikeNotifications({
     productType,
     auction: productContext.position.positionAuction as AaveLikeHistoryEvent,
+    triggers: productContext.automation.positionTriggers,
+    priceFormat,
   })
 
   switch (productType) {


### PR DESCRIPTION
This pull request adds Aave-like omni automation notifications to the codebase. It includes changes to the `getAaveLikeNotifications` function and the `useAaveLikeMetadata` hook. These changes allow for the display of notifications related to trailing stop-loss execution price increases.