### PR TITLE
Refactor labels in useOmniAutoBSOrderInformationItems

### DIFF
--- a/features/omni-kit/automation/hooks/useOmniAutoBSOrderInformationItems.ts
+++ b/features/omni-kit/automation/hooks/useOmniAutoBSOrderInformationItems.ts
@@ -41,19 +41,31 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
 
   return [
     {
-      label: t('auto-sell.target-ltv-each-sell'),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.target-ltv-each-sell')
+          : t('auto-buy.target-ltv-each-buy'),
       value: afterTargetLtv ? formatDecimalAsPercent(afterTargetLtv.div(100)) : '-',
     },
     {
-      label: t('auto-sell.target-multiple-each-sell'),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.target-multiple-each-sell')
+          : t('auto-buy.target-multiple-each-buy'),
       value: afterTargetMultiply ? `${afterTargetMultiply.toFixed(2)}x` : '-',
     },
     {
-      label: t('auto-sell.trigger-ltv-to-perform-sell'),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.trigger-ltv-to-perform-sell')
+          : t('auto-buy.trigger-ltv-to-perform-buy'),
       value: afterTriggerLtv ? formatDecimalAsPercent(afterTriggerLtv.div(100)) : '-',
     },
     {
-      label: t('auto-sell.target-ratio-with-deviation'),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.target-ratio-with-deviation')
+          : t('auto-buy.target-ratio-with-deviation'),
       value: deviation
         ? `${formatDecimalAsPercent(
             new BigNumber(deviation[0]).div(10000),
@@ -62,21 +74,30 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
       isLoading: isSimulationLoading,
     },
     {
-      label: t('auto-sell.collateral-after-next-sell'),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.collateral-after-next-sell')
+          : t('auto-buy.collateral-after-next-buy'),
       value: collateralAmountAfterExecution
         ? `${formatCryptoBalance(collateralAmountAfterExecution)} ${collateralToken}`
         : '-',
       isLoading: isSimulationLoading,
     },
     {
-      label: t('auto-sell.outstanding-debt-after-next-sell'),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.outstanding-debt-after-next-sell')
+          : t('auto-buy.outstanding-debt-after-next-buy'),
       value: debtAmountAfterExecution
         ? `${formatCryptoBalance(debtAmountAfterExecution)} ${quoteToken}`
         : '-',
       isLoading: isSimulationLoading,
     },
     {
-      label: t('auto-sell.col-to-be-sold', { token: collateralToken }),
+      label:
+        type === AutomationFeatures.AUTO_SELL
+          ? t('auto-sell.col-to-be-sold', { token: collateralToken })
+          : t('auto-buy.col-to-be-purchased', { token: collateralToken }),
       value: collateralToBuyOrSellOnExecution
         ? `${formatCryptoBalance(collateralToBuyOrSellOnExecution)} ${collateralToken}`
         : '-',

--- a/features/omni-kit/automation/hooks/useOmniAutoBSOrderInformationItems.ts
+++ b/features/omni-kit/automation/hooks/useOmniAutoBSOrderInformationItems.ts
@@ -27,6 +27,8 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
     ? AutomationFeatures.AUTO_SELL
     : AutomationFeatures.AUTO_BUY
 
+  const isAutoSell = type === AutomationFeatures.AUTO_SELL
+
   const {
     afterTargetMultiply,
     afterTargetLtv,
@@ -41,31 +43,25 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
 
   return [
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.target-ltv-each-sell')
-          : t('auto-buy.target-ltv-each-buy'),
+      label: isAutoSell ? t('auto-sell.target-ltv-each-sell') : t('auto-buy.target-ltv-each-buy'),
       value: afterTargetLtv ? formatDecimalAsPercent(afterTargetLtv.div(100)) : '-',
     },
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.target-multiple-each-sell')
-          : t('auto-buy.target-multiple-each-buy'),
+      label: isAutoSell
+        ? t('auto-sell.target-multiple-each-sell')
+        : t('auto-buy.target-multiple-each-buy'),
       value: afterTargetMultiply ? `${afterTargetMultiply.toFixed(2)}x` : '-',
     },
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.trigger-ltv-to-perform-sell')
-          : t('auto-buy.trigger-ltv-to-perform-buy'),
+      label: isAutoSell
+        ? t('auto-sell.trigger-ltv-to-perform-sell')
+        : t('auto-buy.trigger-ltv-to-perform-buy'),
       value: afterTriggerLtv ? formatDecimalAsPercent(afterTriggerLtv.div(100)) : '-',
     },
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.target-ratio-with-deviation')
-          : t('auto-buy.target-ratio-with-deviation'),
+      label: isAutoSell
+        ? t('auto-sell.target-ratio-with-deviation')
+        : t('auto-buy.target-ratio-with-deviation'),
       value: deviation
         ? `${formatDecimalAsPercent(
             new BigNumber(deviation[0]).div(10000),
@@ -74,30 +70,27 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
       isLoading: isSimulationLoading,
     },
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.collateral-after-next-sell')
-          : t('auto-buy.collateral-after-next-buy'),
+      label: isAutoSell
+        ? t('auto-sell.collateral-after-next-sell')
+        : t('auto-buy.collateral-after-next-buy'),
       value: collateralAmountAfterExecution
         ? `${formatCryptoBalance(collateralAmountAfterExecution)} ${collateralToken}`
         : '-',
       isLoading: isSimulationLoading,
     },
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.outstanding-debt-after-next-sell')
-          : t('auto-buy.outstanding-debt-after-next-buy'),
+      label: isAutoSell
+        ? t('auto-sell.outstanding-debt-after-next-sell')
+        : t('auto-buy.outstanding-debt-after-next-buy'),
       value: debtAmountAfterExecution
         ? `${formatCryptoBalance(debtAmountAfterExecution)} ${quoteToken}`
         : '-',
       isLoading: isSimulationLoading,
     },
     {
-      label:
-        type === AutomationFeatures.AUTO_SELL
-          ? t('auto-sell.col-to-be-sold', { token: collateralToken })
-          : t('auto-buy.col-to-be-purchased', { token: collateralToken }),
+      label: isAutoSell
+        ? t('auto-sell.col-to-be-sold', { token: collateralToken })
+        : t('auto-buy.col-to-be-purchased', { token: collateralToken }),
       value: collateralToBuyOrSellOnExecution
         ? `${formatCryptoBalance(collateralToBuyOrSellOnExecution)} ${collateralToken}`
         : '-',


### PR DESCRIPTION
This pull request refactors the labels in the useOmniAutoBSOrderInformationItems function to dynamically select the appropriate label based on the automation feature type. This improves code readability and maintainability.