### PR TITLE
Add positionId to OmniFormView and use it in useOmniProductTypeTransition

### DIFF
--- a/features/omni-kit/contexts/OmniProductContext.tsx
+++ b/features/omni-kit/contexts/OmniProductContext.tsx
@@ -165,7 +165,7 @@ export function OmniProductContextProvider({
           simulation: simulation?.position,
         },
         isSimulationLoading,
-        resolvedId: positionIdFromDpmProxyData,
+        openFlowResolvedDpmId: positionIdFromDpmProxyData,
         positionAuction,
         swap: {
           current: formatSwapData({

--- a/features/omni-kit/helpers/getOmniAutomationSidebarPrimaryButtonActions.ts
+++ b/features/omni-kit/helpers/getOmniAutomationSidebarPrimaryButtonActions.ts
@@ -24,7 +24,7 @@ interface GetOmniAutomationSidebarPrimaryButtonActionsParams {
   pseudoProtocol?: string
   quoteAddress: string
   quoteToken: string
-  resolvedId?: string
+  openFlowResolvedDpmId?: string
   shouldSwitchNetwork: boolean
   walletAddress?: string
 }
@@ -50,7 +50,7 @@ export function getOmniAutomationSidebarPrimaryButtonActions({
   pseudoProtocol,
   quoteAddress,
   quoteToken,
-  resolvedId,
+  openFlowResolvedDpmId,
   shouldSwitchNetwork,
   walletAddress,
 }: GetOmniAutomationSidebarPrimaryButtonActionsParams) {
@@ -67,7 +67,7 @@ export function getOmniAutomationSidebarPrimaryButtonActions({
           isPoolOracless: isOracless,
           label,
           networkName: network.name,
-          positionId: resolvedId,
+          positionId: openFlowResolvedDpmId,
           productType,
           protocol,
           pseudoProtocol,

--- a/features/omni-kit/helpers/getOmniSidebarPrimaryButtonActions.ts
+++ b/features/omni-kit/helpers/getOmniSidebarPrimaryButtonActions.ts
@@ -28,7 +28,7 @@ interface GetOmniSidebarPrimaryButtonActionsParams {
   pseudoProtocol?: string
   quoteAddress: string
   quoteToken: string
-  resolvedId?: string
+  openFlowResolvedDpmId?: string
   shouldSwitchNetwork: boolean
   walletAddress?: string
 }
@@ -58,7 +58,7 @@ export function getOmniSidebarPrimaryButtonActions({
   pseudoProtocol,
   quoteAddress,
   quoteToken,
-  resolvedId,
+  openFlowResolvedDpmId,
   shouldSwitchNetwork,
   walletAddress,
 }: GetOmniSidebarPrimaryButtonActionsParams) {
@@ -75,7 +75,7 @@ export function getOmniSidebarPrimaryButtonActions({
           isPoolOracless: isOracless,
           label,
           networkName: network.name,
-          positionId: resolvedId,
+          positionId: openFlowResolvedDpmId,
           productType,
           protocol,
           pseudoProtocol,

--- a/features/omni-kit/types.ts
+++ b/features/omni-kit/types.ts
@@ -524,7 +524,7 @@ interface ProductContextPosition<Position, Auction> {
     cached?: OmniSimulationSwap
   }
   isSimulationLoading?: boolean
-  resolvedId?: string
+  openFlowResolvedDpmId?: string
   setCachedPosition: (positionSet: OmniPositionSet<OmniGenericPosition>) => void
   setIsLoadingSimulation: Dispatch<SetStateAction<boolean>>
   setSimulation: Dispatch<SetStateAction<OmniSimulationData<OmniGenericPosition> | undefined>>

--- a/features/omni-kit/views/OmniAutomationFormView.tsx
+++ b/features/omni-kit/views/OmniAutomationFormView.tsx
@@ -68,7 +68,7 @@ export function OmniAutomationFormView({
       setSimulation,
       setCachedOrderInfoItems,
     },
-    position: { resolvedId },
+    position: { openFlowResolvedDpmId },
     dynamicMetadata: {
       featureToggles: { suppressValidation, safetySwitch },
       validations: { isFormFrozen },
@@ -147,7 +147,7 @@ export function OmniAutomationFormView({
     quoteAddress,
     quoteToken,
     shouldSwitchNetwork,
-    resolvedId,
+    openFlowResolvedDpmId,
     walletAddress,
   })
   const textButtonAction = () => {

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -87,7 +87,7 @@ export function OmniFormView({
   } = useOmniGeneralContext()
   const {
     form: { dispatch, state },
-    position: { isSimulationLoading, resolvedId },
+    position: { isSimulationLoading, openFlowResolvedDpmId },
     dynamicMetadata: {
       elements: { sidebarContent },
       featureToggles: { suppressValidation, safetySwitch },
@@ -158,7 +158,7 @@ export function OmniFormView({
     transitionHandler,
   } = useOmniProductTypeTransition({
     action: state.action,
-    positionId: positionId || resolvedId,
+    positionId: positionId || openFlowResolvedDpmId,
     protocol,
     productType,
     tokenPair: `${collateralToken}-${quoteToken}`,
@@ -235,7 +235,7 @@ export function OmniFormView({
     quoteAddress,
     quoteToken,
     shouldSwitchNetwork,
-    resolvedId,
+    openFlowResolvedDpmId,
     walletAddress,
   })
   const textButtonAction = () => {
@@ -263,9 +263,9 @@ export function OmniFormView({
       <Grid gap={3}>
         {sidebarContent}
         {children}
-        {OmniKitDebug && resolvedId && (
+        {OmniKitDebug && openFlowResolvedDpmId && (
           <VaultChangesInformationContainer title="DPM debug data">
-            <VaultChangesInformationItem label="DPM ID" value={resolvedId} />
+            <VaultChangesInformationItem label="DPM ID" value={openFlowResolvedDpmId} />
             <VaultChangesInformationItem
               label="Address"
               value={

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -64,6 +64,7 @@ export function OmniFormView({
       quoteToken,
       settings,
       shouldSwitchNetwork,
+      positionId,
     },
     steps: {
       currentStep,
@@ -149,6 +150,8 @@ export function OmniFormView({
     onEverythingReady: () => setNextStep(),
     onGoBack: () => setStep(editingStep),
   })
+  console.log('debug resolvedId', resolvedId)
+  console.log('debug positionId', positionId)
   const {
     isTransitionAction,
     isTransitionInProgress,
@@ -157,7 +160,7 @@ export function OmniFormView({
     transitionHandler,
   } = useOmniProductTypeTransition({
     action: state.action,
-    positionId: resolvedId,
+    positionId: positionId || resolvedId,
     protocol,
     productType,
     tokenPair: `${collateralToken}-${quoteToken}`,

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -150,8 +150,6 @@ export function OmniFormView({
     onEverythingReady: () => setNextStep(),
     onGoBack: () => setStep(editingStep),
   })
-  console.log('debug resolvedId', resolvedId)
-  console.log('debug positionId', positionId)
   const {
     isTransitionAction,
     isTransitionInProgress,


### PR DESCRIPTION
This pull request adds the positionId parameter to the OmniFormView component and uses it in the useOmniProductTypeTransition hook. This allows for better handling of transitions and resolves an issue with the resolvedId variable.