### PR TITLE
Fix omni aave/spark earn/borrow/multiply switching

### DIFF
--- a/features/omni-kit/controllers/OmniProductController.tsx
+++ b/features/omni-kit/controllers/OmniProductController.tsx
@@ -21,13 +21,12 @@ import {
 import type {
   GetOmniMetadata,
   OmniFormDefaults,
-  OmniProductType,
   OmniProtocolHookProps,
   OmniProtocolSettings,
   OmniSupportedNetworkIds,
   OmniSupportedProtocols,
 } from 'features/omni-kit/types'
-import { OmniSidebarAutomationStep } from 'features/omni-kit/types'
+import { OmniProductType, OmniSidebarAutomationStep } from 'features/omni-kit/types'
 import type { PositionHistoryEvent } from 'features/positionHistory/types'
 import { WithTermsOfService } from 'features/termsOfService/TermsOfService'
 import { WithWalletAssociatedRisk } from 'features/walletAssociatedRisk/WalletAssociatedRisk'
@@ -161,9 +160,9 @@ export const OmniProductController = <Auction, History, Position>({
   const isYieldLoop = getOmniIsOmniYieldLoop({ collateralToken, pseudoProtocol, quoteToken })
 
   // Flag to determine whether full yield-loop UI experience is available for given protocol & pair
-  const isYieldLoopWithData = !!settings.yieldLoopPairsWithData?.[networkId]?.includes(
-    `${collateralToken}-${quoteToken}`,
-  )
+  const isYieldLoopWithData =
+    !!settings.yieldLoopPairsWithData?.[networkId]?.includes(`${collateralToken}-${quoteToken}`) &&
+    dpmPositionData?.product === OmniProductType.Multiply
 
   return (
     <WithConnection>

--- a/features/omni-kit/observables/getDpmPositionData.ts
+++ b/features/omni-kit/observables/getDpmPositionData.ts
@@ -44,7 +44,7 @@ const mapAaveYieldLoopToMultiply = ({
     isCorrelatedPosition(collateralToken, quoteToken) &&
     [LendingProtocol.SparkV3, LendingProtocol.AaveV3, LendingProtocol.AaveV2].includes(protocol)
   ) {
-    return 'Multiply'
+    return 'Multiply' as PositionType
   }
 
   return positionType


### PR DESCRIPTION
This pull request fixes the issue with omni aave/spark earn/borrow/multiply switching. The code changes ensure that the correct position type is returned based on the collateral token, quote token, and protocol.