### PR TITLE
Refactor useOmniPartialTakeProfitDataHandler to calculate startingTakeProfitPriceLong and startingTakeProfitPriceShort based on dynamicParams

### DIFF
--- a/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
+++ b/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
@@ -145,10 +145,14 @@ export const useOmniPartialTakeProfitDataHandler = () => {
 
   const resolvedTriggerLtv = resolvedTrigger?.decodedMappedParams.executionLtv
 
-  const startingTakeProfitPriceLong = resolvedTrigger?.decodedMappedParams.executionPrice
+  const startingTakeProfitPriceLong = resolvedTrigger?.dynamicParams?.nextProfit
+    ? new BigNumber(resolvedTrigger.dynamicParams.nextProfit.triggerPrice).div(
+        lambdaPriceDenomination,
+      )
+    : undefined
 
-  const startingTakeProfitPriceShort = resolvedTrigger?.decodedMappedParams.executionPrice
-    ? one.div(resolvedTrigger?.decodedMappedParams.executionPrice)
+  const startingTakeProfitPriceShort = startingTakeProfitPriceLong
+    ? one.div(startingTakeProfitPriceLong)
     : undefined
 
   const resolvedWithdrawalLtv =


### PR DESCRIPTION
This pull request refactors the useOmniPartialTakeProfitDataHandler function to calculate the startingTakeProfitPriceLong and startingTakeProfitPriceShort values based on the dynamicParams. This ensures that the correct values are used for these variables, improving the accuracy of the calculations.