### PR TITLE
Fix next trigger price handling in omni aave/spark take profit automation + adjusted loading states

### DIFF
--- a/features/omni-kit/automation/components/partial-take-profit/OmniPartialTakeProfitSidebarController.tsx
+++ b/features/omni-kit/automation/components/partial-take-profit/OmniPartialTakeProfitSidebarController.tsx
@@ -44,6 +44,7 @@ export const OmniPartialTakeProfitSidebarController = () => {
   } = useOmniGeneralContext()
   const {
     automation: {
+      isSimulationLoading,
       automationForms: {
         partialTakeProfit: { state: automationFormState, updateState: automationUpdateState },
       },
@@ -635,8 +636,8 @@ export const OmniPartialTakeProfitSidebarController = () => {
           t('protection.partial-take-profit-sidebar.profits-table.total-profit'),
           t('protection.partial-take-profit-sidebar.profits-table.stop-loss'),
         ]}
-        rows={parsedProfits}
-        loading={!parsedProfits}
+        rows={isSimulationLoading ? [] : parsedProfits}
+        loading={!parsedProfits || isSimulationLoading}
         wrapperSx={{
           gridGap: 1,
           backgroundColor: 'transparent',

--- a/features/omni-kit/automation/hooks/useOmniAutoBSOrderInformationItems.ts
+++ b/features/omni-kit/automation/hooks/useOmniAutoBSOrderInformationItems.ts
@@ -13,7 +13,6 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
     environment: { productType, collateralToken, quoteToken },
   } = useOmniGeneralContext()
   const {
-    automation: { isSimulationLoading },
     dynamicMetadata: {
       values: { automation },
     },
@@ -67,7 +66,6 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
             new BigNumber(deviation[0]).div(10000),
           )} - ${formatDecimalAsPercent(new BigNumber(deviation[1]).div(10000))}`
         : '-',
-      isLoading: isSimulationLoading,
     },
     {
       label: isAutoSell
@@ -76,7 +74,6 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
       value: collateralAmountAfterExecution
         ? `${formatCryptoBalance(collateralAmountAfterExecution)} ${collateralToken}`
         : '-',
-      isLoading: isSimulationLoading,
     },
     {
       label: isAutoSell
@@ -85,7 +82,6 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
       value: debtAmountAfterExecution
         ? `${formatCryptoBalance(debtAmountAfterExecution)} ${quoteToken}`
         : '-',
-      isLoading: isSimulationLoading,
     },
     {
       label: isAutoSell
@@ -94,7 +90,6 @@ export const useOmniAutoBSOrderInformationItems = (): ItemProps[] => {
       value: collateralToBuyOrSellOnExecution
         ? `${formatCryptoBalance(collateralToBuyOrSellOnExecution)} ${collateralToken}`
         : '-',
-      isLoading: isSimulationLoading,
     },
-  ]
+  ] as ItemProps[]
 }

--- a/features/omni-kit/automation/hooks/useOmniAutomationOrderInformationItems.tsx
+++ b/features/omni-kit/automation/hooks/useOmniAutomationOrderInformationItems.tsx
@@ -35,6 +35,11 @@ export const useOmniAutomationOrderInformationItems = (): {
 
   const isLoading = !isTxSuccess && isSimulationLoading
 
+  const decorateIsLoading = (loading?: boolean) => (item: ItemProps) => ({
+    ...item,
+    isLoading: !!loading,
+  })
+
   const estimationItem = {
     label: t('max-gas-fee'),
     value: <OmniGasEstimation />,
@@ -59,14 +64,14 @@ export const useOmniAutomationOrderInformationItems = (): {
     case AutomationFeatures.STOP_LOSS: {
       const stopLossItems = useOmniStopLossOrderInformationItems()
       return {
-        items: stopLossItems,
+        items: stopLossItems.map(decorateIsLoading(isLoading)),
         gasItem,
       }
     }
     case AutomationFeatures.TRAILING_STOP_LOSS: {
       const trailingStopLossItems = useOmniTrailingStopLossOrderInformationItems()
       return {
-        items: trailingStopLossItems,
+        items: trailingStopLossItems.map(decorateIsLoading(isLoading)),
         gasItem,
       }
     }
@@ -74,14 +79,14 @@ export const useOmniAutomationOrderInformationItems = (): {
     case AutomationFeatures.AUTO_SELL: {
       const autoBSItems = useOmniAutoBSOrderInformationItems()
       return {
-        items: autoBSItems,
+        items: autoBSItems.map(decorateIsLoading(isLoading)),
         gasItem,
       }
     }
     case AutomationFeatures.PARTIAL_TAKE_PROFIT:
       const partialTakeProfitItems = useOmniPartialTakeProfitOrderInformationItems()
       return {
-        items: partialTakeProfitItems,
+        items: partialTakeProfitItems.map(decorateIsLoading(isLoading)),
         gasItem,
       }
 

--- a/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
+++ b/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
@@ -409,6 +409,7 @@ export const useOmniPartialTakeProfitDataHandler = () => {
     ),
     multiple: castedPosition.riskRatio.multiple,
     startingTakeProfitPrice,
+    afterNextDynamicTriggerPrice,
     resolvedWithdrawalLtv,
     resolvedTriggerLtv,
     positionPriceRatio,

--- a/features/omni-kit/automation/hooks/useOmniPartialTakeProfitOrderInformationItems.ts
+++ b/features/omni-kit/automation/hooks/useOmniPartialTakeProfitOrderInformationItems.ts
@@ -1,3 +1,4 @@
+import type { ItemProps } from 'components/infoSection/Item'
 import { useOmniPartialTakeProfitDataHandler } from 'features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
@@ -13,14 +14,19 @@ export const useOmniPartialTakeProfitOrderInformationItems = () => {
     automation: { automationForms },
   } = useOmniProductContext(productType)
 
-  const { afterResolvedEstimatedToReceive, resolveToToken } = useOmniPartialTakeProfitDataHandler()
+  const {
+    afterResolvedEstimatedToReceive,
+    resolveToToken,
+    startingTakeProfitPrice,
+    afterNextDynamicTriggerPrice,
+  } = useOmniPartialTakeProfitDataHandler()
+
+  const nextTriggerPrice = afterNextDynamicTriggerPrice || startingTakeProfitPrice
 
   return [
     {
       label: t('partial-take-profit.next-trigger-price'),
-      value: automationForms.partialTakeProfit.state.price
-        ? `${formatCryptoBalance(automationForms.partialTakeProfit.state.price)} ${priceFormat}`
-        : '-',
+      value: nextTriggerPrice ? `${formatCryptoBalance(nextTriggerPrice)} ${priceFormat}` : '-',
     },
     {
       label: t('partial-take-profit.next-realized-profit'),
@@ -50,5 +56,5 @@ export const useOmniPartialTakeProfitOrderInformationItems = () => {
           },
         ]
       : []),
-  ]
+  ] as ItemProps[]
 }

--- a/features/omni-kit/automation/hooks/useOmniStopLossOrderInformationItems.ts
+++ b/features/omni-kit/automation/hooks/useOmniStopLossOrderInformationItems.ts
@@ -1,3 +1,4 @@
+import type { ItemProps } from 'components/infoSection/Item'
 import { useOmniStopLossDataHandler } from 'features/omni-kit/automation/hooks/useOmniStopLossDataHandler'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { formatCryptoBalance, formatDecimalAsPercent } from 'helpers/formatters/format'
@@ -35,5 +36,5 @@ export const useOmniStopLossOrderInformationItems = () => {
         ? `${formatCryptoBalance(savingCompareToLiquidation)} ${closeToToken}`
         : '-',
     },
-  ]
+  ] as ItemProps[]
 }

--- a/features/omni-kit/automation/hooks/useOmniTrailingStopLossOrderInformationItems.ts
+++ b/features/omni-kit/automation/hooks/useOmniTrailingStopLossOrderInformationItems.ts
@@ -1,3 +1,4 @@
+import type { ItemProps } from 'components/infoSection/Item'
 import { useOmniTrailingStopLossDataHandler } from 'features/omni-kit/automation/hooks/useOmniTrailingStopLossDataHandler'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { formatCryptoBalance } from 'helpers/formatters/format'
@@ -37,5 +38,5 @@ export const useOmniTrailingStopLossOrderInformationItems = () => {
         ? `${formatCryptoBalance(savingCompareToLiquidation)} ${closeToToken}`
         : '-',
     },
-  ]
+  ] as ItemProps[]
 }


### PR DESCRIPTION
This pull request fixes the issue with the next trigger price handling in the omni aave/spark take profit automation. It also adjusts the loading states to ensure a smoother user experience.