### PR TITLE
Fix missing server side translations on deprectated url

### DIFF
--- a/pages/[networkOrProduct]/aave/[version]/[...position].tsx
+++ b/pages/[networkOrProduct]/aave/[version]/[...position].tsx
@@ -18,6 +18,7 @@ import type { OmniProductPage } from 'features/omni-kit/types'
 import type { AaveLendingProtocol } from 'lendingProtocols'
 import { LendingProtocol } from 'lendingProtocols'
 import type { GetServerSidePropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
 
 export type AavePositionPageProps = OmniProductPage & {
@@ -85,6 +86,7 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
     const networkId = getNetworkByName(query.networkOrProduct as unknown as NetworkNames).id
     return {
       props: {
+        ...(await serverSideTranslations(locale || 'en', ['common'])),
         deprecatedPositionId,
         networkId,
         isDeprecatedUrl: true,

--- a/pages/[networkOrProduct]/spark/[...position].tsx
+++ b/pages/[networkOrProduct]/spark/[...position].tsx
@@ -18,6 +18,7 @@ import type { OmniProductPage } from 'features/omni-kit/types'
 import type { SparkLendingProtocol } from 'lendingProtocols'
 import { LendingProtocol } from 'lendingProtocols'
 import type { GetServerSidePropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import React from 'react'
 
 type SparkPositionPageProps = OmniProductPage
@@ -81,6 +82,7 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
     const networkId = getNetworkByName(query.networkOrProduct as unknown as NetworkNames).id
     return {
       props: {
+        ...(await serverSideTranslations(locale || 'en', ['common'])),
         deprecatedPositionId,
         networkId,
         isDeprecatedUrl: true,


### PR DESCRIPTION
# Fix missing server side translations on deprecated url

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added missing serverside translations to props
  
## How to test 🧪
  <Please explain how to test your changes>

- deprecated urls shouldn't complain about missing translations
