### PR TITLE
feat: fetch positions from blokchain events if fork is used

### DIFF
--- a/features/omni-kit/observables/getPositionFromUrlParams.ts
+++ b/features/omni-kit/observables/getPositionFromUrlParams.ts
@@ -89,9 +89,8 @@ export async function getPositionsFromUrlData({
   networkId,
   pairId,
   positionId,
-  protocol
+  protocol,
 }: GetPositionFromUrlDataParams): Promise<GetPositionFromUrlDataResponse> {
-
   const accounts = await getAccounts({ networkId, positionId })
 
   if (!accounts) return emptyResponse
@@ -160,22 +159,20 @@ export async function getPositionsFromUrlData({
 
 /**
  * Retrieves accounts based on the network and position ID.
- * 
+ *
  * @dev if the network is a custom fork, the accounts are retrieved from the blochchain events.
  * Otherwise, the accounts are retrieved from the subgraph.
- * @param network - The network configuration.
+ * @param networkId - The network chain Id.
  * @param positionId - The position ID.
  * @returns An array of accounts or null if the accounts cannot be retrieved.
  */
-async function getAccounts({ networkId,
-  positionId }: GetAccountByPositionIdParams
-) {
+async function getAccounts({ networkId, positionId }: GetAccountByPositionIdParams) {
   const network = networkSetById[networkId]
   if (network && network.isCustomFork) {
     const dpm = await getUserDpmProxy(positionId, network.id)
     if (!dpm) return null
 
-    const createEvents = await getPositionCreatedEventForProxyAddress(network.id, dpm.proxy);
+    const createEvents = await getPositionCreatedEventForProxyAddress(network.id, dpm.proxy)
     if (createEvents.length === 0) return null
 
     return [
@@ -192,7 +189,6 @@ async function getAccounts({ networkId,
         },
       },
     ]
-
   } else {
     const response = (await loadSubgraph('SummerDpm', 'getUserCreateEvents', networkId, {
       positionId,

--- a/features/omni-kit/observables/getPositionFromUrlParams.ts
+++ b/features/omni-kit/observables/getPositionFromUrlParams.ts
@@ -181,14 +181,14 @@ async function getAccounts({ networkId,
     return [
       {
         createEvents: createEvents.map((e) => ({
-          collateralToken: e.args.collateralToken,
-          debtToken: e.args.debtToken,
-          positionType: e.args.positionType,
+          collateralToken: e.args.collateralToken.toLowerCase(),
+          debtToken: e.args.debtToken.toLowerCase(),
+          positionType: e.args.positionType.toLowerCase(),
           protocol: e.args.protocol,
         })),
-        id: dpm.proxy,
+        id: dpm.proxy.toLowerCase(),
         user: {
-          id: dpm.user,
+          id: dpm.user.toLowerCase(),
         },
       },
     ]


### PR DESCRIPTION
# [Title](https://shortcutLink)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
- when fork is usd get the `CreatePosition` events from fork instead of subgraph
- doesnt work for morphoblue - due to the multiple markets and subgraph call
  
## How to test 🧪
- create aave position on fork
