### PR TITLE
Adding data-testid attributes to Morpho Steakhouse deposit token selector

### DIFF
--- a/features/omni-kit/components/sidebars/OmniInputSwap.tsx
+++ b/features/omni-kit/components/sidebars/OmniInputSwap.tsx
@@ -90,7 +90,7 @@ export const OmniInputSwap: FC<OmniInputSwapProps> = ({
       <Flex
         sx={{ alignItems: 'center', columnGap: 1, ml: '14px', cursor: 'pointer' }}
         onClick={() => setIsOpen(!isOpen)}
-        data-testid='deposit-token-selector'
+        data-testid="deposit-token-selector"
       >
         <TokensGroup tokens={[selectedToken]} forceSize={32} />
         <ExpandableArrow direction={isOpen ? 'up' : 'down'} size={14} />
@@ -149,7 +149,7 @@ export const OmniInputSwap: FC<OmniInputSwapProps> = ({
               borderRadius: 'large',
             },
           }}
-          data-testid='deposit-token-list'
+          data-testid="deposit-token-list"
         >
           {tokensList?.map(({ balance, token, ...rest }) => (
             <Flex

--- a/features/omni-kit/components/sidebars/OmniInputSwap.tsx
+++ b/features/omni-kit/components/sidebars/OmniInputSwap.tsx
@@ -90,6 +90,7 @@ export const OmniInputSwap: FC<OmniInputSwapProps> = ({
       <Flex
         sx={{ alignItems: 'center', columnGap: 1, ml: '14px', cursor: 'pointer' }}
         onClick={() => setIsOpen(!isOpen)}
+        data-testid='deposit-token-selector'
       >
         <TokensGroup tokens={[selectedToken]} forceSize={32} />
         <ExpandableArrow direction={isOpen ? 'up' : 'down'} size={14} />
@@ -148,6 +149,7 @@ export const OmniInputSwap: FC<OmniInputSwapProps> = ({
               borderRadius: 'large',
             },
           }}
+          data-testid='deposit-token-list'
         >
           {tokensList?.map(({ balance, token, ...rest }) => (
             <Flex


### PR DESCRIPTION
# [[E2E tests] Adding data-testid attributes for Morpho Blue Steakhouse](https://app.shortcut.com/oazo-apps/story/15170/e2e-tests-adding-data-testid-attributes-for-morpho-blue-steakhouse)
  
## Changes 👷‍♀️
- data-testid='deposit-token-selector'
- data-testid='deposit-token-list'

<img width="1066" alt="Screenshot 2024-04-17 at 22 21 03" src="https://github.com/OasisDEX/oasis-borrow/assets/139757623/94851678-60d4-4ab0-bb50-21afd470b283">

