### PR TITLE
Migration banner and portfolio filters fix

### DIFF
--- a/features/migrations/useMigrationBannerMeta.tsx
+++ b/features/migrations/useMigrationBannerMeta.tsx
@@ -1,17 +1,16 @@
-import { getMigrationLink } from 'features/migrations/getMigrationLink'
 import { useMigrationsClient } from 'features/migrations/migrationsClient'
-import type { ProductHubSupportedNetworks } from 'features/productHub/types'
 import type { PortfolioPosition } from 'handlers/portfolio/types'
+import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useEffect, useState } from 'react'
 
 /**
- * Should generate biggest position link
+ * Should generate the biggest position link
  * @returns string
  */
 export const useMigrationBannerMeta = ({ address }: { address: string | undefined }) => {
   const { fetchMigrationPositions } = useMigrationsClient()
 
-  const [biggestPosition, setBiggestPosition] = useState<PortfolioPosition | undefined | null>(
+  const [positionToMigrate, setPositionToMigrate] = useState<PortfolioPosition | undefined | null>(
     undefined,
   )
   const [migrationsCount, setMigrationsCount] = useState<number>(0)
@@ -24,24 +23,20 @@ export const useMigrationBannerMeta = ({ address }: { address: string | undefine
       }
       const positions = await fetchMigrationPositions(address)
       if (!positions || positions.length === 0) {
-        setBiggestPosition(null)
+        setPositionToMigrate(null)
         return
       }
-      setBiggestPosition(positions[0])
+      setPositionToMigrate(positions[0])
       setMigrationsCount(positions.length)
     }
 
     void fetchBiggestPosition()
   }, [fetchMigrationPositions, address])
 
-  const link =
-    biggestPosition != null && address
-      ? getMigrationLink({
-          network: biggestPosition.network as ProductHubSupportedNetworks,
-          protocol: biggestPosition.protocol,
-          address,
-        })
-      : undefined
+  const portfolioLink = `${INTERNAL_LINKS.portfolio}/${address}`
 
-  return { biggestPositionLink: link, migrationsCount }
+  return {
+    link: migrationsCount > 1 ? portfolioLink : positionToMigrate?.url || portfolioLink,
+    migrationsCount,
+  }
 }

--- a/features/productHub/hooks/useProductHubBanner.tsx
+++ b/features/productHub/hooks/useProductHubBanner.tsx
@@ -30,11 +30,11 @@ export const useProductHubBanner = ({
   } = useAppConfig('features')
   const { t } = useTranslation()
   const { walletAddress } = useAccount()
-  const { biggestPositionLink, migrationsCount } = useMigrationBannerMeta({
+  const { link, migrationsCount } = useMigrationBannerMeta({
     address: walletAddress,
   })
 
-  if (migrationsCount > 0 && biggestPositionLink && migrationsEnabled) {
+  if (migrationsCount > 0 && migrationsEnabled) {
     return {
       title: t('product-hub.banners.migration.title', {
         migrationsCount,
@@ -42,7 +42,7 @@ export const useProductHubBanner = ({
       children: t('product-hub.banners.migration.description'),
       cta: {
         label: t('product-hub.banners.migration.cta'),
-        url: biggestPositionLink,
+        url: link,
       },
       image: staticFilesRuntimeUrl(migrationsIcon),
     }

--- a/handlers/portfolio/positions/helpers/getAllDpmsForWallet.ts
+++ b/handlers/portfolio/positions/helpers/getAllDpmsForWallet.ts
@@ -3,6 +3,7 @@ import type { OmniProductType } from 'features/omni-kit/types'
 import request, { gql } from 'graphql-request'
 import type { ConfigResponseType } from 'helpers/config'
 import { configCacheTime, getRemoteConfigWithCache } from 'helpers/config'
+import { uniq } from 'ramda'
 
 const dpmListQuery = gql`
   query dpmData($walletAddress: String) {
@@ -100,7 +101,7 @@ export const getAllDpmsForWallet = async ({ address }: { address: string }) => {
   // It has created position events associated
   // Those events can be other protocols with other token pairs relative to the DPM primary properties
   // therefore we are mapping it
-  return await Promise.all(dpmCallList).then((dpmNetworkList) => {
+  const dpms = await Promise.all(dpmCallList).then((dpmNetworkList) => {
     return dpmNetworkList.flatMap((dpm) => {
       return dpm.accounts.flatMap((account) => {
         return account.createEvents.map((createEvent) => ({
@@ -117,4 +118,8 @@ export const getAllDpmsForWallet = async ({ address }: { address: string }) => {
       })
     })
   })
+
+  // Since we are mapping nested events, there is a possibility that output array will contain duplicates
+  // which should not be passed on UI
+  return uniq(dpms)
 }

--- a/helpers/applicationLinks.ts
+++ b/helpers/applicationLinks.ts
@@ -1,6 +1,11 @@
 export const INTERNAL_LINKS = {
   appUrl: 'https://summer.fi',
   homepage: '/',
+  /**
+   To be used with address
+   `${INTERNAL_LINKS.portfolio}/${walletAddress}`
+   */
+  portfolio: '/portfolio',
   about: '/about',
   notFound: '/not-found',
   privacy: '/privacy',


### PR DESCRIPTION
# [Migration banner and portfolio filters fix](https://app.shortcut.com/oazo-apps/story/15186/bug-migration-product-hub-migrate-positions-banner-incorrectly-opens-page-with-no-positions-to-migrate-text)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue with migration banner in PH
- fixed issue with filters in portfolio
  
## How to test 🧪
  <Please explain how to test your changes>

- product filters in portfolio should work as expected
- migration banner should redirect to position (if only 1 position available to migrate, or to portfolio if more)
