### PR TITLE
Refinance banner typo fix

### DIFF
--- a/features/refinance/hooks/useInitializeRefinanceContext.ts
+++ b/features/refinance/hooks/useInitializeRefinanceContext.ts
@@ -26,7 +26,6 @@ const steps = [
   RefinanceSidebarStep.Dpm,
   RefinanceSidebarStep.Give,
   RefinanceSidebarStep.Changes,
-  RefinanceSidebarStep.Transaction,
 ]
 
 export const useInitializeRefinanceContext = ({

--- a/features/refinance/hooks/useSdkSimulation.tsx
+++ b/features/refinance/hooks/useSdkSimulation.tsx
@@ -4,7 +4,7 @@ import { useRefinanceGeneralContext } from 'features/refinance/contexts'
 import { getEmode } from 'features/refinance/helpers/getEmode'
 import { replaceETHWithWETH } from 'features/refinance/helpers/replaceETHwithWETH'
 import { mapTokenToSdkToken } from 'features/refinance/mapTokenToSdkToken'
-import { type SparkPoolId } from 'features/refinance/types'
+import { RefinanceSidebarStep, type SparkPoolId } from 'features/refinance/types'
 import { useEffect, useMemo, useState } from 'react'
 import type { Chain, Protocol, User } from 'summerfi-sdk-client'
 import { makeSDK, PositionUtils } from 'summerfi-sdk-client'
@@ -53,6 +53,19 @@ export function useSdkSimulation(): SDKSimulation {
   const { ctx, cache } = useRefinanceGeneralContext()
 
   const sdk = useMemo(() => makeSDK({ apiURL: '/api/sdk' }), [])
+
+  // Reset state when user go back to strategy or option step
+  useEffect(() => {
+    if (
+      ctx &&
+      [RefinanceSidebarStep.Option, RefinanceSidebarStep.Strategy].includes(ctx.steps.currentStep)
+    ) {
+      setError(null)
+      setRefinanceSimulation(null)
+      setLiquidationPrice('')
+      setLiquidationThreshold(null)
+    }
+  }, [ctx?.steps.currentStep])
 
   useEffect(() => {
     if (!ctx || !cache.positionOwner) {

--- a/features/refinance/hooks/useSdkTransaction.tsx
+++ b/features/refinance/hooks/useSdkTransaction.tsx
@@ -1,4 +1,5 @@
 import { useRefinanceContext } from 'features/refinance/contexts'
+import { RefinanceSidebarStep } from 'features/refinance/types'
 import { useEffect, useMemo, useState } from 'react'
 import { makeSDK } from 'summerfi-sdk-client'
 import type { ISimulation, Order, SimulationType } from 'summerfi-sdk-common'
@@ -27,8 +28,18 @@ export function useSdkRefinanceTransaction({
     form: {
       state: { strategy, dpm },
     },
+    steps: { currentStep },
   } = useRefinanceContext()
   const sdk = useMemo(() => makeSDK({ apiURL: '/api/sdk' }), [])
+
+  // Reset state when user go back to strategy or option step
+  useEffect(() => {
+    if ([RefinanceSidebarStep.Option, RefinanceSidebarStep.Strategy].includes(currentStep)) {
+      setError(null)
+      setTxImportPosition(null)
+      setTxRefinance(null)
+    }
+  }, [currentStep])
 
   useEffect(() => {
     if (

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3856,7 +3856,7 @@
     "mobile-not-available": "Refinance is not available on mobile. Please use desktop to Refinance your position.",
     "banner": {
       "title": "Refinance",
-      "description": "Refinance your position to a new one in one go. Move your funds between products becomes a breeze.",
+      "description": "Refinance your position to a new one in one go. Moving your funds between products becomes a breeze.",
       "button": "Get Started"
     }
   },


### PR DESCRIPTION
# [Refinance banner typo fix](https://app.shortcut.com/oazo-apps/story/15299/bug-refinance-banner-grammar-mistake)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed typo
- fixed issue with simulation not being cleared when user goes back to strategy step
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
