### PR TITLE
Refinance block button when simulation is loading

### DIFF
--- a/features/refinance/helpers/getRefinanceSidebarButtonStatus.ts
+++ b/features/refinance/helpers/getRefinanceSidebarButtonStatus.ts
@@ -27,16 +27,18 @@ export function getRefinanceSidebarButtonsStatus({
   suppressValidation,
   walletAddress,
 }: GetOmniSidebarButtonsStatusParams) {
-  const isPrimaryButtonDisabled = suppressValidation
+  const isPrimaryButtonDisabled =
+    suppressValidation || isTxSuccess
+      ? false
+      : !!walletAddress &&
+        !shouldSwitchNetwork &&
+        (hasErrors || isSimulationLoading || isTxInProgress || isTxWaitingForApproval)
+
+  const isPrimaryButtonLoading = isTxSuccess
     ? false
     : !!walletAddress &&
       !shouldSwitchNetwork &&
-      (hasErrors || isSimulationLoading || isTxInProgress || isTxWaitingForApproval)
-
-  const isPrimaryButtonLoading =
-    !!walletAddress &&
-    !shouldSwitchNetwork &&
-    (isSimulationLoading || isTxInProgress || isTxWaitingForApproval)
+      (isSimulationLoading || isTxInProgress || isTxWaitingForApproval)
 
   const isPrimaryButtonHidden =
     !!(walletAddress && !isOwner) ||

--- a/features/refinance/hooks/useSdkSimulation.tsx
+++ b/features/refinance/hooks/useSdkSimulation.tsx
@@ -37,6 +37,7 @@ export type SDKSimulation = {
   liquidationThreshold: Percentage | null
   debtPrice: string | null
   collateralPrice: string | null
+  isLoading: boolean
 }
 
 export function useSdkSimulation(): SDKSimulation {
@@ -249,6 +250,10 @@ export function useSdkSimulation(): SDKSimulation {
     cache.positionOwner,
   ])
 
+  const isLoading =
+    (ctx?.steps.currentStep === RefinanceSidebarStep.Give && !importPositionSimulation) ||
+    (ctx?.steps.currentStep === RefinanceSidebarStep.Changes && !refinanceSimulation)
+
   return {
     error,
     chain,
@@ -260,5 +265,6 @@ export function useSdkSimulation(): SDKSimulation {
     liquidationThreshold,
     debtPrice,
     collateralPrice,
+    isLoading,
   }
 }

--- a/features/refinance/views/RefinanceFormView.tsx
+++ b/features/refinance/views/RefinanceFormView.tsx
@@ -55,11 +55,12 @@ export const RefinanceFormView: FC = ({ children }) => {
       setNextStep,
       setPrevStep,
     },
+    simulation: { isLoading },
   } = useRefinanceContext()
 
   const txHandler = useRefinanceTxHandler()
 
-  const isSimulationLoading = txHandler === null
+  const isSimulationLoading = isLoading
 
   const shouldSwitchNetwork = chainId !== walletChainId
 


### PR DESCRIPTION
# Refinance block button when simulation is loading

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- blocked button when simulation is loading
  
## How to test 🧪
  <Please explain how to test your changes>

- when either give or refinance simulation is being loaded, button should have loading state and be disabled
