### PR TITLE
Add debug mode to Product Hub

### DIFF
--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -3,6 +3,7 @@ import { AssetsTableDataCellAsset } from 'components/assetsTable/cellComponents/
 import { AssetsTableTooltip } from 'components/assetsTable/cellComponents/AssetsTableTooltip'
 import type { AssetsTableRowData } from 'components/assetsTable/types'
 import { BrandTag } from 'components/BrandTag'
+import { AppLink } from 'components/Links'
 import { ProtocolLabel } from 'components/ProtocolLabel'
 import { OmniProductType } from 'features/omni-kit/types'
 import {
@@ -15,8 +16,11 @@ import type {
   ProductHubFeaturedProducts,
   ProductHubItem,
 } from 'features/productHub/types'
+import { getLocalAppConfig } from 'helpers/config'
 import { isEqual, omit } from 'lodash'
 import React from 'react'
+import { Button } from 'theme-ui'
+import { FeaturesEnum } from 'types/config'
 
 interface ParseRowsParams {
   featured: ProductHubFeaturedProducts
@@ -35,6 +39,7 @@ export function parseRows({
   product,
   rows,
 }: ParseRowsParams): AssetsTableRowData[] {
+  const isDebugEnabled = getLocalAppConfig('features')[FeaturesEnum.ProductHubDebug]
   const featuredRows = filterFeaturedProducts({ filters: featured, product, rows })
 
   return rows.map((row) => {
@@ -81,6 +86,13 @@ export function parseRows({
             protocol={protocol}
           />
         ),
+        ...(isDebugEnabled && {
+          action: (
+            <AppLink href={url} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button variant="bean">Open</Button>
+            </AppLink>
+          ),
+        }),
       },
       hiddenColumns ?? [],
     )
@@ -89,7 +101,7 @@ export function parseRows({
       items,
       isHighlighted: isFeatured && featured.isHighlighted,
       isStickied: isFeatured && (featured.isStickied || featured.isPromoted),
-      ...(!isUrlDisabled && { link: url }),
+      ...(!isUrlDisabled && !isDebugEnabled && { link: url }),
       ...(onRowClick && {
         onClick: () => onRowClick(row),
       }),


### PR DESCRIPTION
# Add debug mode to Product Hub

It was extremely annoying to work with Product Hub since buttons were removed because there was no way to preview position link without clicking it or opening it in new tab. And on local env, it may take a while to load position page, so precious minutes were lost here and there.

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/d5d00228-4fd3-4af7-a820-8d7680d4ca46)
  
## Changes 👷‍♀️

- Added support for `ProductHubDebug` in Product Hub.
- Added action button to each table row and removed clickable rows in debug moge.

Feel free to expand the debug mode if you feel like it.
