### PR TITLE
Restrict reusability of DPM in refinance

### DIFF
--- a/features/refinance/contexts/RefinanceGeneralContext.tsx
+++ b/features/refinance/contexts/RefinanceGeneralContext.tsx
@@ -2,7 +2,7 @@ import type { RiskRatio } from '@oasisdex/dma-library'
 import type { TxStatus } from '@oasisdex/transactions'
 import type { GasEstimationContext } from 'components/context/GasEstimationContextProvider'
 import type { OmniGeneralContextTx } from 'features/omni-kit/contexts'
-import type { OmniFiltersParameters, OmniValidations } from 'features/omni-kit/types'
+import type { OmniValidations } from 'features/omni-kit/types'
 import type { RefinanceInterestRatesMetadata } from 'features/refinance/helpers'
 import { useInitializeRefinanceContext } from 'features/refinance/hooks'
 import type { useRefinanceFormReducto } from 'features/refinance/state'
@@ -106,7 +106,6 @@ export type RefinanceGeneralContextBase = {
     pairId: number
   }
   metadata: {
-    flowStateFilter: (params: OmniFiltersParameters) => Promise<boolean>
     validations: OmniValidations
     safetySwitch: boolean
     suppressValidation: boolean

--- a/features/refinance/controllers/RefinanceFlowSidebarController.tsx
+++ b/features/refinance/controllers/RefinanceFlowSidebarController.tsx
@@ -1,5 +1,4 @@
 import { FlowSidebar } from 'components/FlowSidebar'
-import { getOmniFilterConsumedProxy } from 'features/omni-kit/helpers'
 import { useRefinanceContext } from 'features/refinance/contexts'
 import { RefinanceSidebarStep } from 'features/refinance/types'
 import { useFlowState } from 'helpers/useFlowState'
@@ -9,7 +8,6 @@ import { Box } from 'theme-ui'
 
 export const RefinanceFlowSidebarController = () => {
   const {
-    metadata: { flowStateFilter },
     environment: { chainInfo },
     form: { updateState },
     poolData: { pairId },
@@ -23,16 +21,8 @@ export const RefinanceFlowSidebarController = () => {
     networkId: chainInfo.chainId,
     amount: zero,
     token: 'ETH',
-    filterConsumedProxy: async (events) => getOmniFilterConsumedProxy(events, flowStateFilter),
-    onProxiesAvailable: async (events) => {
-      const filteredEventsBooleanMap = await Promise.all(
-        events.map((event) => flowStateFilter({ event })),
-      )
-      const filteredEvents = events.filter(
-        (_event, eventIndex) => filteredEventsBooleanMap[eventIndex],
-      )
-      updateState('hasSimilarPosition', !!filteredEvents.length)
-    },
+    // Take only proxies without CreatePosition events
+    filterConsumedProxy: async (events) => events.length === 0,
     onEverythingReady: ({ availableProxies }) => {
       // Check if owner is already dpm and use it as dpm for refinance, if not fallback to first available dpm
       const dpm =

--- a/features/refinance/helpers/getRefinanceFlowStateFilter.ts
+++ b/features/refinance/helpers/getRefinanceFlowStateFilter.ts
@@ -14,6 +14,7 @@ import type { RefinanceFormState } from 'features/refinance/state/refinanceFormR
 import { getPairIdFromLabel } from 'helpers/getPairIdFromLabel'
 import { LendingProtocol } from 'lendingProtocols'
 
+// not used for now, but we may use it (with some adjustments) in future
 export const getRefinanceFlowStateFilter = ({
   filterConsumed,
   event,

--- a/features/refinance/hooks/useInitializeRefinanceContext.ts
+++ b/features/refinance/hooks/useInitializeRefinanceContext.ts
@@ -10,8 +10,7 @@ import type {
   RefinanceGeneralContextBase,
   RefinanceSteps,
 } from 'features/refinance/contexts/RefinanceGeneralContext'
-import { getRefinanceFlowStateFilter, getRefinanceValidations } from 'features/refinance/helpers'
-import { positionTypeToOmniProductType } from 'features/refinance/helpers/positionTypeToOmniProductType'
+import { getRefinanceValidations } from 'features/refinance/helpers'
 import { mapTokenToSdkToken } from 'features/refinance/mapTokenToSdkToken'
 import { useRefinanceFormReducto } from 'features/refinance/state'
 import { RefinanceSidebarStep } from 'features/refinance/types'
@@ -134,17 +133,9 @@ export const useInitializeRefinanceContext = ({
   if (!type) {
     throw new Error('Unsupported position type')
   }
-  const currentProductType = positionTypeToOmniProductType(type)
 
   const ctx: RefinanceGeneralContextBase = {
     metadata: {
-      flowStateFilter: ({ event, filterConsumed }) =>
-        getRefinanceFlowStateFilter({
-          event,
-          filterConsumed,
-          currentProductType,
-          formState: form.state,
-        }),
       validations: getRefinanceValidations({ state: form.state }),
       safetySwitch: isSafetySwitchEnabled,
       suppressValidation: isSuppressValidationEnabled,


### PR DESCRIPTION
# Restrict reusability of DPM in refinance

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- force creation of dpm or use existing one without any create position events
  
## How to test 🧪
  <Please explain how to test your changes>

- while doing refinance only empty DPM should be used
