### PR TITLE
fix: [sc-15382] Auto-sell in omni kit uses values wrong way around in the desciption

### DIFF
--- a/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
+++ b/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
@@ -92,8 +92,14 @@ export const OmniAutoBSSidebarController: FC<{ type: OmniAutoBSAutomationTypes }
 
   const description = useMemo(() => {
     return getAutoBuyAutoSellDescription({
-      triggerLtv: new BigNumber(sliderValues.value0),
-      targetLtv: new BigNumber(sliderValues.value1),
+      triggerLtv:
+        type === AutomationFeatures.AUTO_BUY
+          ? new BigNumber(sliderValues.value0)
+          : new BigNumber(sliderValues.value1),
+      targetLtv:
+        type === AutomationFeatures.AUTO_BUY
+          ? new BigNumber(sliderValues.value1)
+          : new BigNumber(sliderValues.value0),
       automationFormState,
       t,
       position: castedPosition,


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/15382