### PR TITLE
Adding data-testid attribute to Portfolio - Positions controls

### DIFF
--- a/components/context/PreloadAppDataContextProvider.tsx
+++ b/components/context/PreloadAppDataContextProvider.tsx
@@ -17,7 +17,7 @@ const configFetcher = () =>
 export const emptyConfig = {
   features: Object.fromEntries(
     Object.values(FeaturesEnum).map((feature: FeaturesEnum) => [feature, false]),
-  ) as Record<FeaturesEnum, boolean>,
+  ) as Record<FeaturesEnum, boolean | {}>,
   parameters: {},
 } as ConfigResponseType
 

--- a/components/portfolio/positions/PortfolioPositionsView.tsx
+++ b/components/portfolio/positions/PortfolioPositionsView.tsx
@@ -156,6 +156,7 @@ export const PortfolioPositionsView = ({
         justifyContent: 'space-between',
         alignItems: ['flex-start', 'center'],
       }}
+      data-testid="portfolio-positions-controls"
     >
       <Flex sx={{ flexDirection: 'row', mt: [2, 0] }}>
         <PortfolioPositionsProductSelect onChange={updatePortfolioPositionsFilters('product')} />

--- a/features/aave/open/sidebars/components/SidebarOpenAaveVaultStopLoss.tsx
+++ b/features/aave/open/sidebars/components/SidebarOpenAaveVaultStopLoss.tsx
@@ -10,7 +10,7 @@ import type { FeaturesEnum } from 'types/config'
 function getLambdaProtectionFlag(
   protocol: LendingProtocol,
   networkId: NetworkIds,
-  features: Record<FeaturesEnum, boolean>,
+  features: Record<FeaturesEnum, boolean | {}>,
 ) {
   if (protocol === LendingProtocol.SparkV3) {
     return features.SparkProtectionLambdaEthereum


### PR DESCRIPTION
# [Adding data-testid attribute to Portfolio - Positions controls](https://app.shortcut.com/oazo-apps/story/15470/adding-data-testid-attribute-to-portfolio-positions-controls-for-e2e-tests)

Adding data-testid="portfolio-positions-controls" attribute

![Screenshot 2024-05-06 at 18 37 44](https://github.com/OasisDEX/oasis-borrow/assets/139757623/79da4d77-f7f3-4d65-b469-b343100bd9e5)

