### PR TITLE
fix: [sc-15542] [BUG] - Aave V2 positions on DS Proxy showing as Not Found

### DIFF
--- a/handlers/portfolio/positions/handlers/aave-v2/ds-proxy-position.ts
+++ b/handlers/portfolio/positions/handlers/aave-v2/ds-proxy-position.ts
@@ -115,6 +115,7 @@ export const getAaveV2DsProxyPosition: PortfolioPositionsHandler = async ({ addr
       positions: [
         {
           ...commonData,
+          url: `/${commonData.network.toLowerCase()}/old/aave/v2/${address}`,
           lendingType: stEthPosition.debt.amount.gt(zero) ? 'loop' : 'passive',
           details: [
             {


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/15542

Added URL field in the Aave v2 handler file to enhance data tracking capabilities. This update allows easy access to specific data related to the given address on the Aave v2 protocol.