### PR TITLE
Update OmniAutoBSSidebarController trigger and target LTV values

### DIFF
--- a/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
+++ b/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
@@ -48,15 +48,15 @@ export const OmniAutoBSSidebarController: FC<{ type: OmniAutoBSAutomationTypes }
   const defaultTriggerValues = useMemo(() => {
     if (type === AutomationFeatures.AUTO_BUY) {
       return {
-        triggerLtv: loanToValue.times(100),
-        targetLtv: loanToValue.times(100).plus(5),
+        triggerLtv: loanToValue.times(100).minus(5),
+        targetLtv: loanToValue.times(100),
       }
     }
     return {
-      targetLtv: loanToValue.times(100),
-      triggerLtv: loanToValue.times(100).plus(5),
+      targetLtv: loanToValue.times(100).minus(5),
+      triggerLtv: loanToValue.times(100),
     }
-  }, [loanToValue])
+  }, [loanToValue, type])
 
   const { state: automationFormState, updateState: updateFormState } = automationForms[type]
 


### PR DESCRIPTION
This pull request updates the trigger and target loan-to-value (LTV) values in the OmniAutoBSSidebarController. For the AUTO_BUY automation feature, the trigger LTV is decreased by 5% and the target LTV remains the same. For other automation features, the target LTV is decreased by 5% and the trigger LTV remains the same. This change ensures that the LTV values are set correctly for each automation feature.