### PR TITLE
Max ltv in overview headline if multiple markets

### DIFF
--- a/features/omni-kit/controllers/OmniLayoutController.tsx
+++ b/features/omni-kit/controllers/OmniLayoutController.tsx
@@ -51,7 +51,6 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
       network,
       networkId,
       owner,
-      pairId,
       poolId,
       positionId,
       priceFormat,
@@ -93,6 +92,7 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
   })
 
   const ltv = 'riskRatio' in position ? position.riskRatio.loanToValue : undefined
+  const maxLtv = 'maxRiskRatio' in position ? position.maxRiskRatio.loanToValue : undefined
   const netValue = 'netValue' in position ? position.netValue : undefined
   const minNetValue = useOmniMinNetAutomationValue({ protocol, networkId })
 
@@ -110,12 +110,12 @@ export function OmniLayoutController({ txHandler }: { txHandler: () => () => voi
           headline,
           isYieldLoopWithData,
           networkName: network.name,
-          pairId,
           positionId,
           productType,
           protocol,
           quoteIcon,
           quoteToken,
+          maxLtv,
         })}
         details={[
           ...(headlineDetails || []),

--- a/features/omni-kit/controllers/OmniProductController.tsx
+++ b/features/omni-kit/controllers/OmniProductController.tsx
@@ -205,7 +205,6 @@ export const OmniProductController = <Auction, History, Position>({
                     collateralIcon: tokensIconsData?.collateralToken,
                     collateralToken: dpmPositionData?.collateralToken,
                     headline: label,
-                    pairId,
                     positionId,
                     productType: dpmPositionData?.product as OmniProductType,
                     protocol,

--- a/features/omni-kit/helpers/getOmniHeadlineProps.ts
+++ b/features/omni-kit/helpers/getOmniHeadlineProps.ts
@@ -1,6 +1,8 @@
+import type BigNumber from 'bignumber.js'
 import type { NetworkNames } from 'blockchain/networks'
 import { shouldShowPairId } from 'features/omni-kit/helpers'
 import type { OmniProductType } from 'features/omni-kit/types'
+import { formatDecimalAsPercent } from 'helpers/formatters/format'
 import type { LendingProtocol } from 'lendingProtocols'
 import { uniq, upperFirst } from 'lodash'
 import { useTranslation } from 'next-i18next'
@@ -14,13 +16,13 @@ interface OmniHeadlinePropsParams {
   headline?: string
   isYieldLoopWithData?: boolean
   networkName: NetworkNames
-  pairId: number
   positionId?: string
   productType?: OmniProductType
   protocol: LendingProtocol
   quoteAddress?: string
   quoteIcon?: string
   quoteToken?: string
+  maxLtv?: BigNumber
 }
 
 export function getOmniHeadlineProps({
@@ -29,26 +31,27 @@ export function getOmniHeadlineProps({
   headline,
   isYieldLoopWithData,
   networkName,
-  pairId,
   positionId,
   productType,
   protocol,
   quoteIcon,
   quoteToken,
+  maxLtv,
 }: OmniHeadlinePropsParams) {
   const { t } = useTranslation()
 
   const resolvedPositionId = positionId ? ` #${positionId}` : ''
-  const resolvedPairId =
+  const resolvedMaxLtv =
     collateralToken &&
     quoteToken &&
+    maxLtv &&
     shouldShowPairId({
       collateralToken,
       networkName,
       protocol,
       quoteToken,
     })
-      ? `-${pairId}`
+      ? ` ${formatDecimalAsPercent(maxLtv)}`
       : ''
   const resolvedProductType = isYieldLoopWithData
     ? t('omni-kit.headline.yield-multiple')
@@ -63,7 +66,9 @@ export function getOmniHeadlineProps({
       collateralToken: collateralTokenHeaderName,
       productType: resolvedProductType,
       quoteToken: quoteTokenHeaderName,
-      pairId: resolvedPairId,
+      // ux stuff, we are using max ltv as pair id here, so it's easy from user
+      // perspective to distinguish between markets instead of using 1,2,3 etc.
+      pairId: resolvedMaxLtv,
     })
 
   return {


### PR DESCRIPTION
# [Max ltv in overview headline if multiple markets](https://app.shortcut.com/oazo-apps/story/15500/change-morpho-market-names-to-include-ltv)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added max ltv param to position headline if there are more than one market available for given pair
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
