### PR TITLE
Refactor useOmniPartialTakeProfitDataHandler to use maxLoanToValue directly

### DIFF
--- a/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
+++ b/features/omni-kit/automation/hooks/useOmniPartialTakeProfitDataHandler.tsx
@@ -284,9 +284,7 @@ export const useOmniPartialTakeProfitDataHandler = () => {
       ? `${formatCryptoBalance(currentTrailingStopLossDistance.div(10000))}${nbsp}${priceFormat}`
       : ''
 
-  const defaultStopLossLevel = castedPosition.category.maxLoanToValue
-    .minus(stopLossConstants.offsets.max)
-    .times(100)
+  const defaultStopLossLevel = maxLoanToValue.minus(stopLossConstants.offsets.max).times(100)
 
   const extraTriggerLtv =
     state.extraTriggerLtv ?? currentStopLossLevel?.times(100) ?? defaultStopLossLevel

--- a/helpers/lambda/triggers/setup-triggers/setup-partial-take-profit.ts
+++ b/helpers/lambda/triggers/setup-triggers/setup-partial-take-profit.ts
@@ -31,6 +31,7 @@ export const setupLambdaPartialTakeProfit = async (
                 .integerValue()
                 .toString(),
               token: params.stopLoss.triggerData.token,
+              poolId,
             },
             action: params.stopLoss.action,
           }


### PR DESCRIPTION
This pull request refactors the `useOmniPartialTakeProfitDataHandler` function to directly use the `maxLoanToValue` property instead of calculating it from the `category` object. This simplifies the code and improves readability.