### PR TITLE
Wsteth-eth yield loop deposit wsteth as default

### DIFF
--- a/features/omni-kit/protocols/morpho-blue/settings.ts
+++ b/features/omni-kit/protocols/morpho-blue/settings.ts
@@ -48,9 +48,6 @@ export const settings: OmniProtocolSettings = {
       manage: omniSidebarManageBorrowishSteps,
     },
   },
-  entryTokens: {
-    [NetworkIds.MAINNET]: { 'WSTETH-ETH': 'ETH' },
-  },
   availableAutomations: {
     [NetworkIds.MAINNET]: [
       ...(automationFeatureFlags.autoBuy ? [AutomationFeatures.AUTO_BUY] : []),


### PR DESCRIPTION
# [Wsteth-eth yield loop deposit wsteth as default](https://app.shortcut.com/oazo-apps/story/15349/prod-wsteth-eth-on-morpho-blue-and-ajna-enters-with-eth-instead-of-wsteth)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- removed entry token from morpho settings
  
## How to test 🧪
  <Please explain how to test your changes>

- for wsteth-eth pair deposit token should be wsteth
