### PR TITLE
Auto sell tweak default slider values

### DIFF
--- a/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
+++ b/features/omni-kit/automation/components/auto-buy-sell/OmniAutoBSSidebarController.tsx
@@ -54,8 +54,8 @@ export const OmniAutoBSSidebarController: FC<{ type: OmniAutoBSAutomationTypes }
       }
     }
     return {
-      targetLtv: loanToValue.times(100).minus(5),
-      triggerLtv: loanToValue.times(100),
+      targetLtv: loanToValue.times(100),
+      triggerLtv: loanToValue.times(100).plus(5),
     }
   }, [loanToValue, type])
 


### PR DESCRIPTION
# [Auto sell tweak default slider values](https://app.shortcut.com/oazo-apps/story/15637/bug-auto-sell-wrong-default-values-for-trigger-and-target)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- adjusted default values on slider for auto sell feature
  
## How to test 🧪
  <Please explain how to test your changes>

- target ltv should equal to current position ltv, trigger should be 5% higher
