### PR TITLE
Close action visible when position has debt, copy fix

### DIFF
--- a/features/omni-kit/controllers/borrow/OmniBorrowFormController.tsx
+++ b/features/omni-kit/controllers/borrow/OmniBorrowFormController.tsx
@@ -41,6 +41,11 @@ export function OmniBorrowFormController({ txHandler }: { txHandler: () => () =>
     dynamicMetadata: {
       elements: { riskSidebar },
     },
+    position: {
+      currentPosition: {
+        position: { debtAmount },
+      },
+    },
   } = useOmniProductContext(OmniProductType.Borrow)
 
   return (
@@ -95,18 +100,22 @@ export function OmniBorrowFormController({ txHandler }: { txHandler: () => () =>
                       updateState('action', OmniBorrowFormAction.SwitchBorrow)
                     },
                   },
-                  {
-                    label: t('system.actions.common.close-position'),
-                    icon: circle_close,
-                    iconShrink: 2,
-                    panel: OmniSidebarBorrowPanel.Close,
-                    action: () => {
-                      dispatch({ type: 'reset' })
-                      updateState('uiDropdown', OmniSidebarBorrowPanel.Close)
-                      updateState('closeTo', 'collateral')
-                      updateState('action', OmniBorrowFormAction.CloseBorrow)
-                    },
-                  },
+                  ...(!debtAmount.isZero()
+                    ? [
+                        {
+                          label: t('system.actions.common.close-position'),
+                          icon: circle_close,
+                          iconShrink: 2,
+                          panel: OmniSidebarBorrowPanel.Close,
+                          action: () => {
+                            dispatch({ type: 'reset' })
+                            updateState('uiDropdown', OmniSidebarBorrowPanel.Close)
+                            updateState('closeTo', 'collateral')
+                            updateState('action', OmniBorrowFormAction.CloseBorrow)
+                          },
+                        },
+                      ]
+                    : []),
                 ]
               : []),
           ],

--- a/features/omni-kit/controllers/multiply/OmniMultiplyFormController.tsx
+++ b/features/omni-kit/controllers/multiply/OmniMultiplyFormController.tsx
@@ -32,6 +32,11 @@ export function OmniMultiplyFormController({ txHandler }: { txHandler: () => () 
     dynamicMetadata: {
       elements: { riskSidebar },
     },
+    position: {
+      currentPosition: {
+        position: { debtAmount },
+      },
+    },
   } = useOmniProductContext(OmniProductType.Multiply)
 
   return (
@@ -92,18 +97,22 @@ export function OmniMultiplyFormController({ txHandler }: { txHandler: () => () 
                 updateState('action', OmniMultiplyFormAction.SwitchMultiply)
               },
             },
-            {
-              label: t('system.actions.common.close-position'),
-              icon: circle_close,
-              iconShrink: 2,
-              panel: OmniMultiplyPanel.Close,
-              action: () => {
-                dispatch({ type: 'reset' })
-                updateState('uiDropdown', OmniMultiplyPanel.Close)
-                updateState('closeTo', 'collateral')
-                updateState('action', OmniMultiplyFormAction.CloseMultiply)
-              },
-            },
+            ...(!debtAmount.isZero()
+              ? [
+                  {
+                    label: t('system.actions.common.close-position'),
+                    icon: circle_close,
+                    iconShrink: 2,
+                    panel: OmniMultiplyPanel.Close,
+                    action: () => {
+                      dispatch({ type: 'reset' })
+                      updateState('uiDropdown', OmniMultiplyPanel.Close)
+                      updateState('closeTo', 'collateral')
+                      updateState('action', OmniMultiplyFormAction.CloseMultiply)
+                    },
+                  },
+                ]
+              : []),
           ],
         },
       })}

--- a/features/omni-kit/protocols/aave-like/components/AaveLikeCostToBorrowContentCardModal.tsx
+++ b/features/omni-kit/protocols/aave-like/components/AaveLikeCostToBorrowContentCardModal.tsx
@@ -60,9 +60,6 @@ export const AaveLikeCostToBorrowContentCardModal = ({
             rate: formatDecimalAsPercent(collateralLiquidityRate),
           })}
         </Text>
-        <Text as="span" variant="paragraph3" sx={{ mb: 1 }}>
-          {t('aave-position-modal.net-borrow-cost.supply-apy-note')}
-        </Text>
       </Text>
       <Heading variant="header4">
         {t('aave-position-modal.net-borrow-cost.second-header', {


### PR DESCRIPTION
# Close action visible when position has debt, copy fix

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- fixed issue with copy
- when position has zero debt, close action in dropdown will be hidden
  
## How to test 🧪
  <Please explain how to test your changes>

- self explanatory
