### PR TITLE
Refinance PH strategies filtering

### DIFF
--- a/features/omni-kit/observables/getPositionFromUrlParams.ts
+++ b/features/omni-kit/observables/getPositionFromUrlParams.ts
@@ -11,6 +11,8 @@ import {
 } from 'features/aave/services'
 import type { SubgraphsResponses } from 'features/subgraphLoader/types'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+import type { GetTriggersResponse } from 'helpers/lambda/triggers'
+import { getTriggersRequest } from 'helpers/lambda/triggers'
 import type { LendingProtocol } from 'lendingProtocols'
 import { uniq } from 'lodash'
 
@@ -59,6 +61,11 @@ export interface PositionFromUrl extends PositionCreated {
   pairId: number
 }
 
+export interface PositionFromUrlWithTriggers extends PositionCreated {
+  pairId: number
+  triggers: GetTriggersResponse
+}
+
 interface GetPositionFromUrlDataParams {
   networkId: number
   pairId: number
@@ -72,10 +79,16 @@ interface GetAccountByPositionIdParams {
   positionId: number
 }
 
-interface GetPositionFromUrlDataResponse {
+export interface GetPositionFromUrlDataResponse {
   dpmAddress: string
   owner: string
   positions: PositionFromUrl[]
+}
+
+export interface GetPositionFromUrlDataWithTriggersResponse {
+  dpmAddress: string
+  owner: string
+  positions: PositionFromUrlWithTriggers[]
 }
 
 const emptyResponse = {
@@ -128,6 +141,35 @@ export async function getPositionsFromUrlData({
       ),
     }
   } else return emptyResponse
+}
+
+export async function getPositionsFromUlrDataWithTriggers({
+  networkId,
+  pairId,
+  positionId,
+  protocol,
+}: GetPositionFromUrlDataParams): Promise<GetPositionFromUrlDataWithTriggersResponse> {
+  const positionFromUrl = await getPositionsFromUrlData({
+    networkId,
+    pairId,
+    positionId,
+    protocol,
+  })
+
+  const triggers = await Promise.all(
+    positionFromUrl.positions.map((event) =>
+      getTriggersRequest({
+        dpmProxy: event.proxyAddress,
+        networkId,
+        protocol: event.protocol,
+      }),
+    ),
+  )
+
+  return {
+    ...positionFromUrl,
+    positions: positionFromUrl.positions.map((item, idx) => ({ ...item, triggers: triggers[idx] })),
+  }
 }
 
 /**

--- a/features/omni-kit/observables/getPositionFromUrlParams.ts
+++ b/features/omni-kit/observables/getPositionFromUrlParams.ts
@@ -143,7 +143,7 @@ export async function getPositionsFromUrlData({
   } else return emptyResponse
 }
 
-export async function getPositionsFromUlrDataWithTriggers({
+export async function getPositionsFromUrlDataWithTriggers({
   networkId,
   pairId,
   positionId,

--- a/features/refinance/components/steps/RefinanceProductTableStep.tsx
+++ b/features/refinance/components/steps/RefinanceProductTableStep.tsx
@@ -2,6 +2,7 @@ import { getNetworkById } from 'blockchain/networks'
 import { OmniProductType } from 'features/omni-kit/types'
 import { ProductHubView } from 'features/productHub/views'
 import {
+  refinanceCustomProductHubFiltersOptions,
   refinanceProductHubHiddenColumns,
   refinanceProductHubItemsPerPage,
 } from 'features/refinance/constants'
@@ -10,32 +11,10 @@ import {
   getRefinanceProductHubDataParser,
   getRefinanceProductHubSeparator,
 } from 'features/refinance/helpers'
+import { getRefinanceStrategiesToBeFiltered } from 'features/refinance/helpers/getRefinanceStrategiesToBeFiltered'
 import { RefinanceOptions } from 'features/refinance/types'
 import { LendingProtocol } from 'lendingProtocols'
-import { lendingProtocolsByName } from 'lendingProtocols/lendingProtocolsConfigs'
 import React, { useCallback } from 'react'
-import { FeaturesEnum } from 'types/config'
-
-const customFiltersOptions = {
-  protocols: [
-    {
-      label: lendingProtocolsByName[LendingProtocol.AaveV3].label,
-      value: lendingProtocolsByName[LendingProtocol.AaveV3].name,
-      image: lendingProtocolsByName[LendingProtocol.AaveV3].icon,
-    },
-    {
-      label: lendingProtocolsByName[LendingProtocol.MorphoBlue].label,
-      value: lendingProtocolsByName[LendingProtocol.MorphoBlue].name,
-      image: lendingProtocolsByName[LendingProtocol.MorphoBlue].icon,
-      featureFlag: FeaturesEnum.MorphoBlue,
-    },
-    {
-      label: lendingProtocolsByName[LendingProtocol.SparkV3].label,
-      value: lendingProtocolsByName[LendingProtocol.SparkV3].name,
-      image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
-    },
-  ],
-}
 
 export const RefinanceProductTableStep = () => {
   const {
@@ -58,7 +37,7 @@ export const RefinanceProductTableStep = () => {
       lendingProtocol,
     },
     steps: { setNextStep },
-    environment: { chainInfo },
+    environment: { chainInfo, dpmEvents },
   } = useRefinanceContext()
 
   const onRowClick = useCallback(
@@ -89,7 +68,7 @@ export const RefinanceProductTableStep = () => {
       customSortByDefault={(table) => table}
       dataParser={(table) =>
         getRefinanceProductHubDataParser({
-          table,
+          table: getRefinanceStrategiesToBeFiltered({ events: dpmEvents.positions, table }),
           interestRates,
           collateralToken,
           collateralAmount,
@@ -119,7 +98,7 @@ export const RefinanceProductTableStep = () => {
       onRowClick={onRowClick}
       wrapperSx={{ mt: 0 }}
       separator={(table) => getRefinanceProductHubSeparator({ table, collateralToken, debtToken })}
-      customFiltersOptions={customFiltersOptions}
+      customFiltersOptions={refinanceCustomProductHubFiltersOptions[lendingProtocol]}
     />
   )
 }

--- a/features/refinance/constants.ts
+++ b/features/refinance/constants.ts
@@ -1,5 +1,8 @@
 import type { ProductHubColumnKey } from 'features/productHub/types'
 import { RefinanceSidebarStep } from 'features/refinance/types'
+import { LendingProtocol } from 'lendingProtocols'
+import { lendingProtocolsByName } from 'lendingProtocols/lendingProtocolsConfigs'
+import { FeaturesEnum } from 'types/config'
 
 export const refinanceProductHubHiddenColumns: ProductHubColumnKey[] = [
   'automation',
@@ -21,3 +24,79 @@ export const refinanceStepsWithoutDpm = [
   RefinanceSidebarStep.Strategy,
   RefinanceSidebarStep.Changes,
 ]
+
+export const refinanceCustomProductHubFiltersOptions = {
+  [LendingProtocol.Maker]: {
+    protocols: [
+      {
+        label: lendingProtocolsByName[LendingProtocol.AaveV3].label,
+        value: lendingProtocolsByName[LendingProtocol.AaveV3].name,
+        image: lendingProtocolsByName[LendingProtocol.AaveV3].icon,
+      },
+      {
+        label: lendingProtocolsByName[LendingProtocol.MorphoBlue].label,
+        value: lendingProtocolsByName[LendingProtocol.MorphoBlue].name,
+        image: lendingProtocolsByName[LendingProtocol.MorphoBlue].icon,
+        featureFlag: FeaturesEnum.MorphoBlue,
+      },
+      {
+        label: lendingProtocolsByName[LendingProtocol.SparkV3].label,
+        value: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+        image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
+      },
+    ],
+  },
+  [LendingProtocol.AaveV3]: {
+    protocols: [
+      {
+        label: lendingProtocolsByName[LendingProtocol.MorphoBlue].label,
+        value: lendingProtocolsByName[LendingProtocol.MorphoBlue].name,
+        image: lendingProtocolsByName[LendingProtocol.MorphoBlue].icon,
+        featureFlag: FeaturesEnum.MorphoBlue,
+      },
+      {
+        label: lendingProtocolsByName[LendingProtocol.SparkV3].label,
+        value: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+        image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
+      },
+    ],
+  },
+
+  [LendingProtocol.SparkV3]: {
+    protocols: [
+      {
+        label: lendingProtocolsByName[LendingProtocol.AaveV3].label,
+        value: lendingProtocolsByName[LendingProtocol.AaveV3].name,
+        image: lendingProtocolsByName[LendingProtocol.AaveV3].icon,
+      },
+      {
+        label: lendingProtocolsByName[LendingProtocol.MorphoBlue].label,
+        value: lendingProtocolsByName[LendingProtocol.MorphoBlue].name,
+        image: lendingProtocolsByName[LendingProtocol.MorphoBlue].icon,
+        featureFlag: FeaturesEnum.MorphoBlue,
+      },
+    ],
+  },
+  [LendingProtocol.MorphoBlue]: {
+    protocols: [
+      {
+        label: lendingProtocolsByName[LendingProtocol.AaveV3].label,
+        value: lendingProtocolsByName[LendingProtocol.AaveV3].name,
+        image: lendingProtocolsByName[LendingProtocol.AaveV3].icon,
+      },
+      {
+        label: lendingProtocolsByName[LendingProtocol.MorphoBlue].label,
+        value: lendingProtocolsByName[LendingProtocol.MorphoBlue].name,
+        image: lendingProtocolsByName[LendingProtocol.MorphoBlue].icon,
+        featureFlag: FeaturesEnum.MorphoBlue,
+      },
+      {
+        label: lendingProtocolsByName[LendingProtocol.SparkV3].label,
+        value: lendingProtocolsByName[LendingProtocol.SparkV3].name,
+        image: lendingProtocolsByName[LendingProtocol.SparkV3].icon,
+      },
+    ],
+  },
+  [LendingProtocol.AaveV2]: undefined,
+  [LendingProtocol.Ajna]: undefined,
+}

--- a/features/refinance/contexts/RefinanceContext.tsx
+++ b/features/refinance/contexts/RefinanceContext.tsx
@@ -1,3 +1,4 @@
+import type { GetPositionFromUrlDataWithTriggersResponse } from 'features/omni-kit/observables'
 import type { RefinanceGeneralContextBase } from 'features/refinance/contexts/RefinanceGeneralContext'
 import type { RefinanceInterestRatesMetadata } from 'features/refinance/helpers'
 import type { SDKSimulation } from 'features/refinance/hooks/useSdkSimulation'
@@ -9,6 +10,7 @@ export type RefinanceContext = {
     marketPrices: {
       ethPrice: string
     }
+    dpmEvents: GetPositionFromUrlDataWithTriggersResponse
   }
   position: RefinanceGeneralContextBase['position'] & {
     owner: string

--- a/features/refinance/controllers/RefinanceModalController.tsx
+++ b/features/refinance/controllers/RefinanceModalController.tsx
@@ -1,6 +1,7 @@
 import { usePreloadAppDataContext } from 'components/context/PreloadAppDataContextProvider'
 import { useProductContext } from 'components/context/ProductContextProvider'
 import { Modal } from 'components/Modal'
+import { getPositionsFromUlrDataWithTriggers } from 'features/omni-kit/observables'
 import {
   RefinanceHeader,
   RefinanceModalSkeleton,
@@ -73,6 +74,19 @@ export const RefinanceModalController: FC<RefinanceModalProps> = ({ contextInput
     ],
   )
 
+  const dpmEvents = useMemo(
+    () =>
+      from(
+        getPositionsFromUlrDataWithTriggers({
+          networkId: contextInput.environment.chainId,
+          pairId: contextInput.poolData.pairId,
+          positionId: Number(contextInput.position.positionId.id),
+          protocol: contextInput.position.lendingProtocol,
+        }),
+      ),
+    [contextInput.position.positionId.id],
+  )
+
   const interestRates = useMemo(
     () =>
       !cache.interestRates
@@ -88,6 +102,7 @@ export const RefinanceModalController: FC<RefinanceModalProps> = ({ contextInput
 
   const [positionOwnerData, positionOwnerError] = useObservable(positionOwner)
   const [interestRatesData, interestRatesError] = useObservable(interestRates)
+  const [dpmEventsData, dpmEventsError] = useObservable(dpmEvents)
 
   // cache data
   useEffect(() => {
@@ -121,17 +136,27 @@ export const RefinanceModalController: FC<RefinanceModalProps> = ({ contextInput
 
   return (
     <Modal sx={{ margin: '0 auto' }} close={onClose} variant="modalAutoWidth">
-      <WithErrorHandler error={[positionOwnerError, interestRatesError, tokenPriceUSDError]}>
+      <WithErrorHandler
+        error={[positionOwnerError, interestRatesError, tokenPriceUSDError, dpmEventsError]}
+      >
         <WithLoadingIndicator
-          value={[ctx, positionOwnerData, interestRatesData, tokenPriceUSDData, netAPY]}
+          value={[
+            ctx,
+            positionOwnerData,
+            interestRatesData,
+            tokenPriceUSDData,
+            netAPY,
+            dpmEventsData,
+          ]}
           customLoader={<RefinanceModalSkeleton onClose={onClose} />}
         >
-          {([_ctx, _owner, _interestRates, _tokenPriceUSD, _netApy]) => (
+          {([_ctx, _owner, _interestRates, _tokenPriceUSD, _netApy, _dpmEvents]) => (
             <RefinanceContextProvider
               ctx={{
                 ..._ctx,
                 environment: {
                   ..._ctx.environment,
+                  dpmEvents: _dpmEvents,
                   marketPrices: {
                     ethPrice: _tokenPriceUSD['ETH'].toString(),
                   },

--- a/features/refinance/controllers/RefinanceModalController.tsx
+++ b/features/refinance/controllers/RefinanceModalController.tsx
@@ -1,7 +1,7 @@
 import { usePreloadAppDataContext } from 'components/context/PreloadAppDataContextProvider'
 import { useProductContext } from 'components/context/ProductContextProvider'
 import { Modal } from 'components/Modal'
-import { getPositionsFromUlrDataWithTriggers } from 'features/omni-kit/observables'
+import { getPositionsFromUrlDataWithTriggers } from 'features/omni-kit/observables'
 import {
   RefinanceHeader,
   RefinanceModalSkeleton,
@@ -77,7 +77,7 @@ export const RefinanceModalController: FC<RefinanceModalProps> = ({ contextInput
   const dpmEvents = useMemo(
     () =>
       from(
-        getPositionsFromUlrDataWithTriggers({
+        getPositionsFromUrlDataWithTriggers({
           networkId: contextInput.environment.chainId,
           pairId: contextInput.poolData.pairId,
           positionId: Number(contextInput.position.positionId.id),

--- a/features/refinance/helpers/getRefinanceProductHubDataParser.ts
+++ b/features/refinance/helpers/getRefinanceProductHubDataParser.ts
@@ -118,8 +118,15 @@ export const getRefinanceProductHubDataParser = ({
   debtToken: string
   currentLTV: string
 }) => {
+  // Filter ajna as it's not supported in refinance
+  const filteredAjna = table.filter((item) => item.protocol !== LendingProtocol.Ajna)
+
   // Map only items with enough liquidity to perform refinance
-  const availableLiquidityMapped = availableLiquidityMapping({ table, debtAmount, debtToken })
+  const availableLiquidityMapped = availableLiquidityMapping({
+    table: filteredAjna,
+    debtAmount,
+    debtToken,
+  })
 
   // Overwrite borrow rates from PH (which are per pool, not per position) for aave-like protocols
   const borrowRatesMapped = borrowRateMapping({

--- a/features/refinance/helpers/getRefinanceStrategiesToBeFiltered.ts
+++ b/features/refinance/helpers/getRefinanceStrategiesToBeFiltered.ts
@@ -1,0 +1,78 @@
+import type { PositionFromUrlWithTriggers } from 'features/omni-kit/observables'
+import type { ProductHubItem } from 'features/productHub/types'
+import { LendingProtocol } from 'lendingProtocols'
+
+/**
+ * Strategies that should be filtered out from product hub.
+ *
+ * @remarks
+ * while doing refinance, target strategy / position can't have automation enabled,
+ * because it could lead to trigger being executed immediately
+ *
+ * @param events - position dpm events with trigger data
+ * @param table - product hub table data
+ * @returns filtered table data
+ *
+ * Aave / Spark
+ * - we support only 1x Aave and 1x Spark position on single dpm
+ * - if there is only Spark position, user should be able to pick any Aave strategy (the same other way around)
+ * - if there is for example Spark position and Aave position on dpm, while doing refinance from Spark to Aave
+ *   this Aave position should be used in refinance unless there is automation enabled (all other strategies should be filtered out)
+ *
+ * MorphoBlue
+ * - single dpm can have multiple MorphoBlue positions, but on different markets
+ * - each position can have automation enabled
+ *
+ * Maker
+ * - no restrictions since we are using new (empty) dpm to do refinance, therefore all strategies are available
+ *
+ */
+export const getRefinanceStrategiesToBeFiltered = ({
+  events,
+  table,
+}: {
+  events: PositionFromUrlWithTriggers[]
+  table: ProductHubItem[]
+}): ProductHubItem[] => {
+  const mappedEvents = events.map((event) => ({
+    protocol: event.protocol,
+    collateralTokenSymbol: event.collateralTokenSymbol,
+    debtTokenSymbol: event.debtTokenSymbol,
+    pairId: event.pairId,
+    triggers: event.triggers,
+  }))
+  return table.filter((item) => {
+    const existingPosition = mappedEvents.find((event) => event.protocol === item.protocol)
+
+    if (!existingPosition) {
+      return true
+    }
+
+    switch (item.protocol) {
+      case LendingProtocol.AaveV3:
+      case LendingProtocol.SparkV3: {
+        const flag = existingPosition.protocol
+          .replace('aavev3', 'aave3')
+          .replace('sparkv3', 'spark')
+
+        const automations = existingPosition.triggers.flags[flag as 'aave3' | 'spark']
+        const isAutomationEnabled = Object.values(automations).some((record) => record)
+
+        if (isAutomationEnabled) {
+          return false
+        }
+
+        return (
+          item.primaryToken === existingPosition.collateralTokenSymbol &&
+          item.secondaryToken === existingPosition.debtTokenSymbol
+        )
+      }
+      case LendingProtocol.MorphoBlue:
+        const pairId = Number(item.label.split('-')[1] || 1)
+
+        return pairId !== existingPosition.pairId
+      default:
+        return true
+    }
+  })
+}


### PR DESCRIPTION
# [Refinance PH strategies filtering](https://app.shortcut.com/oazo-apps/story/15716/bug-aave-wsteth-usdc-probably-all-to-aave-current-pool-is-incorrectly-suggested-as-the-best-one-to-swap-to)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added filtering of strategies based on user dpm events
  
## How to test 🧪
  <Please explain how to test your changes>

- read docs added in code
