### PR TITLE
Disable MorphoBlue pairs in refinance strategies filter

### DIFF
--- a/features/refinance/disabledMorphoPairs.ts
+++ b/features/refinance/disabledMorphoPairs.ts
@@ -1,0 +1,1 @@
+export const disabledMorphoPairs = ['WSTETH/USDA', 'PTWEETH/USDA']

--- a/features/refinance/helpers/getRefinanceStrategiesToBeFiltered.ts
+++ b/features/refinance/helpers/getRefinanceStrategiesToBeFiltered.ts
@@ -1,5 +1,6 @@
 import type { PositionFromUrlWithTriggers } from 'features/omni-kit/observables'
 import type { ProductHubItem } from 'features/productHub/types'
+import { disabledMorphoPairs } from 'features/refinance/disabledMorphoPairs'
 import { LendingProtocol } from 'lendingProtocols'
 
 /**
@@ -43,6 +44,10 @@ export const getRefinanceStrategiesToBeFiltered = ({
   }))
   return table.filter((item) => {
     const existingPosition = mappedEvents.find((event) => event.protocol === item.protocol)
+
+    if (item.protocol === LendingProtocol.MorphoBlue && disabledMorphoPairs.includes(item.label)) {
+      return false
+    }
 
     if (!existingPosition) {
       return true


### PR DESCRIPTION
This pull request disables the MorphoBlue pairs in the refinance strategies filter. Previously, these pairs were not being properly filtered out. With this change, the disabled MorphoBlue pairs ['WSTETH/USDA', 'PTWEETH/USDA'] will be excluded from the filter.