### PR TITLE
Update fee price calculation and add getTokenUsdPrice

### DIFF
--- a/features/refinance/components/steps/RefinanceSwapSection.tsx
+++ b/features/refinance/components/steps/RefinanceSwapSection.tsx
@@ -9,10 +9,11 @@ import React from 'react'
 export const RefinanceSwapSection = () => {
   const { t } = useTranslation()
   const {
-    simulation: { refinanceSimulation, debtPrice, collateralPrice },
+    environment: { getTokenUsdPrice },
+    simulation: { refinanceSimulation },
   } = useRefinanceContext()
 
-  if (!refinanceSimulation || !collateralPrice || !debtPrice) {
+  if (!refinanceSimulation) {
     return null
   }
 
@@ -36,7 +37,7 @@ export const RefinanceSwapSection = () => {
 
     const priceImpact = new BigNumber(swap.priceImpact.value).div(100)
     const slippage = new BigNumber(swap.slippage.value)
-    const feePrice = new BigNumber(isCollateral ? collateralPrice : debtPrice)
+    const feePrice = getTokenUsdPrice(swap.summerFee.token.symbol.toUpperCase())
     const fee = new BigNumber(swap.summerFee.amount).times(feePrice)
     const rawPrice = new BigNumber(1).div(swap.offerPrice.value)
 

--- a/features/refinance/components/steps/RefinanceWhatsChangingStep.tsx
+++ b/features/refinance/components/steps/RefinanceWhatsChangingStep.tsx
@@ -18,7 +18,7 @@ export const RefinanceWhatsChangingStep = () => {
   const { t } = useTranslation()
 
   const {
-    environment: { gasEstimation },
+    environment: { gasEstimation, getTokenUsdPrice },
     metadata: {
       validations: { errors, warnings, notices, successes },
     },
@@ -31,7 +31,7 @@ export const RefinanceWhatsChangingStep = () => {
         token: { symbol: oldDebtToken },
       },
     },
-    simulation: { refinanceSimulation, collateralPrice, debtPrice },
+    simulation: { refinanceSimulation },
     tx: { isTxSuccess, isTxInProgress },
     form: {
       state: { dpm },
@@ -76,12 +76,10 @@ export const RefinanceWhatsChangingStep = () => {
   }
 
   let summerFee = new BigNumber(0)
-  const { swaps, sourcePosition } = refinanceSimulation || {}
+  const { swaps } = refinanceSimulation || {}
 
   swaps?.forEach((swap) => {
-    const isCollateral =
-      swap.fromTokenAmount.token.symbol === sourcePosition?.collateralAmount.token.symbol
-    const feePrice = new BigNumber(isCollateral ? collateralPrice || 0 : debtPrice || 0)
+    const feePrice = getTokenUsdPrice(swap.summerFee.token.symbol.toUpperCase())
     const fee = new BigNumber(swap.summerFee.amount).times(feePrice)
     summerFee = summerFee.plus(fee)
   })

--- a/features/refinance/contexts/RefinanceGeneralContext.tsx
+++ b/features/refinance/contexts/RefinanceGeneralContext.tsx
@@ -89,6 +89,7 @@ export type RefinanceGeneralContextBase = {
     slippage: number
     gasEstimation: GasEstimationContext | undefined
     isOwner: boolean
+    getTokenUsdPrice: (symbol: string) => string
   }
   position: {
     positionId: PositionId

--- a/features/refinance/hooks/useInitializeRefinanceContextBase.ts
+++ b/features/refinance/hooks/useInitializeRefinanceContextBase.ts
@@ -1,4 +1,6 @@
 import { type AddressValue, TokenAmount } from '@summer_fi/summerfi-sdk-common'
+import { getTokenPrice } from 'blockchain/prices'
+import { tokenPriceStore } from 'blockchain/prices.constants'
 import type { GasEstimationContext } from 'components/context/GasEstimationContextProvider'
 import {
   getOmniTxStatuses,
@@ -74,6 +76,13 @@ export const useInitializeRefinanceContextBase = ({
     [LendingProtocol.AaveV2]: [],
     [LendingProtocol.Ajna]: [],
   }[contextInput.position.lendingProtocol]
+
+  const getTokenUsdPrice = (symbol: string) =>
+    getTokenPrice(
+      symbol.toUpperCase(),
+      tokenPriceStore.prices,
+      'getTokenUsdPrice - init refinance context base',
+    ).toString()
 
   const {
     environment: { slippage, address, isOwner },
@@ -154,6 +163,7 @@ export const useInitializeRefinanceContextBase = ({
       slippage,
       gasEstimation,
       isOwner,
+      getTokenUsdPrice,
     },
     position: {
       collateralTokenData,


### PR DESCRIPTION
This pull request updates the fee price calculation in the `RefinanceSwapSection` and `RefinanceWhatsChangingStep` components. It replaces the previous calculation with a new function `getTokenUsdPrice` that retrieves the USD price of a token. This ensures more robust fee price calculation.