### PR TITLE
Update stop loss max offset

### DIFF
--- a/features/omni-kit/automation/constants.ts
+++ b/features/omni-kit/automation/constants.ts
@@ -8,7 +8,7 @@ export const stopLossConstants = {
   defaultResolveTo: 'collateral' as OmniCloseTo,
   offsets: {
     min: new BigNumber(0.01),
-    max: new BigNumber(0.01), // we have 1% offset from max ltv in contracts
+    max: new BigNumber(0.011), // we have 1% offset from max ltv in contracts
   },
 }
 


### PR DESCRIPTION
# [Update stop loss max offset](https://app.shortcut.com/oazo-apps/story/15875/bug-auto-take-profit-morpho-blue-default-stop-loss-value-is-too-high-and-blocks-automation-set-up)

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- updated SL max slider value offset
  
## How to test 🧪
  <Please explain how to test your changes>

- it should be possible to add SL with max value
