### PR TITLE
Update disconnect wallet button text and functionality

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -194,6 +194,7 @@
   "disconnect": "Disconnect",
   "disconnect-magic": "Log out",
   "disconnect-wallet": "Disconnect Wallet",
+  "disconnect-wallet-and-clear-data": "Clear all data and Disconnect Wallet",
   "discover": {
     "heading": "Discover Summer.fi",
     "intro": "Discover and find the most interesting Vaults on Summer.fi in real-time.",


### PR DESCRIPTION
The disconnect wallet button text and functionality have been updated to provide a clearer user experience. The button now displays different text and color based on whether the user is holding the Shift key or not. If the user is holding the Shift key, the button text is changed to "Clear all data and Disconnect Wallet" and the button color is set to a warning color. Otherwise, the button text remains as "Disconnect Wallet" and the color is set to the primary color. Additionally, the disconnect callback now accepts a boolean parameter to determine whether to clear the local storage or not. This change improves the usability of the user settings page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a more nuanced disconnect action that allows users to clear their data when disconnecting by holding the Shift key.
  - Added visual feedback on the disconnect button, changing text and icon color based on Shift key status.
  
- **Enhancements**
  - Improved wallet management options with updated language for disconnecting and clearing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->