### PR TITLE
Triggering e2e tests after staging deployment

### DIFF
--- a/.github/workflows/aws-staging.yaml
+++ b/.github/workflows/aws-staging.yaml
@@ -165,3 +165,16 @@ jobs:
         run:
           AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id
           ${{secrets.CF_DIST_ID_STAGING }} --paths "/*"
+
+      - name: Trigger e2e tests in e2e-tests repository
+        env:
+          E2E_TESTS_PAT: ${{ secrets.E2E_TESTS_PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.E2E_TESTS_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml/dispatches \
+            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\"}}"
+          echo 'See test results in https://github.com/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml --> Job with RUN_ID ${{ github.run_id }} in the logs.'

--- a/.github/workflows/e2e-tests-result.yaml
+++ b/.github/workflows/e2e-tests-result.yaml
@@ -1,0 +1,29 @@
+name: Staging E2E tests result
+
+on: 
+  workflow_dispatch:
+    inputs:
+      tests_run_id:
+        description: 'E2E tests run_id'
+        type: string
+        required: true
+      tests_result:
+        description: 'E2E tests result -- faillure | success'
+        type: string
+        required: true
+
+jobs:
+  e2e-tests-result:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Link to tests run -> https://github.com/OasisDEX/e2e-tests/actions/runs/${{ inputs.tests_run_id }}
+        run: echo 'See tests results in https://github.com/OasisDEX/e2e-tests/actions/runs/${{ inputs.tests_run_id }}'
+      - name: E2E tests failed
+        if: ${{ inputs.tests_result == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('E2E tests failed - Link to tests run https://github.com/OasisDEX/e2e-tests/actions/runs/${{ inputs.tests_run_id }}')
+      - name: E2E tests passed
+        if: ${{ inputs.tests_result == 'success' }}
+        run: echo 'E2E tests passed'

--- a/.github/workflows/e2e-tests-result.yaml
+++ b/.github/workflows/e2e-tests-result.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       tests_result:
-        description: 'E2E tests result -- faillure | success'
+        description: 'E2E tests result -- failure | success'
         type: string
         required: true
 


### PR DESCRIPTION
# Triggering e2e tests after staging deployment

  
## Changes 👷‍♀️
- Extra step added to [aws-staging.yaml](https://github.com/OasisDEX/oasis-borrow/compare/ci-e2e-tests?expand=1#diff-b35bce22280d5ae9ade0b1d58f8ca8696c018406aac6aea1512e19585f7649b4) so that e2e tests in `e2e-tests` repository are triggered after staging deployment.
- New workflow added to show the e2e tests result (and a link to the specific run in `e2e-tests` repository).
![Screenshot 2024-08-26 at 13 29 45](https://github.com/user-attachments/assets/bb506590-a3f5-4865-8779-97b39963103c)
![Screenshot 2024-08-26 at 13 30 06](https://github.com/user-attachments/assets/56add734-0d9c-4e58-a6d5-31eab2d74135)

  




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a job to trigger end-to-end tests in a separate repository, enhancing the CI/CD process.
	- Added a new workflow to manage and report the results of end-to-end tests, providing clear feedback based on test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->