### PR TITLE
Maker guni yields subgraph

### DIFF
--- a/blockchain/abi/mcd-osm.json
+++ b/blockchain/abi/mcd-osm.json
@@ -1,1 +1,230 @@
-[{"inputs":[{"internalType":"address","name":"src_","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":true,"inputs":[{"indexed":true,"internalType":"bytes4","name":"sig","type":"bytes4"},{"indexed":true,"internalType":"address","name":"usr","type":"address"},{"indexed":true,"internalType":"bytes32","name":"arg1","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"arg2","type":"bytes32"},{"indexed":false,"internalType":"bytes","name":"data","type":"bytes"}],"name":"LogNote","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"bytes32","name":"val","type":"bytes32"}],"name":"LogValue","type":"event"},{"constant":true,"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"bud","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"src_","type":"address"}],"name":"change","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"usr","type":"address"}],"name":"deny","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address[]","name":"a","type":"address[]"}],"name":"diss","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"a","type":"address"}],"name":"diss","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"hop","outputs":[{"internalType":"uint16","name":"","type":"uint16"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address[]","name":"a","type":"address[]"}],"name":"kiss","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"a","type":"address"}],"name":"kiss","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"pass","outputs":[{"internalType":"bool","name":"ok","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"peek","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"},{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"peep","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"},{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"poke","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"read","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"usr","type":"address"}],"name":"rely","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"src","outputs":[{"internalType":"address","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"start","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"uint16","name":"ts","type":"uint16"}],"name":"step","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"stop","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"stopped","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"void","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"wards","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"zzz","outputs":[{"internalType":"uint64","name":"","type":"uint64"}],"payable":false,"stateMutability":"view","type":"function"}]
+[
+  {
+    "inputs": [{ "internalType": "address", "name": "src_", "type": "address" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": true,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes4", "name": "sig", "type": "bytes4" },
+      { "indexed": true, "internalType": "address", "name": "usr", "type": "address" },
+      { "indexed": true, "internalType": "bytes32", "name": "arg1", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "arg2", "type": "bytes32" },
+      { "indexed": false, "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "LogNote",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "bytes32", "name": "val", "type": "bytes32" }],
+    "name": "LogValue",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "bud",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "src_", "type": "address" }],
+    "name": "change",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "usr", "type": "address" }],
+    "name": "deny",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address[]", "name": "a", "type": "address[]" }],
+    "name": "diss",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "a", "type": "address" }],
+    "name": "diss",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "hop",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address[]", "name": "a", "type": "address[]" }],
+    "name": "kiss",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "a", "type": "address" }],
+    "name": "kiss",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pass",
+    "outputs": [{ "internalType": "bool", "name": "ok", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "peek",
+    "outputs": [
+      { "internalType": "bytes32", "name": "", "type": "bytes32" },
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "peep",
+    "outputs": [
+      { "internalType": "bytes32", "name": "", "type": "bytes32" },
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "poke",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "read",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "usr", "type": "address" }],
+    "name": "rely",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "src",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "start",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint16", "name": "ts", "type": "uint16" }],
+    "name": "step",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "stop",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "stopped",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "void",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "wards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "zzz",
+    "outputs": [{ "internalType": "uint64", "name": "", "type": "uint64" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/features/earn/makerOracleTokenPrices.ts
+++ b/features/earn/makerOracleTokenPrices.ts
@@ -1,37 +1,38 @@
+import type { Block } from '@ethersproject/providers'
 import BigNumber from 'bignumber.js'
 import { getNetworkContracts } from 'blockchain/contracts'
 import type { Context } from 'blockchain/network.types'
-import { NetworkIds } from 'blockchain/networks'
+import { getRpcProvider, NetworkIds } from 'blockchain/networks'
 import dayjs from 'dayjs'
-import { gql, GraphQLClient } from 'graphql-request'
+import type { SubgraphsResponses } from 'features/subgraphLoader/types'
+import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+import {
+  getEstimatedBlockNumber,
+  getEstimatedBlockNumberSync,
+} from 'helpers/getEstimatedBlockNumber'
 import type { Observable } from 'rxjs'
-import { first, map, switchMap } from 'rxjs/operators'
+import { first, switchMap } from 'rxjs/operators'
 
-const makerOraclePrice = gql`
-  mutation prices($token: String!, $date: Datetime) {
-    makerOracleTokenPrices(input: { token: $token, date: $date }) {
-      tokenPrice {
-        token
-        price
-        timestamp
-        requestedTimestamp
-      }
-    }
-  }
-`
-
-const makerOraclePriceInMultipleDates = gql`
-  mutation pricesInDates($token: String!, $dates: [Datetime!]!) {
-    makerOracleTokenPricesInDates(input: { token: $token, dates: $dates }) {
-      tokenPrices {
-        price
-        token
-        timestamp
-        requestedTimestamp
-      }
-    }
-  }
-`
+const getOsmRawQuery = ({
+  timestamps,
+  lastBlock,
+  osmId,
+}: {
+  timestamps: dayjs.Dayjs[]
+  lastBlock: Block
+  osmId: string
+}) =>
+  `
+    {${timestamps
+      .map(
+        (timestamp) => `
+         price_${timestamp.unix().toString()}: osm(id: "${osmId.toLowerCase()}", block: { number: ${getEstimatedBlockNumberSync(timestamp.unix(), lastBlock)} }) {
+            value
+          }
+        `,
+      )
+      .join('')}
+      }`.replaceAll(' ', '')
 
 export interface MakerOracleTokenPrice {
   token: string
@@ -47,20 +48,32 @@ export function createMakerOracleTokenPrices$(
 ): Observable<MakerOracleTokenPrice> {
   return context$.pipe(
     first(),
-    switchMap(({ chainId }) => {
-      const apiClient = new GraphQLClient(getNetworkContracts(NetworkIds.MAINNET, chainId).cacheApi)
-      return apiClient.request(makerOraclePrice, {
-        token,
-        date: timestamp.toISOString(),
-      })
-    }),
-    map((apiResponse) => {
-      const respRaw = apiResponse.makerOracleTokenPrices.tokenPrice
+    switchMap(async ({ chainId }) => {
+      const provider = getRpcProvider(chainId)
+      const mcdOsms = getNetworkContracts(NetworkIds.MAINNET).mcdOsms
+      const osmId = mcdOsms[token].address.toLowerCase()
+
+      if (!osmId) {
+        console.error('There is no OSM available for given token', token)
+      }
+
+      const block = await getEstimatedBlockNumber(provider, timestamp.unix())
+
+      const { response } = (await loadSubgraph({
+        subgraph: 'Discover',
+        method: 'getOsm',
+        networkId: chainId,
+        params: {
+          id: osmId,
+          block,
+        },
+      })) as SubgraphsResponses['Discover']['getOsm']
+
       return {
-        token: respRaw.token,
-        price: new BigNumber(respRaw.price),
-        timestamp: dayjs(respRaw.timestamp),
-        requestedTimestamp: dayjs(respRaw.requestedTimestamp),
+        token,
+        price: new BigNumber(response.osm.value),
+        timestamp: dayjs(timestamp),
+        requestedTimestamp: dayjs(timestamp),
       }
     }),
   )
@@ -70,22 +83,36 @@ export function createMakerOracleTokenPricesForDates$(
   context$: Observable<Context>,
   token: string,
   timestamps: dayjs.Dayjs[],
-): Observable<MakerOracleTokenPrice> {
+): Observable<MakerOracleTokenPrice[]> {
   return context$.pipe(
     first(),
-    switchMap(({ chainId }) => {
-      const apiClient = new GraphQLClient(getNetworkContracts(NetworkIds.MAINNET, chainId).cacheApi)
-      return apiClient.request(makerOraclePriceInMultipleDates, {
+    switchMap(async ({ chainId }) => {
+      const provider = getRpcProvider(chainId)
+      const mcdOsms = getNetworkContracts(NetworkIds.MAINNET).mcdOsms
+      const osmId = mcdOsms[token].address.toLowerCase()
+
+      if (!osmId) {
+        console.error('There is no OSM available for given token', token)
+      }
+
+      const lastBlock = await provider.getBlock('latest')
+
+      const { response } = (await loadSubgraph({
+        subgraph: 'Discover',
+        method: 'getOsm',
+        networkId: chainId,
+        rawQuery: getOsmRawQuery({
+          timestamps,
+          lastBlock,
+          osmId,
+        }),
+      })) as SubgraphsResponses['Discover']['getOsm']
+
+      return Object.entries(response).map(([key, value]) => ({
         token,
-        dates: timestamps.map((t) => t.toISOString()),
-      })
-    }),
-    map((apiResponse) => {
-      return apiResponse.makerOracleTokenPricesInDates.tokenPrices.map((resp: any) => ({
-        token: resp.token,
-        price: new BigNumber(resp.price),
-        timestamp: dayjs(resp.timestamp),
-        requestedTimestamp: dayjs(resp.requestedTimestamp),
+        price: new BigNumber(value.value),
+        timestamp: dayjs(),
+        requestedTimestamp: dayjs(Number(key.split('_')[1]) * 1000),
       }))
     }),
   )

--- a/features/subgraphLoader/consts.ts
+++ b/features/subgraphLoader/consts.ts
@@ -890,4 +890,11 @@ export const subgraphMethodsRecord: SubgraphMethodsRecord = {
       }
     }
   `,
+  getOsm: gql`
+    query getOsm($id: ID!, $block: Int!) {
+      osm(id: $id, block: { number: $block }) {
+        value
+      }
+    }
+  `,
 }

--- a/features/subgraphLoader/types.ts
+++ b/features/subgraphLoader/types.ts
@@ -28,7 +28,10 @@ import type { ClaimedReferralRewards } from 'features/referralOverview/getClaime
 import type { GetAaveLikeInterestRatesResponse } from 'features/refinance/graph/getRefinanceTargetInterestRates'
 import type { AjnaDpmPositionsResponse } from 'handlers/portfolio/positions/handlers/ajna/types'
 import type { Erc4626DpmPositionsResponse } from 'handlers/portfolio/positions/handlers/erc-4626/types'
-import type { MakerDiscoverPositionsResponse } from 'handlers/portfolio/positions/handlers/maker/types'
+import type {
+  MakerDiscoverPositionsResponse,
+  MakerOsmResponse,
+} from 'handlers/portfolio/positions/handlers/maker/types'
 import type { MorphoDpmPositionsResponse } from 'handlers/portfolio/positions/handlers/morpho-blue/types'
 import type { Erc4626InterestRatesResponse } from 'handlers/product-hub/update-handlers/erc-4626/erc4626Handler'
 
@@ -63,6 +66,7 @@ export type Subgraphs = {
   }
   Discover: {
     getMakerDiscoverPositions: { walletAddress: string }
+    getOsm: { id: string; block: number }
   }
   Morpho: {
     getMorphoVauldIdPositions: { positionId: number }
@@ -165,6 +169,7 @@ export type SubgraphsResponses = {
   }
   Discover: {
     getMakerDiscoverPositions: SubgraphBaseResponse<MakerDiscoverPositionsResponse>
+    getOsm: SubgraphBaseResponse<MakerOsmResponse>
   }
   Morpho: {
     getMorphoVauldIdPositions: SubgraphBaseResponse<MorphoVauldIdPositionsResponse>

--- a/handlers/portfolio/positions/handlers/maker/types.ts
+++ b/handlers/portfolio/positions/handlers/maker/types.ts
@@ -34,3 +34,9 @@ export interface MakerDiscoverPositionsResponse {
     creator: string // dsProxy
   }[]
 }
+
+export interface MakerOsmResponse {
+  osm: {
+    value: string
+  }
+}

--- a/handlers/product-hub/helpers/empty-yields.ts
+++ b/handlers/product-hub/helpers/empty-yields.ts
@@ -1,9 +1,0 @@
-import type { RiskRatio } from '@oasisdex/dma-library'
-import type {
-  AaveLikeYieldsResponse,
-  FilterYieldFieldsType,
-} from 'lendingProtocols/aave-like-common'
-
-export const emptyYields = (_risk: RiskRatio, _fields: FilterYieldFieldsType[]) => {
-  return Promise.resolve<AaveLikeYieldsResponse>({})
-}

--- a/helpers/earn/calculations.ts
+++ b/helpers/earn/calculations.ts
@@ -127,7 +127,10 @@ export function getYields$(
           { ilk: ilk, yields: {} },
         )
     }),
-    catchError(() => of({ ilk: ilk, yields: {} })),
+    catchError((error) => {
+      console.error('Maker yield calcs error', error)
+      return of({ ilk: ilk, yields: {} })
+    }),
     distinctUntilChanged(isEqual),
   )
 }

--- a/helpers/getEstimatedBlockNumber.ts
+++ b/helpers/getEstimatedBlockNumber.ts
@@ -1,0 +1,78 @@
+import type { Block } from '@ethersproject/providers'
+import type { ethers } from 'ethers'
+
+/**
+ * Estimates the block number closest to a given target timestamp.
+ *
+ * This function estimates the Ethereum block number corresponding to a given timestamp.
+ * It assumes an average block time of 12 seconds. The function fetches the most recent block,
+ * calculates the difference in time from the target timestamp, and estimates the block number.
+ * It then verifies the estimated block's timestamp and adjusts accordingly if needed.
+ *
+ * @param provider - An instance of an ethers.js provider used to interact with the Ethereum blockchain.
+ * @param targetTimestamp - The Unix timestamp (in seconds) to find the corresponding block number.
+ * @param _lastBlock - Optional: A pre-fetched block to avoid fetching the latest block again if already available.
+ * @returns A promise that resolves to the estimated block number closest to the target timestamp.
+ */
+export async function getEstimatedBlockNumber(
+  provider: ethers.providers.Provider,
+  targetTimestamp: number,
+  _lastBlock?: Block,
+): Promise<number> {
+  // Fetch the block corresponding to the last block number
+  const lastBlock = _lastBlock || (await provider.getBlock('latest'))
+
+  // If the target timestamp is in the future, return lastBlock
+  if (targetTimestamp >= lastBlock.timestamp) {
+    console.warn('The provided timestamp is in the future.')
+    return lastBlock.number - 1
+  }
+
+  // Calculate the time difference in seconds
+  const timeDifference = lastBlock.timestamp - targetTimestamp
+
+  // Estimate how many blocks have been minted since the target timestamp
+  const blockDifference = Math.floor(timeDifference / 12) // assuming 12 seconds per block
+
+  // Estimate the target block number
+  const estimatedBlockNumber = lastBlock.number - blockDifference
+
+  // Fetch the block corresponding to the estimated block number to verify
+  const estimatedBlock = await provider.getBlock(estimatedBlockNumber)
+
+  // Ensure the estimated block's timestamp is not later than the target timestamp
+  if (estimatedBlock.timestamp <= targetTimestamp) {
+    return estimatedBlockNumber
+  } else {
+    // Adjust the block number downward by one if it's still in the future
+    return estimatedBlockNumber - 1
+  }
+}
+
+/**
+ * Synchronously estimates the block number closest to a given target timestamp.
+ *
+ * This function estimates the Ethereum block number corresponding to a given timestamp.
+ * It assumes an average block time of 12 seconds and synchronously estimates the block
+ * number based on the provided last block and target timestamp.
+ *
+ * @param targetTimestamp - The Unix timestamp (in seconds) to find the corresponding block number.
+ * @param lastBlock - The latest known block, which serves as the reference point for the estimation.
+ * @returns The estimated block number closest to the target timestamp.
+ */
+export function getEstimatedBlockNumberSync(targetTimestamp: number, lastBlock: Block): number {
+  // If the target timestamp is in the future, return lastBlock
+  if (targetTimestamp >= lastBlock.timestamp) {
+    console.warn('The provided timestamp is in the future.')
+    return lastBlock.number - 1
+  }
+
+  // Calculate the time difference in seconds
+  const timeDifference = lastBlock.timestamp - targetTimestamp
+
+  // Estimate how many blocks have been minted since the target timestamp
+  const blockDifference = Math.floor(timeDifference / 12) // assuming 12 seconds per block
+
+  // Estimate the target block number
+  return lastBlock.number - blockDifference
+}

--- a/lendingProtocols/aave-like-common/yields/index.ts
+++ b/lendingProtocols/aave-like-common/yields/index.ts
@@ -1,25 +1,4 @@
-import type BigNumber from 'bignumber.js'
 import type { GetYieldsResponseMapped } from 'helpers/lambda/yields'
-
-export type FilterYieldFieldsType =
-  | '7Days'
-  | '7DaysOffset'
-  | '30Days'
-  | '90Days'
-  | '90DaysOffset'
-  | '1Year'
-  | 'Inception'
-export const yieldsDateFormat = 'YYYY-MM-DD'
-
-export interface AaveLikeYieldsResponse {
-  annualisedYield7days?: BigNumber
-  annualisedYield7daysOffset?: BigNumber
-  annualisedYield30days?: BigNumber
-  annualisedYield90days?: BigNumber
-  annualisedYield90daysOffset?: BigNumber
-  annualisedYield1Year?: BigNumber
-  annualisedYieldSinceInception?: BigNumber
-}
 
 export function has7daysYield(
   yields: GetYieldsResponseMapped,


### PR DESCRIPTION
# Maker guni yields subgraph

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- replaced price source for yields calcs from cache to subgraph
  
## How to test 🧪
  <Please explain how to test your changes>

- yields values should be the same as on prod


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced token price retrieval with dynamic querying based on timestamps and blocks.
	- Introduced new functionality for estimating Ethereum block numbers with both asynchronous and synchronous methods.
	- Added a new GraphQL query for fetching specific data related to the OSM entity.

- **Bug Fixes**
	- Improved error handling and logging in yield calculations for better observability.

- **Refactor**
	- Restructured ABI definitions for improved readability without changing functionality.
	- Streamlined yield response model by removing unnecessary types and interfaces. 

- **Documentation**
	- Updated documentation to reflect changes in API capabilities and error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->