### PR TITLE
Refactor getStrategyConfig to handle old positions with no debt

### DIFF
--- a/features/aave/helpers/getStrategyConfig.ts
+++ b/features/aave/helpers/getStrategyConfig.ts
@@ -82,6 +82,7 @@ export function getStrategyConfig$(
       switch (true) {
         // For aave v3 we should have the event. and we don't support changing vault type in aave v2
         case aaveUserConfigurations.hasAssets(['STETH'], ['ETH', 'WETH']):
+        case aaveUserConfigurations.hasAssets(['STETH'], []): // special case for old positions with no debt
           return loadStrategyFromTokens(
             'STETH',
             'ETH',

--- a/pages/not-found.tsx
+++ b/pages/not-found.tsx
@@ -24,6 +24,13 @@ function NotFoundPage() {
           <AppLink href="/">
             <Button>{t('404-button')}</Button>
           </AppLink>
+          {process.env.NODE_ENV !== 'production' && (
+            <AppLink href="/" sx={{ mt: '-20px' }}>
+              <Button variant="secondary" onClick={() => window.history.back()}>
+                {t('404-back')}
+              </Button>
+            </AppLink>
+          )}
         </Grid>
       </Container>
     </MarketingLayout>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "get-started-button": "Get started on Summer.fi",
   "404-button": "Go to homepage",
+  "404-back": "Go back",
   "404-message": "Sorry, page not found.",
   "about": {
     "heading": "About us",


### PR DESCRIPTION
This pull request refactors the `getStrategyConfig` function to handle old positions with no debt. It includes changes to the `getStrategyConfig` function and the `hasAssets` function. Additionally, a new button has been added to the 404 page for going back (dev only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Aave user configuration to support users with 'STETH' assets and no debts.
	- Added a button on the Not Found page for easier navigation back to the previous page during non-production modes.
	- Introduced a new translation key for the 404 error page to improve user navigation.

- **Bug Fixes**
	- Improved case sensitivity handling for asset names in Aave user configuration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->