### PR TITLE
Fixed swap on mainnet if WBTC we need to remove CURVE from LP

### DIFF
--- a/helpers/swap.ts
+++ b/helpers/swap.ts
@@ -98,7 +98,7 @@ export function getOneInchCall(
     slippage: BigNumber,
     protocols: string[] = [],
   ) => {
-    const resolvedProcotols = match({ protocols, networkId })
+    let resolvedProcotols = match({ protocols, networkId })
       .with(
         { protocols: [], networkId: NetworkIds.OPTIMISMMAINNET },
         () => OPTIMISM_DEFAULT_PROCOTOLS,
@@ -116,6 +116,11 @@ export function getOneInchCall(
         () => BASE_DEFAULT_LIQUIDITY_PROVIDERS,
       )
       .otherwise(() => protocols)
+
+    // on mainnet if WBTC we need to remove CURVE from LP
+    if (networkId === NetworkIds.MAINNET && from === '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599') {
+      resolvedProcotols = resolvedProcotols.filter((protocol) => protocol !== 'CURVE')
+    }
 
     const response = await swapOneInchTokens(
       from,

--- a/helpers/swap.ts
+++ b/helpers/swap.ts
@@ -117,11 +117,9 @@ export function getOneInchCall(
       )
       .otherwise(() => protocols)
 
+    const WBTC_ADDRESS = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
     // on mainnet if WBTC we need to remove CURVE from LP
-    if (
-      networkId === NetworkIds.MAINNET &&
-      from.toLowerCase() === '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
-    ) {
+    if (networkId === NetworkIds.MAINNET && from.toLowerCase() === WBTC_ADDRESS) {
       resolvedProcotols = resolvedProcotols.filter((protocol) => protocol !== 'CURVE')
     }
 

--- a/helpers/swap.ts
+++ b/helpers/swap.ts
@@ -118,7 +118,10 @@ export function getOneInchCall(
       .otherwise(() => protocols)
 
     // on mainnet if WBTC we need to remove CURVE from LP
-    if (networkId === NetworkIds.MAINNET && from === '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599') {
+    if (
+      networkId === NetworkIds.MAINNET &&
+      from.toLowerCase() === '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+    ) {
       resolvedProcotols = resolvedProcotols.filter((protocol) => protocol !== 'CURVE')
     }
 


### PR DESCRIPTION
# [Title](https://shortcutLink)

Fix big swaps of WBTC (> 1BTC), to not fail
  
## Changes 👷‍♀️
on mainnet if WBTC we need to remove CURVE from LP
  
## How to test 🧪
create an ETH/WBTC position, deposit at least 250 ETH and try to take debt to swap at least several BTCs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the swapping logic to filter out the 'CURVE' protocol for WBTC on the MAINNET, improving the accuracy of protocol selection during token swaps.

- **Bug Fixes**
	- Refined the control flow for determining protocols, ensuring better handling of specific token and network combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->