### PR TITLE
Refactor Aave V3 EMode category handling

### DIFF
--- a/blockchain/aave-v3/aave-v3-pool-data-provider.ts
+++ b/blockchain/aave-v3/aave-v3-pool-data-provider.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import { NetworkIds } from 'blockchain/networks'
 import { amountFromRay, amountFromWei } from 'blockchain/utils'
 import { warnIfAddressIsZero } from 'helpers/warnIfAddressIsZero'
-import { zero } from 'helpers/zero'
+import { one, zero } from 'helpers/zero'
 import { AaveV3PoolDataProvider__factory } from 'types/ethers-contracts'
 
 import type { BaseParameters } from './utils'
@@ -191,14 +191,20 @@ export function getAaveV3ReserveConfigurationData({
   })
 }
 
-export interface AaveV3EModeForAssetParameters extends BaseParameters {
-  token: string
+export interface AaveV3EModeForAssetsParameters extends BaseParameters {
+  debtToken: string
+  collateralToken: string
 }
 
-export function getAaveV3EModeCategoryForAsset(
-  _props: AaveV3EModeForAssetParameters,
-): Promise<BigNumber> {
-  return Promise.resolve(zero)
+export function getAaveV3EModeCategoryForAssets({
+  collateralToken,
+  debtToken,
+}: AaveV3EModeForAssetsParameters): Promise<BigNumber> {
+  const isCollateralEthCorrelated = collateralToken.toUpperCase().includes('ETH')
+  const isDebtEthCorrelated = debtToken.toUpperCase().includes('ETH')
+  const strategyEModeCategory = isCollateralEthCorrelated || isDebtEthCorrelated ? one : zero
+
+  return Promise.resolve(strategyEModeCategory)
 }
 
 export interface AaveV3ReserveCapParameters extends BaseParameters {

--- a/blockchain/aave-v3/aave-v3-pool.ts
+++ b/blockchain/aave-v3/aave-v3-pool.ts
@@ -90,7 +90,8 @@ export function getEModeCategoryData({
   categoryId,
 }: GetEModeCategoryDataParameters): Promise<GetEModeCategoryDataResult> {
   const { contract } = networkMappings[networkId]()
-  return contract.getEModeCategoryData(categoryId.toString(16)).then((result) => {
+
+  return contract.getEModeCategoryCollateralConfig(categoryId.toString(16)).then((result) => {
     return {
       ltv: new BigNumber(result.ltv.toString()).div(10000),
       liquidationThreshold: new BigNumber(result.liquidationThreshold.toString()).div(10000),

--- a/blockchain/abi/aave-v3-pool.json
+++ b/blockchain/abi/aave-v3-pool.json
@@ -277,25 +277,6 @@
         "internalType": "address",
         "name": "user",
         "type": "address"
-      }
-    ],
-    "name": "RebalanceStableBorrowRate",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "reserve",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
       },
       {
         "indexed": true,
@@ -443,31 +424,6 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "reserve",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "enum DataTypes.InterestRateMode",
-        "name": "interestRateMode",
-        "type": "uint8"
-      }
-    ],
-    "name": "SwapBorrowRateMode",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
         "name": "user",
         "type": "address"
       },
@@ -528,131 +484,60 @@
   {
     "inputs": [],
     "name": "BRIDGE_PROTOCOL_FEE",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "FLASHLOAN_PREMIUM_TOTAL",
-    "outputs": [
-      {
-        "internalType": "uint128",
-        "name": "",
-        "type": "uint128"
-      }
-    ],
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "FLASHLOAN_PREMIUM_TO_PROTOCOL",
-    "outputs": [
-      {
-        "internalType": "uint128",
-        "name": "",
-        "type": "uint128"
-      }
-    ],
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "MAX_NUMBER_RESERVES",
-    "outputs": [
-      {
-        "internalType": "uint16",
-        "name": "",
-        "type": "uint16"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAX_STABLE_RATE_BORROW_SIZE_PERCENT",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "POOL_REVISION",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "fee",
-        "type": "uint256"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "uint256", "name": "fee", "type": "uint256" }
     ],
     "name": "backUnbacked",
-    "outputs": [],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "interestRateMode",
         "type": "uint256"
       },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
-      },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      }
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" },
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" }
     ],
     "name": "borrow",
     "outputs": [],
@@ -661,18 +546,10 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint8",
-        "name": "id",
-        "type": "uint8"
-      },
+      { "internalType": "uint8", "name": "id", "type": "uint8" },
       {
         "components": [
-          {
-            "internalType": "uint16",
-            "name": "ltv",
-            "type": "uint16"
-          },
+          { "internalType": "uint16", "name": "ltv", "type": "uint16" },
           {
             "internalType": "uint16",
             "name": "liquidationThreshold",
@@ -683,18 +560,9 @@
             "name": "liquidationBonus",
             "type": "uint16"
           },
-          {
-            "internalType": "address",
-            "name": "priceSource",
-            "type": "address"
-          },
-          {
-            "internalType": "string",
-            "name": "label",
-            "type": "string"
-          }
+          { "internalType": "string", "name": "label", "type": "string" }
         ],
-        "internalType": "struct DataTypes.EModeCategory",
+        "internalType": "struct DataTypes.EModeCategoryBaseConfiguration",
         "name": "category",
         "type": "tuple"
       }
@@ -706,26 +574,38 @@
   },
   {
     "inputs": [
+      { "internalType": "uint8", "name": "id", "type": "uint8" },
       {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
+        "internalType": "uint128",
+        "name": "borrowableBitmap",
+        "type": "uint128"
       }
+    ],
+    "name": "configureEModeCategoryBorrowableBitmap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint8", "name": "id", "type": "uint8" },
+      {
+        "internalType": "uint128",
+        "name": "collateralBitmap",
+        "type": "uint128"
+      }
+    ],
+    "name": "configureEModeCategoryCollateralBitmap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" },
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" }
     ],
     "name": "deposit",
     "outputs": [],
@@ -733,13 +613,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
     "name": "dropReserve",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -747,26 +621,10 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "from",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "balanceFromBefore",
@@ -790,36 +648,16 @@
         "name": "receiverAddress",
         "type": "address"
       },
-      {
-        "internalType": "address[]",
-        "name": "assets",
-        "type": "address[]"
-      },
-      {
-        "internalType": "uint256[]",
-        "name": "amounts",
-        "type": "uint256[]"
-      },
+      { "internalType": "address[]", "name": "assets", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" },
       {
         "internalType": "uint256[]",
         "name": "interestRateModes",
         "type": "uint256[]"
       },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "params",
-        "type": "bytes"
-      },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
-      }
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" },
+      { "internalType": "bytes", "name": "params", "type": "bytes" },
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" }
     ],
     "name": "flashLoan",
     "outputs": [],
@@ -833,26 +671,10 @@
         "name": "receiverAddress",
         "type": "address"
       },
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bytes",
-        "name": "params",
-        "type": "bytes"
-      },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "bytes", "name": "params", "type": "bytes" },
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" }
     ],
     "name": "flashLoanSimple",
     "outputs": [],
@@ -860,23 +682,25 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
+    "name": "getBorrowLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBridgeLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
     "name": "getConfiguration",
     "outputs": [
       {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "data",
-            "type": "uint256"
-          }
-        ],
+        "components": [{ "internalType": "uint256", "name": "data", "type": "uint256" }],
         "internalType": "struct DataTypes.ReserveConfigurationMap",
         "name": "",
         "type": "tuple"
@@ -886,22 +710,52 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [{ "internalType": "uint8", "name": "id", "type": "uint8" }],
+    "name": "getEModeCategoryBorrowableBitmap",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint8", "name": "id", "type": "uint8" }],
+    "name": "getEModeCategoryCollateralBitmap",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint8", "name": "id", "type": "uint8" }],
+    "name": "getEModeCategoryCollateralConfig",
+    "outputs": [
       {
-        "internalType": "uint8",
-        "name": "id",
-        "type": "uint8"
+        "components": [
+          { "internalType": "uint16", "name": "ltv", "type": "uint16" },
+          {
+            "internalType": "uint16",
+            "name": "liquidationThreshold",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "liquidationBonus",
+            "type": "uint16"
+          }
+        ],
+        "internalType": "struct DataTypes.CollateralConfig",
+        "name": "",
+        "type": "tuple"
       }
     ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint8", "name": "id", "type": "uint8" }],
     "name": "getEModeCategoryData",
     "outputs": [
       {
         "components": [
-          {
-            "internalType": "uint16",
-            "name": "ltv",
-            "type": "uint16"
-          },
+          { "internalType": "uint16", "name": "ltv", "type": "uint16" },
           {
             "internalType": "uint16",
             "name": "liquidationThreshold",
@@ -917,13 +771,9 @@
             "name": "priceSource",
             "type": "address"
           },
-          {
-            "internalType": "string",
-            "name": "label",
-            "type": "string"
-          }
+          { "internalType": "string", "name": "label", "type": "string" }
         ],
-        "internalType": "struct DataTypes.EModeCategory",
+        "internalType": "struct DataTypes.EModeCategoryLegacy",
         "name": "",
         "type": "tuple"
       }
@@ -932,44 +782,62 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint16",
-        "name": "id",
-        "type": "uint16"
-      }
-    ],
-    "name": "getReserveAddressById",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "uint8", "name": "id", "type": "uint8" }],
+    "name": "getEModeCategoryLabel",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
+    "name": "getEModeLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFlashLoanLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getLiquidationGracePeriod",
+    "outputs": [{ "internalType": "uint40", "name": "", "type": "uint40" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLiquidationLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint16", "name": "id", "type": "uint16" }],
+    "name": "getReserveAddressById",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
     "name": "getReserveData",
     "outputs": [
       {
         "components": [
           {
-            "components": [
-              {
-                "internalType": "uint256",
-                "name": "data",
-                "type": "uint256"
-              }
-            ],
+            "components": [{ "internalType": "uint256", "name": "data", "type": "uint256" }],
             "internalType": "struct DataTypes.ReserveConfigurationMap",
             "name": "configuration",
             "type": "tuple"
@@ -1004,11 +872,7 @@
             "name": "lastUpdateTimestamp",
             "type": "uint40"
           },
-          {
-            "internalType": "uint16",
-            "name": "id",
-            "type": "uint16"
-          },
+          { "internalType": "uint16", "name": "id", "type": "uint16" },
           {
             "internalType": "address",
             "name": "aTokenAddress",
@@ -1034,14 +898,103 @@
             "name": "accruedToTreasury",
             "type": "uint128"
           },
+          { "internalType": "uint128", "name": "unbacked", "type": "uint128" },
           {
             "internalType": "uint128",
-            "name": "unbacked",
+            "name": "isolationModeTotalDebt",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct DataTypes.ReserveDataLegacy",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getReserveDataExtended",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [{ "internalType": "uint256", "name": "data", "type": "uint256" }],
+            "internalType": "struct DataTypes.ReserveConfigurationMap",
+            "name": "configuration",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint128",
+            "name": "liquidityIndex",
             "type": "uint128"
           },
           {
             "internalType": "uint128",
+            "name": "currentLiquidityRate",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "variableBorrowIndex",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "currentVariableBorrowRate",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "__deprecatedStableBorrowRate",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint40",
+            "name": "lastUpdateTimestamp",
+            "type": "uint40"
+          },
+          { "internalType": "uint16", "name": "id", "type": "uint16" },
+          {
+            "internalType": "uint40",
+            "name": "liquidationGracePeriodUntil",
+            "type": "uint40"
+          },
+          {
+            "internalType": "address",
+            "name": "aTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "__deprecatedStableDebtTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "variableDebtTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "interestRateStrategyAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint128",
+            "name": "accruedToTreasury",
+            "type": "uint128"
+          },
+          { "internalType": "uint128", "name": "unbacked", "type": "uint128" },
+          {
+            "internalType": "uint128",
             "name": "isolationModeTotalDebt",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "virtualUnderlyingBalance",
             "type": "uint128"
           }
         ],
@@ -1054,64 +1007,42 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
     "name": "getReserveNormalizedIncome",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
     "name": "getReserveNormalizedVariableDebt",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReservesCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "getReservesList",
-    "outputs": [
-      {
-        "internalType": "address[]",
-        "name": "",
-        "type": "address[]"
-      }
-    ],
+    "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
+    "name": "getSupplyLogic",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
     "name": "getUserAccountData",
     "outputs": [
       {
@@ -1119,11 +1050,7 @@
         "name": "totalCollateralBase",
         "type": "uint256"
       },
-      {
-        "internalType": "uint256",
-        "name": "totalDebtBase",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "totalDebtBase", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "availableBorrowsBase",
@@ -1134,38 +1061,18 @@
         "name": "currentLiquidationThreshold",
         "type": "uint256"
       },
-      {
-        "internalType": "uint256",
-        "name": "ltv",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "healthFactor",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "ltv", "type": "uint256" },
+      { "internalType": "uint256", "name": "healthFactor", "type": "uint256" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
     "name": "getUserConfiguration",
     "outputs": [
       {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "data",
-            "type": "uint256"
-          }
-        ],
+        "components": [{ "internalType": "uint256", "name": "data", "type": "uint256" }],
         "internalType": "struct DataTypes.UserConfigurationMap",
         "name": "",
         "type": "tuple"
@@ -1175,41 +1082,23 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
     "name": "getUserEMode",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getVirtualUnderlyingBalance",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "aTokenAddress",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "stableDebtAddress",
-        "type": "address"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "aTokenAddress", "type": "address" },
       {
         "internalType": "address",
         "name": "variableDebtAddress",
@@ -1246,26 +1135,10 @@
         "name": "collateralAsset",
         "type": "address"
       },
-      {
-        "internalType": "address",
-        "name": "debtAsset",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "debtToCover",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "receiveAToken",
-        "type": "bool"
-      }
+      { "internalType": "address", "name": "debtAsset", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "debtToCover", "type": "uint256" },
+      { "internalType": "bool", "name": "receiveAToken", "type": "bool" }
     ],
     "name": "liquidationCall",
     "outputs": [],
@@ -1273,13 +1146,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "assets",
-        "type": "address[]"
-      }
-    ],
+    "inputs": [{ "internalType": "address[]", "name": "assets", "type": "address[]" }],
     "name": "mintToTreasury",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -1287,26 +1154,10 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" },
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" }
     ],
     "name": "mintUnbacked",
     "outputs": [],
@@ -1315,68 +1166,24 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "user",
-        "type": "address"
-      }
-    ],
-    "name": "rebalanceStableBorrowRate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "interestRateMode",
         "type": "uint256"
       },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" }
     ],
     "name": "repay",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "interestRateMode",
@@ -1384,87 +1191,35 @@
       }
     ],
     "name": "repayWithATokens",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "interestRateMode",
         "type": "uint256"
       },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "deadline",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint8",
-        "name": "permitV",
-        "type": "uint8"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "permitR",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "permitS",
-        "type": "bytes32"
-      }
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "permitV", "type": "uint8" },
+      { "internalType": "bytes32", "name": "permitR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "permitS", "type": "bytes32" }
     ],
     "name": "repayWithPermit",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
     ],
     "name": "rescueTokens",
     "outputs": [],
@@ -1472,13 +1227,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
     "name": "resetIsolationModeTotalDebt",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -1486,19 +1235,9 @@
   },
   {
     "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
       {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "data",
-            "type": "uint256"
-          }
-        ],
+        "components": [{ "internalType": "uint256", "name": "data", "type": "uint256" }],
         "internalType": "struct DataTypes.ReserveConfigurationMap",
         "name": "configuration",
         "type": "tuple"
@@ -1511,11 +1250,17 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint40", "name": "until", "type": "uint40" }
+    ],
+    "name": "setLiquidationGracePeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
       {
         "internalType": "address",
         "name": "rateStrategyAddress",
@@ -1528,13 +1273,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint8",
-        "name": "categoryId",
-        "type": "uint8"
-      }
-    ],
+    "inputs": [{ "internalType": "uint8", "name": "categoryId", "type": "uint8" }],
     "name": "setUserEMode",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -1542,16 +1281,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "useAsCollateral",
-        "type": "bool"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "bool", "name": "useAsCollateral", "type": "bool" }
     ],
     "name": "setUserUseReserveAsCollateral",
     "outputs": [],
@@ -1560,26 +1291,10 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" },
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" }
     ],
     "name": "supply",
     "outputs": [],
@@ -1588,46 +1303,14 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "onBehalfOf",
-        "type": "address"
-      },
-      {
-        "internalType": "uint16",
-        "name": "referralCode",
-        "type": "uint16"
-      },
-      {
-        "internalType": "uint256",
-        "name": "deadline",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint8",
-        "name": "permitV",
-        "type": "uint8"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "permitR",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "permitS",
-        "type": "bytes32"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "onBehalfOf", "type": "address" },
+      { "internalType": "uint16", "name": "referralCode", "type": "uint16" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "permitV", "type": "uint8" },
+      { "internalType": "bytes32", "name": "permitR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "permitS", "type": "bytes32" }
     ],
     "name": "supplyWithPermit",
     "outputs": [],
@@ -1635,31 +1318,21 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "interestRateMode",
-        "type": "uint256"
-      }
-    ],
-    "name": "swapBorrowRateMode",
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "syncIndexesState",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "protocolFee",
-        "type": "uint256"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "syncRatesState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "protocolFee", "type": "uint256" }],
     "name": "updateBridgeProtocolFee",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -1685,30 +1358,12 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "asset",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" }
     ],
     "name": "withdraw",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/handlers/product-hub/update-handlers/aaveV3/aaveV3Handler.ts
+++ b/handlers/product-hub/update-handlers/aaveV3/aaveV3Handler.ts
@@ -237,8 +237,6 @@ export default async function (tickers: Tickers): ProductHubHandlerResponse {
 
         const { tokens } = contracts
 
-        console.log('maxLtv.toString()', maxLtv.toString())
-
         return {
           ...product,
           product: [isMultiply && isYieldLoop ? OmniProductType.Earn : product.product[0]],

--- a/lendingProtocols/aave-v3/index.ts
+++ b/lendingProtocols/aave-v3/index.ts
@@ -48,11 +48,11 @@ export function getAaveV3Services({
     'aaveLikeReserveConfigurationData$',
   )
 
-  const getAaveV3EModeCategoryForAsset$ = makeObservableForNetworkId(
+  const getAaveV3EModeCategoryForAssets$ = makeObservableForNetworkId(
     refresh$,
-    blockchainCalls.getAaveV3EModeCategoryForAsset,
+    blockchainCalls.getAaveV3EModeCategoryForAssets,
     networkId,
-    'getAaveV3EModeCategoryForAsset$',
+    'getAaveV3EModeCategoryForAssets$',
   )
 
   const aaveLikeLiquidations$ = makeObservableForNetworkId(
@@ -136,7 +136,7 @@ export function getAaveV3Services({
   const reserveConfigurationDataWithEMode$ = memoize(
     curry(getReserveConfigurationDataWithEMode$)(
       aaveLikeReserveConfigurationData$,
-      getAaveV3EModeCategoryForAsset$,
+      getAaveV3EModeCategoryForAssets$,
       getEModeCategoryData$,
     ),
     (args: { collateralToken: string; debtToken: string }) =>

--- a/lendingProtocols/aave-v3/pipelines/get-reserve-configuration-data-with-emode.ts
+++ b/lendingProtocols/aave-v3/pipelines/get-reserve-configuration-data-with-emode.ts
@@ -14,22 +14,28 @@ export function getReserveConfigurationDataWithEMode$(
   getReserveConfigurationData: (args: {
     token: string
   }) => Observable<AaveLikeReserveConfigurationData>,
-  getAaveV3EModeCategoryForAsset: (args: { token: string }) => Observable<BigNumber>,
+  getAaveV3EModeCategoryForAssets: (args: {
+    debtToken: string
+    collateralToken: string
+  }) => Observable<BigNumber>,
   getEModeCategoryData: (
     params: Omit<GetEModeCategoryDataParameters, 'networkId'>,
   ) => Observable<GetEModeCategoryDataResult>,
   parameters: GetReserveConfigurationDataWithEModeParameters,
 ): Observable<AaveLikeReserveConfigurationData> {
   return combineLatest(
-    getAaveV3EModeCategoryForAsset({ token: parameters.collateralToken }),
-    getAaveV3EModeCategoryForAsset({ token: parameters.debtToken }),
+    getAaveV3EModeCategoryForAssets({
+      debtToken: parameters.debtToken,
+      collateralToken: parameters.collateralToken,
+    }),
     getReserveConfigurationData({ token: parameters.collateralToken }),
   ).pipe(
-    switchMap(([collateralCategory, debtCategory, reserveData]) => {
-      if (collateralCategory.isZero()) return of(reserveData)
-      if (!collateralCategory.eq(debtCategory)) return of(reserveData)
+    switchMap(([strategyCategory, reserveData]) => {
+      if (strategyCategory.isZero()) return of(reserveData)
 
-      return getEModeCategoryData({ categoryId: collateralCategory })
+      return getEModeCategoryData({
+        categoryId: strategyCategory,
+      })
     }),
   )
 }


### PR DESCRIPTION
This commit refactors the Aave V3 EMode category handling by renaming some functions and variables for clarity. The changes include:
- Renaming `getAaveV3EModeCategoryForAsset` to `getAaveV3EModeCategoryForAssets` for consistency.
- Updating the function signature of `getAaveV3EModeCategoryForAssets` to accept `debtToken` and `collateralToken` parameters instead of a single `token` parameter.
- Adding logic to determine the EMode category based on whether the collateral or debt token is correlated with ETH.
- Renaming the `primaryTokenEModeCategory` and `secondaryTokenEModeCategory` variables to `strategyEmodeCategory` for better naming.

These changes improve the readability and maintainability of the code related to Aave V3 EMode category handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of EMode categories with support for multiple assets.
	- New events and functions added to improve contract interactions and data retrieval.

- **Bug Fixes**
	- Streamlined logic for fetching reserve data related to EMode categories.

- **Documentation**
	- Updated function signatures and event definitions for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->