### PR TITLE
chore: handle new morpho token and wrapper

### DIFF
--- a/blockchain/abi/erc20-proxy-actions.json
+++ b/blockchain/abi/erc20-proxy-actions.json
@@ -26,6 +26,34 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "oldToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "newToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "wrapper",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approveAndWrap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_token",
         "type": "address"
       },

--- a/blockchain/token-metadata-list/token-configs.ts
+++ b/blockchain/token-metadata-list/token-configs.ts
@@ -998,6 +998,15 @@ export const tokenConfigs: TokenConfig[] = [
     tags: [],
   },
   {
+    symbol: 'MORPHO_LEGACY',
+    precision: 18,
+    digits: 5,
+    name: 'Legacy Morpho Blue',
+    icon: morpho_circle_color,
+    iconCircle: morpho_circle_color,
+    tags: [],
+  },
+  {
     symbol: 'RBN',
     precision: 18,
     digits: 5,

--- a/blockchain/tokens/mainnet.ts
+++ b/blockchain/tokens/mainnet.ts
@@ -74,6 +74,7 @@ export const tokensMainnet = {
   LUSD: contractDesc(erc20, mainnet.common.LUSD),
   MKR: contractDesc(erc20, mainnet.maker.common.McdGov),
   MORPHO: contractDesc(erc20, mainnet.common.MORPHO),
+  MORPHO_LEGACY: contractDesc(erc20, mainnet.common.MORPHO_LEGACY),
   RENBTC: contractDesc(erc20, mainnet.common.RENBTC),
   RETH: contractDesc(erc20, mainnet.common.RETH),
   RSETH: contractDesc(erc20, mainnet.common.RSETH),

--- a/features/notices/VaultsNoticesView.tsx
+++ b/features/notices/VaultsNoticesView.tsx
@@ -325,6 +325,7 @@ export function VaultLiquidatedNotice({
           })}
         </Text>
         <ReclaimCollateralButton {...{ token, id, amount: unlockedCollateral }} />
+        {console.debug('ReclaimCollateralButton props:', { token, id, amount: unlockedCollateral })}
       </>
     ) : (
       fallbackSubheader

--- a/features/omni-kit/components/details-section/OmniDetailSectionRewardsClaims.tsx
+++ b/features/omni-kit/components/details-section/OmniDetailSectionRewardsClaims.tsx
@@ -3,7 +3,11 @@ import { Network } from '@oasisdex/dma-library'
 import { networkIdToLibraryNetwork } from 'actions/aave-like/helpers'
 import type BigNumber from 'bignumber.js'
 import { encodeClaimAllRewards, getAllUserRewards } from 'blockchain/better-calls/aave-like-rewards'
-import { encodeTransferToOwnerProxyAction, tokenBalance } from 'blockchain/better-calls/erc20'
+import {
+  encodeApproveAndWrapProxyAction,
+  encodeTransferToOwnerProxyAction,
+  tokenBalance,
+} from 'blockchain/better-calls/erc20'
 import { NetworkIds } from 'blockchain/networks'
 import { tokenPriceStore } from 'blockchain/prices.constants'
 import { getTokenByAddress } from 'blockchain/tokensMetadata'
@@ -17,7 +21,13 @@ import React, { useEffect, useReducer } from 'react'
 import { OmniDetailsSectionContentRewardsLoadingState } from './OmniDetailsSectionContentRewardsLoadingState'
 import { OmniRewardsClaims } from './OmniRewardsClaims'
 
-const claimableErc20: Record<NetworkIds, string[]> = {
+interface OmniDetailSectionRewardsClaimsInternalProps {
+  isEligibleForErc20Claims: boolean
+  isEligibleForProtocolRewards: boolean
+  isEligibleForMorphoLegacy: boolean
+}
+
+const claimableErc20ByNetwork: Record<NetworkIds, string[]> = {
   [NetworkIds.MAINNET]: ['ENA', 'SENA'],
   [NetworkIds.OPTIMISMMAINNET]: [],
   [NetworkIds.ARBITRUMMAINNET]: [],
@@ -32,13 +42,21 @@ const claimableErc20: Record<NetworkIds, string[]> = {
   [NetworkIds.OPTIMISMGOERLI]: [],
 }
 
+const morphoLegacyByNetwork: Partial<Record<NetworkIds, string>> = {
+  [NetworkIds.MAINNET]: 'MORPHO_LEGACY',
+}
+
 type Claim = {
   token: string
   claimable: BigNumber
   tx: OmniTxData
 }
 
-const OmniDetailSectionRewardsClaimsInternal: FC = () => {
+const OmniDetailSectionRewardsClaimsInternal: FC<OmniDetailSectionRewardsClaimsInternalProps> = ({
+  isEligibleForErc20Claims,
+  isEligibleForProtocolRewards,
+  isEligibleForMorphoLegacy,
+}) => {
   const {
     environment: { dpmProxy, networkId, protocol, quoteAddress },
   } = useOmniGeneralContext()
@@ -48,9 +66,9 @@ const OmniDetailSectionRewardsClaimsInternal: FC = () => {
   }, [])
 
   useEffect(() => {
-    if (dpmProxy) {
-      // Existing ERC20 claims logic
-      claimableErc20[networkId].forEach((token) => {
+    if (!dpmProxy) return
+    if (isEligibleForErc20Claims) {
+      claimableErc20ByNetwork[networkId].forEach((token) => {
         tokenBalance({ token, account: dpmProxy, networkId: networkId })
           .then((balance) => {
             if (balance.gt(zero)) {
@@ -72,64 +90,97 @@ const OmniDetailSectionRewardsClaimsInternal: FC = () => {
             console.error(`Error fetching token balance for ${token}: ${error}`)
           })
       })
-
-      // New Aave and Spark rewards check
-      if ([LendingProtocol.AaveV3, LendingProtocol.SparkV3].includes(protocol)) {
-        let rewardsControllerAddress: string | undefined
-        let poolDataProviderAddress: string | undefined
+    }
+    if (isEligibleForMorphoLegacy) {
+      const morphoLegacyToken = morphoLegacyByNetwork[networkId]
+      console.log('morphoLegacyToken', morphoLegacyToken)
+      if (morphoLegacyToken) {
+        console.log('morphoLegacyToken', morphoLegacyToken)
         const network = networkIdToLibraryNetwork(networkId)
-        if (
-          protocol === LendingProtocol.AaveV3 &&
-          network !== Network.HARDHAT &&
-          network !== Network.LOCAL &&
-          network !== Network.TENDERLY
-        ) {
-          rewardsControllerAddress = ADDRESSES[network].aave.v3.RewardsController
-          poolDataProviderAddress = ADDRESSES[network].aave.v3.PoolDataProvider
-        } else if (
-          protocol === LendingProtocol.SparkV3 &&
-          network !== Network.HARDHAT &&
-          network !== Network.LOCAL &&
-          network !== Network.TENDERLY
-        ) {
-          rewardsControllerAddress = ADDRESSES[network].spark.RewardsController
-          poolDataProviderAddress = ADDRESSES[network].spark.PoolDataProvider
-        } else {
-          console.warn(`Unsupported protocol or network for rewards: ${protocol} on ${network}`)
-          throw new Error(`Unsupported protocol or network for rewards: ${protocol} on ${network}`)
-        }
-
-        getAllUserRewards({
-          networkId,
-          token: quoteAddress,
-          account: dpmProxy,
-          rewardsController: rewardsControllerAddress as string,
-          poolDataProvider: poolDataProviderAddress as string,
-        })
-          .then(async ({ rewardsList, unclaimedAmounts, assets }) => {
-            if (unclaimedAmounts.some((amount) => amount.gt(zero))) {
-              const tx = encodeClaimAllRewards({
-                networkId,
-                assets: assets as string[],
-                dpmAccount: dpmProxy,
-                rewardsController: rewardsControllerAddress as string,
-              })
-
-              rewardsList.forEach((token, index) => {
-                if (unclaimedAmounts[index].gt(zero)) {
-                  dispatchClaim({
-                    token: getTokenByAddress(token, networkId).symbol,
-                    claimable: unclaimedAmounts[index],
-                    tx,
+        console.log('network', network)
+        if (network === Network.MAINNET) {
+          tokenBalance({ token: morphoLegacyToken, account: dpmProxy, networkId })
+            .then((balance) => {
+              console.log('balance mmm', balance)
+              if (balance.gt(zero)) {
+                encodeApproveAndWrapProxyAction({
+                  oldToken: morphoLegacyToken,
+                  newToken: 'MORPHO',
+                  wrapper: ADDRESSES[network].morphoblue.Wrapper,
+                  amount: balance,
+                  networkId,
+                })
+                  .then((tx) => {
+                    dispatchClaim({ token: 'MORPHO', claimable: balance, tx })
                   })
-                }
-              })
-            }
-          })
-          .catch((error) => {
-            console.error(`Error fetching ${protocol} rewards:`, error)
-          })
+                  .catch((error) => {
+                    console.error(
+                      `Error encoding approve and wrap action for MORPHO_LEGACY: ${error}`,
+                    )
+                  })
+              }
+            })
+            .catch((error) => {
+              console.error(`Error fetching MORPHO_LEGACY balance: ${error}`)
+            })
+        }
       }
+    }
+    if (isEligibleForProtocolRewards) {
+      let rewardsControllerAddress: string | undefined
+      let poolDataProviderAddress: string | undefined
+      const network = networkIdToLibraryNetwork(networkId)
+      if (
+        protocol === LendingProtocol.AaveV3 &&
+        network !== Network.HARDHAT &&
+        network !== Network.LOCAL &&
+        network !== Network.TENDERLY
+      ) {
+        rewardsControllerAddress = ADDRESSES[network].aave.v3.RewardsController
+        poolDataProviderAddress = ADDRESSES[network].aave.v3.PoolDataProvider
+      } else if (
+        protocol === LendingProtocol.SparkV3 &&
+        network !== Network.HARDHAT &&
+        network !== Network.LOCAL &&
+        network !== Network.TENDERLY
+      ) {
+        rewardsControllerAddress = ADDRESSES[network].spark.RewardsController
+        poolDataProviderAddress = ADDRESSES[network].spark.PoolDataProvider
+      } else {
+        console.warn(`Unsupported protocol or network for rewards: ${protocol} on ${network}`)
+        throw new Error(`Unsupported protocol or network for rewards: ${protocol} on ${network}`)
+      }
+
+      getAllUserRewards({
+        networkId,
+        token: quoteAddress,
+        account: dpmProxy,
+        rewardsController: rewardsControllerAddress as string,
+        poolDataProvider: poolDataProviderAddress as string,
+      })
+        .then(async ({ rewardsList, unclaimedAmounts, assets }) => {
+          if (unclaimedAmounts.some((amount) => amount.gt(zero))) {
+            const tx = encodeClaimAllRewards({
+              networkId,
+              assets: assets as string[],
+              dpmAccount: dpmProxy,
+              rewardsController: rewardsControllerAddress as string,
+            })
+
+            rewardsList.forEach((token, index) => {
+              if (unclaimedAmounts[index].gt(zero)) {
+                dispatchClaim({
+                  token: getTokenByAddress(token, networkId).symbol,
+                  claimable: unclaimedAmounts[index],
+                  tx,
+                })
+              }
+            })
+          }
+        })
+        .catch((error) => {
+          console.error(`Error fetching ${protocol} rewards:`, error)
+        })
     }
   }, [dpmProxy, networkId, protocol, quoteAddress])
 
@@ -152,19 +203,33 @@ const OmniDetailSectionRewardsClaimsInternal: FC = () => {
 
 export const OmniDetailSectionRewardsClaims: FC = () => {
   const {
-    environment: { protocol, collateralToken, quoteToken },
+    environment: { protocol, collateralToken, quoteToken, networkId },
   } = useOmniGeneralContext()
 
-  const eligibleTokens = ['SUSDE', 'USDE', 'WETH', 'ETH']
+  const rewardsEligibleTokens = ['SUSDE', 'USDE', 'WETH', 'ETH']
 
-  const isEligible =
-    [
-      LendingProtocol.MorphoBlue,
-      LendingProtocol.Ajna,
-      LendingProtocol.AaveV3,
-      LendingProtocol.SparkV3,
-    ].includes(protocol) &&
-    (eligibleTokens.includes(collateralToken) || eligibleTokens.includes(quoteToken))
+  // Regular ERC20 claims eligibility
+  const isEligibleForErc20Claims = claimableErc20ByNetwork[networkId].length > 0
 
-  return isEligible ? <OmniDetailSectionRewardsClaimsInternal /> : <></>
+  // Aave/Spark rewards eligibility
+  const isEligibleForProtocolRewards =
+    [LendingProtocol.AaveV3, LendingProtocol.SparkV3].includes(protocol) &&
+    (rewardsEligibleTokens.includes(collateralToken) || rewardsEligibleTokens.includes(quoteToken))
+
+  // Legacy Morpho claims eligibility
+  const isEligibleForMorphoLegacy =
+    networkId === NetworkIds.MAINNET && protocol === LendingProtocol.MorphoBlue
+
+  const hasAnyEligibleClaims =
+    isEligibleForErc20Claims || isEligibleForProtocolRewards || isEligibleForMorphoLegacy
+
+  return hasAnyEligibleClaims ? (
+    <OmniDetailSectionRewardsClaimsInternal
+      isEligibleForErc20Claims={isEligibleForErc20Claims}
+      isEligibleForProtocolRewards={isEligibleForProtocolRewards}
+      isEligibleForMorphoLegacy={isEligibleForMorphoLegacy}
+    />
+  ) : (
+    <></>
+  )
 }

--- a/features/omni-kit/protocols/erc-4626/settings.ts
+++ b/features/omni-kit/protocols/erc-4626/settings.ts
@@ -92,6 +92,10 @@ const morphoRewards = {
   token: 'MORPHO',
   label: 'Morpho token rewards',
 }
+const legacyMorphoRewards = {
+  token: 'MORPHO_LEGACY',
+  label: 'Legacy Morpho token rewards',
+}
 const wstethRewards = {
   token: 'WSTETH',
   label: 'Lido rewards in WSTETH',
@@ -112,7 +116,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
     protocol: LendingProtocol.MorphoBlue,
-    rewards: [morphoRewards, wstethRewards],
+    rewards: [morphoRewards, wstethRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Steakhouse MetaMorpho Vault',
     token: {
@@ -129,7 +133,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     protocol: LendingProtocol.MorphoBlue,
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
+    rewards: [morphoRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Steakhouse MetaMorpho Vault',
     token: {
@@ -146,7 +150,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     protocol: LendingProtocol.MorphoBlue,
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
+    rewards: [morphoRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Steakhouse MetaMorpho Vault',
     token: {
@@ -163,7 +167,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     protocol: LendingProtocol.MorphoBlue,
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
+    rewards: [morphoRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Steakhouse MetaMorpho Vault',
     token: {
@@ -180,7 +184,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     protocol: LendingProtocol.MorphoBlue,
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
+    rewards: [morphoRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Flagship MetaMorpho Vault',
     token: {
@@ -197,7 +201,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     protocol: LendingProtocol.MorphoBlue,
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
+    rewards: [morphoRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Flagship MetaMorpho Vault',
     token: {
@@ -214,7 +218,7 @@ export const erc4626Vaults: Erc4626Config[] = [
     protocol: LendingProtocol.MorphoBlue,
     networkId: NetworkIds.MAINNET,
     pricePicker: morphoPricePicker,
-    rewards: [morphoRewards],
+    rewards: [morphoRewards, legacyMorphoRewards],
     rewardsType: Erc4626RewardsType.MetaMorpho,
     strategy: 'Flagship MetaMorpho Vault',
     token: {

--- a/features/reclaimCollateral/reclaimCollateralView.tsx
+++ b/features/reclaimCollateral/reclaimCollateralView.tsx
@@ -16,9 +16,14 @@ export function ReclaimCollateralButton({ amount, token, id }: ReclaimCollateral
   const { reclaimCollateral$ } = useProductContext()
   const [state] = useObservable(reclaimCollateral$(id, token, amount))
 
+  console.debug('ReclaimCollateralButton state:', state)
+
   if (!state) return null
   const { reclaim, txStatus } = state
   const isLoading = txStatus === 'reclaimWaitingForApproval' || txStatus === 'reclaimInProgress'
+
+  console.debug('Recv aimCollateralButton txStatus:', txStatus)
+  console.debug('ReclaimCollateralButton isLoading:', isLoading)
 
   return (
     <Button onClick={reclaim} variant="secondary" disabled={isLoading}>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@lifi/wallet-management": "^2.6.1",
     "@lifi/widget": "^2.10.2",
     "@metamask/eth-sig-util": "^5.0.2",
-    "@oasisdex/addresses": "0.1.88",
+    "@oasisdex/addresses": "0.1.89",
     "@oasisdex/automation": "1.6.5-morpho.6",
     "@oasisdex/dma-library": "0.6.77",
     "@oasisdex/multiply": "^0.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,10 +2502,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oasisdex/addresses@0.1.88":
-  version "0.1.88"
-  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.1.88.tgz#7cc2dde4cc52c17a607fb063c26800a9bec52b39"
-  integrity sha512-er4veOy0konuDJ6jvdh131eIR5hu0NwKgcZjP37wfP//5EazW8Ze2f8i2cOE0McCsD4jKPajr8BrrUEJZ75dkw==
+"@oasisdex/addresses@0.1.89":
+  version "0.1.89"
+  resolved "https://registry.yarnpkg.com/@oasisdex/addresses/-/addresses-0.1.89.tgz#650951335e469e2123d09474bf0f9daa74041621"
+  integrity sha512-dhJDiJqd3UVc4KUzDRK0QxgoBeIj9CgxDXMXaRKNo6e6/96U00RNLebDegb2WXtTXU1QP+W7RpolbLvZbXDD6g==
 
 "@oasisdex/automation@1.6.5-morpho.6":
   version "1.6.5-morpho.6"


### PR DESCRIPTION
# [Add MORPHO Legacy token migration support](shortcutLink)

## Changes 👷‍♀️
- Added new `approveAndWrap` function to ERC20 proxy actions to support MORPHO legacy token migration
- Implemented `encodeApproveAndWrapProxyAction` in better-calls/erc20.ts
- Added MORPHO_LEGACY token configuration and mainnet address
- Restructured rewards claims logic to handle three distinct cases:
  - Regular ERC20 claims
  - Protocol rewards (Aave/Spark)
  - MORPHO legacy token migration
- Added MORPHO_LEGACY rewards to MetaMorpho vaults configuration
- Updated @oasisdex/addresses to 0.1.89

## How to test 🧪
1. Connect wallet with MORPHO_LEGACY tokens to mainnet
2. Open any MetaMorpho vault
3. Verify MORPHO_LEGACY tokens appear in rewards section
4. Attempt to claim MORPHO_LEGACY tokens:
   - Should approve wrapper contract
   - Should wrap legacy tokens
   - Should receive new MORPHO tokens
5. Verify balance updates correctly after claim

The PR implements support for migrating legacy MORPHO tokens to the new MORPHO token format using OpenZeppelin's ERC20Wrapper pattern. This allows users to easily upgrade their tokens through the UI while interacting with MetaMorpho vaults.