### PR TITLE
Add LazySummerSidebar components and integrate into Omni borrow/multiply forms

### DIFF
--- a/components/sidebar/SidebarSectionFooterButton.tsx
+++ b/components/sidebar/SidebarSectionFooterButton.tsx
@@ -1,5 +1,6 @@
 import { AppLink } from 'components/Links'
 import React from 'react'
+import type { ThemeUIStyleObject } from 'theme-ui'
 import { Button, Link, Spinner } from 'theme-ui'
 
 export interface SidebarSectionFooterButtonProps {
@@ -12,12 +13,15 @@ export interface SidebarSectionFooterButtonProps {
   variant?: string
   withoutNextLink?: boolean
   action?: () => void
+  sx?: ThemeUIStyleObject
+  target?: string
 }
 
 export function SidebarSectionFooterButton({
   hidden,
   url,
   withoutNextLink,
+  target,
   ...rest
 }: SidebarSectionFooterButtonProps) {
   return (
@@ -25,11 +29,11 @@ export function SidebarSectionFooterButton({
       {!hidden &&
         (url ? (
           withoutNextLink ? (
-            <Link href={url} sx={{ display: 'block' }}>
+            <Link href={url} sx={{ display: 'block' }} target={target}>
               <SidebarSectionFooterButtonIner {...rest} />
             </Link>
           ) : (
-            <AppLink href={url} sx={{ display: 'block' }}>
+            <AppLink href={url} sx={{ display: 'block' }} target={target}>
               <SidebarSectionFooterButtonIner {...rest} />
             </AppLink>
           )
@@ -47,6 +51,7 @@ export function SidebarSectionFooterButtonIner({
   disabled,
   isLoading,
   action,
+  sx,
 }: Omit<SidebarSectionFooterButtonProps, 'hidden' | 'url'>) {
   return (
     <Button
@@ -60,6 +65,7 @@ export function SidebarSectionFooterButtonIner({
         alignItems: 'center',
         justifyContent: 'center',
         width: '100%',
+        ...sx,
       }}
     >
       {isLoading && <Spinner size={24} color="neutral10" sx={{ mr: 2, mb: '2px' }} />}

--- a/features/lazy-summer/components/LazySummerSidebarBanner.tsx
+++ b/features/lazy-summer/components/LazySummerSidebarBanner.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+
+export const LazySummerSidebarBanner = () => {
+  return (
+    <svg
+      width="373"
+      height="172"
+      viewBox="0 0 373 172"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        opacity="0.15"
+        cx="328.276"
+        cy="57.0555"
+        r="36.1063"
+        fill="url(#paint0_linear_6702_539800)"
+      />
+      <path
+        d="M326.275 54.2043C331.878 55.4244 335.402 58.1973 335.402 62.6895C335.402 68.2909 330.087 71.4521 323.444 71.4521C317.32 71.4521 312.41 68.4018 311.428 63.2441L318.88 61.9685C319.227 64.3533 321.133 65.5734 323.444 65.5734C325.87 65.5734 327.314 64.5197 327.314 63.0777C327.314 61.5249 325.755 60.8039 324.137 60.4711L320.671 59.8056C315.356 58.5855 311.89 55.7571 311.89 51.2095C311.89 45.719 317.32 42.6133 323.444 42.6133C329.51 42.6133 333.727 45.719 334.594 50.9322L327.141 52.1523C326.852 49.9339 325.35 48.6029 323.04 48.6029C321.075 48.6029 319.516 49.4902 319.516 51.0431C319.516 52.5405 320.786 53.206 322.462 53.5387L326.275 54.2043Z"
+        fill="url(#paint1_linear_6702_539800)"
+      />
+      <path
+        d="M340.312 66.877C337.653 66.877 335.498 68.9461 335.498 71.4986H345.126C345.126 68.9461 342.971 66.877 340.312 66.877Z"
+        fill="url(#paint2_linear_6702_539800)"
+      />
+      <circle
+        opacity="0.15"
+        cx="293.45"
+        cy="105.892"
+        r="11.8877"
+        fill="url(#paint3_linear_6702_539800)"
+      />
+      <circle
+        opacity="0.15"
+        cx="242.979"
+        cy="170.18"
+        r="32.7051"
+        fill="url(#paint4_linear_6702_539800)"
+      />
+      <circle
+        opacity="0.15"
+        cx="24.9678"
+        cy="2.64551"
+        r="24.4404"
+        fill="url(#paint5_linear_6702_539800)"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_6702_539800"
+          x1="292.17"
+          y1="57.0555"
+          x2="364.382"
+          y2="57.0555"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF49A4" />
+          <stop offset="0.93" stopColor="#B049FF" />
+        </linearGradient>
+        <linearGradient
+          id="paint1_linear_6702_539800"
+          x1="311.428"
+          y1="57.0327"
+          x2="335.402"
+          y2="57.0327"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF49A4" />
+          <stop offset="0.93" stopColor="#B049FF" />
+        </linearGradient>
+        <linearGradient
+          id="paint2_linear_6702_539800"
+          x1="335.498"
+          y1="69.1878"
+          x2="345.126"
+          y2="69.1878"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF49A4" />
+          <stop offset="0.93" stopColor="#B049FF" />
+        </linearGradient>
+        <linearGradient
+          id="paint3_linear_6702_539800"
+          x1="281.562"
+          y1="105.892"
+          x2="305.338"
+          y2="105.892"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF49A4" />
+          <stop offset="0.93" stopColor="#B049FF" />
+        </linearGradient>
+        <linearGradient
+          id="paint4_linear_6702_539800"
+          x1="210.273"
+          y1="170.18"
+          x2="275.684"
+          y2="170.18"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF49A4" />
+          <stop offset="0.93" stopColor="#B049FF" />
+        </linearGradient>
+        <linearGradient
+          id="paint5_linear_6702_539800"
+          x1="0.527344"
+          y1="2.64551"
+          x2="49.4082"
+          y2="2.64551"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF49A4" />
+          <stop offset="0.93" stopColor="#B049FF" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}

--- a/features/lazy-summer/components/LazySummerSidebarContent.tsx
+++ b/features/lazy-summer/components/LazySummerSidebarContent.tsx
@@ -1,0 +1,74 @@
+import { Icon } from 'components/Icon'
+import type { FC } from 'react'
+import React from 'react'
+import { sparks } from 'theme/icons'
+import { Box, Card, Flex, Text } from 'theme-ui'
+
+import { LazySummerSidebarBanner } from './LazySummerSidebarBanner'
+interface LazySummerSidebarContentProps {
+  closeToToken: string
+}
+
+export const LazySummerSidebarContent: FC<LazySummerSidebarContentProps> = ({ closeToToken }) => {
+  return (
+    <Flex sx={{ flexDirection: 'column', gap: 2 }}>
+      <Card
+        sx={{
+          background:
+            'linear-gradient(90deg, rgba(255, 73, 164, 0.15) 0%, rgba(176, 73, 255, 0.15) 93%)',
+          border: 'unset',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <Box sx={{ position: 'absolute', top: 0, left: 0 }}>
+          <LazySummerSidebarBanner />
+        </Box>
+        <Text as="h5" variant="header5" sx={{ maxWidth: '285px', mb: 2 }}>
+          Don’t let your {closeToToken} sit idle and earn nothing.
+        </Text>
+        <Text
+          as="p"
+          variant="paragraph3"
+          sx={{ color: 'rgba(89, 111, 120, 1)', maxWidth: '335px' }}
+        >
+          Get effortless access to Defi’s highest quality yields through Lazy Summer.
+        </Text>
+      </Card>
+      <Card
+        sx={{
+          background: '#F3F7F9',
+          border: 'unset',
+          gap: 1,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Text as="p" variant="paragraph3" sx={{ fontWeight: '600' }}>
+          Earn the best rates all of the time
+        </Text>
+        <Text as="p" variant="paragraph4" sx={{ color: 'neutral80', fontWeight: '600' }}>
+          Automated rebalancing means no switching times or costs
+        </Text>
+        <Text as="p" variant="paragraph4" sx={{ color: 'neutral80', mb: 1 }}>
+          Only the top tier protocols, with risk managed by Block Analitica
+        </Text>
+        <Text
+          as="p"
+          variant="paragraph4"
+          sx={{
+            background: 'linear-gradient(90deg, #FF49A4 0%, #B049FF 93%)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            color: 'white',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+          }}
+        >
+          <Icon icon={sparks} color="#FF49A4" /> Earn SUMR token rewards on all strategies
+        </Text>
+      </Card>
+    </Flex>
+  )
+}

--- a/features/omni-kit/components/sidebars/borrow/OmniBorrowFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/borrow/OmniBorrowFormOrder.tsx
@@ -1,9 +1,10 @@
 import { negativeToZero, normalizeValue } from '@oasisdex/dma-library'
 import { InfoSection } from 'components/infoSection/InfoSection'
+import { LazySummerSidebarContent } from 'features/lazy-summer/components/LazySummerSidebarContent'
 import { OmniGasEstimation } from 'features/omni-kit/components/sidebars'
 import { useOmniGeneralContext, useOmniProductContext } from 'features/omni-kit/contexts'
 import { resolveIfCachedPosition } from 'features/omni-kit/protocols/ajna/helpers'
-import { OmniProductType } from 'features/omni-kit/types'
+import { OmniProductType, OmniSidebarBorrowPanel } from 'features/omni-kit/types'
 import {
   formatCryptoBalance,
   formatDecimalAsPercent,
@@ -22,6 +23,9 @@ export function OmniBorrowFormOrder() {
     tx: { isTxSuccess, txDetails },
   } = useOmniGeneralContext()
   const {
+    form: {
+      state: { closeTo, uiDropdown },
+    },
     position: { cachedPosition, currentPosition, isSimulationLoading },
     dynamicMetadata: {
       values: { shouldShowDynamicLtv, afterPositionDebt, afterAvailableToBorrow },
@@ -74,7 +78,13 @@ export function OmniBorrowFormOrder() {
     totalCost: txDetails?.txCost ? formatUsdValue(txDetails.txCost) : '-',
   }
 
-  return (
+  const withLazySummer = isTxSuccess && uiDropdown === OmniSidebarBorrowPanel.Close
+
+  return withLazySummer ? (
+    <LazySummerSidebarContent
+      closeToToken={closeTo === 'collateral' ? collateralToken : quoteToken}
+    />
+  ) : (
     <InfoSection
       title={t('vault-changes.order-information')}
       items={[

--- a/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
+++ b/features/omni-kit/components/sidebars/multiply/OmniMultiplyFormOrder.tsx
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import { amountFromWei } from 'blockchain/utils'
 import { InfoSection } from 'components/infoSection/InfoSection'
 import type { SecondaryVariantType } from 'components/infoSection/Item'
+import { LazySummerSidebarContent } from 'features/lazy-summer/components/LazySummerSidebarContent'
 import {
   OmniGasEstimation,
   OmniSlippageInfoWithSettings,
@@ -16,6 +17,7 @@ import {
 import {
   OmniBorrowFormAction,
   OmniMultiplyFormAction,
+  OmniMultiplyPanel,
   OmniProductType,
 } from 'features/omni-kit/types'
 import { calculatePriceImpact } from 'features/shared/priceImpact'
@@ -70,7 +72,7 @@ export function OmniMultiplyFormOrder() {
   } = useOmniGeneralContext()
   const {
     form: {
-      state: { action, loanToValue },
+      state: { action, loanToValue, uiDropdown, closeTo },
     },
     position: { cachedPosition, isSimulationLoading, currentPosition, swap },
     dynamicMetadata: {
@@ -204,7 +206,13 @@ export function OmniMultiplyFormOrder() {
     totalCost: txDetails?.txCost ? formatUsdValue(txDetails.txCost) : '-',
   }
 
-  return (
+  const withLazySummer = isTxSuccess && uiDropdown === OmniMultiplyPanel.Close
+
+  return withLazySummer ? (
+    <LazySummerSidebarContent
+      closeToToken={closeTo === 'collateral' ? collateralToken : quoteToken}
+    />
+  ) : (
     <InfoSection
       title={t('vault-changes.order-information')}
       items={[

--- a/features/omni-kit/helpers/getOmniPrimaryButtonLabelKey.ts
+++ b/features/omni-kit/helpers/getOmniPrimaryButtonLabelKey.ts
@@ -31,6 +31,7 @@ export function getOmniPrimaryButtonLabelKey({
       return 'i-understand'
     case OmniSidebarStep.Transaction:
       if (isTxSuccess && isOpening) return 'system.go-to-position'
+      else if (isTxSuccess && uiDropdown === OmniMultiplyPanel.Close) return 'system.try-it-now'
       else if (isTxSuccess && !isOpening) return 'continue'
       else if (isTxError) return 'retry'
       else return 'confirm'

--- a/features/omni-kit/views/OmniFormView.tsx
+++ b/features/omni-kit/views/OmniFormView.tsx
@@ -25,8 +25,9 @@ import {
 } from 'features/omni-kit/helpers'
 import { getOmniSidebarRaysBanner } from 'features/omni-kit/helpers/getOmniSidebarRaysBanner'
 import { useOmniProductTypeTransition, useOmniSidebarTitle } from 'features/omni-kit/hooks'
-import { OmniProductType, OmniSidebarStep } from 'features/omni-kit/types'
+import { OmniMultiplyPanel, OmniProductType, OmniSidebarStep } from 'features/omni-kit/types'
 import { useConnection } from 'features/web3OnBoard/useConnection'
+import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import { getLocalAppConfig } from 'helpers/config'
 import { useModalContext } from 'helpers/modalHook'
 import { useAccount } from 'helpers/useAccount'
@@ -117,6 +118,13 @@ export function OmniFormView({
   } = useOmniProductContext(productType)
 
   const txHandler = _txHandler()
+
+  const positionClosedTitle =
+    isTxSuccess &&
+    currentStep === OmniSidebarStep.Transaction &&
+    state.uiDropdown === OmniMultiplyPanel.Close
+      ? 'Position Closed'
+      : undefined
 
   const { connect, setChain } = useConnection()
   const { walletAddress } = useAccount()
@@ -300,8 +308,20 @@ export function OmniFormView({
     settings,
   })
 
+  const withLazySummer =
+    isTxSuccess && state.uiDropdown === OmniMultiplyPanel.Close
+      ? {
+          url: EXTERNAL_LINKS.LAZY_SUMMER,
+          target: '_blank',
+          sx: {
+            background: 'linear-gradient(90deg, #FF49A4 0%, #B049FF 93%)',
+            border: 'unset',
+          },
+        }
+      : {}
+
   const sidebarSectionProps: SidebarSectionProps = {
-    title: sidebarTitle ?? genericSidebarTitle,
+    title: positionClosedTitle ?? sidebarTitle ?? genericSidebarTitle,
     dropdown,
     aboveButton: Rays
       ? getOmniSidebarRaysBanner({
@@ -350,6 +370,7 @@ export function OmniFormView({
       hidden: isPrimaryButtonHidden,
       withoutNextLink: true,
       ...primaryButtonActions,
+      ...withLazySummer,
     },
     textButton: {
       label: t('back-to-editing'),

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1284,6 +1284,7 @@
     "collateral-ratio": "Collateral Ratio",
     "collateralization-ratio": "Collateralization Ratio",
     "go-to-position": "Go to position",
+    "try-it-now": "Try it now ->",
     "dai": "Dai",
     "dai-available": "Dai Available",
     "dai-debt": "Dai Debt",


### PR DESCRIPTION
# Lazy Summer positon close sidebar redirect

## Changes 👷‍♀️
- Added Lazy Summer banner and content components for sidebar integration
- Implemented Lazy Summer content display in Omni Borrow and Multiply forms
- Added "Try it now" button with gradient styling for Lazy Summer promotion
- Updated translations for new "Try it now" button text
- Added target="_blank" support to SidebarSectionFooterButton component
- Moved SVG background to separate component for better maintainability

## How to test 🧪
1. Open an Omni position (Borrow or Multiply)
2. Navigate to the Close position flow
3. Complete the position closing transaction
4. Verify that:
   - The Lazy Summer banner appears with gradient background
   - The "Try it now" button is visible with proper gradient styling
   - Clicking the button opens Lazy Summer in a new tab
   - The button is fully clickable (not just the text)
   - The content displays correctly with proper spacing and typography

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sidebar buttons now support custom styling and can direct links to new targets.
  - A visually appealing sidebar banner with gradient designs has been introduced.
  - Dynamic sidebar content adapts to transaction states, highlighting benefits and rewards.
  - Transaction views now display contextual titles and a new call-to-action button labeled "Try it now ->".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->