### PR TITLE
Add lazy close step for maker

### DIFF
--- a/components/LazySummerBanner.tsx
+++ b/components/LazySummerBanner.tsx
@@ -50,8 +50,7 @@ export const LazySummerBanner = ({ address, isOwner, raysData }: LazySummerBanne
         }}
       >
         <Text variant="boldParagraph3" color="#868385">
-          $SUMR powers the Lazy Summer Protocol – DeFi’s best yield optimizer. Claim your $SUMR now
-          and get ready for the protocol launching on February 11th!
+          $SUMR powers the Lazy Summer Protocol – DeFi’s best yield optimizer. Claim your $SUMR now!
         </Text>
       </ActionBanner>
     </Box>

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVault.tsx
@@ -17,6 +17,7 @@ import { isDropdownDisabled } from 'features/sidebar/isDropdownDisabled'
 import { progressTrackingEvent, regressTrackingEvent } from 'features/sidebar/trackingEvents'
 import type { SidebarFlow } from 'features/types/vaults/sidebarLabels'
 import { mapAutomationEvents } from 'features/vaultHistory/vaultHistory'
+import { EXTERNAL_LINKS } from 'helpers/applicationLinks'
 import { extractGasDataFromState } from 'helpers/extractGasDataFromState'
 import {
   extractPrimaryButtonLabelParams,
@@ -90,6 +91,18 @@ export function SidebarManageMultiplyVault(props: ManageMultiplyVaultState) {
     }
   }, [stage, otherAction])
 
+  const withLazySummer =
+    props.otherAction === 'closeVault' && props.stage === 'manageSuccess'
+      ? {
+          url: EXTERNAL_LINKS.LAZY_SUMMER,
+          target: '_blank',
+          sx: {
+            background: 'linear-gradient(90deg, #FF49A4 0%, #B049FF 93%)',
+            border: 'unset',
+          },
+        }
+      : {}
+
   const sidebarSectionProps: SidebarSectionProps = {
     title: getSidebarTitle({
       flow,
@@ -100,6 +113,7 @@ export function SidebarManageMultiplyVault(props: ManageMultiplyVaultState) {
         stopLossTriggered,
         autoTakeProfitTriggered,
       }),
+      otherAction: props.otherAction,
     }),
     dropdown: {
       forcePanel,
@@ -219,6 +233,7 @@ export function SidebarManageMultiplyVault(props: ManageMultiplyVaultState) {
           progressTrackingEvent({ props })
         } else setIsClosedVaultPanelVisible(false)
       },
+      ...withLazySummer,
     },
     textButton: {
       label: getTextButtonLabel({ flow, stage, token }),

--- a/features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage.tsx
+++ b/features/multiply/manage/sidebars/SidebarManageMultiplyVaultManageStage.tsx
@@ -1,6 +1,7 @@
 import { VaultChangesWithADelayCard } from 'components/vault/VaultChangesWithADelayCard'
 import { ManageVaultChangesInformation } from 'features/borrow/manage/containers/ManageVaultChangesInformation'
 import { VaultType } from 'features/generalManageVault/vaultType.types'
+import { LazySummerSidebarContent } from 'features/lazy-summer/components/LazySummerSidebarContent'
 import { ManageMultiplyVaultChangesInformation } from 'features/multiply/manage/containers/ManageMultiplyVaultChangesInformation'
 import type { ManageMultiplyVaultState } from 'features/multiply/manage/pipes/ManageMultiplyVaultState.types'
 import { useTranslation } from 'next-i18next'
@@ -11,7 +12,13 @@ import { Text } from 'theme-ui'
 export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVaultState) {
   const { t } = useTranslation()
 
-  const { stage, vaultType, otherAction } = props
+  const {
+    stage,
+    vaultType,
+    otherAction,
+    closeVaultTo,
+    vault: { token },
+  } = props
 
   const [, setVaultChanges] = useState<ManageMultiplyVaultState>(props)
 
@@ -19,10 +26,22 @@ export function SidebarManageMultiplyVaultManageStage(props: ManageMultiplyVault
     if (props.stage !== 'manageSuccess') setVaultChanges(props)
   }, [props])
 
+  const isClosingToCollateral = closeVaultTo === 'collateral'
+  const closeToTokenSymbol = isClosingToCollateral ? token : 'DAI'
+
   switch (stage) {
     case 'manageInProgress':
       return <OpenVaultAnimation />
     case 'manageSuccess':
+      if (props.originalEditingStage === 'otherActions' && otherAction === 'closeVault') {
+        return (
+          <>
+            <LazySummerSidebarContent closeToToken={closeToTokenSymbol} />
+            <VaultChangesWithADelayCard />
+          </>
+        )
+      }
+
       return (
         <>
           {vaultType === VaultType.Multiply ||

--- a/features/sidebar/getPrimaryButtonLabel.ts
+++ b/features/sidebar/getPrimaryButtonLabel.ts
@@ -84,6 +84,7 @@ export function getPrimaryButtonLabel({
   canTransition = true,
   isClosedVaultPanelVisible = false,
   vaultType,
+  otherAction,
 }: PrimaryButtonLabelParams & { flow: SidebarFlow; vaultType: VaultType }): string {
   const { t } = useTranslation()
   const allowanceToken =
@@ -143,6 +144,10 @@ export function getPrimaryButtonLabel({
     case 'manageFailure':
       return t('retry')
     case 'manageSuccess':
+      if (otherAction === 'closeVault') {
+        return t('system.try-it-now')
+      }
+
       return t('ok')
     case 'txInProgress':
       const txInProgressKey = getPrimaryButtonLabelTxInProgressTranslationKey({ flow })

--- a/features/sidebar/getSidebarTitle.ts
+++ b/features/sidebar/getSidebarTitle.ts
@@ -1,6 +1,7 @@
 import type BigNumber from 'bignumber.js'
 import { autoKindToCopyMap } from 'features/automation/common/consts'
 import type { AutomationKinds } from 'features/automation/common/types'
+import type { OtherAction } from 'features/multiply/manage/pipes/OtherAction.types'
 import type { SidebarFlow, SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
 import { getLocalAppConfig } from 'helpers/config'
 import { UnreachableCaseError } from 'helpers/UnreachableCaseError'
@@ -14,6 +15,7 @@ interface GetSidebarTitleParams {
   openFlowWithStopLoss?: boolean
   isStopLossEnabled?: boolean
   automationThatClosedVault?: AutomationKinds.AUTO_TAKE_PROFIT | AutomationKinds.STOP_LOSS
+  otherAction?: OtherAction
 }
 
 function getSidebarTitleEditingTranslationKey({ flow }: { flow: SidebarFlow }) {
@@ -99,6 +101,7 @@ export function getSidebarTitle({
   openFlowWithStopLoss = false,
   isStopLossEnabled = false,
   automationThatClosedVault,
+  otherAction,
 }: GetSidebarTitleParams) {
   const { t } = useTranslation()
   const allowanceToken = flow === 'openGuni' ? 'DAI' : token?.toUpperCase()
@@ -183,6 +186,10 @@ export function getSidebarTitle({
     case 'manageFailure':
       return t('vault-form.header.confirm-manage')
     case 'manageSuccess':
+      if (otherAction === 'closeVault') {
+        return t('system.position-closed')
+      }
+
       return t('vault-form.header.success-manage')
     default:
       throw new UnreachableCaseError(stage)

--- a/helpers/extractSidebarHelpers.ts
+++ b/helpers/extractSidebarHelpers.ts
@@ -1,5 +1,6 @@
 import type BigNumber from 'bignumber.js'
 import type { AllowanceOption } from 'features/allowance/allowance.types'
+import type { OtherAction } from 'features/multiply/manage/pipes/OtherAction.types'
 import type { SidebarVaultStages } from 'features/types/vaults/sidebarLabels'
 import { pick } from 'ramda'
 
@@ -32,6 +33,7 @@ export interface PrimaryButtonLabelParams extends SharedStateExtractions {
   canTransition?: boolean
   isClosedVaultPanelVisible?: boolean
   shouldRedirectToCloseVault?: boolean
+  otherAction?: OtherAction
 }
 
 export interface SidebarTxData extends SharedStateExtractions {
@@ -78,6 +80,7 @@ export function extractPrimaryButtonLabelParams(state: PrimaryButtonLabelParams)
         'insufficientDaiAllowance',
         'insufficientAllowance',
         'canTransition',
+        'otherAction',
       ],
       state,
     ),

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1285,6 +1285,7 @@
     "collateralization-ratio": "Collateralization Ratio",
     "go-to-position": "Go to position",
     "try-it-now": "Try it now ->",
+    "position-closed": "Position Closed",
     "dai": "Dai",
     "dai-available": "Dai Available",
     "dai-debt": "Dai Debt",


### PR DESCRIPTION
# Lazy Summer maker vault close step integration

## Changes 👷‍♀️

- Updated Lazy Summer banner text to remove launch date reference
- Added Lazy Summer integration to vault management flow:
  - Added "Try it now" button with gradient styling after vault closure
  - Integrated Lazy Summer sidebar content in vault management
  - Added position closed state handling
- Updated translations:
  - Added "Position Closed" text
  - Added "Try it now" button text
- Added support for `otherAction` in sidebar title and button label logic

## How to test 🧪

1. Test vault closure flow:
   - Open a multiply vault
   - Navigate to close vault option
   - Complete the closure transaction
   - Verify Lazy Summer content appears
   - Check "Try it now" button styling and functionality
2. Verify translations:
   - Check "Position Closed" text appears after closure
   - Verify "Try it now" button text is correct
3. Test different vault management scenarios:
   - Verify Lazy Summer integration only appears after closure
   - Check other management actions work as expected