### PR TITLE
Add caching to getMorphoCumulatives for improved performance

### DIFF
--- a/features/omni-kit/protocols/morpho-blue/helpers/getMorphoCumulatives.ts
+++ b/features/omni-kit/protocols/morpho-blue/helpers/getMorphoCumulatives.ts
@@ -4,11 +4,32 @@ import { mapOmniLendingCumulatives } from 'features/omni-kit/helpers'
 import type { OmniSupportedNetworkIds } from 'features/omni-kit/types'
 import type { SubgraphsResponses } from 'features/subgraphLoader/types'
 import { loadSubgraph } from 'features/subgraphLoader/useSubgraphLoader'
+import NodeCache from 'node-cache'
+
+// Cache with 5 minute TTL (300 seconds)
+const cache = new NodeCache({ stdTTL: 300 })
+
+const createCacheKey = (
+  networkId: OmniSupportedNetworkIds,
+  proxy: string,
+  marketId: string,
+): string => {
+  return `${networkId}-${proxy.toLowerCase()}-${marketId.toLowerCase()}`
+}
 
 export const getMorphoCumulatives: (
   networkId: OmniSupportedNetworkIds,
 ) => GetCumulativesData<MorphoCumulativesData> =
   (networkId) => async (proxy: string, marketId: string) => {
+    const cacheKey = createCacheKey(networkId, proxy, marketId)
+
+    // Check cache first
+    const cachedResult = cache.get<MorphoCumulativesData>(cacheKey)
+    if (cachedResult) {
+      return cachedResult
+    }
+
+    // Fetch fresh data
     const { response } = (await loadSubgraph({
       subgraph: 'Morpho',
       method: 'getMorphoCumulatives',
@@ -21,11 +42,17 @@ export const getMorphoCumulatives: (
 
     const lendingCumulatives = response.account?.borrowPositions[0]
 
+    let result: MorphoCumulativesData
     if (!lendingCumulatives) {
-      return defaultLendingCumulatives
+      result = defaultLendingCumulatives
+    } else {
+      result = {
+        ...mapOmniLendingCumulatives(lendingCumulatives),
+      }
     }
 
-    return {
-      ...mapOmniLendingCumulatives(lendingCumulatives),
-    }
+    // Store in cache with automatic expiration
+    cache.set(cacheKey, result)
+
+    return result
   }


### PR DESCRIPTION
# Add caching to getMorphoCumulatives for improved performance

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- added a simple in memory cache for morpho cumulatives per given dpm 

  
## How to test 🧪
  <Please explain how to test your changes>

- cache should store cumulatives data for 5 min per given key (network-dpm-marketid)
