### PR TITLE
Update @oasisdex/dma-library to version 0.6.84 in package.json and ya…

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/eth-sig-util": "^5.0.2",
     "@oasisdex/addresses": "0.1.92",
     "@oasisdex/automation": "1.6.5-morpho.6",
-    "@oasisdex/dma-library": "0.6.83",
+    "@oasisdex/dma-library": "0.6.84",
     "@oasisdex/multiply": "^0.2.11",
     "@oasisdex/transactions": "0.1.4-alpha.0",
     "@oasisdex/utils": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,10 +2600,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@oasisdex/dma-library@0.6.83":
-  version "0.6.83"
-  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.83.tgz#5cdb970da7f6a3cc5630f6d1f51bde131db4bbbf"
-  integrity sha512-bZ3+uWCxxfyEKp61yYUxjsP5WTk+dNuCZ1qdmKTbGZS42nGp+5U+RhT8+p0orB+qy7DH129eCu99pDG197ThqQ==
+"@oasisdex/dma-library@0.6.84":
+  version "0.6.84"
+  resolved "https://registry.yarnpkg.com/@oasisdex/dma-library/-/dma-library-0.6.84.tgz#b86f7b0265dab4a81ee91a2f0fcfcff5fc6c5834"
+  integrity sha512-2Hazfp+/faAC1S2ct2yXkHM+wRpkuTH3s2PV6lE7DfZyjY/RVqYxvM7IRTc8ltyDQDrndXUrYDIPGd/jcZ2UYw==
   dependencies:
     bignumber.js "9.0.1"
     ethers "^5.7.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded core dependency to @oasisdex/dma-library v0.6.84 to keep the application current.
  * No functional or UI changes are expected from this update.
  * Routine maintenance; improves alignment with latest upstream fixes.
  * Standard dependency refresh with low risk; standard regression testing recommended.
  * End users should not notice any differences in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->