### PR TITLE
Omni gas estimation fallback

### DIFF
--- a/features/omni-kit/observables/sendOmniTransaction.ts
+++ b/features/omni-kit/observables/sendOmniTransaction.ts
@@ -50,9 +50,12 @@ export const sendOmniTransaction$ = ({
             })
 
         return from(
-          estimateGasRequest.then((val) =>
-            new BigNumber(val.toString()).multipliedBy(GasMultiplier).toFixed(0),
-          ),
+          estimateGasRequest
+            .then((val) => new BigNumber(val.toString()).multipliedBy(GasMultiplier).toFixed(0))
+            .catch((error) => {
+              console.warn('Estimating gas failed, fallback to wallet provider gas limit', error)
+              return undefined
+            }),
         ).pipe(
           switchMap((gasLimit) => {
             const sendTxRequest = sendAsSinger
@@ -61,12 +64,12 @@ export const sendOmniTransaction$ = ({
                   to: txData.to,
                   data: txData.data,
                   value: txData.value,
-                  gasLimit: gasLimit ?? undefined,
+                  gasLimit: gasLimit,
                 })
               : dpm.execute(txData.to, txData.data, {
                   ...override,
                   value: txData.value,
-                  gasLimit: gasLimit ?? undefined,
+                  gasLimit: gasLimit,
                 })
 
             return from(sendTxRequest).pipe(


### PR DESCRIPTION
# Omni gas estimation fallback

<please insert a shortcut link above>
  
## Changes 👷‍♀️
  <Please add short list of changes>

- handled gas estimation request locally, if fails fallback to undefined so wallet itself can handle gasLimit
  
## How to test 🧪
  <Please explain how to test your changes>

- check if fallback works as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions no longer fail when gas estimation is unavailable; the app falls back to the wallet/provider’s default gas limit, improving reliability across networks and edge cases.
  * A warning is logged when gas estimation fails to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->